### PR TITLE
Use `missingType` instead of `undefinedType` for optional methods under `exactOptionalPropertyTypes`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11235,7 +11235,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return baseTypeVariable ? getIntersectionType([type, baseTypeVariable]) : type;
         }
         else {
-            return strictNullChecks && symbol.flags & SymbolFlags.Optional ? getOptionalType(type) : type;
+            return strictNullChecks && symbol.flags & SymbolFlags.Optional ? getOptionalType(type, /*isProperty*/ true) : type;
         }
     }
 

--- a/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/stripMembersOptionality.ts ===
+// repro from #52494
+
+declare const someVal: Required<{
+>someVal : Symbol(someVal, Decl(stripMembersOptionality.ts, 2, 13))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+
+    fn?(key: string): string | null;
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 2, 33))
+>key : Symbol(key, Decl(stripMembersOptionality.ts, 3, 8))
+
+}>;
+someVal.fn("");
+>someVal.fn : Symbol(fn, Decl(stripMembersOptionality.ts, 2, 33))
+>someVal : Symbol(someVal, Decl(stripMembersOptionality.ts, 2, 13))
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 2, 33))
+
+declare const someVal2: Required<{
+>someVal2 : Symbol(someVal2, Decl(stripMembersOptionality.ts, 7, 13))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+
+    fn?: (key: string) => string | null;
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 7, 34))
+>key : Symbol(key, Decl(stripMembersOptionality.ts, 8, 10))
+
+}>;
+someVal2.fn("");
+>someVal2.fn : Symbol(fn, Decl(stripMembersOptionality.ts, 7, 34))
+>someVal2 : Symbol(someVal2, Decl(stripMembersOptionality.ts, 7, 13))
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 7, 34))
+

--- a/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=false).types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/stripMembersOptionality.ts ===
+// repro from #52494
+
+declare const someVal: Required<{
+>someVal : Required<{ fn?(key: string): string | null; }>
+
+    fn?(key: string): string | null;
+>fn : ((key: string) => string | null) | undefined
+>key : string
+>null : null
+
+}>;
+someVal.fn("");
+>someVal.fn("") : string | null
+>someVal.fn : (key: string) => string | null
+>someVal : Required<{ fn?(key: string): string | null; }>
+>fn : (key: string) => string | null
+>"" : ""
+
+declare const someVal2: Required<{
+>someVal2 : Required<{ fn?: ((key: string) => string | null) | undefined; }>
+
+    fn?: (key: string) => string | null;
+>fn : ((key: string) => string | null) | undefined
+>key : string
+>null : null
+
+}>;
+someVal2.fn("");
+>someVal2.fn("") : string | null
+>someVal2.fn : (key: string) => string | null
+>someVal2 : Required<{ fn?: ((key: string) => string | null) | undefined; }>
+>fn : (key: string) => string | null
+>"" : ""
+

--- a/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/stripMembersOptionality.ts ===
+// repro from #52494
+
+declare const someVal: Required<{
+>someVal : Symbol(someVal, Decl(stripMembersOptionality.ts, 2, 13))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+
+    fn?(key: string): string | null;
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 2, 33))
+>key : Symbol(key, Decl(stripMembersOptionality.ts, 3, 8))
+
+}>;
+someVal.fn("");
+>someVal.fn : Symbol(fn, Decl(stripMembersOptionality.ts, 2, 33))
+>someVal : Symbol(someVal, Decl(stripMembersOptionality.ts, 2, 13))
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 2, 33))
+
+declare const someVal2: Required<{
+>someVal2 : Symbol(someVal2, Decl(stripMembersOptionality.ts, 7, 13))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+
+    fn?: (key: string) => string | null;
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 7, 34))
+>key : Symbol(key, Decl(stripMembersOptionality.ts, 8, 10))
+
+}>;
+someVal2.fn("");
+>someVal2.fn : Symbol(fn, Decl(stripMembersOptionality.ts, 7, 34))
+>someVal2 : Symbol(someVal2, Decl(stripMembersOptionality.ts, 7, 13))
+>fn : Symbol(fn, Decl(stripMembersOptionality.ts, 7, 34))
+

--- a/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/stripMembersOptionality(exactoptionalpropertytypes=true).types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/stripMembersOptionality.ts ===
+// repro from #52494
+
+declare const someVal: Required<{
+>someVal : Required<{ fn?(key: string): string | null; }>
+
+    fn?(key: string): string | null;
+>fn : ((key: string) => string | null) | undefined
+>key : string
+>null : null
+
+}>;
+someVal.fn("");
+>someVal.fn("") : string | null
+>someVal.fn : (key: string) => string | null
+>someVal : Required<{ fn?(key: string): string | null; }>
+>fn : (key: string) => string | null
+>"" : ""
+
+declare const someVal2: Required<{
+>someVal2 : Required<{ fn?: (key: string) => string | null; }>
+
+    fn?: (key: string) => string | null;
+>fn : ((key: string) => string | null) | undefined
+>key : string
+>null : null
+
+}>;
+someVal2.fn("");
+>someVal2.fn("") : string | null
+>someVal2.fn : (key: string) => string | null
+>someVal2 : Required<{ fn?: (key: string) => string | null; }>
+>fn : (key: string) => string | null
+>"" : ""
+

--- a/tests/cases/compiler/stripMembersOptionality.ts
+++ b/tests/cases/compiler/stripMembersOptionality.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true, false
+// @noEmit: true
+
+// repro from #52494
+
+declare const someVal: Required<{
+    fn?(key: string): string | null;
+}>;
+someVal.fn("");
+
+declare const someVal2: Required<{
+    fn?: (key: string) => string | null;
+}>;
+someVal2.fn("");


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/52494