### PR TITLE
Speed up debug attach by setting outFiles

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -40,6 +40,10 @@
       "env": {
         "NODE_ENV": "testing"
       },
+      "outFiles": [
+        "${workspaceFolder}/built/**/*.js",
+        "!**/node_modules/**"
+      ],
       "sourceMaps": true,
       "smartStep": true,
       "preLaunchTask": "npm: build:tests",

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -41,7 +41,9 @@
         "NODE_ENV": "testing"
       },
       "outFiles": [
-        "${workspaceFolder}/built/**/*.{js,mjs,cjs}",
+        "${workspaceFolder}/built/**/*.js",
+        "${workspaceFolder}/built/**/*.mjs",
+        "${workspaceFolder}/built/**/*.cjs",
         "!**/node_modules/**"
       ],
       "sourceMaps": true,

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -41,7 +41,7 @@
         "NODE_ENV": "testing"
       },
       "outFiles": [
-        "${workspaceFolder}/built/**/*.js",
+        "${workspaceFolder}/built/**/*.{js,mjs,cjs}",
         "!**/node_modules/**"
       ],
       "sourceMaps": true,


### PR DESCRIPTION
This improves the startup time of the debugger. This is a template, so everyone will have to manually copy this if they want it.

(I had this locally after it was suggested by @connor4312 and then proceeded to entirely forget to send this.)
