### PR TITLE
Fix error in herebyfile after comparison strictness change

### DIFF
--- a/scripts/build/options.mjs
+++ b/scripts/build/options.mjs
@@ -26,13 +26,13 @@ const parsed = minimist(process.argv.slice(2), {
         inspect: process.env.inspect || process.env["inspect-brk"] || process.env.i,
         host: process.env.TYPESCRIPT_HOST || process.env.host || "node",
         browser: process.env.browser || process.env.b || (os.platform() === "win32" ? "edge" : "chrome"),
-        timeout: process.env.timeout || 40000,
+        timeout: +(process.env.timeout ?? 0) || 40000,
         tests: process.env.test || process.env.tests || process.env.t,
         runners: process.env.runners || process.env.runner || process.env.ru,
         light: process.env.light === undefined || process.env.light !== "false",
         reporter: process.env.reporter || process.env.r,
         fix: process.env.fix || process.env.f,
-        workers: process.env.workerCount || ((os.cpus().length - (ci ? 0 : 1)) || 1),
+        workers: +(process.env.workerCount ?? 0) || ((os.cpus().length - (ci ? 0 : 1)) || 1),
         failed: false,
         keepFailed: false,
         lkg: true,
@@ -73,11 +73,11 @@ export default options;
  * @property {string | boolean} break
  * @property {string | boolean} inspect
  * @property {string} runners
- * @property {string|number} workers
+ * @property {number} workers
  * @property {string} host
  * @property {string} reporter
  * @property {string} stackTraceLimit
- * @property {string|number} timeout
+ * @property {number} timeout
  * @property {boolean} failed
  * @property {boolean} keepFailed
  * @property {boolean} ci

--- a/scripts/build/tests.mjs
+++ b/scripts/build/tests.mjs
@@ -175,9 +175,9 @@ export async function cleanTestDirs() {
  * @param {string} runners
  * @param {boolean} light
  * @param {string} [taskConfigsFolder]
- * @param {string | number} [workerCount]
+ * @param {number} [workerCount]
  * @param {string} [stackTraceLimit]
- * @param {string | number} [timeout]
+ * @param {number} [timeout]
  * @param {boolean} [keepFailed]
  * @param {number | undefined} [shards]
  * @param {number | undefined} [shardId]


### PR DESCRIPTION
After #52048, we have an error in our Herebyfile:

![image](https://user-images.githubusercontent.com/5341706/214146282-6173f769-698d-4721-814f-13894e846329.png)

Try and type these more strictly (they should really just be numbers).