### PR TITLE
return `baseType` in `getSubstitutionType` when `baseType` is `any`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15217,7 +15217,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getSubstitutionType(baseType: Type, constraint: Type) {
-        if (constraint.flags & TypeFlags.AnyOrUnknown || constraint === baseType) {
+        if (constraint.flags & TypeFlags.AnyOrUnknown || constraint === baseType || baseType.flags & TypeFlags.Any) {
             return baseType;
         }
         const id = `${getTypeId(baseType)}>${getTypeId(constraint)}`;

--- a/tests/baselines/reference/conditionalTypeAnyUnion.js
+++ b/tests/baselines/reference/conditionalTypeAnyUnion.js
@@ -1,0 +1,11 @@
+//// [conditionalTypeAnyUnion.ts]
+// repro from #52568
+
+type Spec = any extends object ? any : string;
+
+type WithSpec<T extends number> = T
+
+type R = WithSpec<Spec> // should not error
+
+//// [conditionalTypeAnyUnion.js]
+// repro from #52568

--- a/tests/baselines/reference/conditionalTypeAnyUnion.symbols
+++ b/tests/baselines/reference/conditionalTypeAnyUnion.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/conditionalTypeAnyUnion.ts ===
+// repro from #52568
+
+type Spec = any extends object ? any : string;
+>Spec : Symbol(Spec, Decl(conditionalTypeAnyUnion.ts, 0, 0))
+
+type WithSpec<T extends number> = T
+>WithSpec : Symbol(WithSpec, Decl(conditionalTypeAnyUnion.ts, 2, 46))
+>T : Symbol(T, Decl(conditionalTypeAnyUnion.ts, 4, 14))
+>T : Symbol(T, Decl(conditionalTypeAnyUnion.ts, 4, 14))
+
+type R = WithSpec<Spec> // should not error
+>R : Symbol(R, Decl(conditionalTypeAnyUnion.ts, 4, 35))
+>WithSpec : Symbol(WithSpec, Decl(conditionalTypeAnyUnion.ts, 2, 46))
+>Spec : Symbol(Spec, Decl(conditionalTypeAnyUnion.ts, 0, 0))
+

--- a/tests/baselines/reference/conditionalTypeAnyUnion.types
+++ b/tests/baselines/reference/conditionalTypeAnyUnion.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/conditionalTypeAnyUnion.ts ===
+// repro from #52568
+
+type Spec = any extends object ? any : string;
+>Spec : any
+
+type WithSpec<T extends number> = T
+>WithSpec : T
+
+type R = WithSpec<Spec> // should not error
+>R : any
+

--- a/tests/cases/compiler/conditionalTypeAnyUnion.ts
+++ b/tests/cases/compiler/conditionalTypeAnyUnion.ts
@@ -1,0 +1,8 @@
+
+// repro from #52568
+
+type Spec = any extends object ? any : string;
+
+type WithSpec<T extends number> = T
+
+type R = WithSpec<Spec> // should not error


### PR DESCRIPTION
Fixes #52568 