### PR TITLE
Remove line/col for all lib file diagnostics in baselines, completions

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -59,10 +59,7 @@ export const generateLibs = task({
 
             for (const source of lib.sources) {
                 const contents = await fs.promises.readFile(source, "utf-8");
-                // TODO(jakebailey): "\n\n" is for compatibility with our current tests; our test baselines
-                // are sensitive to the positions of things in the lib files. Eventually remove this,
-                // or remove lib.d.ts line numbers from our baselines.
-                output += "\n\n" + contents.replace(/\r\n/g, "\n");
+                output += "\n" + contents.replace(/\r\n/g, "\n");
             }
 
             await fs.promises.writeFile(lib.target, output);

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2055,7 +2055,7 @@ export class TestState {
                             if (/lib(?:.*)\.d\.ts$/.test(link.target.fileName)) {
                                 // elidedSpan doesn't have the correct type, but we're only going to
                                 // use these results in the baseline for diffing, so just overwrite.
-                                (link.target.textSpan as any) = { start: "--", end: "--" };
+                                (link.target.textSpan as any) = { start: "--", length: "--" };
                             }
                         }
                     }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2047,9 +2047,9 @@ export class TestState {
                     : [`(${entry.kindModifiers}${entry.kind}) ${entry.name}`])
         );
         for (const r of result) {
-            for (const entry of r.item.entries ?? []) {
-                for (const tag of entry.tags ?? []) {
-                    for (const part of tag.text ?? []) {
+            for (const entry of r.item.entries ?? ts.emptyArray) {
+                for (const tag of entry.tags ?? ts.emptyArray) {
+                    for (const part of tag.text ?? ts.emptyArray) {
                         if (part.kind === "linkName") {
                             const link = part as ts.JSDocLinkDisplayPart;
                             if (/lib(?:.*)\.d\.ts$/.test(link.target.fileName)) {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2046,6 +2046,22 @@ export class TestState {
                     ? entry.displayParts.map(p => p.text).join("").split("\n")
                     : [`(${entry.kindModifiers}${entry.kind}) ${entry.name}`])
         );
+        for (const r of result) {
+            for (const entry of r.item.entries ?? []) {
+                for (const tag of entry.tags ?? []) {
+                    for (const part of tag.text ?? []) {
+                        if (part.kind === "linkName") {
+                            const link = part as ts.JSDocLinkDisplayPart;
+                            if (/lib(?:.*)\.d\.ts$/.test(link.target.fileName)) {
+                                // elidedSpan doesn't have the correct type, but we're only going to
+                                // use these results in the baseline for diffing, so just overwrite.
+                                (link.target.textSpan as any) = { start: "--", end: "--" };
+                            }
+                        }
+                    }
+                }
+            }
+        }
         Harness.Baseline.runBaseline(baselineFile, annotations + "\n\n" + stringify(result));
     }
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2053,7 +2053,7 @@ export class TestState {
                         if (part.kind === "linkName") {
                             const link = part as ts.JSDocLinkDisplayPart;
                             if (/lib(?:.*)\.d\.ts$/.test(link.target.fileName)) {
-                                // This doesn't have the correct type, but we're only going to
+                                // The object literal isn't a complete TextSpan, but we're only going to
                                 // use these results in the baseline for diffing, so just overwrite.
                                 (link.target.textSpan as any) = { start: "--", length: "--" };
                             }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2053,7 +2053,7 @@ export class TestState {
                         if (part.kind === "linkName") {
                             const link = part as ts.JSDocLinkDisplayPart;
                             if (/lib(?:.*)\.d\.ts$/.test(link.target.fileName)) {
-                                // elidedSpan doesn't have the correct type, but we're only going to
+                                // This doesn't have the correct type, but we're only going to
                                 // use these results in the baseline for diffing, so just overwrite.
                                 (link.target.textSpan as any) = { start: "--", length: "--" };
                             }

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -616,7 +616,11 @@ export namespace Compiler {
             }
         }
 
-        yield [diagnosticSummaryMarker, Utils.removeTestPathPrefixes(minimalDiagnosticsToString(diagnostics, options && options.pretty)) + IO.newLine() + IO.newLine(), diagnostics.length];
+        let topDiagnostics = minimalDiagnosticsToString(diagnostics, options && options.pretty);
+        topDiagnostics = Utils.removeTestPathPrefixes(topDiagnostics);
+        topDiagnostics = topDiagnostics.replace(/^(lib(?:.*)\.d\.ts)\(\d+,\d+\)/igm, "$1(--,--)");
+
+        yield [diagnosticSummaryMarker, topDiagnostics + IO.newLine() + IO.newLine(), diagnostics.length];
 
         // Report global errors
         const globalErrors = diagnostics.filter(err => !err.file);

--- a/tests/baselines/reference/completionsStringMethods.baseline
+++ b/tests/baselines/reference/completionsStringMethods.baseline
@@ -1106,7 +1106,7 @@
                     "fileName": "lib.d.ts",
                     "textSpan": {
                       "start": "--",
-                      "end": "--"
+                      "length": "--"
                     }
                   }
                 },
@@ -1129,7 +1129,7 @@
                     "fileName": "lib.d.ts",
                     "textSpan": {
                       "start": "--",
-                      "end": "--"
+                      "length": "--"
                     }
                   }
                 },

--- a/tests/baselines/reference/completionsStringMethods.baseline
+++ b/tests/baselines/reference/completionsStringMethods.baseline
@@ -1105,8 +1105,8 @@
                   "target": {
                     "fileName": "lib.d.ts",
                     "textSpan": {
-                      "start": 18529,
-                      "length": 28
+                      "start": "--",
+                      "end": "--"
                     }
                   }
                 },
@@ -1128,8 +1128,8 @@
                   "target": {
                     "fileName": "lib.d.ts",
                     "textSpan": {
-                      "start": 18529,
-                      "length": 28
+                      "start": "--",
+                      "end": "--"
                     }
                   }
                 },

--- a/tests/baselines/reference/duplicateNumericIndexers.errors.txt
+++ b/tests/baselines/reference/duplicateNumericIndexers.errors.txt
@@ -10,8 +10,8 @@ tests/cases/conformance/types/members/duplicateNumericIndexers.ts(24,5): error T
 tests/cases/conformance/types/members/duplicateNumericIndexers.ts(25,5): error TS2374: Duplicate index signature for type 'number'.
 tests/cases/conformance/types/members/duplicateNumericIndexers.ts(29,5): error TS2374: Duplicate index signature for type 'number'.
 tests/cases/conformance/types/members/duplicateNumericIndexers.ts(30,5): error TS2374: Duplicate index signature for type 'number'.
-lib.es5.d.ts(520,5): error TS2374: Duplicate index signature for type 'number'.
-lib.es5.d.ts(1484,5): error TS2374: Duplicate index signature for type 'number'.
+lib.es5.d.ts(--,--): error TS2374: Duplicate index signature for type 'number'.
+lib.es5.d.ts(--,--): error TS2374: Duplicate index signature for type 'number'.
 
 
 ==== tests/cases/conformance/types/members/duplicateNumericIndexers.ts (12 errors) ====

--- a/tests/baselines/reference/objectTypeHidingMembersOfExtendedObject.errors.txt
+++ b/tests/baselines/reference/objectTypeHidingMembersOfExtendedObject.errors.txt
@@ -1,11 +1,11 @@
 tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts(10,5): error TS2411: Property 'data' of type 'A' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(127,5): error TS2411: Property 'constructor' of type 'Function' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(130,5): error TS2411: Property 'toString' of type '() => string' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(133,5): error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(136,5): error TS2411: Property 'valueOf' of type '() => Object' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(142,5): error TS2411: Property 'hasOwnProperty' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(148,5): error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(154,5): error TS2411: Property 'propertyIsEnumerable' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'constructor' of type 'Function' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'toString' of type '() => string' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'valueOf' of type '() => Object' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'hasOwnProperty' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'propertyIsEnumerable' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
 
 
 ==== tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts (1 errors) ====

--- a/tests/baselines/reference/objectTypeWithStringIndexerHidingObjectIndexer.errors.txt
+++ b/tests/baselines/reference/objectTypeWithStringIndexerHidingObjectIndexer.errors.txt
@@ -1,10 +1,10 @@
-lib.es5.d.ts(127,5): error TS2411: Property 'constructor' of type 'Function' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(130,5): error TS2411: Property 'toString' of type '() => string' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(133,5): error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(136,5): error TS2411: Property 'valueOf' of type '() => Object' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(142,5): error TS2411: Property 'hasOwnProperty' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(148,5): error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to 'string' index type 'Object'.
-lib.es5.d.ts(154,5): error TS2411: Property 'propertyIsEnumerable' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'constructor' of type 'Function' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'toString' of type '() => string' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'toLocaleString' of type '() => string' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'valueOf' of type '() => Object' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'hasOwnProperty' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'isPrototypeOf' of type '(v: Object) => boolean' is not assignable to 'string' index type 'Object'.
+lib.es5.d.ts(--,--): error TS2411: Property 'propertyIsEnumerable' of type '(v: PropertyKey) => boolean' is not assignable to 'string' index type 'Object'.
 
 
 ==== tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts (0 errors) ====

--- a/tests/baselines/reference/variableDeclarationInStrictMode1.errors.txt
+++ b/tests/baselines/reference/variableDeclarationInStrictMode1.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/variableDeclarationInStrictMode1.ts(2,5): error TS1100: Invalid use of 'eval' in strict mode.
 tests/cases/compiler/variableDeclarationInStrictMode1.ts(2,5): error TS2300: Duplicate identifier 'eval'.
-lib.es5.d.ts(35,18): error TS2300: Duplicate identifier 'eval'.
+lib.es5.d.ts(--,--): error TS2300: Duplicate identifier 'eval'.
 
 
 ==== tests/cases/compiler/variableDeclarationInStrictMode1.ts (2 errors) ====


### PR DESCRIPTION
This drops the last of the lib.d.ts line/col information out of our baselines.

Now, the only way that baselines will change on lib.d.ts updates is if the types themselves change (`.types` or `.symbols` files) or documentation is updated that is encoded in a completions/quickinfo baseline.

This finally allows me to remove a hack I put into the new build in order to stop baselines from changing thanks to the differing way that the new build builds the lib.d.ts files compared to the old gulp pipelines.