### PR TITLE
Restore global `onProfilerEvent` hook for ts-perf

### DIFF
--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -11,6 +11,9 @@ import {
 
 /** Performance measurements for the compiler. */
 
+// NOTE: declared global is injected by ts-perf to monitor profiler marks to generate heap snapshots.
+declare var onProfilerEvent: ((eventName: string) => void) | undefined;
+
 let perfHooks: PerformanceHooks | undefined;
 // when set, indicates the implementation of `Performance` to use for user timing.
 // when unset, indicates user timing is unavailable or disabled.
@@ -74,6 +77,9 @@ export function mark(markName: string) {
         counts.set(markName, count + 1);
         marks.set(markName, timestamp());
         performanceImpl?.mark(markName);
+        if (typeof onProfilerEvent === "function") {
+            onProfilerEvent(markName);
+        }
     }
 }
 

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -12,7 +12,7 @@ import {
 /** Performance measurements for the compiler. */
 
 // NOTE: declared global is injected by ts-perf to monitor profiler marks to generate heap snapshots.
-declare var onProfilerEvent: ((eventName: string) => void) | undefined;
+declare let onProfilerEvent: ((eventName: string) => void) | undefined;
 
 let perfHooks: PerformanceHooks | undefined;
 // when set, indicates the implementation of `Performance` to use for user timing.


### PR DESCRIPTION
This was previously used by our perf tooling to generate point-in-time heap snapshots, but was lost during one of the many refactors of the `ts.performance` API.