### PR TITLE
Update lib to allow type narrowing for arrays using Array#forEach and assertion function

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1224,6 +1224,12 @@ interface ReadonlyArray<T> {
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
+    forEach<S extends T>(callbackfn: (value: T, index: number, array: readonly T[]) => asserts value is S, thisArg?: any): asserts this is readonly S[];
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: T, index: number, array: readonly T[]) => void, thisArg?: any): void;
     /**
      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
@@ -1410,6 +1416,12 @@ interface Array<T> {
      * If thisArg is omitted, undefined is used as the this value.
      */
     some(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+    /**
+     * Performs the specified action for each element in an array.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
+    forEach<S extends T>(callbackfn: (value: T, index: number, array: T[]) => asserts value is S, thisArg?: any): asserts this is S[];
     /**
      * Performs the specified action for each element in an array.
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.

--- a/tests/baselines/reference/arrayForEachNarrowing.js
+++ b/tests/baselines/reference/arrayForEachNarrowing.js
@@ -1,0 +1,19 @@
+//// [arrayForEachNarrowing.ts]
+const foo: (number | string)[] = ['aaa'];
+
+function assertString(x: unknown): asserts x is string {
+  if (typeof x !== 'string') throw new Error('Must be a string!');
+}
+
+foo.forEach(assertString);
+foo[0].slice(0);
+
+
+//// [arrayForEachNarrowing.js]
+var foo = ['aaa'];
+function assertString(x) {
+    if (typeof x !== 'string')
+        throw new Error('Must be a string!');
+}
+foo.forEach(assertString);
+foo[0].slice(0);

--- a/tests/baselines/reference/arrayForEachNarrowing.symbols
+++ b/tests/baselines/reference/arrayForEachNarrowing.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/arrayForEachNarrowing.ts ===
+const foo: (number | string)[] = ['aaa'];
+>foo : Symbol(foo, Decl(arrayForEachNarrowing.ts, 0, 5))
+
+function assertString(x: unknown): asserts x is string {
+>assertString : Symbol(assertString, Decl(arrayForEachNarrowing.ts, 0, 41))
+>x : Symbol(x, Decl(arrayForEachNarrowing.ts, 2, 22))
+>x : Symbol(x, Decl(arrayForEachNarrowing.ts, 2, 22))
+
+  if (typeof x !== 'string') throw new Error('Must be a string!');
+>x : Symbol(x, Decl(arrayForEachNarrowing.ts, 2, 22))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+}
+
+foo.forEach(assertString);
+>foo.forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>foo : Symbol(foo, Decl(arrayForEachNarrowing.ts, 0, 5))
+>forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>assertString : Symbol(assertString, Decl(arrayForEachNarrowing.ts, 0, 41))
+
+foo[0].slice(0);
+>foo[0].slice : Symbol(String.slice, Decl(lib.es5.d.ts, --, --))
+>foo : Symbol(foo, Decl(arrayForEachNarrowing.ts, 0, 5))
+>slice : Symbol(String.slice, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/arrayForEachNarrowing.types
+++ b/tests/baselines/reference/arrayForEachNarrowing.types
@@ -1,0 +1,36 @@
+=== tests/cases/compiler/arrayForEachNarrowing.ts ===
+const foo: (number | string)[] = ['aaa'];
+>foo : (string | number)[]
+>['aaa'] : string[]
+>'aaa' : "aaa"
+
+function assertString(x: unknown): asserts x is string {
+>assertString : (x: unknown) => asserts x is string
+>x : unknown
+
+  if (typeof x !== 'string') throw new Error('Must be a string!');
+>typeof x !== 'string' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'string' : "string"
+>new Error('Must be a string!') : Error
+>Error : ErrorConstructor
+>'Must be a string!' : "Must be a string!"
+}
+
+foo.forEach(assertString);
+>foo.forEach(assertString) : void
+>foo.forEach : { <S extends string | number>(callbackfn: (value: string | number, index: number, array: (string | number)[]) => asserts value is S, thisArg?: any): asserts this is S[]; (callbackfn: (value: string | number, index: number, array: (string | number)[]) => void, thisArg?: any): void; }
+>foo : (string | number)[]
+>forEach : { <S extends string | number>(callbackfn: (value: string | number, index: number, array: (string | number)[]) => asserts value is S, thisArg?: any): asserts this is S[]; (callbackfn: (value: string | number, index: number, array: (string | number)[]) => void, thisArg?: any): void; }
+>assertString : (x: unknown) => asserts x is string
+
+foo[0].slice(0);
+>foo[0].slice(0) : string
+>foo[0].slice : (start?: number, end?: number) => string
+>foo[0] : string
+>foo : string[]
+>0 : 0
+>slice : (start?: number, end?: number) => string
+>0 : 0
+

--- a/tests/cases/compiler/arrayForEachNarrowing.ts
+++ b/tests/cases/compiler/arrayForEachNarrowing.ts
@@ -1,0 +1,8 @@
+const foo: (number | string)[] = ['aaa'];
+
+function assertString(x: unknown): asserts x is string {
+  if (typeof x !== 'string') throw new Error('Must be a string!');
+}
+
+foo.forEach(assertString);
+foo[0].slice(0);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

This PR add support for array type narrowing using `Array#forEach` in a fashion similar to `Array#every`. `ReadonlyArray` is also supported.

The functionality can be tested by copying this script to a TypeScript playground.

```typescript
interface Array<T> {
  forEach<S extends T>(callbackfn: (value: T, index: number, array: T[]) => asserts value is S, thisArg?: any): asserts this is S[];
}

const foo: (number | string)[] = ['aaa'];

function assertString(x: unknown): asserts x is string {
  if (typeof x !== 'string') throw new Error('Must be a string!');
}

foo.forEach(assertString);
foo[0].slice(0); // foo is now string[]
```

