### PR TITLE
[experimental] Cache all internally created Printers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6123,9 +6123,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function symbolToStringWorker(writer: EmitTextWriter) {
             const entity = builder(symbol, meaning!, enclosingDeclaration, nodeFlags)!; // TODO: GH#18217
             // add neverAsciiEscape for GH#39027
-            const printer = enclosingDeclaration?.kind === SyntaxKind.SourceFile
-                ? createOrReusePrinter({ removeComments: true, neverAsciiEscape: true })
-                : createOrReusePrinter({ removeComments: true });
+            const printer = enclosingDeclaration?.kind === SyntaxKind.SourceFile ? createOrReusePrinter({ removeComments: true, neverAsciiEscape: true }) : createOrReusePrinter({ removeComments: true });
             const sourceFile = enclosingDeclaration && getSourceFileOfNode(enclosingDeclaration);
             printer.writeNode(EmitHint.Unspecified, entity, /*sourceFile*/ sourceFile, writer);
             return writer;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -111,7 +111,10 @@ import {
     createGetCanonicalFileName,
     createGetSymbolWalker,
     createModeAwareCacheKey,
-    createPrinter,
+    createPrinterWithDefaults,
+    createPrinterWithRemoveComments,
+    createPrinterWithRemoveCommentsNeverAsciiEscape,
+    createPrinterWithRemoveCommentsOmitTrailingSemicolon,
     createPropertyNameNodeForIdentifierOrLiteral,
     createSymbolTable,
     createTextWriter,
@@ -2172,9 +2175,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         [".jsx", ".jsx"],
         [".json", ".json"],
     ];
-
-    const symbolToStringWorkerSourceFilePrinter = memoize(() => createPrinter({ removeComments: true, neverAsciiEscape: true }));
-    const symbolToStringWorkerNonSourceFilePrinter = memoize(() => createPrinter({ removeComments: true }));
 
     initializeTypeChecker();
 
@@ -6127,8 +6127,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const entity = builder(symbol, meaning!, enclosingDeclaration, nodeFlags)!; // TODO: GH#18217
             // add neverAsciiEscape for GH#39027
             const printer = enclosingDeclaration?.kind === SyntaxKind.SourceFile
-                ? symbolToStringWorkerSourceFilePrinter()
-                : symbolToStringWorkerNonSourceFilePrinter();
+                ? createPrinterWithRemoveCommentsNeverAsciiEscape()
+                : createPrinterWithRemoveComments();
             const sourceFile = enclosingDeclaration && getSourceFileOfNode(enclosingDeclaration);
             printer.writeNode(EmitHint.Unspecified, entity, /*sourceFile*/ sourceFile, writer);
             return writer;
@@ -6147,7 +6147,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 sigOutput = kind === SignatureKind.Construct ? SyntaxKind.ConstructSignature : SyntaxKind.CallSignature;
             }
             const sig = nodeBuilder.signatureToSignatureDeclaration(signature, sigOutput, enclosingDeclaration, toNodeBuilderFlags(flags) | NodeBuilderFlags.IgnoreErrors | NodeBuilderFlags.WriteTypeParametersInQualifiedName);
-            const printer = createPrinter({ removeComments: true, omitTrailingSemicolon: true });
+            const printer = createPrinterWithRemoveCommentsOmitTrailingSemicolon();
             const sourceFile = enclosingDeclaration && getSourceFileOfNode(enclosingDeclaration);
             printer.writeNode(EmitHint.Unspecified, sig!, /*sourceFile*/ sourceFile, getTrailingSemicolonDeferringWriter(writer)); // TODO: GH#18217
             return writer;
@@ -6160,8 +6160,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (typeNode === undefined) return Debug.fail("should always get typenode");
         // The unresolved type gets a synthesized comment on `any` to hint to users that it's not a plain `any`.
         // Otherwise, we always strip comments out.
-        const options = { removeComments: type !== unresolvedType };
-        const printer = createPrinter(options);
+        const printer = type !== unresolvedType ? createPrinterWithRemoveComments() : createPrinterWithDefaults();
         const sourceFile = enclosingDeclaration && getSourceFileOfNode(enclosingDeclaration);
         printer.writeNode(EmitHint.Unspecified, typeNode, /*sourceFile*/ sourceFile, writer);
         const result = writer.getText();
@@ -9641,7 +9640,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 typePredicate.kind === TypePredicateKind.Identifier || typePredicate.kind === TypePredicateKind.AssertsIdentifier ? factory.createIdentifier(typePredicate.parameterName) : factory.createThisTypeNode(),
                 typePredicate.type && nodeBuilder.typeToTypeNode(typePredicate.type, enclosingDeclaration, toNodeBuilderFlags(flags) | NodeBuilderFlags.IgnoreErrors | NodeBuilderFlags.WriteTypeParametersInQualifiedName)! // TODO: GH#18217
             );
-            const printer = createPrinter({ removeComments: true });
+            const printer = createPrinterWithRemoveComments();
             const sourceFile = enclosingDeclaration && getSourceFileOfNode(enclosingDeclaration);
             printer.writeNode(EmitHint.Unspecified, predicate, /*sourceFile*/ sourceFile, writer);
             return writer;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2917,33 +2917,3 @@ export function isNodeLikeSystem(): boolean {
         && !process.browser
         && typeof module === "object";
 }
-
-/** @internal */
-export function pooled<T>(fn: () => T, reset: (value: T) => void): () => [value: T, dispose: () => void] {
-    // TODO(jakebailey): this is supposed to be something like Go's sync.Pool,
-    // but I don't know of a way to "eventually" return the pool's contents to GC.
-    // For now, this just holds onto the objects even when they may not have been
-    // in use for a long time.
-    const pool: T[] = [];
-
-    return () => {
-        let value: T;
-        if (pool.length > 1) {
-            const end = pool.length - 1;
-            value = pool[end];
-            pool.length = end;
-        }
-        else {
-            value = fn();
-        }
-
-        const dispose = () => {
-            if (pool.length < 8) {
-                reset(value);
-                pool.push(value);
-            }
-        };
-
-        return [value, dispose];
-    };
-}

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1343,6 +1343,18 @@ const enum PipelinePhase {
     Emit,
 }
 
+/** @internal */
+export const createPrinterWithDefaults = memoize(() => createPrinter({}));
+
+/** @internal */
+export const createPrinterWithRemoveComments = memoize(() => createPrinter({ removeComments: true }));
+
+/** @internal */
+export const createPrinterWithRemoveCommentsNeverAsciiEscape = memoize(() => createPrinter({ removeComments: true, neverAsciiEscape: true }));
+
+/** @internal */
+export const createPrinterWithRemoveCommentsOmitTrailingSemicolon = memoize(() => createPrinter({ removeComments: true, omitTrailingSemicolon: true }));
+
 export function createPrinter(printerOptions: PrinterOptions = {}, handlers: PrintHandlers = {}): Printer {
     const {
         hasGlobalName,

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1428,7 +1428,8 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         writeList,
         writeFile,
         writeBundle,
-        bundleFileInfo
+        bundleFileInfo,
+        reset,
     };
 
     function printNode(hint: EmitHint, node: Node, sourceFile: SourceFile): string {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1429,7 +1429,6 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         writeFile,
         writeBundle,
         bundleFileInfo,
-        reset,
     };
 
     function printNode(hint: EmitHint, node: Node, sourceFile: SourceFile): string {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1343,17 +1343,29 @@ const enum PipelinePhase {
     Emit,
 }
 
+const printerCache = new Map<string, Printer>();
+
+// If updating this, make sure the cache key is updated too.
 /** @internal */
-export const createPrinterWithDefaults = memoize(() => createPrinter({}));
+export type ReusablePrinterOptions = Pick<PrinterOptions, "removeComments" | "neverAsciiEscape" | "omitTrailingSemicolon" | "module" | "target" | "newLine">;
 
 /** @internal */
-export const createPrinterWithRemoveComments = memoize(() => createPrinter({ removeComments: true }));
+export function createOrReusePrinter(o: ReusablePrinterOptions = {}) {
+    const key = `${keyBool(o.removeComments)}|${keyBool(o.neverAsciiEscape)}|${keyBool(o.omitTrailingSemicolon)}|${keyNum(o.module)}|${keyNum(o.target)}|${keyNum(o.newLine)}`;
+    let printer = printerCache.get(key);
+    if (!printer) {
+        printerCache.set(key, printer = createPrinter(o));
+    }
+    return printer;
 
-/** @internal */
-export const createPrinterWithRemoveCommentsNeverAsciiEscape = memoize(() => createPrinter({ removeComments: true, neverAsciiEscape: true }));
+    function keyBool(value: boolean | undefined) {
+        return value === undefined ? "u" : value ? 1 : 0;
+    }
 
-/** @internal */
-export const createPrinterWithRemoveCommentsOmitTrailingSemicolon = memoize(() => createPrinter({ removeComments: true, omitTrailingSemicolon: true }));
+    function keyNum(value: number | undefined) {
+        return value === undefined ? "u" : `${value}`;
+    }
+}
 
 export function createPrinter(printerOptions: PrinterOptions = {}, handlers: PrintHandlers = {}): Printer {
     const {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1428,7 +1428,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         writeList,
         writeFile,
         writeBundle,
-        bundleFileInfo,
+        bundleFileInfo
     };
 
     function printNode(hint: EmitHint, node: Node, sourceFile: SourceFile): string {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -9165,6 +9165,7 @@ export interface Printer {
     /** @internal */ writeFile(sourceFile: SourceFile, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined): void;
     /** @internal */ writeBundle(bundle: Bundle, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined): void;
     /** @deprecated @internal */ bundleFileInfo?: BundleFileInfo;
+    /** @internal */ reset(): void;
 }
 
 /** @deprecated @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -9165,7 +9165,6 @@ export interface Printer {
     /** @internal */ writeFile(sourceFile: SourceFile, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined): void;
     /** @internal */ writeBundle(bundle: Bundle, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined): void;
     /** @deprecated @internal */ bundleFileInfo?: BundleFileInfo;
-    /** @internal */ reset(): void;
 }
 
 /** @deprecated @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -9160,10 +9160,10 @@ export interface Printer {
      * Prints a bundle of source files as-is, without any emit transformations.
      */
     printBundle(bundle: Bundle): string;
-    /** @internal */ writeNode(hint: EmitHint, node: Node, sourceFile: SourceFile | undefined, writer: EmitTextWriter): void;
-    /** @internal */ writeList<T extends Node>(format: ListFormat, list: NodeArray<T> | undefined, sourceFile: SourceFile | undefined, writer: EmitTextWriter): void;
-    /** @internal */ writeFile(sourceFile: SourceFile, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined): void;
-    /** @internal */ writeBundle(bundle: Bundle, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined): void;
+    /** @internal */ writeNode(hint: EmitHint, node: Node, sourceFile: SourceFile | undefined, writer: EmitTextWriter, handlers?: PrintHandlers): void;
+    /** @internal */ writeList<T extends Node>(format: ListFormat, list: NodeArray<T> | undefined, sourceFile: SourceFile | undefined, writer: EmitTextWriter, handlers?: PrintHandlers): void;
+    /** @internal */ writeFile(sourceFile: SourceFile, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined, handlers?: PrintHandlers): void;
+    /** @internal */ writeBundle(bundle: Bundle, writer: EmitTextWriter, sourceMapGenerator: SourceMapGenerator | undefined, handlers?: PrintHandlers): void;
     /** @deprecated @internal */ bundleFileInfo?: BundleFileInfo;
 }
 

--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -14,7 +14,7 @@ import {
     ClassLikeDeclaration,
     ClassStaticBlockDeclaration,
     compareStringsCaseSensitive,
-    createPrinter,
+    createPrinterWithRemoveCommentsOmitTrailingSemicolon,
     createTextRangeFromNode,
     createTextSpanFromBounds,
     createTextSpanFromRange,
@@ -245,7 +245,7 @@ function getCallHierarchyItemName(program: Program, node: CallHierarchyDeclarati
     }
     if (text === undefined) {
         // get the text from printing the node on a single line without comments...
-        const printer = createPrinter({ removeComments: true, omitTrailingSemicolon: true });
+        const printer = createPrinterWithRemoveCommentsOmitTrailingSemicolon();
         text = usingSingleLineStringWriter(writer => printer.writeNode(EmitHint.Unspecified, node, node.getSourceFile(), writer));
     }
     return { text, pos: declName.getStart(), end: declName.getEnd() };

--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -14,7 +14,7 @@ import {
     ClassLikeDeclaration,
     ClassStaticBlockDeclaration,
     compareStringsCaseSensitive,
-    createPrinterWithRemoveCommentsOmitTrailingSemicolon,
+    createOrReusePrinter,
     createTextRangeFromNode,
     createTextSpanFromBounds,
     createTextSpanFromRange,
@@ -245,7 +245,7 @@ function getCallHierarchyItemName(program: Program, node: CallHierarchyDeclarati
     }
     if (text === undefined) {
         // get the text from printing the node on a single line without comments...
-        const printer = createPrinterWithRemoveCommentsOmitTrailingSemicolon();
+        const printer = createOrReusePrinter({ removeComments: true, omitTrailingSemicolon: true });
         text = usingSingleLineStringWriter(writer => printer.writeNode(EmitHint.Unspecified, node, node.getSourceFile(), writer));
     }
     return { text, pos: declName.getStart(), end: declName.getEnd() };

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -36,7 +36,6 @@ import {
     createModuleSpecifierResolutionHost,
     createOrReusePrinter,
     createPackageJsonImportFilter,
-    createPrinter,
     createSortedArray,
     createTextRangeFromSpan,
     createTextSpanFromBounds,
@@ -292,7 +291,6 @@ import {
     positionBelongsToNode,
     positionIsASICandidate,
     positionsAreOnSameLine,
-    PrinterOptions,
     probablyUsesSemicolons,
     Program,
     programContainsModules,
@@ -308,6 +306,7 @@ import {
     rangeContainsPosition,
     rangeContainsPositionExclusive,
     rangeIsOnSingleLine,
+    ReusablePrinterOptions,
     ScriptElementKind,
     ScriptElementKindModifier,
     ScriptTarget,
@@ -1851,11 +1850,11 @@ function createObjectLiteralMethod(
 }
 
 function createSnippetPrinter(
-    printerOptions: PrinterOptions,
+    printerOptions: ReusablePrinterOptions,
 ) {
     let escapes: TextChange[] | undefined;
     const baseWriter = textChanges.createWriter(getNewLineCharacter(printerOptions));
-    const printer = createPrinter(printerOptions, baseWriter);
+    const printer = createOrReusePrinter(printerOptions);
     const writer: EmitTextWriter = {
         ...baseWriter,
         write: s => escapingWrite(s, () => baseWriter.write(s)),
@@ -1909,7 +1908,7 @@ function createSnippetPrinter(
     ): string {
         escapes = undefined;
         writer.clear();
-        printer.writeList(format, list, sourceFile, writer);
+        printer.writeList(format, list, sourceFile, writer, baseWriter);
         return writer.getText();
     }
 
@@ -1956,7 +1955,7 @@ function createSnippetPrinter(
     function printUnescapedNode(hint: EmitHint, node: Node, sourceFile: SourceFile): string {
         escapes = undefined;
         writer.clear();
-        printer.writeNode(hint, node, sourceFile, writer);
+        printer.writeNode(hint, node, sourceFile, writer, baseWriter);
         return writer.getText();
     }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -34,6 +34,7 @@ import {
     ConstructorDeclaration,
     ContextFlags,
     createModuleSpecifierResolutionHost,
+    createOrReusePrinter,
     createPackageJsonImportFilter,
     createPrinter,
     createSortedArray,
@@ -1747,7 +1748,7 @@ function getEntryForObjectLiteralMethodCompletion(
         insertText = printer.printSnippetList(ListFormat.CommaDelimited | ListFormat.AllowTrailingComma, factory.createNodeArray([method], /*hasTrailingComma*/ true), sourceFile);
     }
 
-    const signaturePrinter = createPrinter({
+    const signaturePrinter = createOrReusePrinter({
         removeComments: true,
         module: options.module,
         target: options.target,

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -2,7 +2,7 @@ import {
     __String,
     ArrowFunction,
     CallExpression,
-    createPrinter,
+    createPrinterWithRemoveComments,
     Debug,
     EmitHint,
     EnumMember,
@@ -53,7 +53,6 @@ import {
     NodeBuilderFlags,
     ParameterDeclaration,
     PrefixUnaryExpression,
-    PrinterOptions,
     PropertyDeclaration,
     Signature,
     skipParentheses,
@@ -383,8 +382,7 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
 
     function printTypeInSingleLine(type: Type) {
         const flags = NodeBuilderFlags.IgnoreErrors | TypeFormatFlags.AllowUniqueESSymbolType | TypeFormatFlags.UseAliasDefinedOutsideCurrentScope;
-        const options: PrinterOptions = { removeComments: true };
-        const printer = createPrinter(options);
+        const printer = createPrinterWithRemoveComments();
 
         return usingSingleLineStringWriter(writer => {
             const typeNode = checker.typeToTypeNode(type, /*enclosingDeclaration*/ undefined, flags);

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -2,7 +2,7 @@ import {
     __String,
     ArrowFunction,
     CallExpression,
-    createPrinterWithRemoveComments,
+    createOrReusePrinter,
     Debug,
     EmitHint,
     EnumMember,
@@ -382,7 +382,7 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
 
     function printTypeInSingleLine(type: Type) {
         const flags = NodeBuilderFlags.IgnoreErrors | TypeFormatFlags.AllowUniqueESSymbolType | TypeFormatFlags.UseAliasDefinedOutsideCurrentScope;
-        const printer = createPrinterWithRemoveComments();
+        const printer = createOrReusePrinter({ removeComments: true });
 
         return usingSingleLineStringWriter(writer => {
             const typeNode = checker.typeToTypeNode(type, /*enclosingDeclaration*/ undefined, flags);

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -7,7 +7,7 @@ import {
     CheckFlags,
     contains,
     countWhere,
-    createPrinter,
+    createPrinterWithRemoveComments,
     createTextSpan,
     createTextSpanFromBounds,
     createTextSpanFromNode,
@@ -659,7 +659,7 @@ function createTypeHelpItems(
 function getTypeHelpItem(symbol: Symbol, typeParameters: readonly TypeParameter[], checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItem {
     const typeSymbolDisplay = symbolToDisplayParts(checker, symbol);
 
-    const printer = createPrinter({ removeComments: true });
+    const printer = createPrinterWithRemoveComments();
     const parameters = typeParameters.map(t => createSignatureHelpParameterForTypeParameter(t, checker, enclosingDeclaration, sourceFile, printer));
 
     const documentation = symbol.getDocumentationComment(checker);
@@ -699,7 +699,7 @@ interface SignatureHelpItemInfo { readonly isVariadic: boolean; readonly paramet
 
 function itemInfoForTypeParameters(candidateSignature: Signature, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItemInfo[] {
     const typeParameters = (candidateSignature.target || candidateSignature).typeParameters;
-    const printer = createPrinter({ removeComments: true });
+    const printer = createPrinterWithRemoveComments();
     const parameters = (typeParameters || emptyArray).map(t => createSignatureHelpParameterForTypeParameter(t, checker, enclosingDeclaration, sourceFile, printer));
     const thisParameter = candidateSignature.thisParameter ? [checker.symbolToParameterDeclaration(candidateSignature.thisParameter, enclosingDeclaration, signatureHelpNodeBuilderFlags)!] : [];
 
@@ -713,7 +713,7 @@ function itemInfoForTypeParameters(candidateSignature: Signature, checker: TypeC
 }
 
 function itemInfoForParameters(candidateSignature: Signature, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItemInfo[] {
-    const printer = createPrinter({ removeComments: true });
+    const printer = createPrinterWithRemoveComments();
     const typeParameterParts = mapToDisplayParts(writer => {
         if (candidateSignature.typeParameters && candidateSignature.typeParameters.length) {
             const args = factory.createNodeArray(candidateSignature.typeParameters.map(p => checker.typeParameterToDeclaration(p, enclosingDeclaration, signatureHelpNodeBuilderFlags)!));

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -7,7 +7,7 @@ import {
     CheckFlags,
     contains,
     countWhere,
-    createPrinterWithRemoveComments,
+    createOrReusePrinter,
     createTextSpan,
     createTextSpanFromBounds,
     createTextSpanFromNode,
@@ -659,7 +659,7 @@ function createTypeHelpItems(
 function getTypeHelpItem(symbol: Symbol, typeParameters: readonly TypeParameter[], checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItem {
     const typeSymbolDisplay = symbolToDisplayParts(checker, symbol);
 
-    const printer = createPrinterWithRemoveComments();
+    const printer = createOrReusePrinter({ removeComments: true });
     const parameters = typeParameters.map(t => createSignatureHelpParameterForTypeParameter(t, checker, enclosingDeclaration, sourceFile, printer));
 
     const documentation = symbol.getDocumentationComment(checker);
@@ -699,7 +699,7 @@ interface SignatureHelpItemInfo { readonly isVariadic: boolean; readonly paramet
 
 function itemInfoForTypeParameters(candidateSignature: Signature, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItemInfo[] {
     const typeParameters = (candidateSignature.target || candidateSignature).typeParameters;
-    const printer = createPrinterWithRemoveComments();
+    const printer = createOrReusePrinter({ removeComments: true });
     const parameters = (typeParameters || emptyArray).map(t => createSignatureHelpParameterForTypeParameter(t, checker, enclosingDeclaration, sourceFile, printer));
     const thisParameter = candidateSignature.thisParameter ? [checker.symbolToParameterDeclaration(candidateSignature.thisParameter, enclosingDeclaration, signatureHelpNodeBuilderFlags)!] : [];
 
@@ -713,7 +713,7 @@ function itemInfoForTypeParameters(candidateSignature: Signature, checker: TypeC
 }
 
 function itemInfoForParameters(candidateSignature: Signature, checker: TypeChecker, enclosingDeclaration: Node, sourceFile: SourceFile): SignatureHelpItemInfo[] {
-    const printer = createPrinterWithRemoveComments();
+    const printer = createOrReusePrinter({ removeComments: true });
     const typeParameterParts = mapToDisplayParts(writer => {
         if (candidateSignature.typeParameters && candidateSignature.typeParameters.length) {
             const args = factory.createNodeArray(candidateSignature.typeParameters.map(p => checker.typeParameterToDeclaration(p, enclosingDeclaration, signatureHelpNodeBuilderFlags)!));

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -5,7 +5,7 @@ import {
     CallExpression,
     CheckFlags,
     contains,
-    createPrinter,
+    createPrinterWithRemoveComments,
     Debug,
     displayPart,
     EmitHint,
@@ -75,7 +75,6 @@ import {
     NodeBuilderFlags,
     ObjectFlags,
     operatorPart,
-    Printer,
     PropertyAccessExpression,
     PropertyDeclaration,
     punctuationPart,
@@ -259,7 +258,6 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
     let hasAddedSymbolInfo = false;
     const isThisExpression = location.kind === SyntaxKind.ThisKeyword && isInExpressionContext(location) || isThisInTypeQuery(location);
     let type: Type | undefined;
-    let printer: Printer;
     let documentationFromAlias: SymbolDisplayPart[] | undefined;
     let tagsFromAlias: JSDocTagInfo[] | undefined;
     let hasMultipleSignatures = false;
@@ -730,10 +728,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
     return { displayParts, documentation, symbolKind, tags: tags.length === 0 ? undefined : tags };
 
     function getPrinter() {
-        if (!printer) {
-            printer = createPrinter({ removeComments: true });
-        }
-        return printer;
+        return createPrinterWithRemoveComments();
     }
 
     function prefixNextMeaning() {

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -5,7 +5,7 @@ import {
     CallExpression,
     CheckFlags,
     contains,
-    createPrinterWithRemoveComments,
+    createOrReusePrinter,
     Debug,
     displayPart,
     EmitHint,
@@ -728,7 +728,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
     return { displayParts, documentation, symbolKind, tags: tags.length === 0 ? undefined : tags };
 
     function getPrinter() {
-        return createPrinterWithRemoveComments();
+        return createOrReusePrinter({ removeComments: true });
     }
 
     function prefixNextMeaning() {

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -11,7 +11,7 @@ import {
     ConstructorDeclaration,
     contains,
     createNodeFactory,
-    createPrinter,
+    createOrReusePrinter,
     createRange,
     createSourceFile,
     createTextChange,
@@ -1301,12 +1301,12 @@ namespace changesToText {
     export function getNonformattedText(node: Node, sourceFile: SourceFile | undefined, newLineCharacter: string): { text: string, node: Node } {
         const writer = createWriter(newLineCharacter);
         const newLine = getNewLineKind(newLineCharacter);
-        createPrinter({
+        createOrReusePrinter({
             newLine,
             neverAsciiEscape: true,
             preserveSourceNewlines: true,
             terminateUnterminatedLiterals: true
-        }, writer).writeNode(EmitHint.Unspecified, node, sourceFile, writer);
+        }).writeNode(EmitHint.Unspecified, node, sourceFile, writer, writer);
         return { text: writer.getText(), node: assignPositionsToNode(node) };
     }
 }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -30,7 +30,7 @@ import {
     ConditionalExpression,
     contains,
     ContextFlags,
-    createPrinter,
+    createPrinterWithRemoveCommentsOmitTrailingSemicolon,
     createRange,
     createScanner,
     createTextSpan,
@@ -2984,7 +2984,7 @@ export function signatureToDisplayParts(typechecker: TypeChecker, signature: Sig
 export function nodeToDisplayParts(node: Node, enclosingDeclaration: Node): SymbolDisplayPart[] {
     const file = enclosingDeclaration.getSourceFile();
     return mapToDisplayParts(writer => {
-        const printer = createPrinter({ removeComments: true, omitTrailingSemicolon: true });
+        const printer = createPrinterWithRemoveCommentsOmitTrailingSemicolon();
         printer.writeNode(EmitHint.Unspecified, node, file, writer);
     });
 }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -30,7 +30,7 @@ import {
     ConditionalExpression,
     contains,
     ContextFlags,
-    createPrinterWithRemoveCommentsOmitTrailingSemicolon,
+    createOrReusePrinter,
     createRange,
     createScanner,
     createTextSpan,
@@ -2984,7 +2984,7 @@ export function signatureToDisplayParts(typechecker: TypeChecker, signature: Sig
 export function nodeToDisplayParts(node: Node, enclosingDeclaration: Node): SymbolDisplayPart[] {
     const file = enclosingDeclaration.getSourceFile();
     return mapToDisplayParts(writer => {
-        const printer = createPrinterWithRemoveCommentsOmitTrailingSemicolon();
+        const printer = createOrReusePrinter({ removeComments: true, omitTrailingSemicolon: true });
         printer.writeNode(EmitHint.Unspecified, node, file, writer);
     });
 }


### PR DESCRIPTION
More invasive version of #52382 which gets rid of the rest of the `createPrinter` calls at the cost of changing our internal API to accept handlers too.

This isn't a totally clean approach, but I want to see how it goes.