### PR TITLE
Suppress verbatimModuleSyntax error on ambient `export default`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -43901,6 +43901,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         const isIllegalExportDefaultInCJS = !node.isExportEquals &&
+            !(node.flags & NodeFlags.Ambient) &&
             compilerOptions.verbatimModuleSyntax &&
             (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS);
 

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.errors.txt
@@ -1,4 +1,3 @@
-/decl.d.ts(2,1): error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
 /main.ts(1,8): error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
 /main.ts(2,13): error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
 /main.ts(3,10): error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
@@ -12,12 +11,16 @@
 /main7.ts(2,1): error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
 
 
-==== /decl.d.ts (1 errors) ====
+==== /decl.d.ts (0 errors) ====
     declare function esmy(): void;
     export default esmy;
-    ~~~~~~~~~~~~~~~~~~~~
-!!! error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
     export declare function funciton(): void;
+    
+==== /ambient.d.ts (0 errors) ====
+    declare module "ambient" {
+        const _default: number;
+        export default _default;
+    }
     
 ==== /main.ts (6 errors) ====
     import esmy from "./decl"; // error

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.js
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.js
@@ -5,6 +5,12 @@ declare function esmy(): void;
 export default esmy;
 export declare function funciton(): void;
 
+//// [ambient.d.ts]
+declare module "ambient" {
+    const _default: number;
+    export default _default;
+}
+
 //// [main.ts]
 import esmy from "./decl"; // error
 import * as esmy2 from "./decl"; // error

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.symbols
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.symbols
@@ -8,6 +8,17 @@ export default esmy;
 export declare function funciton(): void;
 >funciton : Symbol(funciton, Decl(decl.d.ts, 1, 20))
 
+=== /ambient.d.ts ===
+declare module "ambient" {
+>"ambient" : Symbol("ambient", Decl(ambient.d.ts, 0, 0))
+
+    const _default: number;
+>_default : Symbol(_default, Decl(ambient.d.ts, 1, 9))
+
+    export default _default;
+>_default : Symbol(_default, Decl(ambient.d.ts, 1, 9))
+}
+
 === /main.ts ===
 import esmy from "./decl"; // error
 >esmy : Symbol(esmy, Decl(main.ts, 0, 6))

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.types
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsCJS.types
@@ -8,6 +8,17 @@ export default esmy;
 export declare function funciton(): void;
 >funciton : () => void
 
+=== /ambient.d.ts ===
+declare module "ambient" {
+>"ambient" : typeof import("ambient")
+
+    const _default: number;
+>_default : number
+
+    export default _default;
+>_default : number
+}
+
 === /main.ts ===
 import esmy from "./decl"; // error
 >esmy : () => void

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).errors.txt
@@ -17,6 +17,12 @@
     declare class CJSy {}
     export = CJSy;
     
+==== /ambient.d.ts (0 errors) ====
+    declare module "ambient" {
+        const _export: number;
+        export = _export;
+    }
+    
 ==== /types.ts (0 errors) ====
     interface Typey {}
     export type { Typey };

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).js
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).js
@@ -4,6 +4,12 @@
 declare class CJSy {}
 export = CJSy;
 
+//// [ambient.d.ts]
+declare module "ambient" {
+    const _export: number;
+    export = _export;
+}
+
 //// [types.ts]
 interface Typey {}
 export type { Typey };

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).errors.txt
@@ -13,6 +13,12 @@
     declare class CJSy {}
     export = CJSy;
     
+==== /ambient.d.ts (0 errors) ====
+    declare module "ambient" {
+        const _export: number;
+        export = _export;
+    }
+    
 ==== /types.ts (0 errors) ====
     interface Typey {}
     export type { Typey };

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).js
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).js
@@ -4,6 +4,12 @@
 declare class CJSy {}
 export = CJSy;
 
+//// [ambient.d.ts]
+declare module "ambient" {
+    const _export: number;
+    export = _export;
+}
+
 //// [types.ts]
 interface Typey {}
 export type { Typey };

--- a/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsCJS.ts
+++ b/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsCJS.ts
@@ -9,6 +9,12 @@ declare function esmy(): void;
 export default esmy;
 export declare function funciton(): void;
 
+// @Filename: /ambient.d.ts
+declare module "ambient" {
+    const _default: number;
+    export default _default;
+}
+
 // @Filename: /main.ts
 import esmy from "./decl"; // error
 import * as esmy2 from "./decl"; // error

--- a/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
+++ b/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
@@ -8,6 +8,12 @@
 declare class CJSy {}
 export = CJSy;
 
+// @Filename: /ambient.d.ts
+declare module "ambient" {
+    const _export: number;
+    export = _export;
+}
+
 // @Filename: /types.ts
 interface Typey {}
 export type { Typey };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Noticed an error in @types/node .d.ts files showing up when I was trying `verbatimModuleSyntax` on a little side project. `.d.ts` files should never have `verbatimModuleSyntax` errors since the errors are all about JS emit.
