### PR TITLE
Mark allowArbitraryExtensions as affectsProgramStructure

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1221,7 +1221,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
     {
         name: "allowArbitraryExtensions",
         type: "boolean",
-        affectsModuleResolution: true,
+        affectsSemanticDiagnostics: true,
         category: Diagnostics.Modules,
         description: Diagnostics.Enable_importing_files_with_any_extension_provided_a_declaration_file_is_present,
         defaultValueDescription: false,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1221,7 +1221,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
     {
         name: "allowArbitraryExtensions",
         type: "boolean",
-        affectsSemanticDiagnostics: true,
+        affectsProgramStructure: true,
         category: Diagnostics.Modules,
         description: Diagnostics.Enable_importing_files_with_any_extension_provided_a_declaration_file_is_present,
         defaultValueDescription: false,

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -275,6 +275,45 @@ describe("unittests:: tsc-watch:: program updates", () => {
 
     verifyTscWatch({
         scenario,
+        subScenario: "Updates diagnostics when '--allowArbitraryExtensions' changes",
+        commandLineArgs: ["-w", "-p", "/tsconfig.json"],
+        sys: () => {
+            const aTs: File = {
+                path: "/a.ts",
+                content: "import {} from './b.css'"
+            };
+            const bCssTs: File = {
+                path: "/b.d.css.ts",
+                content: "declare const style: string;"
+            };
+            const tsconfig: File = {
+                path: "/tsconfig.json",
+                content: JSON.stringify({
+                    compilerOptions: { allowArbitraryExtensions: true }
+                })
+            };
+            return createWatchedSystem([libFile, aTs, bCssTs, tsconfig]);
+        },
+        edits: [
+            {
+                caption: "Disable  allowArbitraryExtensions",
+                edit: sys => sys.modifyFile("/tsconfig.json", JSON.stringify({
+                    compilerOptions: { allowArbitraryExtensions: false }
+                })),
+                timeouts: sys => sys.checkTimeoutQueueLengthAndRun(1)
+            },
+            {
+                caption: "Enable  allowArbitraryExtensions",
+                edit: sys => sys.modifyFile("/tsconfig.json", JSON.stringify({
+                    compilerOptions: { allowArbitraryExtensions: true }
+                })),
+                timeouts: sys => sys.checkTimeoutQueueLengthAndRun(1),
+            }
+        ]
+    });
+
+    verifyTscWatch({
+        scenario,
         subScenario: "updates diagnostics and emit for decorators",
         commandLineArgs: ["-w"],
         sys: () => {

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -290,7 +290,7 @@ describe("unittests:: tsc-watch:: program updates", () => {
                 path: "/tsconfig.json",
                 content: JSON.stringify({
                     compilerOptions: { allowArbitraryExtensions: true },
-                    files: [aTs.path],
+                    files: ["/a.ts"],
                 })
             };
             return createWatchedSystem([libFile, aTs, bCssTs, tsconfig]);
@@ -299,14 +299,16 @@ describe("unittests:: tsc-watch:: program updates", () => {
             {
                 caption: "Disable  allowArbitraryExtensions",
                 edit: sys => sys.modifyFile("/tsconfig.json", JSON.stringify({
-                    compilerOptions: { allowArbitraryExtensions: false }
+                    compilerOptions: { allowArbitraryExtensions: false },
+                    files: ["/a.ts"],
                 })),
                 timeouts: sys => sys.checkTimeoutQueueLengthAndRun(1)
             },
             {
                 caption: "Enable  allowArbitraryExtensions",
                 edit: sys => sys.modifyFile("/tsconfig.json", JSON.stringify({
-                    compilerOptions: { allowArbitraryExtensions: true }
+                    compilerOptions: { allowArbitraryExtensions: true },
+                    files: ["/a.ts"],
                 })),
                 timeouts: sys => sys.checkTimeoutQueueLengthAndRun(1),
             }

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -289,7 +289,8 @@ describe("unittests:: tsc-watch:: program updates", () => {
             const tsconfig: File = {
                 path: "/tsconfig.json",
                 content: JSON.stringify({
-                    compilerOptions: { allowArbitraryExtensions: true }
+                    compilerOptions: { allowArbitraryExtensions: true },
+                    files: [aTs.path],
                 })
             };
             return createWatchedSystem([libFile, aTs, bCssTs, tsconfig]);

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
@@ -1,0 +1,181 @@
+Input::
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+//// [/a.ts]
+import {} from './b.css'
+
+//// [/b.d.css.ts]
+declare const style: string;
+
+//// [/tsconfig.json]
+{"compilerOptions":{"allowArbitraryExtensions":true}}
+
+
+/a/lib/tsc.js -w -p /tsconfig.json
+Output::
+>> Screen clear
+[[90m12:00:15 AM[0m] Starting compilation in watch mode...
+
+[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2306: [0mFile '/b.d.css.ts' is not a module.
+
+[7m1[0m import {} from './b.css'
+[7m [0m [91m               ~~~~~~~~~[0m
+
+[[90m12:00:18 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
+Program options: {"allowArbitraryExtensions":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/b.d.css.ts
+/a.ts
+/a/lib/lib.d.ts
+
+Semantic diagnostics in builder refreshed for::
+/b.d.css.ts
+/a.ts
+/a/lib/lib.d.ts
+
+Shape signatures in builder refreshed for::
+/b.d.css.ts (used version)
+/a.ts (used version)
+/a/lib/lib.d.ts (used version)
+
+PolledWatches::
+
+FsWatches::
+/tsconfig.json:
+  {}
+/a.ts:
+  {}
+/b.d.css.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+
+FsWatchesRecursive::
+/:
+  {}
+
+exitCode:: ExitStatus.undefined
+
+//// [/a.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+
+Change:: Disable  allowArbitraryExtensions
+
+Input::
+//// [/tsconfig.json]
+{"compilerOptions":{"allowArbitraryExtensions":false}}
+
+
+Output::
+>> Screen clear
+[[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
+
+[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2306: [0mFile '/b.d.css.ts' is not a module.
+
+[7m1[0m import {} from './b.css'
+[7m [0m [91m               ~~~~~~~~~[0m
+
+[[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
+Program options: {"allowArbitraryExtensions":false,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/a.ts
+/b.d.css.ts
+/a/lib/lib.d.ts
+
+Semantic diagnostics in builder refreshed for::
+
+No shapes updated in the builder::
+
+PolledWatches::
+
+FsWatches::
+/tsconfig.json:
+  {}
+/a.ts:
+  {}
+/b.d.css.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+
+FsWatchesRecursive::
+/:
+  {}
+
+exitCode:: ExitStatus.undefined
+
+
+Change:: Enable  allowArbitraryExtensions
+
+Input::
+//// [/tsconfig.json]
+{"compilerOptions":{"allowArbitraryExtensions":true}}
+
+
+Output::
+>> Screen clear
+[[90m12:00:25 AM[0m] File change detected. Starting incremental compilation...
+
+[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2306: [0mFile '/b.d.css.ts' is not a module.
+
+[7m1[0m import {} from './b.css'
+[7m [0m [91m               ~~~~~~~~~[0m
+
+[[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
+
+
+
+Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
+Program options: {"allowArbitraryExtensions":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
+Program structureReused: Not
+Program files::
+/b.d.css.ts
+/a.ts
+/a/lib/lib.d.ts
+
+Semantic diagnostics in builder refreshed for::
+
+No shapes updated in the builder::
+
+PolledWatches::
+
+FsWatches::
+/tsconfig.json:
+  {}
+/a.ts:
+  {}
+/b.d.css.ts:
+  {}
+/a/lib/lib.d.ts:
+  {}
+
+FsWatchesRecursive::
+/:
+  {}
+
+exitCode:: ExitStatus.undefined
+

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
@@ -19,7 +19,7 @@ import {} from './b.css'
 declare const style: string;
 
 //// [/tsconfig.json]
-{"compilerOptions":{"allowArbitraryExtensions":true}}
+{"compilerOptions":{"allowArbitraryExtensions":true},"files":["/a.ts"]}
 
 
 /a/lib/tsc.js -w -p /tsconfig.json
@@ -36,23 +36,23 @@ Output::
 
 
 
-Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
+Program root files: ["/a.ts"]
 Program options: {"allowArbitraryExtensions":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
 Program structureReused: Not
 Program files::
+/a/lib/lib.d.ts
 /b.d.css.ts
 /a.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
 /b.d.css.ts
 /a.ts
-/a/lib/lib.d.ts
 
 Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
 /b.d.css.ts (used version)
 /a.ts (used version)
-/a/lib/lib.d.ts (used version)
 
 PolledWatches::
 
@@ -67,8 +67,6 @@ FsWatches::
   {}
 
 FsWatchesRecursive::
-/:
-  {}
 
 exitCode:: ExitStatus.undefined
 
@@ -100,7 +98,7 @@ Output::
 
 Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
 Program options: {"allowArbitraryExtensions":false,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
-Program structureReused: SafeModules
+Program structureReused: Not
 Program files::
 /a.ts
 /b.d.css.ts

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
@@ -89,7 +89,7 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
 
-[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2306: [0mFile '/b.d.css.ts' is not a module.
+[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS6263: [0mModule './b.css' was resolved to '/b.d.css.ts', but '--allowArbitraryExtensions' is not set.
 
 [7m1[0m import {} from './b.css'
 [7m [0m [91m               ~~~~~~~~~[0m
@@ -100,13 +100,16 @@ Output::
 
 Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
 Program options: {"allowArbitraryExtensions":false,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
-Program structureReused: Not
+Program structureReused: Completely
 Program files::
-/a.ts
 /b.d.css.ts
+/a.ts
 /a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/b.d.css.ts
+/a.ts
+/a/lib/lib.d.ts
 
 No shapes updated in the builder::
 
@@ -151,13 +154,16 @@ Output::
 
 Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
 Program options: {"allowArbitraryExtensions":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
-Program structureReused: Not
+Program structureReused: Completely
 Program files::
 /b.d.css.ts
 /a.ts
 /a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/b.d.css.ts
+/a.ts
+/a/lib/lib.d.ts
 
 No shapes updated in the builder::
 

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
@@ -80,33 +80,34 @@ Change:: Disable  allowArbitraryExtensions
 
 Input::
 //// [/tsconfig.json]
-{"compilerOptions":{"allowArbitraryExtensions":false}}
+{"compilerOptions":{"allowArbitraryExtensions":false},"files":["/a.ts"]}
 
 
 Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
 
-[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2306: [0mFile '/b.d.css.ts' is not a module.
+[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS6263: [0mModule './b.css' was resolved to '/b.d.css.ts', but '--allowArbitraryExtensions' is not set.
 
 [7m1[0m import {} from './b.css'
 [7m [0m [91m               ~~~~~~~~~[0m
 
-[[90m12:00:22 AM[0m] Found 1 error. Watching for file changes.
+[[90m12:00:25 AM[0m] Found 1 error. Watching for file changes.
 
 
 
-Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
+Program root files: ["/a.ts"]
 Program options: {"allowArbitraryExtensions":false,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
-Program structureReused: Not
+Program structureReused: SafeModules
 Program files::
-/a.ts
-/b.d.css.ts
 /a/lib/lib.d.ts
+/a.ts
 
 Semantic diagnostics in builder refreshed for::
+/a.ts
 
-No shapes updated in the builder::
+Shape signatures in builder refreshed for::
+/a.ts (computed .d.ts)
 
 PolledWatches::
 
@@ -115,49 +116,51 @@ FsWatches::
   {}
 /a.ts:
   {}
-/b.d.css.ts:
-  {}
 /a/lib/lib.d.ts:
   {}
 
 FsWatchesRecursive::
-/:
-  {}
 
 exitCode:: ExitStatus.undefined
 
+//// [/a.js] file written with same contents
 
 Change:: Enable  allowArbitraryExtensions
 
 Input::
 //// [/tsconfig.json]
-{"compilerOptions":{"allowArbitraryExtensions":true}}
+{"compilerOptions":{"allowArbitraryExtensions":true},"files":["/a.ts"]}
 
 
 Output::
 >> Screen clear
-[[90m12:00:25 AM[0m] File change detected. Starting incremental compilation...
+[[90m12:00:28 AM[0m] File change detected. Starting incremental compilation...
 
 [96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2306: [0mFile '/b.d.css.ts' is not a module.
 
 [7m1[0m import {} from './b.css'
 [7m [0m [91m               ~~~~~~~~~[0m
 
-[[90m12:00:26 AM[0m] Found 1 error. Watching for file changes.
+[[90m12:00:32 AM[0m] Found 1 error. Watching for file changes.
 
 
 
-Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
+Program root files: ["/a.ts"]
 Program options: {"allowArbitraryExtensions":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
 Program structureReused: SafeModules
 Program files::
+/a/lib/lib.d.ts
 /b.d.css.ts
 /a.ts
-/a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/b.d.css.ts
+/a.ts
 
-No shapes updated in the builder::
+Shape signatures in builder refreshed for::
+/b.d.css.ts (used version)
+/a.ts (computed .d.ts)
 
 PolledWatches::
 
@@ -166,14 +169,13 @@ FsWatches::
   {}
 /a.ts:
   {}
-/b.d.css.ts:
-  {}
 /a/lib/lib.d.ts:
+  {}
+/b.d.css.ts:
   {}
 
 FsWatchesRecursive::
-/:
-  {}
 
 exitCode:: ExitStatus.undefined
 
+//// [/a.js] file written with same contents

--- a/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/Updates-diagnostics-when-'--allowArbitraryExtensions'-changes.js
@@ -89,7 +89,7 @@ Output::
 >> Screen clear
 [[90m12:00:21 AM[0m] File change detected. Starting incremental compilation...
 
-[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS6263: [0mModule './b.css' was resolved to '/b.d.css.ts', but '--allowArbitraryExtensions' is not set.
+[96ma.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2306: [0mFile '/b.d.css.ts' is not a module.
 
 [7m1[0m import {} from './b.css'
 [7m [0m [91m               ~~~~~~~~~[0m
@@ -100,16 +100,13 @@ Output::
 
 Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
 Program options: {"allowArbitraryExtensions":false,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
-Program structureReused: Completely
+Program structureReused: SafeModules
 Program files::
-/b.d.css.ts
 /a.ts
+/b.d.css.ts
 /a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
-/b.d.css.ts
-/a.ts
-/a/lib/lib.d.ts
 
 No shapes updated in the builder::
 
@@ -154,16 +151,13 @@ Output::
 
 Program root files: ["/a.ts","/b.d.css.ts","/a/lib/lib.d.ts"]
 Program options: {"allowArbitraryExtensions":true,"watch":true,"project":"/tsconfig.json","configFilePath":"/tsconfig.json"}
-Program structureReused: Completely
+Program structureReused: SafeModules
 Program files::
 /b.d.css.ts
 /a.ts
 /a/lib/lib.d.ts
 
 Semantic diagnostics in builder refreshed for::
-/b.d.css.ts
-/a.ts
-/a/lib/lib.d.ts
 
 No shapes updated in the builder::
 


### PR DESCRIPTION
Per https://github.com/microsoft/TypeScript/pull/51435#discussion_r1084491113 and skimming the code, this flag only controls whether or not certain diagnostics are shown (see `getResolutionDiagnostic`).