### PR TITLE
fix(52386): JSDoc code fixes for arrow-function initialized const duplicates comment

### DIFF
--- a/src/services/codefixes/fixUnmatchedParameter.ts
+++ b/src/services/codefixes/fixUnmatchedParameter.ts
@@ -83,7 +83,7 @@ function getDeleteAction(context: CodeFixContext, { name, jsDocHost, jsDocParame
     );
 }
 
-function getRenameAction(context: CodeFixContext, { name, signature, jsDocParameterTag }: Info) {
+function getRenameAction(context: CodeFixContext, { name, jsDocHost, signature, jsDocParameterTag }: Info) {
     if (!length(signature.parameters)) return undefined;
 
     const sourceFile = context.sourceFile;
@@ -110,7 +110,7 @@ function getRenameAction(context: CodeFixContext, { name, signature, jsDocParame
         jsDocParameterTag.comment
     );
     const changes = textChanges.ChangeTracker.with(context, changeTracker =>
-        changeTracker.replaceJSDocComment(sourceFile, signature, map(tags, t => t === jsDocParameterTag ? newJSDocParameterTag : t)));
+        changeTracker.replaceJSDocComment(sourceFile, jsDocHost, map(tags, t => t === jsDocParameterTag ? newJSDocParameterTag : t)));
     return createCodeFixActionWithoutFixAll(renameUnmatchedParameter, changes, [Diagnostics.Rename_param_tag_name_0_to_1, name.getText(sourceFile), parameterName]);
 }
 

--- a/tests/cases/fourslash/codeFixRenameUnmatchedParameter4.ts
+++ b/tests/cases/fourslash/codeFixRenameUnmatchedParameter4.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: /a.ts
+/////**
+//// * @param {string} y
+//// * @returns
+//// */
+////export const foo = (x: string) => x;
+
+verify.codeFix({
+    description: [ts.Diagnostics.Rename_param_tag_name_0_to_1.message, "y", "x"],
+    index: 1,
+    newFileContent:
+`/**
+ * @param {string} x
+ * @returns
+ */
+export const foo = (x: string) => x;`,
+});


### PR DESCRIPTION
Fixes #52386