### PR TITLE
Mark new createPrinter vars as pure to remove new code from typingsInstaller

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1344,16 +1344,16 @@ const enum PipelinePhase {
 }
 
 /** @internal */
-export const createPrinterWithDefaults = memoize(() => createPrinter({}));
+export const createPrinterWithDefaults = /* @__PURE__ */ memoize(() => createPrinter({}));
 
 /** @internal */
-export const createPrinterWithRemoveComments = memoize(() => createPrinter({ removeComments: true }));
+export const createPrinterWithRemoveComments = /* @__PURE__ */ memoize(() => createPrinter({ removeComments: true }));
 
 /** @internal */
-export const createPrinterWithRemoveCommentsNeverAsciiEscape = memoize(() => createPrinter({ removeComments: true, neverAsciiEscape: true }));
+export const createPrinterWithRemoveCommentsNeverAsciiEscape = /* @__PURE__ */ memoize(() => createPrinter({ removeComments: true, neverAsciiEscape: true }));
 
 /** @internal */
-export const createPrinterWithRemoveCommentsOmitTrailingSemicolon = memoize(() => createPrinter({ removeComments: true, omitTrailingSemicolon: true }));
+export const createPrinterWithRemoveCommentsOmitTrailingSemicolon = /* @__PURE__ */ memoize(() => createPrinter({ removeComments: true, omitTrailingSemicolon: true }));
 
 export function createPrinter(printerOptions: PrinterOptions = {}, handlers: PrintHandlers = {}): Printer {
     const {


### PR DESCRIPTION
#52382 added a few new top-level variables to `emitter.ts`; but, I noticed in https://github.com/microsoft/TypeScript/commit/dcad07ffd29854e2b93a86da0ba197f6eec21698 (which pulled this change into release-5.0) that typingsInstaller grew by 5000+ lines.

This is because the memoize function isn't seen as pure (it could reasonably call the function it accepts immediately). I don't want to totally throw off the bundle size, so just mark the new things as pure to restore the old size.