### PR TITLE
Source map with single source: Stop generating empty mappings.

### DIFF
--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -313,13 +313,20 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
     function toJSON(): RawSourceMap {
         commitPendingMapping();
         flushMappingBuffer();
+
+        let finalMappings = mappings;
+        if (sources.length === 1 && finalMappings === "") {
+            // Prevent generating a source map with empty mappings
+            finalMappings = "AAAA";
+        }
+
         return {
             version: 3,
             file,
             sourceRoot,
             sources,
             names,
-            mappings,
+            mappings: finalMappings,
             sourcesContent,
         };
     }

--- a/tests/baselines/reference/sourceMap-EmptyExport.js
+++ b/tests/baselines/reference/sourceMap-EmptyExport.js
@@ -1,0 +1,7 @@
+//// [sourceMap-EmptyExport.ts]
+export { }
+
+//// [sourceMap-EmptyExport.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=sourceMap-EmptyExport.js.map

--- a/tests/baselines/reference/sourceMap-EmptyExport.js.map
+++ b/tests/baselines/reference/sourceMap-EmptyExport.js.map
@@ -1,0 +1,3 @@
+//// [sourceMap-EmptyExport.js.map]
+{"version":3,"file":"sourceMap-EmptyExport.js","sourceRoot":"","sources":["sourceMap-EmptyExport.ts"],"names":[],"mappings":"AAAA"}
+//// https://sokra.github.io/source-map-visualization#base64,InVzZSBzdHJpY3QiOw0KT2JqZWN0LmRlZmluZVByb3BlcnR5KGV4cG9ydHMsICJfX2VzTW9kdWxlIiwgeyB2YWx1ZTogdHJ1ZSB9KTsNCi8vIyBzb3VyY2VNYXBwaW5nVVJMPXNvdXJjZU1hcC1FbXB0eUV4cG9ydC5qcy5tYXA=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLUVtcHR5RXhwb3J0LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsic291cmNlTWFwLUVtcHR5RXhwb3J0LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBIn0=,ZXhwb3J0IHsgfQ==

--- a/tests/baselines/reference/sourceMap-EmptyExport.sourcemap.txt
+++ b/tests/baselines/reference/sourceMap-EmptyExport.sourcemap.txt
@@ -1,0 +1,18 @@
+===================================================================
+JsFile: sourceMap-EmptyExport.js
+mapUrl: sourceMap-EmptyExport.js.map
+sourceRoot: 
+sources: sourceMap-EmptyExport.ts
+===================================================================
+-------------------------------------------------------------------
+emittedFile:tests/cases/compiler/sourceMap-EmptyExport.js
+sourceFile:sourceMap-EmptyExport.ts
+-------------------------------------------------------------------
+>>>"use strict";
+1 >
+2 >^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+1 >
+1 >Emitted(1, 1) Source(1, 1) + SourceIndex(0)
+---
+>>>Object.defineProperty(exports, "__esModule", { value: true });
+>>>//# sourceMappingURL=sourceMap-EmptyExport.js.map

--- a/tests/baselines/reference/sourceMap-EmptyExport.symbols
+++ b/tests/baselines/reference/sourceMap-EmptyExport.symbols
@@ -1,0 +1,3 @@
+=== tests/cases/compiler/sourceMap-EmptyExport.ts ===
+
+export { }

--- a/tests/baselines/reference/sourceMap-EmptyExport.types
+++ b/tests/baselines/reference/sourceMap-EmptyExport.types
@@ -1,0 +1,3 @@
+=== tests/cases/compiler/sourceMap-EmptyExport.ts ===
+
+export { }

--- a/tests/baselines/reference/sourceMap-EmptyFile1.js.map
+++ b/tests/baselines/reference/sourceMap-EmptyFile1.js.map
@@ -1,3 +1,3 @@
 //// [sourceMap-EmptyFile1.js.map]
-{"version":3,"file":"sourceMap-EmptyFile1.js","sourceRoot":"","sources":["sourceMap-EmptyFile1.ts"],"names":[],"mappings":""}
-//// https://sokra.github.io/source-map-visualization#base64,Ly8jIHNvdXJjZU1hcHBpbmdVUkw9c291cmNlTWFwLUVtcHR5RmlsZTEuanMubWFw,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLUVtcHR5RmlsZTEuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2VNYXAtRW1wdHlGaWxlMS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiIn0=,
+{"version":3,"file":"sourceMap-EmptyFile1.js","sourceRoot":"","sources":["sourceMap-EmptyFile1.ts"],"names":[],"mappings":"AAAA"}
+//// https://sokra.github.io/source-map-visualization#base64,Ly8jIHNvdXJjZU1hcHBpbmdVUkw9c291cmNlTWFwLUVtcHR5RmlsZTEuanMubWFw,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLUVtcHR5RmlsZTEuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJzb3VyY2VNYXAtRW1wdHlGaWxlMS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSJ9,

--- a/tests/baselines/reference/sourceMap-EmptyFile1.sourcemap.txt
+++ b/tests/baselines/reference/sourceMap-EmptyFile1.sourcemap.txt
@@ -4,4 +4,12 @@ mapUrl: sourceMap-EmptyFile1.js.map
 sourceRoot: 
 sources: sourceMap-EmptyFile1.ts
 ===================================================================
->>>//# sourceMappingURL=sourceMap-EmptyFile1.js.map
+-------------------------------------------------------------------
+emittedFile:tests/cases/compiler/sourceMap-EmptyFile1.js
+sourceFile:sourceMap-EmptyFile1.ts
+-------------------------------------------------------------------
+>>>//# sourceMappingURL=sourceMap-EmptyFile1.js.map1 >
+2 >^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+1 >
+1 >Emitted(1, 1) Source(1, 1) + SourceIndex(0)
+---

--- a/tests/baselines/reference/sourceMap-NewLine1.js.map
+++ b/tests/baselines/reference/sourceMap-NewLine1.js.map
@@ -1,3 +1,3 @@
 //// [sourceMap-NewLine1.js.map]
-{"version":3,"file":"sourceMap-NewLine1.js","sourceRoot":"","sources":["sourceMap-NewLine1.ts"],"names":[],"mappings":""}
-//// https://sokra.github.io/source-map-visualization#base64,Ly8jIHNvdXJjZU1hcHBpbmdVUkw9c291cmNlTWFwLU5ld0xpbmUxLmpzLm1hcA==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLU5ld0xpbmUxLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsic291cmNlTWFwLU5ld0xpbmUxLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiIifQ==,
+{"version":3,"file":"sourceMap-NewLine1.js","sourceRoot":"","sources":["sourceMap-NewLine1.ts"],"names":[],"mappings":"AAAA"}
+//// https://sokra.github.io/source-map-visualization#base64,Ly8jIHNvdXJjZU1hcHBpbmdVUkw9c291cmNlTWFwLU5ld0xpbmUxLmpzLm1hcA==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLU5ld0xpbmUxLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsic291cmNlTWFwLU5ld0xpbmUxLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBIn0=,

--- a/tests/baselines/reference/sourceMap-NewLine1.sourcemap.txt
+++ b/tests/baselines/reference/sourceMap-NewLine1.sourcemap.txt
@@ -4,4 +4,12 @@ mapUrl: sourceMap-NewLine1.js.map
 sourceRoot: 
 sources: sourceMap-NewLine1.ts
 ===================================================================
->>>//# sourceMappingURL=sourceMap-NewLine1.js.map
+-------------------------------------------------------------------
+emittedFile:tests/cases/compiler/sourceMap-NewLine1.js
+sourceFile:sourceMap-NewLine1.ts
+-------------------------------------------------------------------
+>>>//# sourceMappingURL=sourceMap-NewLine1.js.map1 >
+2 >^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+1 >
+1 >Emitted(1, 1) Source(1, 1) + SourceIndex(0)
+---

--- a/tests/baselines/reference/sourceMap-SingleSpace1.js.map
+++ b/tests/baselines/reference/sourceMap-SingleSpace1.js.map
@@ -1,3 +1,3 @@
 //// [sourceMap-SingleSpace1.js.map]
-{"version":3,"file":"sourceMap-SingleSpace1.js","sourceRoot":"","sources":["sourceMap-SingleSpace1.ts"],"names":[],"mappings":""}
-//// https://sokra.github.io/source-map-visualization#base64,Ly8jIHNvdXJjZU1hcHBpbmdVUkw9c291cmNlTWFwLVNpbmdsZVNwYWNlMS5qcy5tYXA=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLVNpbmdsZVNwYWNlMS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInNvdXJjZU1hcC1TaW5nbGVTcGFjZTEudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiJ9,IA==
+{"version":3,"file":"sourceMap-SingleSpace1.js","sourceRoot":"","sources":["sourceMap-SingleSpace1.ts"],"names":[],"mappings":"AAAA"}
+//// https://sokra.github.io/source-map-visualization#base64,Ly8jIHNvdXJjZU1hcHBpbmdVUkw9c291cmNlTWFwLVNpbmdsZVNwYWNlMS5qcy5tYXA=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLVNpbmdsZVNwYWNlMS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbInNvdXJjZU1hcC1TaW5nbGVTcGFjZTEudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEifQ==,IA==

--- a/tests/baselines/reference/sourceMap-SingleSpace1.sourcemap.txt
+++ b/tests/baselines/reference/sourceMap-SingleSpace1.sourcemap.txt
@@ -4,4 +4,12 @@ mapUrl: sourceMap-SingleSpace1.js.map
 sourceRoot: 
 sources: sourceMap-SingleSpace1.ts
 ===================================================================
->>>//# sourceMappingURL=sourceMap-SingleSpace1.js.map
+-------------------------------------------------------------------
+emittedFile:tests/cases/compiler/sourceMap-SingleSpace1.js
+sourceFile:sourceMap-SingleSpace1.ts
+-------------------------------------------------------------------
+>>>//# sourceMappingURL=sourceMap-SingleSpace1.js.map1 >
+2 >^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+1 >
+1 >Emitted(1, 1) Source(1, 1) + SourceIndex(0)
+---

--- a/tests/baselines/reference/sourceMap-TypeOnly.js
+++ b/tests/baselines/reference/sourceMap-TypeOnly.js
@@ -1,0 +1,7 @@
+//// [sourceMap-TypeOnly.ts]
+export type T = number;
+
+//// [sourceMap-TypeOnly.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=sourceMap-TypeOnly.js.map

--- a/tests/baselines/reference/sourceMap-TypeOnly.js.map
+++ b/tests/baselines/reference/sourceMap-TypeOnly.js.map
@@ -1,0 +1,3 @@
+//// [sourceMap-TypeOnly.js.map]
+{"version":3,"file":"sourceMap-TypeOnly.js","sourceRoot":"","sources":["sourceMap-TypeOnly.ts"],"names":[],"mappings":"AAAA"}
+//// https://sokra.github.io/source-map-visualization#base64,InVzZSBzdHJpY3QiOw0KT2JqZWN0LmRlZmluZVByb3BlcnR5KGV4cG9ydHMsICJfX2VzTW9kdWxlIiwgeyB2YWx1ZTogdHJ1ZSB9KTsNCi8vIyBzb3VyY2VNYXBwaW5nVVJMPXNvdXJjZU1hcC1UeXBlT25seS5qcy5tYXA=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoic291cmNlTWFwLVR5cGVPbmx5LmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsic291cmNlTWFwLVR5cGVPbmx5LnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBIn0=,ZXhwb3J0IHR5cGUgVCA9IG51bWJlcjs=

--- a/tests/baselines/reference/sourceMap-TypeOnly.sourcemap.txt
+++ b/tests/baselines/reference/sourceMap-TypeOnly.sourcemap.txt
@@ -1,0 +1,18 @@
+===================================================================
+JsFile: sourceMap-TypeOnly.js
+mapUrl: sourceMap-TypeOnly.js.map
+sourceRoot: 
+sources: sourceMap-TypeOnly.ts
+===================================================================
+-------------------------------------------------------------------
+emittedFile:tests/cases/compiler/sourceMap-TypeOnly.js
+sourceFile:sourceMap-TypeOnly.ts
+-------------------------------------------------------------------
+>>>"use strict";
+1 >
+2 >^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+1 >
+1 >Emitted(1, 1) Source(1, 1) + SourceIndex(0)
+---
+>>>Object.defineProperty(exports, "__esModule", { value: true });
+>>>//# sourceMappingURL=sourceMap-TypeOnly.js.map

--- a/tests/baselines/reference/sourceMap-TypeOnly.symbols
+++ b/tests/baselines/reference/sourceMap-TypeOnly.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/sourceMap-TypeOnly.ts ===
+export type T = number;
+>T : Symbol(T, Decl(sourceMap-TypeOnly.ts, 0, 0))
+

--- a/tests/baselines/reference/sourceMap-TypeOnly.types
+++ b/tests/baselines/reference/sourceMap-TypeOnly.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/sourceMap-TypeOnly.ts ===
+export type T = number;
+>T : number
+

--- a/tests/cases/compiler/sourceMap-EmptyExport.ts
+++ b/tests/cases/compiler/sourceMap-EmptyExport.ts
@@ -1,0 +1,2 @@
+// @sourcemap: true
+export { }

--- a/tests/cases/compiler/sourceMap-TypeOnly.ts
+++ b/tests/cases/compiler/sourceMap-TypeOnly.ts
@@ -1,0 +1,2 @@
+// @sourcemap: true
+export type T = number;


### PR DESCRIPTION
Fixes #52005 

## Description
This PR generates a mapping from the beginning of the output code to the beginning of the single source file when there is no mapping already defined.

## Exemples
### Types only
#### Actual behavior

```ts
{
  "version": 3,
  "file": "types.js",
  "sourceRoot": "",
  "sources": [
    "../types.ts"
  ],
  "names": [],
  "mappings": "",
  "sourcesContent": [
    "export type N = number;"
  ]
}
```

#### With this PR
```ts
{
  "version": 3,
  "file": "types.js",
  "sourceRoot": "",
  "sources": [
    "../types.ts"
  ],
  "names": [],
  "mappings": "AAAA",
  "sourcesContent": [
    "export type N = number;"
  ]
}
```

### Empty export
#### Actual behavior
```ts
{
  "version": 3,
  "file": "export.js",
  "sourceRoot": "",
  "sources": [
    "../export.ts"
  ],
  "names": [],
  "mappings": "",
  "sourcesContent": [
    "export { }"
  ]
}
```

#### With this PR
```ts
{
  "version": 3,
  "file": "export.js",
  "sourceRoot": "",
  "sources": [
    "../export.ts"
  ],
  "names": [],
  "mappings": "AAAA",
  "sourcesContent": [
    "export { }"
  ]
}
```

## Tests
This PR breaks a lot of `.map` / `.map.txt` tests with "export {}" or an empty typescript file, I would like to have an opinion on this solution before fixing them all. 

## Possible unintended behavior
With this solution, a mapping is generated for a completely empty file. In my understanding this may be wanted, but this is not related with #52005

## Checklist:
* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [X] There are new or updated unit tests validating the change


-------
PS: I'm aware this may be a naïve solution. My knowledge with source map and Typescript compiler is limited and I hope I'm not too far from the solution here.
