### PR TITLE
feat(52366): @prop is not provided as a valid JSDoc tag in autocompletion

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -147,6 +147,7 @@ const jsDocTagNames = [
     "package",
     "param",
     "private",
+    "prop",
     "property",
     "protected",
     "public",

--- a/tests/cases/fourslash/jsdocPropTagCompletion.ts
+++ b/tests/cases/fourslash/jsdocPropTagCompletion.ts
@@ -1,0 +1,11 @@
+///<reference path="fourslash.ts" />
+
+/////**
+//// * @typedef Foo
+//// * @pr/**/
+//// */
+
+verify.completions({
+    marker: "",
+    includes: ["prop"],
+});


### PR DESCRIPTION
Fixes #52366