### PR TITLE
Port timestamp fix to 4.9

### DIFF
--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -60,7 +60,12 @@ namespace ts {
     export function getLocaleTimeString(system: System) {
         return !system.now ?
             new Date().toLocaleTimeString() :
-            system.now().toLocaleTimeString("en-US", { timeZone: "UTC" });
+            // On some systems / builds of Node, there's a non-breaking space between the time and AM/PM.
+            // This branch is solely for testing, so just switch it to a normal space for baseline stability.
+            // See:
+            //     - https://github.com/nodejs/node/issues/45171
+            //     - https://github.com/nodejs/node/issues/45753
+            system.now().toLocaleTimeString("en-US", { timeZone: "UTC" }).replace("\u202f", " ");
     }
 
     /**


### PR DESCRIPTION
Ports the relevant part of ef70a289b855c402d8bf58a7b3766199ab91c7f2 so that release-4.9 can CI on all versions of Node again