### PR TITLE
Add test which verifies we are getting native performance hooks

### DIFF
--- a/src/testRunner/tests.ts
+++ b/src/testRunner/tests.ts
@@ -12,6 +12,7 @@ import "./unittests/jsonParserRecovery";
 import "./unittests/moduleResolution";
 import "./unittests/parsePseudoBigInt";
 import "./unittests/paths";
+import "./unittests/performance";
 import "./unittests/printer";
 import "./unittests/programApi";
 import "./unittests/publicApi";

--- a/src/testRunner/unittests/performance.ts
+++ b/src/testRunner/unittests/performance.ts
@@ -1,0 +1,8 @@
+import * as ts from "../_namespaces/ts";
+
+describe("performance:: tryGetNativePerformanceHooks", () => {
+    it("should not return undefined", () => {
+        const hooks = ts.tryGetNativePerformanceHooks();
+        assert.isDefined(hooks);
+    });
+});


### PR DESCRIPTION
This will fail before Node 16 because #50267 accidentally (?) disabled it entirely when `clearMeasures` does not exist.