### PR TITLE
Prevent generation of dynamic require in library bundles

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -182,28 +182,6 @@ function createBundler(entrypoint, outfile, taskOptions = {}) {
             packages: "external",
             logLevel: "warning",
             // legalComments: "none", // If we add copyright headers to the source files, uncomment.
-            plugins: [
-                {
-                    name: "fix-require",
-                    setup: (build) => {
-                        build.onEnd(async () => {
-                            // esbuild converts calls to "require" to "__require"; this function
-                            // calls the real require if it exists, or throws if it does not (rather than
-                            // throwing an error like "require not defined"). But, since we want typescript
-                            // to be consumable by other bundlers, we need to convert these calls back to
-                            // require so our imports are visible again.
-                            //
-                            // The leading spaces are to keep the offsets the same within the files to keep
-                            // source maps working (though this only really matters for the line the require is on).
-                            //
-                            // See: https://github.com/evanw/esbuild/issues/1905
-                            let contents = await fs.promises.readFile(outfile, "utf-8");
-                            contents = contents.replace(/__require\(/g, "  require(");
-                            await fs.promises.writeFile(outfile, contents);
-                        });
-                    },
-                }
-            ]
         };
 
         if (taskOptions.exportIsTsObject) {
@@ -213,6 +191,30 @@ function createBundler(entrypoint, outfile, taskOptions = {}) {
             options.globalName = "ts";
             // If we are in a CJS context, export the ts namespace.
             options.footer = { js: `\nif (typeof module !== "undefined" && module.exports) { module.exports = ts; }` };
+
+            // esbuild converts calls to "require" to "__require"; this function
+            // calls the real require if it exists, or throws if it does not (rather than
+            // throwing an error like "require not defined"). But, since we want typescript
+            // to be consumable by other bundlers, we need to convert these calls back to
+            // require so our imports are visible again.
+            //
+            // The leading spaces are to keep the offsets the same within the files to keep
+            // source maps working (though this only really matters for the line the require is on).
+            //
+            // See: https://github.com/evanw/esbuild/issues/1905
+            options.define = { require: "$require" };
+            options.plugins = [
+                {
+                    name: "fix-require",
+                    setup: (build) => {
+                        build.onEnd(async () => {
+                            let contents = await fs.promises.readFile(outfile, "utf-8");
+                            contents = contents.replace(/\$require\(/g, " require(");
+                            await fs.promises.writeFile(outfile, contents);
+                        });
+                    },
+                }
+            ];
         }
 
         return options;

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -202,14 +202,14 @@ function createBundler(entrypoint, outfile, taskOptions = {}) {
             // source maps working (though this only really matters for the line the require is on).
             //
             // See: https://github.com/evanw/esbuild/issues/1905
-            options.define = { require: "$require" };
+            options.define = { require: "$$require" };
             options.plugins = [
                 {
                     name: "fix-require",
                     setup: (build) => {
                         build.onEnd(async () => {
                             let contents = await fs.promises.readFile(outfile, "utf-8");
-                            contents = contents.replace(/\$require\(/g, " require(");
+                            contents = contents.replace(/\$\$require/g, "  require");
                             await fs.promises.writeFile(outfile, contents);
                         });
                     },


### PR DESCRIPTION
Fixes #52521

This is what it does to the output:

```patch
diff --git a/./built/local-old/tsserverlibrary.js b/./built/local/tsserverlibrary.js
index ce83c7801f..eb546a7f22 100644
--- a/./built/local-old/tsserverlibrary.js
+++ b/./built/local/tsserverlibrary.js
@@ -18,17 +18,10 @@ and limitations under the License.
 var ts = (() => {
   var __defProp = Object.defineProperty;
   var __getOwnPropNames = Object.getOwnPropertyNames;
-  var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
-    get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
-  }) : x)(function(x) {
-    if (typeof require !== "undefined")
-      return require.apply(this, arguments);
-    throw new Error('Dynamic require of "' + x + '" is not supported');
-  });
   var __esm = (fn, res) => function __init() {
     return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
   };
-  var __commonJS = (cb, mod) => function __require2() {
+  var __commonJS = (cb, mod) => function __require() {
     return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
   };
   var __export = (target, all) => {
```