### PR TITLE
fix(52418): "Convert to named function" breaks on concise return of async function

### DIFF
--- a/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
+++ b/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
@@ -41,6 +41,7 @@ import {
     RefactorContext,
     RefactorEditInfo,
     ReturnStatement,
+    setTextRange,
     SourceFile,
     Statement,
     suppressLeadingAndTrailingTrivia,
@@ -237,6 +238,7 @@ function convertToBlock(body: ConciseBody): Block {
     if (isExpression(body)) {
         const returnStatement = factory.createReturnStatement(body);
         const file = body.getSourceFile();
+        setTextRange(returnStatement, body);
         suppressLeadingAndTrailingTrivia(returnStatement);
         copyTrailingAsLeadingComments(body, returnStatement, file, /* commentKind */ undefined, /* hasTrailingNewLine */ true);
         return factory.createBlock([returnStatement], /* multiLine */ true);

--- a/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_InnerAsyncFunction1.ts
+++ b/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_InnerAsyncFunction1.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/const fn = () =>
+////    async () => { };/*b*/
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert arrow function or function expression",
+    actionName: "Convert to named function",
+    actionDescription: "Convert to named function",
+    newContent:
+`function fn() {
+    return async () => { };
+}`,
+});

--- a/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_InnerAsyncFunction2.ts
+++ b/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_InnerAsyncFunction2.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/const fn = () =>
+////    async function() { }/*b*/
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert arrow function or function expression",
+    actionName: "Convert to named function",
+    actionDescription: "Convert to named function",
+    newContent:
+`function fn() {
+    return async function() { };
+}`,
+});

--- a/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_InnerAsyncFunction3.ts
+++ b/tests/cases/fourslash/refactorConvertArrowFunctionOrFunctionExpression_InnerAsyncFunction3.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+/////*a*/const fn = () =>
+////    async function*() { }/*b*/
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert arrow function or function expression",
+    actionName: "Convert to named function",
+    actionDescription: "Convert to named function",
+    newContent:
+`function fn() {
+    return async function*() { };
+}`,
+});


### PR DESCRIPTION
Fixes #52418