### PR TITLE
Ensure built/local exists before producing typesMap.json

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -515,6 +515,7 @@ const { main: watchGuard, watch: watchWatchGuard } = entrypointBuildTask({
 export const generateTypesMap = task({
     name: "generate-types-map",
     run: async () => {
+        await fs.promises.mkdir("./built/local", { recursive: true });
         const source = "src/server/typesMap.json";
         const target = "built/local/typesMap.json";
         const contents = await fs.promises.readFile(source, "utf-8");


### PR DESCRIPTION
I've seen this numerous times in CI where the CI fails because it can't write out the JSON. It turns out that when I ported this task over, I didn't add the `mkdir`; the old build did this as part of a serial task so the task previously assumed that the directory exists. But now with `hereby`, this task runs in parallel with other tasks because it has no dependencies.