### PR TITLE
Skip JSDoc in .ts files

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1759,7 +1759,7 @@ namespace Parser {
     }
 
     function withJSDoc<T extends HasJSDoc>(node: T, hasJSDoc: boolean): T {
-        return hasJSDoc ? addJSDocComment(node) : node;
+        return hasJSDoc && (node.flags & NodeFlags.JavaScriptFile) ? addJSDocComment(node) : node;
     }
 
     let hasDeprecatedTag = false;


### PR DESCRIPTION
Just an experiment for now. Current test failures:

- all fourslash tests of jsdoc fail; the parser should produce jsdoc for tsserver.
- Spurious unused-type errors because `@link` isn't parsed and treated as a usage.