### PR TITLE
imports: display completions to files with extensions from ambient modules

### DIFF
--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -531,7 +531,7 @@ function getStringLiteralCompletionsFromModuleNamesWorker(sourceFile: SourceFile
 
     const scriptPath = sourceFile.path;
     const scriptDirectory = getDirectoryPath(scriptPath);
-    const extensionOptions = getExtensionOptions(compilerOptions, ReferenceKind.ModuleSpecifier, sourceFile, preferences, mode);
+    const extensionOptions = getExtensionOptions(compilerOptions, ReferenceKind.ModuleSpecifier, sourceFile, typeChecker, preferences, mode);
 
     return isPathRelativeToScript(literalValue) || !compilerOptions.baseUrl && (isRootedDiskPath(literalValue) || isUrl(literalValue))
         ? getCompletionEntriesForRelativeModules(literalValue, scriptDirectory, compilerOptions, host, scriptPath, extensionOptions)
@@ -546,9 +546,9 @@ interface ExtensionOptions {
     readonly resolutionMode?: ResolutionMode;
 }
 
-function getExtensionOptions(compilerOptions: CompilerOptions, referenceKind: ReferenceKind, importingSourceFile: SourceFile, preferences?: UserPreferences, resolutionMode?: ResolutionMode): ExtensionOptions {
+function getExtensionOptions(compilerOptions: CompilerOptions, referenceKind: ReferenceKind, importingSourceFile: SourceFile, typeChecker?: TypeChecker, preferences?: UserPreferences, resolutionMode?: ResolutionMode): ExtensionOptions {
     return {
-        extensionsToSearch: flatten(getSupportedExtensionsForModuleResolution(compilerOptions)),
+        extensionsToSearch: flatten(getSupportedExtensionsForModuleResolution(compilerOptions, typeChecker)),
         referenceKind,
         importingSourceFile,
         endingPreference: preferences?.importModuleSpecifierEnding,
@@ -565,8 +565,17 @@ function getCompletionEntriesForRelativeModules(literalValue: string, scriptDire
     }
 }
 
-function getSupportedExtensionsForModuleResolution(compilerOptions: CompilerOptions): readonly Extension[][] {
-    const extensions = getSupportedExtensions(compilerOptions);
+function getSupportedExtensionsForModuleResolution(compilerOptions: CompilerOptions, typeChecker?: TypeChecker): readonly Extension[][] {
+    /** file extensions from ambient modules declarations e.g. *.css */
+    const ambientModulesExtensions = !typeChecker ? [] : mapDefined(typeChecker.getAmbientModules(),
+        module => {
+            const name = module.name.slice(1, -1);
+            if (!name.startsWith("*.") || name.includes("/")) return;
+            return name.slice(1);
+        }
+    ) as Extension[];
+
+    const extensions = [...getSupportedExtensions(compilerOptions), ambientModulesExtensions];
     const moduleResolution = getEmitModuleResolutionKind(compilerOptions);
     return moduleResolutionUsesNodeModules(moduleResolution) ?
         getSupportedExtensionsWithJsonIfResolveJsonModule(compilerOptions, extensions) :

--- a/tests/cases/fourslash/pathCompletionsAllowModuleAugmentationExtensions.ts
+++ b/tests/cases/fourslash/pathCompletionsAllowModuleAugmentationExtensions.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /project/foo.css
+//// export const foo = 0;
+
+// @Filename: declarations.d.ts
+//// declare module "*.css" {}
+
+// @Filename: /project/main.ts
+//// import {} from ".//**/"
+
+// Extensionless by default
+verify.completions({
+  marker: "",
+  isNewIdentifierLocation: true,
+  exact: ["foo.css"],
+});


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

TLDR:

<img width="301" alt="Screenshot 2023-01-25 at 15 41 32" src="https://user-images.githubusercontent.com/46503702/214566212-9ae5d781-64b8-4134-9c3b-8ff8133e5c7c.png">


Fixes https://github.com/microsoft/TypeScript/issues/52409