### PR TITLE
[experiment] Check for extended empty tuples in isTupleLikeType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1949,6 +1949,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     const emptyGenericType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, emptyArray) as ObjectType as GenericType;
     emptyGenericType.instantiations = new Map<string, TypeReference>();
 
+    const emptyReadonlyTupleType = createTupleType(emptyArray, emptyArray, /*readonly*/ true);
+
     const anyFunctionType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, emptyArray);
     // The anyFunctionType contains the anyFunctionType by definition. The flag is further propagated
     // in getPropagatingFlagsOfTypes, and it is checked in inferFromTypes.
@@ -22902,7 +22904,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTupleLikeType(type: Type): boolean {
-        return isTupleType(type) || !!getPropertyOfType(type, "0" as __String);
+        return isTupleType(type) || !!getPropertyOfType(type, "0" as __String) || isTypeAssignableTo(type, emptyReadonlyTupleType);
     }
 
     function isArrayOrTupleLikeType(type: Type): boolean {

--- a/tests/baselines/reference/anyInferenceAnonymousFunctions.types
+++ b/tests/baselines/reference/anyInferenceAnonymousFunctions.types
@@ -19,7 +19,7 @@ paired.reduce(function (a1, a2) {
 >{} : {}
 
 } , []);
->[] : undefined[]
+>[] : []
 
 paired.reduce((b1, b2) => {
 >paired.reduce((b1, b2) => {    return b1.concat({});} , []) : any
@@ -38,7 +38,7 @@ paired.reduce((b1, b2) => {
 >{} : {}
 
 } , []);
->[] : undefined[]
+>[] : []
 
 paired.reduce((b3, b4) => b3.concat({}), []);
 >paired.reduce((b3, b4) => b3.concat({}), []) : any
@@ -53,7 +53,7 @@ paired.reduce((b3, b4) => b3.concat({}), []);
 >b3 : any
 >concat : any
 >{} : {}
->[] : undefined[]
+>[] : []
 
 paired.map((c1) => c1.count);
 >paired.map((c1) => c1.count) : any[]

--- a/tests/baselines/reference/assignmentCompatability46.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability46.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/assignmentCompatability46.ts(3,4): error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'never'.
+tests/cases/compiler/assignmentCompatability46.ts(3,4): error TS2345: Argument of type '[number, number, number]' is not assignable to parameter of type 'never'.
 tests/cases/compiler/assignmentCompatability46.ts(4,4): error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type 'never'.
 
 
@@ -7,7 +7,7 @@ tests/cases/compiler/assignmentCompatability46.ts(4,4): error TS2345: Argument o
     
     fn([1, 2, 3])
        ~~~~~~~~~
-!!! error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'never'.
+!!! error TS2345: Argument of type '[number, number, number]' is not assignable to parameter of type 'never'.
     fn({ a: 1, b: 2 })
        ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type 'never'.

--- a/tests/baselines/reference/assignmentCompatability46.types
+++ b/tests/baselines/reference/assignmentCompatability46.types
@@ -6,7 +6,7 @@ declare function fn(x: never): void;
 fn([1, 2, 3])
 >fn([1, 2, 3]) : void
 >fn : (x: never) => void
->[1, 2, 3] : number[]
+>[1, 2, 3] : [number, number, number]
 >1 : 1
 >2 : 2
 >3 : 3

--- a/tests/baselines/reference/assignmentNestedInLiterals.types
+++ b/tests/baselines/reference/assignmentNestedInLiterals.types
@@ -5,9 +5,9 @@ var target, x, y;
 >y : any
 
 target = [x = 1, y = x];
->target = [x = 1, y = x] : number[]
+>target = [x = 1, y = x] : [number, number]
 >target : any
->[x = 1, y = x] : number[]
+>[x = 1, y = x] : [number, number]
 >x = 1 : 1
 >x : any
 >1 : 1

--- a/tests/baselines/reference/bigintWithoutLib.types
+++ b/tests/baselines/reference/bigintWithoutLib.types
@@ -125,7 +125,7 @@ bigIntArray = new BigInt64Array([1n, 2n, 3n]);
 >bigIntArray : BigInt64Array
 >new BigInt64Array([1n, 2n, 3n]) : any
 >BigInt64Array : any
->[1n, 2n, 3n] : bigint[]
+>[1n, 2n, 3n] : [bigint, bigint, bigint]
 >1n : 1n
 >2n : 2n
 >3n : 3n
@@ -135,7 +135,7 @@ bigIntArray = new BigInt64Array([1, 2, 3]);
 >bigIntArray : BigInt64Array
 >new BigInt64Array([1, 2, 3]) : any
 >BigInt64Array : any
->[1, 2, 3] : number[]
+>[1, 2, 3] : [number, number, number]
 >1 : 1
 >2 : 2
 >3 : 3
@@ -205,7 +205,7 @@ bigUintArray = new BigUint64Array([1n, 2n, 3n]);
 >bigUintArray : BigUint64Array
 >new BigUint64Array([1n, 2n, 3n]) : any
 >BigUint64Array : any
->[1n, 2n, 3n] : bigint[]
+>[1n, 2n, 3n] : [bigint, bigint, bigint]
 >1n : 1n
 >2n : 2n
 >3n : 3n
@@ -215,7 +215,7 @@ bigUintArray = new BigUint64Array([1, 2, 3]);
 >bigUintArray : BigUint64Array
 >new BigUint64Array([1, 2, 3]) : any
 >BigUint64Array : any
->[1, 2, 3] : number[]
+>[1, 2, 3] : [number, number, number]
 >1 : 1
 >2 : 2
 >3 : 3

--- a/tests/baselines/reference/castExpressionParentheses.types
+++ b/tests/baselines/reference/castExpressionParentheses.types
@@ -14,7 +14,7 @@ declare var a;
 (<any>[1,3,]); 
 >(<any>[1,3,]) : any
 ><any>[1,3,] : any
->[1,3,] : number[]
+>[1,3,] : [number, number]
 >1 : 1
 >3 : 3
 

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -410,8 +410,8 @@ function zeroOf<T extends number | string | boolean>(value: T) {
 
     return <ZeroOf<T>>(typeof value === "number" ? 0 : typeof value === "string" ? "" : false);
 ><ZeroOf<T>>(typeof value === "number" ? 0 : typeof value === "string" ? "" : false) : ZeroOf<T>
->(typeof value === "number" ? 0 : typeof value === "string" ? "" : false) : false | "" | 0
->typeof value === "number" ? 0 : typeof value === "string" ? "" : false : false | "" | 0
+>(typeof value === "number" ? 0 : typeof value === "string" ? "" : false) : false | 0 | ""
+>typeof value === "number" ? 0 : typeof value === "string" ? "" : false : false | 0 | ""
 >typeof value === "number" : boolean
 >typeof value : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
 >value : T
@@ -476,11 +476,11 @@ function f21<T extends number | string>(x: T, y: ZeroOf<T>) {
 
     let z1: number | string = y;
 >z1 : string | number
->y : "" | 0
+>y : 0 | ""
 
     let z2: 0 | "" = y;
->z2 : "" | 0
->y : "" | 0
+>z2 : 0 | ""
+>y : 0 | ""
 
     x = y;  // Error
 >x = y : ZeroOf<T>

--- a/tests/baselines/reference/constructorOverloads2.types
+++ b/tests/baselines/reference/constructorOverloads2.types
@@ -63,7 +63,7 @@ var f4 = new Foo([f1,f2,f3]);
 >f4 : Foo
 >new Foo([f1,f2,f3]) : Foo
 >Foo : typeof Foo
->[f1,f2,f3] : Foo[]
+>[f1,f2,f3] : [Foo, Foo, Foo]
 >f1 : Foo
 >f2 : Foo
 >f3 : Foo

--- a/tests/baselines/reference/constructorOverloads3.types
+++ b/tests/baselines/reference/constructorOverloads3.types
@@ -56,7 +56,7 @@ var f4 = new Foo([f1,f2,f3]);
 >f4 : Foo
 >new Foo([f1,f2,f3]) : Foo
 >Foo : typeof Foo
->[f1,f2,f3] : Foo[]
+>[f1,f2,f3] : [Foo, Foo, Foo]
 >f1 : Foo
 >f2 : Foo
 >f3 : Foo

--- a/tests/baselines/reference/constructorOverloads6.types
+++ b/tests/baselines/reference/constructorOverloads6.types
@@ -56,7 +56,7 @@ var f4 = new Foo([f1,f2,f3]);
 >f4 : Foo
 >new Foo([f1,f2,f3]) : Foo
 >Foo : typeof Foo
->[f1,f2,f3] : Foo[]
+>[f1,f2,f3] : [Foo, Foo, Foo]
 >f1 : Foo
 >f2 : Foo
 >f3 : Foo

--- a/tests/baselines/reference/controlFlowArrayErrors.types
+++ b/tests/baselines/reference/controlFlowArrayErrors.types
@@ -32,9 +32,9 @@ function f2() {
 >x : any
 
     x = [];
->x = [] : undefined[]
+>x = [] : []
 >x : any
->[] : undefined[]
+>[] : []
 
     let y = x;   // Implicit any[] error
 >y : any[]
@@ -81,16 +81,16 @@ function f4() {
 >x : any
 
     x = [5, "hello"];  // Non-evolving array
->x = [5, "hello"] : (string | number)[]
+>x = [5, "hello"] : [number, string]
 >x : any
->[5, "hello"] : (string | number)[]
+>[5, "hello"] : [number, string]
 >5 : 5
 >"hello" : "hello"
 
     x.push(true);      // Error
 >x.push(true) : number
 >x.push : (...items: (string | number)[]) => number
->x : (string | number)[]
+>x : [number, string]
 >push : (...items: (string | number)[]) => number
 >true : true
 }
@@ -123,9 +123,9 @@ function f6() {
 >cond : () => boolean
 
         x = [];
->x = [] : undefined[]
+>x = [] : []
 >x : any
->[] : undefined[]
+>[] : []
 
         x.push(5);
 >x.push(5) : number
@@ -143,18 +143,18 @@ function f6() {
     }
     else {
         x = [true];  // Non-evolving array
->x = [true] : boolean[]
+>x = [true] : [boolean]
 >x : any
->[true] : boolean[]
+>[true] : [boolean]
 >true : true
     }
     x;           // boolean[] | (string | number)[]
->x : (string | number)[] | boolean[]
+>x : (string | number)[] | [boolean]
 
     x.push(99);  // Error
 >x.push(99) : number
 >x.push : ((...items: (string | number)[]) => number) | ((...items: boolean[]) => number)
->x : (string | number)[] | boolean[]
+>x : (string | number)[] | [boolean]
 >push : ((...items: (string | number)[]) => number) | ((...items: boolean[]) => number)
 >99 : 99
 }

--- a/tests/baselines/reference/controlFlowArrays.types
+++ b/tests/baselines/reference/controlFlowArrays.types
@@ -73,9 +73,9 @@ function f3() {
 >x : any
 
     x = [];
->x = [] : never[]
+>x = [] : []
 >x : any
->[] : never[]
+>[] : []
 
     x.push(5, "hello");
 >x.push(5, "hello") : number
@@ -130,9 +130,9 @@ function f5() {
 >cond : () => boolean
 
         x = [];
->x = [] : never[]
+>x = [] : []
 >x : any
->[] : never[]
+>[] : []
 
         x.push(5);
 >x.push(5) : number
@@ -143,9 +143,9 @@ function f5() {
     }
     else {
         x = [];
->x = [] : never[]
+>x = [] : []
 >x : any
->[] : never[]
+>[] : []
 
         x.push("hello");
 >x.push("hello") : number
@@ -175,9 +175,9 @@ function f6() {
     }
     else {
         x = [];
->x = [] : never[]
+>x = [] : []
 >x : any
->[] : never[]
+>[] : []
 
         x.push("hello");
 >x.push("hello") : number
@@ -202,9 +202,9 @@ function f7() {
 >cond : () => boolean
 
         x = [];
->x = [] : never[]
+>x = [] : []
 >x : any
->[] : never[]
+>[] : []
 
         while (cond()) {
 >cond() : boolean
@@ -387,9 +387,9 @@ function f12() {
 >x : any
 
     x = [];
->x = [] : never[]
+>x = [] : []
 >x : any
->[] : never[]
+>[] : []
 
     if (x.length === 0) {  // x.length ok on implicit any[]
 >x.length === 0 : boolean
@@ -513,9 +513,9 @@ function f16() {
 >(x = [], x).push : (...items: any[]) => number
 >(x = [], x) : any[]
 >x = [], x : any[]
->x = [] : never[]
+>x = [] : []
 >x : any
->[] : never[]
+>[] : []
 >x : any[]
 >push : (...items: any[]) => number
 >5 : 5

--- a/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.js
+++ b/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.js
@@ -25,7 +25,7 @@ declare var x11: number, y11: string;
 declare var a11: undefined, b11: undefined, c11: undefined;
 declare var a2: number, b2: string, x12: number, c2: boolean;
 declare var x13: number, y13: string;
-declare var a3: (string | number)[], b3: {
+declare var a3: [number, string], b3: {
     x: number;
     y: string;
 };

--- a/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
+++ b/tests/baselines/reference/declarationEmitDestructuringArrayPattern2.types
@@ -56,10 +56,10 @@ var [x13, y13] = [1, "hello"];
 >"hello" : "hello"
 
 var [a3, b3] = [[x13, y13], { x: x13, y: y13 }];
->a3 : (string | number)[]
+>a3 : [number, string]
 >b3 : { x: number; y: string; }
->[[x13, y13], { x: x13, y: y13 }] : [(string | number)[], { x: number; y: string; }]
->[x13, y13] : (string | number)[]
+>[[x13, y13], { x: x13, y: y13 }] : [[number, string], { x: number; y: string; }]
+>[x13, y13] : [number, string]
 >x13 : number
 >y13 : string
 >{ x: x13, y: y13 } : { x: number; y: string; }

--- a/tests/baselines/reference/declarationsAndAssignments.types
+++ b/tests/baselines/reference/declarationsAndAssignments.types
@@ -403,10 +403,10 @@ function f13() {
 >"hello" : "hello"
 
     var [a, b] = [[x, y], { x: x, y: y }];
->a : (string | number)[]
+>a : [number, string]
 >b : { x: number; y: string; }
->[[x, y], { x: x, y: y }] : [(string | number)[], { x: number; y: string; }]
->[x, y] : (string | number)[]
+>[[x, y], { x: x, y: y }] : [[number, string], { x: number; y: string; }]
+>[x, y] : [number, string]
 >x : number
 >y : string
 >{ x: x, y: y } : { x: number; y: string; }

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment3.types
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment3.types
@@ -28,20 +28,20 @@ const [f, g = f, h = i, i = f] = [1]; // error for h = i
 
 (function ([a, b = a]) { // ok
 >(function ([a, b = a]) { // ok})([1]) : void
->(function ([a, b = a]) { // ok}) : ([a, b]: number[]) => void
->function ([a, b = a]) { // ok} : ([a, b]: number[]) => void
+>(function ([a, b = a]) { // ok}) : ([a, b]: [number]) => void
+>function ([a, b = a]) { // ok} : ([a, b]: [number]) => void
 >a : number
 >b : number
 >a : number
 
 })([1]);
->[1] : number[]
+>[1] : [number]
 >1 : 1
 
 (function ([c, d = c, e = e]) { // error for e = e
 >(function ([c, d = c, e = e]) { // error for e = e})([1]) : void
->(function ([c, d = c, e = e]) { // error for e = e}) : ([c, d, e]: number[]) => void
->function ([c, d = c, e = e]) { // error for e = e} : ([c, d, e]: number[]) => void
+>(function ([c, d = c, e = e]) { // error for e = e}) : ([c, d, e]: [number]) => void
+>function ([c, d = c, e = e]) { // error for e = e} : ([c, d, e]: [number]) => void
 >c : number
 >d : number
 >c : number
@@ -49,13 +49,13 @@ const [f, g = f, h = i, i = f] = [1]; // error for h = i
 >e : any
 
 })([1]);
->[1] : number[]
+>[1] : [number]
 >1 : 1
 
 (function ([f, g = f, h = i, i = f]) { // error for h = i
 >(function ([f, g = f, h = i, i = f]) { // error for h = i})([1]) : void
->(function ([f, g = f, h = i, i = f]) { // error for h = i}) : ([f, g, h, i]: number[]) => void
->function ([f, g = f, h = i, i = f]) { // error for h = i} : ([f, g, h, i]: number[]) => void
+>(function ([f, g = f, h = i, i = f]) { // error for h = i}) : ([f, g, h, i]: [number]) => void
+>function ([f, g = f, h = i, i = f]) { // error for h = i} : ([f, g, h, i]: [number]) => void
 >f : number
 >g : number
 >f : number
@@ -65,6 +65,6 @@ const [f, g = f, h = i, i = f] = [1]; // error for h = i
 >f : number
 
 })([1])
->[1] : number[]
+>[1] : [number]
 >1 : 1
 

--- a/tests/baselines/reference/didYouMeanSuggestionErrors.types
+++ b/tests/baselines/reference/didYouMeanSuggestionErrors.types
@@ -60,7 +60,7 @@ suite("another suite", () => {
 >Buffer.from : any
 >Buffer : any
 >from : any
->[] : undefined[]
+>[] : []
 
         const z = module.exports;
 >z : any

--- a/tests/baselines/reference/discriminantsAndPrimitives.types
+++ b/tests/baselines/reference/discriminantsAndPrimitives.types
@@ -104,7 +104,7 @@ function f4(x: Foo | Bar | string | number | null) {
 >null : null
 
     if (x && typeof x === "object") {
->x && typeof x === "object" : boolean | "" | 0 | null
+>x && typeof x === "object" : boolean | 0 | "" | null
 >x : string | number | Foo | Bar | null
 >typeof x === "object" : boolean
 >typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2015.types
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2015.types
@@ -12,7 +12,7 @@ const testReflectApply = Reflect.apply(noOp, this, []);
 >apply : any
 >noOp : () => void
 >this : typeof globalThis
->[] : undefined[]
+>[] : []
 
 const testReflectConstruct = Reflect.construct(noOp, []);
 >testReflectConstruct : any
@@ -21,7 +21,7 @@ const testReflectConstruct = Reflect.construct(noOp, []);
 >Reflect : any
 >construct : any
 >noOp : () => void
->[] : undefined[]
+>[] : []
 
 const testReflectDefineProperty = Reflect.defineProperty({}, "", {});
 >testReflectDefineProperty : any
@@ -192,7 +192,7 @@ const testArrayConstructorFrom = Array.from([]);
 >Array.from : any
 >Array : ArrayConstructor
 >from : any
->[] : undefined[]
+>[] : []
 
 const testArrayConstructorOf = Array.of([]);
 >testArrayConstructorOf : any
@@ -200,7 +200,7 @@ const testArrayConstructorOf = Array.of([]);
 >Array.of : any
 >Array : ArrayConstructor
 >of : any
->[] : undefined[]
+>[] : []
 
 const testObjectConstructorAssign = Object.assign({}, {});
 >testObjectConstructorAssign : any
@@ -447,7 +447,7 @@ const testPromiseAll = Promise.all([]);
 >Promise.all : any
 >Promise : any
 >all : any
->[] : undefined[]
+>[] : []
 
 const testPromiseRace = Promise.race([]);
 >testPromiseRace : any
@@ -455,7 +455,7 @@ const testPromiseRace = Promise.race([]);
 >Promise.race : any
 >Promise : any
 >race : any
->[] : undefined[]
+>[] : []
 
 const testPromiseResolve = Promise.resolve();
 >testPromiseResolve : any

--- a/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.types
+++ b/tests/baselines/reference/doYouNeedToChangeYourTargetLibraryES2016Plus.types
@@ -224,7 +224,7 @@ const testPromiseAllSettled = Promise.allSettled([]);
 >Promise.allSettled : any
 >Promise : PromiseConstructor
 >allSettled : any
->[] : undefined[]
+>[] : []
 
 const testStringMatchAll = "".matchAll();
 >testStringMatchAll : any
@@ -256,7 +256,7 @@ const testPromiseAny = Promise.any([]);
 >Promise.any : any
 >Promise : PromiseConstructor
 >any : any
->[] : undefined[]
+>[] : []
 
 const testStringReplaceAll = "".replaceAll();
 >testStringReplaceAll : any

--- a/tests/baselines/reference/duplicateLocalVariable1.types
+++ b/tests/baselines/reference/duplicateLocalVariable1.types
@@ -470,7 +470,7 @@ export var tests: TestRunner = (function () {
 >App.App : any
 >App : any
 >App : any
->[] : undefined[]
+>[] : []
 
             return (app.fixLines === false &&
 >(app.fixLines === false &&                   app.recurse === true &&                   app.lineEndings === "CRLF" &&                   app.matchPattern === undefined &&                   app.rootDirectory === ".\\" &&                   app.encodings[0] === "ascii" &&                   app.encodings[1] === "utf8nobom") : boolean
@@ -551,7 +551,7 @@ export var tests: TestRunner = (function () {
 >App.App : any
 >App : any
 >App : any
->["-dir=C:\\test dir", "-lineEndings=LF", "-encodings=utf16be,ascii", "-recurse=false", "-fixlines"] : string[]
+>["-dir=C:\\test dir", "-lineEndings=LF", "-encodings=utf16be,ascii", "-recurse=false", "-fixlines"] : [string, string, string, string, string]
 >"-dir=C:\\test dir" : "-dir=C:\\test dir"
 >"-lineEndings=LF" : "-lineEndings=LF"
 >"-encodings=utf16be,ascii" : "-encodings=utf16be,ascii"

--- a/tests/baselines/reference/es5-asyncFunctionArrayLiterals.types
+++ b/tests/baselines/reference/es5-asyncFunctionArrayLiterals.types
@@ -9,9 +9,9 @@ async function arrayLiteral0() {
 >arrayLiteral0 : () => Promise<void>
 
     x = [await y, z];
->x = [await y, z] : any[]
+>x = [await y, z] : [any, any]
 >x : any
->[await y, z] : any[]
+>[await y, z] : [any, any]
 >await y : any
 >y : any
 >z : any
@@ -21,9 +21,9 @@ async function arrayLiteral1() {
 >arrayLiteral1 : () => Promise<void>
 
     x = [y, await z];
->x = [y, await z] : any[]
+>x = [y, await z] : [any, any]
 >x : any
->[y, await z] : any[]
+>[y, await z] : [any, any]
 >y : any
 >await z : any
 >z : any
@@ -33,9 +33,9 @@ async function arrayLiteral2() {
 >arrayLiteral2 : () => Promise<void>
 
     x = [...(await y), z];
->x = [...(await y), z] : any[]
+>x = [...(await y), z] : [...any[], any]
 >x : any
->[...(await y), z] : any[]
+>[...(await y), z] : [...any[], any]
 >...(await y) : any
 >(await y) : any
 >await y : any
@@ -47,9 +47,9 @@ async function arrayLiteral3() {
 >arrayLiteral3 : () => Promise<void>
 
     x = [...y, await z];
->x = [...y, await z] : any[]
+>x = [...y, await z] : [...any[], any]
 >x : any
->[...y, await z] : any[]
+>[...y, await z] : [...any[], any]
 >...y : any
 >y : any
 >await z : any
@@ -60,9 +60,9 @@ async function arrayLiteral4() {
 >arrayLiteral4 : () => Promise<void>
 
     x = [await y, ...z];
->x = [await y, ...z] : any[]
+>x = [await y, ...z] : [any, ...any[]]
 >x : any
->[await y, ...z] : any[]
+>[await y, ...z] : [any, ...any[]]
 >await y : any
 >y : any
 >...z : any
@@ -73,9 +73,9 @@ async function arrayLiteral5() {
 >arrayLiteral5 : () => Promise<void>
 
     x = [y, ...(await z)];
->x = [y, ...(await z)] : any[]
+>x = [y, ...(await z)] : [any, ...any[]]
 >x : any
->[y, ...(await z)] : any[]
+>[y, ...(await z)] : [any, ...any[]]
 >y : any
 >...(await z) : any
 >(await z) : any
@@ -87,9 +87,9 @@ async function arrayLiteral6() {
 >arrayLiteral6 : () => Promise<void>
 
     x = [y, await z, a];
->x = [y, await z, a] : any[]
+>x = [y, await z, a] : [any, any, any]
 >x : any
->[y, await z, a] : any[]
+>[y, await z, a] : [any, any, any]
 >y : any
 >await z : any
 >z : any
@@ -100,9 +100,9 @@ async function arrayLiteral7() {
 >arrayLiteral7 : () => Promise<void>
 
     x = [await y, z, await a];
->x = [await y, z, await a] : any[]
+>x = [await y, z, await a] : [any, any, any]
 >x : any
->[await y, z, await a] : any[]
+>[await y, z, await a] : [any, any, any]
 >await y : any
 >y : any
 >z : any

--- a/tests/baselines/reference/fixSignatureCaching.types
+++ b/tests/baselines/reference/fixSignatureCaching.types
@@ -1319,9 +1319,9 @@ define(function () {
 >values : any
 
                     values = [values];
->values = [values] : any[]
+>values = [values] : [any]
 >values : any
->[values] : any[]
+>[values] : [any]
 >values : any
                 }
                 len = values.length;

--- a/tests/baselines/reference/functionType.types
+++ b/tests/baselines/reference/functionType.types
@@ -8,7 +8,7 @@ salt.apply("hello", []);
 >salt : () => void
 >apply : (this: Function, thisArg: any, argArray?: any) => any
 >"hello" : "hello"
->[] : undefined[]
+>[] : []
 
 (new Function("return 5"))();
 >(new Function("return 5"))() : any

--- a/tests/baselines/reference/generatedContextualTyping.types
+++ b/tests/baselines/reference/generatedContextualTyping.types
@@ -110,11 +110,11 @@ var x11: (s: Base[]) => any = n => { var n: Base[]; return null; };
 
 var x12: Genric<Base> = { func: n => { return [d1, d2]; } };
 >x12 : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -212,11 +212,11 @@ class x23 { member: (s: Base[]) => any = n => { var n: Base[]; return null; } }
 class x24 { member: Genric<Base> = { func: n => { return [d1, d2]; } } }
 >x24 : x24
 >member : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -314,11 +314,11 @@ class x35 { private member: (s: Base[]) => any = n => { var n: Base[]; return nu
 class x36 { private member: Genric<Base> = { func: n => { return [d1, d2]; } } }
 >x36 : x36
 >member : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -416,11 +416,11 @@ class x47 { public member: (s: Base[]) => any = n => { var n: Base[]; return nul
 class x48 { public member: Genric<Base> = { func: n => { return [d1, d2]; } } }
 >x48 : x48
 >member : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -518,11 +518,11 @@ class x59 { static member: (s: Base[]) => any = n => { var n: Base[]; return nul
 class x60 { static member: Genric<Base> = { func: n => { return [d1, d2]; } } }
 >x60 : x60
 >member : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -620,11 +620,11 @@ class x71 { private static member: (s: Base[]) => any = n => { var n: Base[]; re
 class x72 { private static member: Genric<Base> = { func: n => { return [d1, d2]; } } }
 >x72 : x72
 >member : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -722,11 +722,11 @@ class x83 { public static member: (s: Base[]) => any = n => { var n: Base[]; ret
 class x84 { public static member: Genric<Base> = { func: n => { return [d1, d2]; } } }
 >x84 : x84
 >member : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -824,11 +824,11 @@ class x95 { constructor(parm: (s: Base[]) => any = n => { var n: Base[]; return 
 class x96 { constructor(parm: Genric<Base> = { func: n => { return [d1, d2]; } }) { } }
 >x96 : x96
 >parm : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -926,11 +926,11 @@ class x107 { constructor(public parm: (s: Base[]) => any = n => { var n: Base[];
 class x108 { constructor(public parm: Genric<Base> = { func: n => { return [d1, d2]; } }) { } }
 >x108 : x108
 >parm : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1028,11 +1028,11 @@ class x119 { constructor(private parm: (s: Base[]) => any = n => { var n: Base[]
 class x120 { constructor(private parm: Genric<Base> = { func: n => { return [d1, d2]; } }) { } }
 >x120 : x120
 >parm : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1130,11 +1130,11 @@ function x131(parm: (s: Base[]) => any = n => { var n: Base[]; return null; }) {
 function x132(parm: Genric<Base> = { func: n => { return [d1, d2]; } }) { }
 >x132 : (parm?: Genric<Base>) => void
 >parm : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1220,11 +1220,11 @@ function x143(): (s: Base[]) => any { return n => { var n: Base[]; return null; 
 
 function x144(): Genric<Base> { return { func: n => { return [d1, d2]; } }; }
 >x144 : () => Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1354,18 +1354,18 @@ function x155(): (s: Base[]) => any { return n => { var n: Base[]; return null; 
 
 function x156(): Genric<Base> { return { func: n => { return [d1, d2]; } }; return { func: n => { return [d1, d2]; } }; }
 >x156 : () => Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1462,12 +1462,12 @@ var x167: () => (s: Base[]) => any = () => { return n => { var n: Base[]; return
 
 var x168: () => Genric<Base> = () => { return { func: n => { return [d1, d2]; } }; };
 >x168 : () => Genric<Base>
->() => { return { func: n => { return [d1, d2]; } }; } : () => { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>() => { return { func: n => { return [d1, d2]; } }; } : () => { func: (n: Base[]) => [Derived1, Derived2]; }
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1564,12 +1564,12 @@ var x179: () => (s: Base[]) => any = function() { return n => { var n: Base[]; r
 
 var x180: () => Genric<Base> = function() { return { func: n => { return [d1, d2]; } }; };
 >x180 : () => Genric<Base>
->function() { return { func: n => { return [d1, d2]; } }; } : () => { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>function() { return { func: n => { return [d1, d2]; } }; } : () => { func: (n: Base[]) => [Derived1, Derived2]; }
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1667,11 +1667,11 @@ module x191 { var t: (s: Base[]) => any = n => { var n: Base[]; return null; }; 
 module x192 { var t: Genric<Base> = { func: n => { return [d1, d2]; } }; }
 >x192 : typeof x192
 >t : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1769,11 +1769,11 @@ module x203 { export var t: (s: Base[]) => any = n => { var n: Base[]; return nu
 module x204 { export var t: Genric<Base> = { func: n => { return [d1, d2]; } }; }
 >x204 : typeof x204
 >t : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -1846,11 +1846,11 @@ var x214 = <{n: Base[]; } >{ n: [d1, d2] };
 var x216 = <Genric<Base>>{ func: n => { return [d1, d2]; } };
 >x216 : Genric<Base>
 ><Genric<Base>>{ func: n => { return [d1, d2]; } } : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -2048,13 +2048,13 @@ var x235: (s: Base[]) => any; x235 = n => { var n: Base[]; return null; };
 
 var x236: Genric<Base>; x236 = { func: n => { return [d1, d2]; } };
 >x236 : Genric<Base>
->x236 = { func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
+>x236 = { func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
 >x236 : Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -2174,13 +2174,13 @@ var x247: { n: (s: Base[]) => any; } = { n: n => { var n: Base[]; return null; }
 var x248: { n: Genric<Base>; } = { n: { func: n => { return [d1, d2]; } } };
 >x248 : { n: Genric<Base>; }
 >n : Genric<Base>
->{ n: { func: n => { return [d1, d2]; } } } : { n: { func: (n: Base[]) => (Derived1 | Derived2)[]; }; }
->n : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ n: { func: n => { return [d1, d2]; } } } : { n: { func: (n: Base[]) => [Derived1, Derived2]; }; }
+>n : { func: (n: Base[]) => [Derived1, Derived2]; }
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -2243,12 +2243,12 @@ var x258: {n: Base[]; } [] = [{ n: [d1, d2] }];
 
 var x260: Genric<Base>[] = [{ func: n => { return [d1, d2]; } }];
 >x260 : Genric<Base>[]
->[{ func: n => { return [d1, d2]; } }] : { func: (n: Base[]) => (Derived1 | Derived2)[]; }[]
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>[{ func: n => { return [d1, d2]; } }] : { func: (n: Base[]) => [Derived1, Derived2]; }[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -2646,20 +2646,20 @@ var x295: (s: Base[]) => any = true ? n => { var n: Base[]; return null; } : n =
 
 var x296: Genric<Base> = true ? { func: n => { return [d1, d2]; } } : { func: n => { return [d1, d2]; } };
 >x296 : Genric<Base>
->true ? { func: n => { return [d1, d2]; } } : { func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
+>true ? { func: n => { return [d1, d2]; } } : { func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
 >true : true
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -2778,14 +2778,14 @@ var x307: (s: Base[]) => any = true ? undefined : n => { var n: Base[]; return n
 
 var x308: Genric<Base> = true ? undefined : { func: n => { return [d1, d2]; } };
 >x308 : Genric<Base>
->true ? undefined : { func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
+>true ? undefined : { func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
 >true : true
 >undefined : undefined
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -2904,13 +2904,13 @@ var x319: (s: Base[]) => any = true ? n => { var n: Base[]; return null; } : und
 
 var x320: Genric<Base> = true ? { func: n => { return [d1, d2]; } } : undefined;
 >x320 : Genric<Base>
->true ? { func: n => { return [d1, d2]; } } : undefined : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
+>true ? { func: n => { return [d1, d2]; } } : undefined : { func: (n: Base[]) => [Derived1, Derived2]; }
 >true : true
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 >undefined : undefined
@@ -3033,11 +3033,11 @@ function x332(n: Genric<Base>) { }; x332({ func: n => { return [d1, d2]; } });
 >n : Genric<Base>
 >x332({ func: n => { return [d1, d2]; } }) : void
 >x332 : (n: Genric<Base>) => void
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -3183,11 +3183,11 @@ var x344 = (n: Genric<Base>) => n; x344({ func: n => { return [d1, d2]; } });
 >n : Genric<Base>
 >x344({ func: n => { return [d1, d2]; } }) : Genric<Base>
 >x344 : (n: Genric<Base>) => Genric<Base>
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 
@@ -3321,11 +3321,11 @@ var x356 = function(n: Genric<Base>) { }; x356({ func: n => { return [d1, d2]; }
 >n : Genric<Base>
 >x356({ func: n => { return [d1, d2]; } }) : void
 >x356 : (n: Genric<Base>) => void
->{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => (Derived1 | Derived2)[]; }
->func : (n: Base[]) => (Derived1 | Derived2)[]
->n => { return [d1, d2]; } : (n: Base[]) => (Derived1 | Derived2)[]
+>{ func: n => { return [d1, d2]; } } : { func: (n: Base[]) => [Derived1, Derived2]; }
+>func : (n: Base[]) => [Derived1, Derived2]
+>n => { return [d1, d2]; } : (n: Base[]) => [Derived1, Derived2]
 >n : Base[]
->[d1, d2] : (Derived1 | Derived2)[]
+>[d1, d2] : [Derived1, Derived2]
 >d1 : Derived1
 >d2 : Derived2
 

--- a/tests/baselines/reference/implicitAnyCastedValue.types
+++ b/tests/baselines/reference/implicitAnyCastedValue.types
@@ -174,7 +174,7 @@ var bar3 = <any>0;
 var array = <any>[null, undefined];
 >array : any
 ><any>[null, undefined] : any
->[null, undefined] : null[]
+>[null, undefined] : [null, undefined]
 >null : null
 >undefined : undefined
 

--- a/tests/baselines/reference/implicitAnyFunctionInvocationWithAnyArguements.types
+++ b/tests/baselines/reference/implicitAnyFunctionInvocationWithAnyArguements.types
@@ -92,20 +92,20 @@ noError(null, []);
 >noError(null, []) : void
 >noError : (variable: any, array?: any) => void
 >null : null
->[] : undefined[]
+>[] : []
 
 noError(undefined, <any>[]);
 >noError(undefined, <any>[]) : void
 >noError : (variable: any, array?: any) => void
 >undefined : undefined
 ><any>[] : any
->[] : undefined[]
+>[] : []
 
 noError(null, [null, undefined]);
 >noError(null, [null, undefined]) : void
 >noError : (variable: any, array?: any) => void
 >null : null
->[null, undefined] : null[]
+>[null, undefined] : [null, undefined]
 >null : null
 >undefined : undefined
 
@@ -128,14 +128,14 @@ var newC = new C([], undefined);
 >newC : C
 >new C([], undefined) : C
 >C : typeof C
->[] : undefined[]
+>[] : []
 >undefined : undefined
 
 var newC1 = new C([], arg0);
 >newC1 : C
 >new C([], arg0) : C
 >C : typeof C
->[] : undefined[]
+>[] : []
 >arg0 : null
 
 var newC2 = new C(<any>[], null) 
@@ -143,6 +143,6 @@ var newC2 = new C(<any>[], null)
 >new C(<any>[], null) : C
 >C : typeof C
 ><any>[] : any
->[] : undefined[]
+>[] : []
 >null : null
 

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -65,8 +65,8 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(140,5): error
   'number' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'any'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(141,5): error TS2322: Type 'string' is not assignable to type 'T[K]'.
   'string' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'any'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(142,5): error TS2322: Type 'number[]' is not assignable to type 'T[K]'.
-  'number[]' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'any'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(142,5): error TS2322: Type '[number, number]' is not assignable to type 'T[K]'.
+  '[number, number]' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'any'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(165,5): error TS2322: Type 'number' is not assignable to type 'T[keyof T]'.
   'number' is assignable to the constraint of type 'T[keyof T]', but 'T[keyof T]' could be instantiated with a different subtype of constraint 'number'.
 
@@ -324,8 +324,8 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(165,5): error
 !!! error TS2322:   'string' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'any'.
         t[k] = [10, 20];  // Error
         ~~~~
-!!! error TS2322: Type 'number[]' is not assignable to type 'T[K]'.
-!!! error TS2322:   'number[]' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'any'.
+!!! error TS2322: Type '[number, number]' is not assignable to type 'T[K]'.
+!!! error TS2322:   '[number, number]' is assignable to the constraint of type 'T[K]', but 'T[K]' could be instantiated with a different subtype of constraint 'any'.
     }
     
     // Repro from #28839

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.types
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.types
@@ -456,11 +456,11 @@ function test1<T extends Record<string, any>, K extends keyof T>(t: T, k: K) {
 >"hello" : "hello"
 
     t[k] = [10, 20];  // Error
->t[k] = [10, 20] : number[]
+>t[k] = [10, 20] : [number, number]
 >t[k] : T[K]
 >t : T
 >k : K
->[10, 20] : number[]
+>[10, 20] : [number, number]
 >10 : 10
 >20 : 20
 }

--- a/tests/baselines/reference/literalTypes1.types
+++ b/tests/baselines/reference/literalTypes1.types
@@ -78,7 +78,7 @@ function f2(x: 0 | 1 | 2) {
 }
 
 type Falsy = false | 0 | "" | null | undefined;
->Falsy : false | "" | 0 | null | undefined
+>Falsy : false | 0 | "" | null | undefined
 >false : false
 >null : null
 

--- a/tests/baselines/reference/logicalAssignment2(target=es2015).types
+++ b/tests/baselines/reference/logicalAssignment2(target=es2015).types
@@ -7,13 +7,13 @@ interface A {
 >bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
 
             baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
         }
         baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
     }
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A
@@ -29,126 +29,126 @@ declare const c: A
 >c : A
 
 a.baz &&= result.baz
->a.baz &&= result.baz : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>a.baz &&= result.baz : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.baz ||= result.baz
->b.baz ||= result.baz : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>b.baz ||= result.baz : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.baz ??= result.baz
->c.baz ??= result.baz : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>c.baz ??= result.baz : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo["baz"] &&= result.foo.baz
->a.foo["baz"] &&= result.foo.baz : "" | 0 | 1 | 42 | undefined
->a.foo["baz"] : "" | 0 | 1 | 42 | undefined
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo["baz"] &&= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>a.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo["baz"] ||= result.foo.baz
->b.foo["baz"] ||= result.foo.baz : "" | 0 | 1 | 42 | undefined
->b.foo["baz"] : "" | 0 | 1 | 42 | undefined
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo["baz"] ||= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>b.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo["baz"] ??= result.foo.baz
->c.foo["baz"] ??= result.foo.baz : "" | 0 | 1 | 42 | undefined
->c.foo["baz"] : "" | 0 | 1 | 42 | undefined
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo["baz"] ??= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>c.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo.bar().baz &&= result.foo.bar().baz
->a.foo.bar().baz &&= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo.bar().baz &&= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo.bar().baz ||= result.foo.bar().baz
->b.foo.bar().baz ||= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo.bar().baz ||= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo.bar().baz ??= result.foo.bar().baz
->c.foo.bar().baz ??= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo.bar().baz ??= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/logicalAssignment2(target=es2020).types
+++ b/tests/baselines/reference/logicalAssignment2(target=es2020).types
@@ -7,13 +7,13 @@ interface A {
 >bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
 
             baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
         }
         baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
     }
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A
@@ -29,126 +29,126 @@ declare const c: A
 >c : A
 
 a.baz &&= result.baz
->a.baz &&= result.baz : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>a.baz &&= result.baz : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.baz ||= result.baz
->b.baz ||= result.baz : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>b.baz ||= result.baz : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.baz ??= result.baz
->c.baz ??= result.baz : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>c.baz ??= result.baz : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo["baz"] &&= result.foo.baz
->a.foo["baz"] &&= result.foo.baz : "" | 0 | 1 | 42 | undefined
->a.foo["baz"] : "" | 0 | 1 | 42 | undefined
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo["baz"] &&= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>a.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo["baz"] ||= result.foo.baz
->b.foo["baz"] ||= result.foo.baz : "" | 0 | 1 | 42 | undefined
->b.foo["baz"] : "" | 0 | 1 | 42 | undefined
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo["baz"] ||= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>b.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo["baz"] ??= result.foo.baz
->c.foo["baz"] ??= result.foo.baz : "" | 0 | 1 | 42 | undefined
->c.foo["baz"] : "" | 0 | 1 | 42 | undefined
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo["baz"] ??= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>c.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo.bar().baz &&= result.foo.bar().baz
->a.foo.bar().baz &&= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo.bar().baz &&= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo.bar().baz ||= result.foo.bar().baz
->b.foo.bar().baz ||= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo.bar().baz ||= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo.bar().baz ??= result.foo.bar().baz
->c.foo.bar().baz ??= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo.bar().baz ??= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/logicalAssignment2(target=es2021).types
+++ b/tests/baselines/reference/logicalAssignment2(target=es2021).types
@@ -7,13 +7,13 @@ interface A {
 >bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
 
             baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
         }
         baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
     }
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A
@@ -29,126 +29,126 @@ declare const c: A
 >c : A
 
 a.baz &&= result.baz
->a.baz &&= result.baz : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>a.baz &&= result.baz : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.baz ||= result.baz
->b.baz ||= result.baz : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>b.baz ||= result.baz : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.baz ??= result.baz
->c.baz ??= result.baz : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>c.baz ??= result.baz : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo["baz"] &&= result.foo.baz
->a.foo["baz"] &&= result.foo.baz : "" | 0 | 1 | 42 | undefined
->a.foo["baz"] : "" | 0 | 1 | 42 | undefined
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo["baz"] &&= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>a.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo["baz"] ||= result.foo.baz
->b.foo["baz"] ||= result.foo.baz : "" | 0 | 1 | 42 | undefined
->b.foo["baz"] : "" | 0 | 1 | 42 | undefined
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo["baz"] ||= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>b.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo["baz"] ??= result.foo.baz
->c.foo["baz"] ??= result.foo.baz : "" | 0 | 1 | 42 | undefined
->c.foo["baz"] : "" | 0 | 1 | 42 | undefined
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo["baz"] ??= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>c.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo.bar().baz &&= result.foo.bar().baz
->a.foo.bar().baz &&= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo.bar().baz &&= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo.bar().baz ||= result.foo.bar().baz
->b.foo.bar().baz ||= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo.bar().baz ||= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo.bar().baz ??= result.foo.bar().baz
->c.foo.bar().baz ??= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo.bar().baz ??= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/logicalAssignment2(target=esnext).types
+++ b/tests/baselines/reference/logicalAssignment2(target=esnext).types
@@ -7,13 +7,13 @@ interface A {
 >bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
 
             baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
         }
         baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
     }
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A
@@ -29,126 +29,126 @@ declare const c: A
 >c : A
 
 a.baz &&= result.baz
->a.baz &&= result.baz : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>a.baz &&= result.baz : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.baz ||= result.baz
->b.baz ||= result.baz : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>b.baz ||= result.baz : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.baz ??= result.baz
->c.baz ??= result.baz : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>c.baz ??= result.baz : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo["baz"] &&= result.foo.baz
->a.foo["baz"] &&= result.foo.baz : "" | 0 | 1 | 42 | undefined
->a.foo["baz"] : "" | 0 | 1 | 42 | undefined
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo["baz"] &&= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>a.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo["baz"] ||= result.foo.baz
->b.foo["baz"] ||= result.foo.baz : "" | 0 | 1 | 42 | undefined
->b.foo["baz"] : "" | 0 | 1 | 42 | undefined
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo["baz"] ||= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>b.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo["baz"] ??= result.foo.baz
->c.foo["baz"] ??= result.foo.baz : "" | 0 | 1 | 42 | undefined
->c.foo["baz"] : "" | 0 | 1 | 42 | undefined
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo["baz"] ??= result.foo.baz : 0 | "" | 1 | 42 | undefined
+>c.foo["baz"] : 0 | "" | 1 | 42 | undefined
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >"baz" : "baz"
->result.foo.baz : "" | 0 | 1 | 42 | undefined
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>result.foo.baz : 0 | "" | 1 | 42 | undefined
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 a.foo.bar().baz &&= result.foo.bar().baz
->a.foo.bar().baz &&= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->a.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->a.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>a.foo.bar().baz &&= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>a.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>a.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >a : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 b.foo.bar().baz ||= result.foo.bar().baz
->b.foo.bar().baz ||= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->b.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->b.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>b.foo.bar().baz ||= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>b.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>b.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >b : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 c.foo.bar().baz ??= result.foo.bar().baz
->c.foo.bar().baz ??= result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->c.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->c.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>c.foo.bar().baz ??= result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>c.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>c.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >c : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar().baz : "" | 0 | 1 | 42 | undefined
->result.foo.bar() : { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo.bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->result.foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar().baz : 0 | "" | 1 | 42 | undefined
+>result.foo.bar() : { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo.bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>result.foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
 >result : A
->foo : { bar(): { baz: "" | 0 | 1 | 42 | undefined; }; baz: "" | 0 | 1 | 42 | undefined; }
->bar : () => { baz: "" | 0 | 1 | 42 | undefined; }
->baz : "" | 0 | 1 | 42 | undefined
+>foo : { bar(): { baz: 0 | "" | 1 | 42 | undefined; }; baz: 0 | "" | 1 | 42 | undefined; }
+>bar : () => { baz: 0 | "" | 1 | 42 | undefined; }
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/logicalAssignment3(target=es2015).types
+++ b/tests/baselines/reference/logicalAssignment3(target=es2015).types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es2021/logicalAssignment/logicalAssignment3.ts ===
 interface A {
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A;
@@ -17,33 +17,33 @@ declare const c: A;
 >c : A
 
 (a.baz) &&= result.baz;
->(a.baz) &&= result.baz : "" | 0 | 1 | 42 | undefined
->(a.baz) : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>(a.baz) &&= result.baz : 0 | "" | 1 | 42 | undefined
+>(a.baz) : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (b.baz) ||= result.baz;
->(b.baz) ||= result.baz : "" | 0 | 1 | 42 | undefined
->(b.baz) : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>(b.baz) ||= result.baz : 0 | "" | 1 | 42 | undefined
+>(b.baz) : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (c.baz) ??= result.baz;
->(c.baz) ??= result.baz : "" | 0 | 1 | 42 | undefined
->(c.baz) : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>(c.baz) ??= result.baz : 0 | "" | 1 | 42 | undefined
+>(c.baz) : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/logicalAssignment3(target=es2020).types
+++ b/tests/baselines/reference/logicalAssignment3(target=es2020).types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es2021/logicalAssignment/logicalAssignment3.ts ===
 interface A {
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A;
@@ -17,33 +17,33 @@ declare const c: A;
 >c : A
 
 (a.baz) &&= result.baz;
->(a.baz) &&= result.baz : "" | 0 | 1 | 42 | undefined
->(a.baz) : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>(a.baz) &&= result.baz : 0 | "" | 1 | 42 | undefined
+>(a.baz) : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (b.baz) ||= result.baz;
->(b.baz) ||= result.baz : "" | 0 | 1 | 42 | undefined
->(b.baz) : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>(b.baz) ||= result.baz : 0 | "" | 1 | 42 | undefined
+>(b.baz) : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (c.baz) ??= result.baz;
->(c.baz) ??= result.baz : "" | 0 | 1 | 42 | undefined
->(c.baz) : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>(c.baz) ??= result.baz : 0 | "" | 1 | 42 | undefined
+>(c.baz) : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/logicalAssignment3(target=es2021).types
+++ b/tests/baselines/reference/logicalAssignment3(target=es2021).types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es2021/logicalAssignment/logicalAssignment3.ts ===
 interface A {
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A;
@@ -17,33 +17,33 @@ declare const c: A;
 >c : A
 
 (a.baz) &&= result.baz;
->(a.baz) &&= result.baz : "" | 0 | 1 | 42 | undefined
->(a.baz) : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>(a.baz) &&= result.baz : 0 | "" | 1 | 42 | undefined
+>(a.baz) : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (b.baz) ||= result.baz;
->(b.baz) ||= result.baz : "" | 0 | 1 | 42 | undefined
->(b.baz) : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>(b.baz) ||= result.baz : 0 | "" | 1 | 42 | undefined
+>(b.baz) : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (c.baz) ??= result.baz;
->(c.baz) ??= result.baz : "" | 0 | 1 | 42 | undefined
->(c.baz) : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>(c.baz) ??= result.baz : 0 | "" | 1 | 42 | undefined
+>(c.baz) : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/logicalAssignment3(target=esnext).types
+++ b/tests/baselines/reference/logicalAssignment3(target=esnext).types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es2021/logicalAssignment/logicalAssignment3.ts ===
 interface A {
     baz: 0 | 1 | 42 | undefined | ''
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 }
 
 declare const result: A;
@@ -17,33 +17,33 @@ declare const c: A;
 >c : A
 
 (a.baz) &&= result.baz;
->(a.baz) &&= result.baz : "" | 0 | 1 | 42 | undefined
->(a.baz) : "" | 0 | 1 | 42 | undefined
->a.baz : "" | 0 | 1 | 42 | undefined
+>(a.baz) &&= result.baz : 0 | "" | 1 | 42 | undefined
+>(a.baz) : 0 | "" | 1 | 42 | undefined
+>a.baz : 0 | "" | 1 | 42 | undefined
 >a : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (b.baz) ||= result.baz;
->(b.baz) ||= result.baz : "" | 0 | 1 | 42 | undefined
->(b.baz) : "" | 0 | 1 | 42 | undefined
->b.baz : "" | 0 | 1 | 42 | undefined
+>(b.baz) ||= result.baz : 0 | "" | 1 | 42 | undefined
+>(b.baz) : 0 | "" | 1 | 42 | undefined
+>b.baz : 0 | "" | 1 | 42 | undefined
 >b : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 (c.baz) ??= result.baz;
->(c.baz) ??= result.baz : "" | 0 | 1 | 42 | undefined
->(c.baz) : "" | 0 | 1 | 42 | undefined
->c.baz : "" | 0 | 1 | 42 | undefined
+>(c.baz) ??= result.baz : 0 | "" | 1 | 42 | undefined
+>(c.baz) : 0 | "" | 1 | 42 | undefined
+>c.baz : 0 | "" | 1 | 42 | undefined
 >c : A
->baz : "" | 0 | 1 | 42 | undefined
->result.baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
+>result.baz : 0 | "" | 1 | 42 | undefined
 >result : A
->baz : "" | 0 | 1 | 42 | undefined
+>baz : 0 | "" | 1 | 42 | undefined
 
 

--- a/tests/baselines/reference/narrowingUnionToUnion.types
+++ b/tests/baselines/reference/narrowingUnionToUnion.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/narrowingUnionToUnion.ts ===
 type Falsy = false | 0 | 0n | '' | null | undefined;
->Falsy : false | "" | 0 | 0n | null | undefined
+>Falsy : false | 0 | "" | 0n | null | undefined
 >false : false
 >null : null
 
@@ -18,7 +18,7 @@ function fx1(x: string | number | undefined) {
 >x : string | number | undefined
 
         x;  // "" | 0 | undefined
->x : "" | 0 | undefined
+>x : 0 | "" | undefined
     }
 }
 
@@ -32,7 +32,7 @@ function fx2<T>(x: T | undefined) {
 >x : T | undefined
 
         x;  // T & Falsy | undefined
->x : (T & null) | (T & false) | (T & "") | (T & 0) | (T & 0n) | undefined
+>x : (T & null) | (T & false) | (T & 0) | (T & "") | (T & 0n) | undefined
     }
 }
 
@@ -46,7 +46,7 @@ function fx3<T extends string | number>(x: T) {
 >x : string | number
 
         x;  // T & "" | T & 0
->x : (T & "") | (T & 0)
+>x : (T & 0) | (T & "")
     }
 }
 

--- a/tests/baselines/reference/newLexicalEnvironmentForConvertedLoop.types
+++ b/tests/baselines/reference/newLexicalEnvironmentForConvertedLoop.types
@@ -25,7 +25,7 @@ function foo(set: any) {
 
     const bar: any = [];
 >bar : any
->[] : undefined[]
+>[] : []
 
     (() => bar);
 >(() => bar) : () => any

--- a/tests/baselines/reference/nullishCoalescingOperator11.types
+++ b/tests/baselines/reference/nullishCoalescingOperator11.types
@@ -1,12 +1,12 @@
 === tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator11.ts ===
 declare const f11: 1 | 0 | '' | null | undefined;
->f11 : "" | 0 | 1 | null | undefined
+>f11 : 0 | "" | 1 | null | undefined
 >null : null
 
 let g11 = f11 ?? f11.toFixed()
 >g11 : any
 >f11 ?? f11.toFixed() : any
->f11 : "" | 0 | 1 | null | undefined
+>f11 : 0 | "" | 1 | null | undefined
 >f11.toFixed() : any
 >f11.toFixed : any
 >f11 : null | undefined

--- a/tests/baselines/reference/nullishCoalescingOperator3.types
+++ b/tests/baselines/reference/nullishCoalescingOperator3.types
@@ -27,11 +27,11 @@ declare const a6: false | undefined | null
 
 
 const aa1 = a1 ?? a2 ?? a3 ?? a4 ?? a5 ?? a6 ?? 'whatever'
->aa1 : boolean | "" | 0 | "literal" | 1 | "whatever"
->a1 ?? a2 ?? a3 ?? a4 ?? a5 ?? a6 ?? 'whatever' : boolean | "" | 0 | "literal" | 1 | "whatever"
->a1 ?? a2 ?? a3 ?? a4 ?? a5 ?? a6 : boolean | "" | 0 | "literal" | 1 | null | undefined
->a1 ?? a2 ?? a3 ?? a4 ?? a5 : true | "" | 0 | "literal" | 1 | null | undefined
->a1 ?? a2 ?? a3 ?? a4 : "" | 0 | "literal" | 1 | null | undefined
+>aa1 : boolean | 0 | "" | "literal" | 1 | "whatever"
+>a1 ?? a2 ?? a3 ?? a4 ?? a5 ?? a6 ?? 'whatever' : boolean | 0 | "" | "literal" | 1 | "whatever"
+>a1 ?? a2 ?? a3 ?? a4 ?? a5 ?? a6 : boolean | 0 | "" | "literal" | 1 | null | undefined
+>a1 ?? a2 ?? a3 ?? a4 ?? a5 : true | 0 | "" | "literal" | 1 | null | undefined
+>a1 ?? a2 ?? a3 ?? a4 : 0 | "" | "literal" | 1 | null | undefined
 >a1 ?? a2 ?? a3 : "" | "literal" | 1 | null | undefined
 >a1 ?? a2 : "" | "literal" | null | undefined
 >a1 : "literal" | null | undefined

--- a/tests/baselines/reference/parser0_004152.types
+++ b/tests/baselines/reference/parser0_004152.types
@@ -6,7 +6,7 @@ export class Game {
 >position : any
 >new DisplayPosition([) : any
 >DisplayPosition : any
->[ : undefined[]
+>[ : []
 >3 : any
 >3 : any
 >3 : any

--- a/tests/baselines/reference/parserForStatement2.types
+++ b/tests/baselines/reference/parserForStatement2.types
@@ -20,7 +20,7 @@ for (a in b[c] = b[c] || [], d) {
 >b[c] : any
 >b : any[]
 >c : any
->[] : undefined[]
+>[] : []
 >d : any
 
 }

--- a/tests/baselines/reference/parserForStatement3.types
+++ b/tests/baselines/reference/parserForStatement3.types
@@ -14,6 +14,6 @@ for(d in _.jh[a]=_.jh[a]||[],b);
 >_ : any
 >jh : any
 >a : any
->[] : undefined[]
+>[] : []
 >b : any
 

--- a/tests/baselines/reference/parserRealSource7.types
+++ b/tests/baselines/reference/parserRealSource7.types
@@ -258,11 +258,11 @@ module TypeScript {
 >instanceType : any
 
         signature.parameters = [];
->signature.parameters = [] : undefined[]
+>signature.parameters = [] : []
 >signature.parameters : any
 >signature : any
 >parameters : any
->[] : undefined[]
+>[] : []
 
         type.construct = new SignatureGroup();
 >type.construct = new SignatureGroup() : any

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -1764,11 +1764,11 @@ module Harness {
 
                 // Clear out bug descriptions
                 assert.bugIds = [];
->assert.bugIds = [] : undefined[]
+>assert.bugIds = [] : []
 >assert.bugIds : any
 >assert : Harness.Assert
 >bugIds : any
->[] : undefined[]
+>[] : []
 
                 async = this.runChild(index, <any>function (e) {
 >async = this.runChild(index, <any>function (e) {                    if (async) {                        that.runChildren(index + 1);                    }                }) : boolean
@@ -7714,7 +7714,7 @@ module Harness {
             // List of names that get overriden by various test code we eval
             var dangerNames: any = ['Array'];
 >dangerNames : any
->['Array'] : string[]
+>['Array'] : [string]
 >'Array' : "Array"
 
             var globalBackup: any = {};

--- a/tests/baselines/reference/reachabilityChecks4.types
+++ b/tests/baselines/reference/reachabilityChecks4.types
@@ -104,25 +104,25 @@ function f2(transition: Transition): any {
 >'LEFT' : "LEFT"
 
                     return []
->[] : undefined[]
+>[] : []
 
                 case 'RIGHT':
 >'RIGHT' : "RIGHT"
 
                     return []
->[] : undefined[]
+>[] : []
 
                 case 'TOP':
 >'TOP' : "TOP"
 
                     return []
->[] : undefined[]
+>[] : []
 
                 case 'BOTTOM':
 >'BOTTOM' : "BOTTOM"
 
                     return []
->[] : undefined[]
+>[] : []
             }
         case 'SLIDE_OUT':
 >'SLIDE_OUT' : "SLIDE_OUT"
@@ -136,25 +136,25 @@ function f2(transition: Transition): any {
 >'LEFT' : "LEFT"
 
                     return []
->[] : undefined[]
+>[] : []
 
                 case 'RIGHT':
 >'RIGHT' : "RIGHT"
 
                     return []
->[] : undefined[]
+>[] : []
 
                 case 'TOP':
 >'TOP' : "TOP"
 
                     return []
->[] : undefined[]
+>[] : []
 
                 case 'BOTTOM':
 >'BOTTOM' : "BOTTOM"
 
                     return []
->[] : undefined[]
+>[] : []
             }
     }
 }

--- a/tests/baselines/reference/recursiveTypeReferences1.types
+++ b/tests/baselines/reference/recursiveTypeReferences1.types
@@ -437,7 +437,7 @@ function parse(node: Tree, index: number[] = []): HTMLUListElement {
 >html('li', [      html('a', { href: `#${el.id}`, rel: 'noopener', 'data-index': idx.join('.') }, el.textContent!),      children.length > 0 ? parse(children, idx) : frag()    ]) : any
 >html : any
 >'li' : "li"
->[      html('a', { href: `#${el.id}`, rel: 'noopener', 'data-index': idx.join('.') }, el.textContent!),      children.length > 0 ? parse(children, idx) : frag()    ] : any[]
+>[      html('a', { href: `#${el.id}`, rel: 'noopener', 'data-index': idx.join('.') }, el.textContent!),      children.length > 0 ? parse(children, idx) : frag()    ] : [any, any]
 
       html('a', { href: `#${el.id}`, rel: 'noopener', 'data-index': idx.join('.') }, el.textContent!),
 >html('a', { href: `#${el.id}`, rel: 'noopener', 'data-index': idx.join('.') }, el.textContent!) : any
@@ -527,18 +527,18 @@ function cons(hs: HTMLHeadingElement[]): Tree {
 >concat(hss, [concat(hs, [h])]) : any
 >concat : any
 >hss : HTMLHeadingElement[][]
->[concat(hs, [h])] : any[]
+>[concat(hs, [h])] : [any]
 >concat(hs, [h]) : any
 >concat : any
 >hs : HTMLHeadingElement[]
->[h] : HTMLHeadingElement[]
+>[h] : [HTMLHeadingElement]
 >h : HTMLHeadingElement
 
         : concat(hss, [hs, [h]]);
 >concat(hss, [hs, [h]]) : any
 >concat : any
 >hss : HTMLHeadingElement[][]
->[hs, [h]] : HTMLHeadingElement[][]
+>[hs, [h]] : [HTMLHeadingElement[], HTMLHeadingElement[]]
 >hs : HTMLHeadingElement[]
 >[h] : HTMLHeadingElement[]
 >h : HTMLHeadingElement
@@ -568,7 +568,7 @@ function cons(hs: HTMLHeadingElement[]): Tree {
 >concat<Tree[number]>(node, [[hs.shift()!, cons(hs)]]) : any
 >concat : any
 >node : Tree
->[[hs.shift()!, cons(hs)]] : (HTMLHeadingElement | Tree)[][]
+>[[hs.shift()!, cons(hs)]] : [(HTMLHeadingElement | Tree)[]]
 >[hs.shift()!, cons(hs)] : (HTMLHeadingElement | Tree)[]
 >hs.shift()! : HTMLHeadingElement
 >hs.shift() : HTMLHeadingElement | undefined

--- a/tests/baselines/reference/returnTypeParameterWithModules.types
+++ b/tests/baselines/reference/returnTypeParameterWithModules.types
@@ -18,12 +18,12 @@ module M1 {
 >reduce : { (callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: any[]) => any): any; (callbackfn: (previousValue: any, currentValue: any, currentIndex: number, array: any[]) => any, initialValue: any): any; <U>(callbackfn: (previousValue: U, currentValue: any, currentIndex: number, array: any[]) => U, initialValue: U): U; }
 >apply : (this: Function, thisArg: any, argArray?: any) => any
 >ar : any
->e ? [f, e] : [f] : any[]
+>e ? [f, e] : [f] : [any, any] | [any]
 >e : any
->[f, e] : any[]
+>[f, e] : [any, any]
 >f : any
 >e : any
->[f] : any[]
+>[f] : [any]
 >f : any
 
     };

--- a/tests/baselines/reference/sourceMapValidationDestructuringForArrayBindingPattern.types
+++ b/tests/baselines/reference/sourceMapValidationDestructuringForArrayBindingPattern.types
@@ -273,9 +273,9 @@ for (let [nameB] = getMultiRobot(), i = 0; i < 1; i++) {
 }
 for (let [nameB] = ["trimmer", ["trimming", "edging"]], i = 0; i < 1; i++) {
 >nameB : string
->["trimmer", ["trimming", "edging"]] : [string, string[]]
+>["trimmer", ["trimming", "edging"]] : [string, [string, string]]
 >"trimmer" : "trimmer"
->["trimming", "edging"] : string[]
+>["trimming", "edging"] : [string, string]
 >"trimming" : "trimming"
 >"edging" : "edging"
 >i : number
@@ -523,10 +523,10 @@ for (let [...multiRobotAInfo] = getMultiRobot(), i = 0; i < 1; i++) {
 >multiRobotAInfo : [string, [string, string]]
 }
 for (let [...multiRobotAInfo] = ["trimmer", ["trimming", "edging"]], i = 0; i < 1; i++) {
->multiRobotAInfo : (string | string[])[]
->["trimmer", ["trimming", "edging"]] : (string | string[])[]
+>multiRobotAInfo : (string | [string, string])[]
+>["trimmer", ["trimming", "edging"]] : (string | [string, string])[]
 >"trimmer" : "trimmer"
->["trimming", "edging"] : string[]
+>["trimming", "edging"] : [string, string]
 >"trimming" : "trimming"
 >"edging" : "edging"
 >i : number
@@ -542,5 +542,5 @@ for (let [...multiRobotAInfo] = ["trimmer", ["trimming", "edging"]], i = 0; i < 
 >console.log : (msg: any) => void
 >console : { log(msg: any): void; }
 >log : (msg: any) => void
->multiRobotAInfo : (string | string[])[]
+>multiRobotAInfo : (string | [string, string])[]
 }

--- a/tests/baselines/reference/sourceMapValidationDestructuringVariableStatementArrayBindingPattern2.types
+++ b/tests/baselines/reference/sourceMapValidationDestructuringVariableStatementArrayBindingPattern2.types
@@ -42,9 +42,9 @@ let [nameMA, [primarySkillA, secondarySkillA]] = multiRobotA;
 
 let [nameMC] = ["roomba", ["vacuum", "mopping"]];
 >nameMC : string
->["roomba", ["vacuum", "mopping"]] : [string, string[]]
+>["roomba", ["vacuum", "mopping"]] : [string, [string, string]]
 >"roomba" : "roomba"
->["vacuum", "mopping"] : string[]
+>["vacuum", "mopping"] : [string, string]
 >"vacuum" : "vacuum"
 >"mopping" : "mopping"
 

--- a/tests/baselines/reference/trailingCommasInBindingPatterns.types
+++ b/tests/baselines/reference/trailingCommasInBindingPatterns.types
@@ -30,7 +30,7 @@ let c, d;
 const [e,] = <any>[];
 >e : any
 ><any>[] : any
->[] : undefined[]
+>[] : []
 
 const {f,} = <any>{};
 >f : any
@@ -47,7 +47,7 @@ let g, h;
 >[g,] : [any]
 >g : any
 ><any>[] : any
->[] : undefined[]
+>[] : []
 
 ({h,} = <any>{});
 >({h,} = <any>{}) : any

--- a/tests/baselines/reference/truthinessCallExpressionCoercion2.types
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion2.types
@@ -130,7 +130,7 @@ function test(required1: () => boolean, required2: () => boolean, b: boolean, op
 >f : () => void
 >apply : (this: Function, thisArg: any, argArray?: any) => any
 >parent : Window
->[] : never[]
+>[] : []
 
     // error
     required1 && required2 && required1() && console.log('foo');

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -271,12 +271,12 @@ _.invoke([[5, 1, 7], [3, 2, 1]], 'sort');
 >_.invoke : { (list: any[], methodName: string, ...args: any[]): any[]; (list: Dictionary<any>, methodName: string, ...args: any[]): any[]; }
 >_ : Underscore.Static
 >invoke : { (list: any[], methodName: string, ...args: any[]): any[]; (list: Dictionary<any>, methodName: string, ...args: any[]): any[]; }
->[[5, 1, 7], [3, 2, 1]] : number[][]
->[5, 1, 7] : number[]
+>[[5, 1, 7], [3, 2, 1]] : [number, number, number][]
+>[5, 1, 7] : [number, number, number]
 >5 : 5
 >1 : 1
 >7 : 7
->[3, 2, 1] : number[]
+>[3, 2, 1] : [number, number, number]
 >3 : 3
 >2 : 2
 >1 : 1
@@ -536,9 +536,9 @@ _.flatten([1, [2]]);
 >_.flatten : { <T>(list: T[][]): T[]; <T>(array: any[], shallow?: boolean): T[]; }
 >_ : Underscore.Static
 >flatten : { <T>(list: T[][]): T[]; <T>(array: any[], shallow?: boolean): T[]; }
->[1, [2]] : (number | number[])[]
+>[1, [2]] : (number | [number])[]
 >1 : 1
->[2] : number[]
+>[2] : [number]
 >2 : 2
 
 // typescript doesn't like the elements being different
@@ -547,11 +547,11 @@ _.flatten([1, [2], [3, [[4]]]]);
 >_.flatten : { <T>(list: T[][]): T[]; <T>(array: any[], shallow?: boolean): T[]; }
 >_ : Underscore.Static
 >flatten : { <T>(list: T[][]): T[]; <T>(array: any[], shallow?: boolean): T[]; }
->[1, [2], [3, [[4]]]] : (number | (number | number[][])[])[]
+>[1, [2], [3, [[4]]]] : (number | [number] | [number, number[][]])[]
 >1 : 1
->[2] : number[]
+>[2] : [number]
 >2 : 2
->[3, [[4]]] : (number | number[][])[]
+>[3, [[4]]] : [number, number[][]]
 >3 : 3
 >[[4]] : number[][]
 >[4] : number[]
@@ -562,11 +562,11 @@ _.flatten([1, [2], [3, [[4]]]], true);
 >_.flatten : { <T>(list: T[][]): T[]; <T>(array: any[], shallow?: boolean): T[]; }
 >_ : Underscore.Static
 >flatten : { <T>(list: T[][]): T[]; <T>(array: any[], shallow?: boolean): T[]; }
->[1, [2], [3, [[4]]]] : (number | (number | number[][])[])[]
+>[1, [2], [3, [[4]]]] : (number | [number] | [number, number[][]])[]
 >1 : 1
->[2] : number[]
+>[2] : [number]
 >2 : 2
->[3, [[4]]] : (number | number[][])[]
+>[3, [[4]]] : [number, number[][]]
 >3 : 3
 >[[4]] : number[][]
 >[4] : number[]
@@ -1321,7 +1321,7 @@ _.isEmpty([1, 2, 3]);
 >_.isEmpty : (object: any) => boolean
 >_ : Underscore.Static
 >isEmpty : (object: any) => boolean
->[1, 2, 3] : number[]
+>[1, 2, 3] : [number, number, number]
 >1 : 1
 >2 : 2
 >3 : 3
@@ -1359,7 +1359,7 @@ _.isArray([1, 2, 3]);
 >_.isArray : (object: any) => boolean
 >_ : Underscore.Static
 >isArray : (object: any) => boolean
->[1, 2, 3] : number[]
+>[1, 2, 3] : [number, number, number]
 >1 : 1
 >2 : 2
 >3 : 3
@@ -1385,7 +1385,7 @@ _.isArguments([1, 2, 3]);
 >_.isArguments : (object: any) => boolean
 >_ : Underscore.Static
 >isArguments : (object: any) => boolean
->[1, 2, 3] : number[]
+>[1, 2, 3] : [number, number, number]
 >1 : 1
 >2 : 2
 >3 : 3

--- a/tests/baselines/reference/unionOfClassCalls.types
+++ b/tests/baselines/reference/unionOfClassCalls.types
@@ -77,7 +77,7 @@ arr.reduce((acc: Array<string>, a: number | string, index: number) => {
 >[] : never[]
 
 }, [])
->[] : never[]
+>[] : []
 
 arr.forEach((a: number | string, index: number) => { 
 >arr.forEach((a: number | string, index: number) => {     return index}) : void

--- a/tests/cases/fourslash/codeFixUndeclaredAcrossFiles1.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredAcrossFiles1.ts
@@ -31,7 +31,7 @@ verify.rangeIs(`
         throw new Error("Method not implemented.");
     }
     static x: any;
-    static m0(arg0: number, arg1: string, arg2: undefined[]) {
+    static m0(arg0: number, arg1: string, arg2: unknown) {
         throw new Error("Method not implemented.");
     }
 `);


### PR DESCRIPTION
I want to export this in #52467 but it doesn't work when you write:

```ts
type EmptyTuple = []

interface MyEmptyTuple extends EmptyTuple {
	extraInfo: any;
}
```

Because `isTupleLikeType` determines tuple-ness by checking for a property named `0` which won't exist on an empty tuple.

I don't think this is the final code but I want to see what this breaks. It seems like there's a lot of code which depends on empty tuples _not_ being handled, and I don't know how much that matters.