### PR TITLE
Add an extra test case related to return statements and annotated return types

### DIFF
--- a/tests/baselines/reference/contextualTypingReturnStatementWithReturnTypeAnnotation.symbols
+++ b/tests/baselines/reference/contextualTypingReturnStatementWithReturnTypeAnnotation.symbols
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts ===
+type PropOfRaw<T> = readonly T[] | "not-array" | "no-prop";
+>PropOfRaw : Symbol(PropOfRaw, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 0, 0))
+>T : Symbol(T, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 0, 15))
+>T : Symbol(T, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 0, 15))
+
+declare function isString(text: unknown): text is string;
+>isString : Symbol(isString, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 0, 59))
+>text : Symbol(text, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 2, 26))
+>text : Symbol(text, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 2, 26))
+
+declare function getPropFromRaw<T>(
+>getPropFromRaw : Symbol(getPropFromRaw, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 2, 57))
+>T : Symbol(T, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 4, 32))
+
+  prop: "files" | "include" | "exclude" | "references",
+>prop : Symbol(prop, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 4, 35))
+
+  validateElement: (value: unknown) => boolean,
+>validateElement : Symbol(validateElement, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 5, 55))
+>value : Symbol(value, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 6, 20))
+
+  elementTypeName: string
+>elementTypeName : Symbol(elementTypeName, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 6, 47))
+
+): PropOfRaw<T>;
+>PropOfRaw : Symbol(PropOfRaw, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 0, 0))
+>T : Symbol(T, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 4, 32))
+
+function getSpecsFromRaw(
+>getSpecsFromRaw : Symbol(getSpecsFromRaw, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 8, 16))
+
+  prop: "files" | "include" | "exclude"
+>prop : Symbol(prop, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 10, 25))
+
+): PropOfRaw<string> {
+>PropOfRaw : Symbol(PropOfRaw, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 0, 0))
+
+  return getPropFromRaw(prop, isString, "string");
+>getPropFromRaw : Symbol(getPropFromRaw, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 2, 57))
+>prop : Symbol(prop, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 10, 25))
+>isString : Symbol(isString, Decl(contextualTypingReturnStatementWithReturnTypeAnnotation.ts, 0, 59))
+}
+

--- a/tests/baselines/reference/contextualTypingReturnStatementWithReturnTypeAnnotation.types
+++ b/tests/baselines/reference/contextualTypingReturnStatementWithReturnTypeAnnotation.types
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts ===
+type PropOfRaw<T> = readonly T[] | "not-array" | "no-prop";
+>PropOfRaw : PropOfRaw<T>
+
+declare function isString(text: unknown): text is string;
+>isString : (text: unknown) => text is string
+>text : unknown
+
+declare function getPropFromRaw<T>(
+>getPropFromRaw : <T>(prop: "files" | "include" | "exclude" | "references", validateElement: (value: unknown) => boolean, elementTypeName: string) => PropOfRaw<T>
+
+  prop: "files" | "include" | "exclude" | "references",
+>prop : "files" | "include" | "exclude" | "references"
+
+  validateElement: (value: unknown) => boolean,
+>validateElement : (value: unknown) => boolean
+>value : unknown
+
+  elementTypeName: string
+>elementTypeName : string
+
+): PropOfRaw<T>;
+
+function getSpecsFromRaw(
+>getSpecsFromRaw : (prop: "files" | "include" | "exclude") => PropOfRaw<string>
+
+  prop: "files" | "include" | "exclude"
+>prop : "files" | "include" | "exclude"
+
+): PropOfRaw<string> {
+  return getPropFromRaw(prop, isString, "string");
+>getPropFromRaw(prop, isString, "string") : PropOfRaw<string>
+>getPropFromRaw : <T>(prop: "files" | "include" | "exclude" | "references", validateElement: (value: unknown) => boolean, elementTypeName: string) => PropOfRaw<T>
+>prop : "files" | "include" | "exclude"
+>isString : (text: unknown) => text is string
+>"string" : "string"
+}
+

--- a/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
+++ b/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
@@ -1,0 +1,18 @@
+// @strict: true
+// @noEmit: true
+
+type PropOfRaw<T> = readonly T[] | "not-array" | "no-prop";
+
+declare function isString(text: unknown): text is string;
+
+declare function getPropFromRaw<T>(
+  prop: "files" | "include" | "exclude" | "references",
+  validateElement: (value: unknown) => boolean,
+  elementTypeName: string
+): PropOfRaw<T>;
+
+function getSpecsFromRaw(
+  prop: "files" | "include" | "exclude"
+): PropOfRaw<string> {
+  return getPropFromRaw(prop, isString, "string");
+}


### PR DESCRIPTION
This is a test case extracted from the "self check". I managed to break it in https://github.com/microsoft/TypeScript/pull/52622 without breaking the test suite so I figured out that it's best to get it into the test suite.