### PR TITLE
Fix crash when looking for `__esModule` during symbol table merging

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3882,7 +3882,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function resolveExportByName(moduleSymbol: Symbol, name: __String, sourceNode: TypeOnlyCompatibleAliasDeclaration | undefined, dontResolveAlias: boolean) {
         const exportValue = moduleSymbol.exports!.get(InternalSymbolName.ExportEquals);
-        const exportSymbol = exportValue ? getPropertyOfType(getTypeOfSymbol(exportValue), name) : moduleSymbol.exports!.get(name);
+        const exportSymbol = exportValue
+            ? getPropertyOfType(getTypeOfSymbol(exportValue), name, /*skipObjectFunctionPropertyAugment*/ true)
+            : moduleSymbol.exports!.get(name);
         const resolved = resolveSymbol(exportSymbol, dontResolveAlias);
         markSymbolOfAliasDeclarationIfTypeOnly(sourceNode, exportSymbol, resolved, /*overwriteEmpty*/ false);
         return resolved;

--- a/tests/baselines/reference/crashDeclareGlobalTypeofExport.symbols
+++ b/tests/baselines/reference/crashDeclareGlobalTypeofExport.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/bar.d.ts ===
+import * as foo from './foo'
+>foo : Symbol(foo, Decl(bar.d.ts, 0, 6))
+
+export as namespace foo
+>foo : Symbol(foo, Decl(bar.d.ts, 0, 28))
+
+export = foo;
+>foo : Symbol(foo, Decl(bar.d.ts, 0, 6))
+
+declare global {
+>global : Symbol(global, Decl(bar.d.ts, 2, 13))
+
+    const foo: typeof foo;
+>foo : Symbol(foo, Decl(foo.d.ts, 7, 13), Decl(bar.d.ts, 5, 9))
+>foo : Symbol(foo, Decl(foo.d.ts, 7, 13), Decl(bar.d.ts, 5, 9))
+}
+
+=== tests/cases/compiler/foo.d.ts ===
+interface Root {
+>Root : Symbol(Root, Decl(foo.d.ts, 0, 0))
+
+    /**
+     * A .default property for ES6 default import compatibility
+     */
+    default: Root;
+>default : Symbol(Root.default, Decl(foo.d.ts, 0, 16))
+>Root : Symbol(Root, Decl(foo.d.ts, 0, 0))
+}
+
+declare const root: Root;
+>root : Symbol(root, Decl(foo.d.ts, 7, 13))
+>Root : Symbol(Root, Decl(foo.d.ts, 0, 0))
+
+export = root;
+>root : Symbol(root, Decl(foo.d.ts, 7, 13))
+

--- a/tests/baselines/reference/crashDeclareGlobalTypeofExport.types
+++ b/tests/baselines/reference/crashDeclareGlobalTypeofExport.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/bar.d.ts ===
+import * as foo from './foo'
+>foo : { default: Root; }
+
+export as namespace foo
+>foo : { default: Root; }
+
+export = foo;
+>foo : { default: Root; }
+
+declare global {
+>global : typeof global
+
+    const foo: typeof foo;
+>foo : Root
+>foo : Root
+}
+
+=== tests/cases/compiler/foo.d.ts ===
+interface Root {
+    /**
+     * A .default property for ES6 default import compatibility
+     */
+    default: Root;
+>default : Root
+}
+
+declare const root: Root;
+>root : Root
+
+export = root;
+>root : Root
+

--- a/tests/cases/compiler/crashDeclareGlobalTypeofExport.ts
+++ b/tests/cases/compiler/crashDeclareGlobalTypeofExport.ts
@@ -1,0 +1,21 @@
+// @esModuleInterop: true
+
+// @Filename: bar.d.ts
+import * as foo from './foo'
+export as namespace foo
+export = foo;
+
+declare global {
+    const foo: typeof foo;
+}
+
+// @Filename: foo.d.ts
+interface Root {
+    /**
+     * A .default property for ES6 default import compatibility
+     */
+    default: Root;
+}
+
+declare const root: Root;
+export = root;

--- a/tests/cases/fourslash/codefixCrashExportGlobal.ts
+++ b/tests/cases/fourslash/codefixCrashExportGlobal.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: bar.ts
+//// import * as foo from './foo'
+//// export as namespace foo
+//// export = foo;
+//// 
+//// declare global {
+////     const foo: typeof foo;
+//// }
+
+// @Filename: foo.d.ts
+//// interface Root {
+////     /**
+////      * A .default property for ES6 default import compatibility
+////      */
+////     default: Root;
+//// }
+//// 
+//// declare const root: Root;
+//// export = root;
+
+goTo.file("bar.ts");
+verify.not.codeFixAvailable();
+goTo.file("foo.d.ts");
+verify.not.codeFixAvailable();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #48701

This is just more of #37964, but for our own lookups of `__esModule`. This function is literally only called with `"__esModule"` and `InternalSymbolName.Default`, so I can guarantee it doesn’t need to look at the global object type for those.
