### PR TITLE
Fix false verbatimModuleSyntax error on `export namespace` in ESM

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -43326,7 +43326,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 if (compilerOptions.verbatimModuleSyntax &&
                     node.parent.kind === SyntaxKind.SourceFile &&
-                    (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
+                    (moduleKind === ModuleKind.CommonJS || node.parent.impliedNodeFormat === ModuleKind.CommonJS)
                 ) {
                     const exportModifier = node.modifiers?.find(m => m.kind === SyntaxKind.ExportKeyword);
                     if (exportModifier) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -43324,7 +43324,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         getNodeLinks(node).flags |= NodeCheckFlags.LexicalModuleMergesWithClass;
                     }
                 }
-                if (compilerOptions.verbatimModuleSyntax && node.parent.kind === SyntaxKind.SourceFile) {
+                if (compilerOptions.verbatimModuleSyntax &&
+                    node.parent.kind === SyntaxKind.SourceFile &&
+                    (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
+                ) {
                     const exportModifier = node.modifiers?.find(m => m.kind === SyntaxKind.ExportKeyword);
                     if (exportModifier) {
                         error(exportModifier, Diagnostics.A_top_level_export_modifier_cannot_be_used_on_value_declarations_in_a_CommonJS_module_when_verbatimModuleSyntax_is_enabled);

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).errors.txt
@@ -2,17 +2,6 @@
 /main.ts(3,8): error TS1259: Module '"/decl"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
 
 
-==== /main.ts (2 errors) ====
-    import CJSy = require("./decl"); // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
-    import type CJSy2 = require("./decl"); // ok I guess?
-    import CJSy3 from "./decl"; // ok in esModuleInterop
-           ~~~~~
-!!! error TS1259: Module '"/decl"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
-!!! related TS2594 /decl.d.ts:2:1: This module is declared with 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
-    import * as types from "./types"; // ok
-    CJSy;
 ==== /decl.d.ts (0 errors) ====
     declare class CJSy {}
     export = CJSy;
@@ -26,4 +15,21 @@
 ==== /types.ts (0 errors) ====
     interface Typey {}
     export type { Typey };
+    
+==== /main.ts (2 errors) ====
+    import CJSy = require("./decl"); // error
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    import type CJSy2 = require("./decl"); // ok I guess?
+    import CJSy3 from "./decl"; // ok in esModuleInterop
+           ~~~~~
+!!! error TS1259: Module '"/decl"' can only be default-imported using the 'allowSyntheticDefaultImports' flag
+!!! related TS2594 /decl.d.ts:2:1: This module is declared with 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
+    import * as types from "./types"; // ok
+    CJSy;
+    
+==== /ns.ts (0 errors) ====
+    export namespace ns {
+        export enum A {}
+    }
     

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).js
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).js
@@ -21,9 +21,22 @@ import CJSy3 from "./decl"; // ok in esModuleInterop
 import * as types from "./types"; // ok
 CJSy;
 
+//// [ns.ts]
+export namespace ns {
+    export enum A {}
+}
+
+
 //// [types.js]
 export {};
 //// [main.js]
 import CJSy3 from "./decl"; // ok in esModuleInterop
 import * as types from "./types"; // ok
 CJSy;
+//// [ns.js]
+export var ns;
+(function (ns) {
+    let A;
+    (function (A) {
+    })(A = ns.A || (ns.A = {}));
+})(ns || (ns = {}));

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).symbols
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).symbols
@@ -1,3 +1,28 @@
+=== /decl.d.ts ===
+declare class CJSy {}
+>CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
+
+export = CJSy;
+>CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
+
+=== /ambient.d.ts ===
+declare module "ambient" {
+>"ambient" : Symbol("ambient", Decl(ambient.d.ts, 0, 0))
+
+    const _export: number;
+>_export : Symbol(_export, Decl(ambient.d.ts, 1, 9))
+
+    export = _export;
+>_export : Symbol(_export, Decl(ambient.d.ts, 1, 9))
+}
+
+=== /types.ts ===
+interface Typey {}
+>Typey : Symbol(Typey, Decl(types.ts, 0, 0))
+
+export type { Typey };
+>Typey : Symbol(Typey, Decl(types.ts, 1, 13))
+
 === /main.ts ===
 import CJSy = require("./decl"); // error
 >CJSy : Symbol(CJSy, Decl(main.ts, 0, 0))
@@ -14,17 +39,11 @@ import * as types from "./types"; // ok
 CJSy;
 >CJSy : Symbol(CJSy, Decl(main.ts, 0, 0))
 
-=== /decl.d.ts ===
-declare class CJSy {}
->CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
+=== /ns.ts ===
+export namespace ns {
+>ns : Symbol(ns, Decl(ns.ts, 0, 0))
 
-export = CJSy;
->CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
-
-=== /types.ts ===
-interface Typey {}
->Typey : Symbol(Typey, Decl(types.ts, 0, 0))
-
-export type { Typey };
->Typey : Symbol(Typey, Decl(types.ts, 1, 13))
+    export enum A {}
+>A : Symbol(A, Decl(ns.ts, 0, 21))
+}
 

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).types
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=false).types
@@ -1,3 +1,26 @@
+=== /decl.d.ts ===
+declare class CJSy {}
+>CJSy : CJSy
+
+export = CJSy;
+>CJSy : CJSy
+
+=== /ambient.d.ts ===
+declare module "ambient" {
+>"ambient" : typeof import("ambient")
+
+    const _export: number;
+>_export : number
+
+    export = _export;
+>_export : number
+}
+
+=== /types.ts ===
+interface Typey {}
+export type { Typey };
+>Typey : Typey
+
 === /main.ts ===
 import CJSy = require("./decl"); // error
 >CJSy : typeof CJSy
@@ -14,15 +37,11 @@ import * as types from "./types"; // ok
 CJSy;
 >CJSy : typeof CJSy
 
-=== /decl.d.ts ===
-declare class CJSy {}
->CJSy : CJSy
+=== /ns.ts ===
+export namespace ns {
+>ns : typeof ns
 
-export = CJSy;
->CJSy : CJSy
-
-=== /types.ts ===
-interface Typey {}
-export type { Typey };
->Typey : Typey
+    export enum A {}
+>A : A
+}
 

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).errors.txt
@@ -1,14 +1,6 @@
 /main.ts(1,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
 
 
-==== /main.ts (1 errors) ====
-    import CJSy = require("./decl"); // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
-    import type CJSy2 = require("./decl"); // ok I guess?
-    import CJSy3 from "./decl"; // ok in esModuleInterop
-    import * as types from "./types"; // ok
-    CJSy;
 ==== /decl.d.ts (0 errors) ====
     declare class CJSy {}
     export = CJSy;
@@ -22,4 +14,18 @@
 ==== /types.ts (0 errors) ====
     interface Typey {}
     export type { Typey };
+    
+==== /main.ts (1 errors) ====
+    import CJSy = require("./decl"); // error
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
+    import type CJSy2 = require("./decl"); // ok I guess?
+    import CJSy3 from "./decl"; // ok in esModuleInterop
+    import * as types from "./types"; // ok
+    CJSy;
+    
+==== /ns.ts (0 errors) ====
+    export namespace ns {
+        export enum A {}
+    }
     

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).js
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).js
@@ -21,9 +21,22 @@ import CJSy3 from "./decl"; // ok in esModuleInterop
 import * as types from "./types"; // ok
 CJSy;
 
+//// [ns.ts]
+export namespace ns {
+    export enum A {}
+}
+
+
 //// [types.js]
 export {};
 //// [main.js]
 import CJSy3 from "./decl"; // ok in esModuleInterop
 import * as types from "./types"; // ok
 CJSy;
+//// [ns.js]
+export var ns;
+(function (ns) {
+    let A;
+    (function (A) {
+    })(A = ns.A || (ns.A = {}));
+})(ns || (ns = {}));

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).symbols
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).symbols
@@ -1,3 +1,28 @@
+=== /decl.d.ts ===
+declare class CJSy {}
+>CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
+
+export = CJSy;
+>CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
+
+=== /ambient.d.ts ===
+declare module "ambient" {
+>"ambient" : Symbol("ambient", Decl(ambient.d.ts, 0, 0))
+
+    const _export: number;
+>_export : Symbol(_export, Decl(ambient.d.ts, 1, 9))
+
+    export = _export;
+>_export : Symbol(_export, Decl(ambient.d.ts, 1, 9))
+}
+
+=== /types.ts ===
+interface Typey {}
+>Typey : Symbol(Typey, Decl(types.ts, 0, 0))
+
+export type { Typey };
+>Typey : Symbol(Typey, Decl(types.ts, 1, 13))
+
 === /main.ts ===
 import CJSy = require("./decl"); // error
 >CJSy : Symbol(CJSy, Decl(main.ts, 0, 0))
@@ -14,17 +39,11 @@ import * as types from "./types"; // ok
 CJSy;
 >CJSy : Symbol(CJSy, Decl(main.ts, 0, 0))
 
-=== /decl.d.ts ===
-declare class CJSy {}
->CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
+=== /ns.ts ===
+export namespace ns {
+>ns : Symbol(ns, Decl(ns.ts, 0, 0))
 
-export = CJSy;
->CJSy : Symbol(CJSy, Decl(decl.d.ts, 0, 0))
-
-=== /types.ts ===
-interface Typey {}
->Typey : Symbol(Typey, Decl(types.ts, 0, 0))
-
-export type { Typey };
->Typey : Symbol(Typey, Decl(types.ts, 1, 13))
+    export enum A {}
+>A : Symbol(A, Decl(ns.ts, 0, 21))
+}
 

--- a/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).types
+++ b/tests/baselines/reference/verbatimModuleSyntaxRestrictionsESM(esmoduleinterop=true).types
@@ -1,3 +1,26 @@
+=== /decl.d.ts ===
+declare class CJSy {}
+>CJSy : CJSy
+
+export = CJSy;
+>CJSy : CJSy
+
+=== /ambient.d.ts ===
+declare module "ambient" {
+>"ambient" : typeof import("ambient")
+
+    const _export: number;
+>_export : number
+
+    export = _export;
+>_export : number
+}
+
+=== /types.ts ===
+interface Typey {}
+export type { Typey };
+>Typey : Typey
+
 === /main.ts ===
 import CJSy = require("./decl"); // error
 >CJSy : typeof CJSy
@@ -14,15 +37,11 @@ import * as types from "./types"; // ok
 CJSy;
 >CJSy : typeof CJSy
 
-=== /decl.d.ts ===
-declare class CJSy {}
->CJSy : CJSy
+=== /ns.ts ===
+export namespace ns {
+>ns : typeof ns
 
-export = CJSy;
->CJSy : CJSy
-
-=== /types.ts ===
-interface Typey {}
-export type { Typey };
->Typey : Typey
+    export enum A {}
+>A : A
+}
 

--- a/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
+++ b/tests/cases/conformance/externalModules/verbatimModuleSyntaxRestrictionsESM.ts
@@ -24,3 +24,8 @@ import type CJSy2 = require("./decl"); // ok I guess?
 import CJSy3 from "./decl"; // ok in esModuleInterop
 import * as types from "./types"; // ok
 CJSy;
+
+// @Filename: /ns.ts
+export namespace ns {
+    export enum A {}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #52461

