### PR TITLE
Do not infer to mapped types from implied index signatures created by rest bindings

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24451,7 +24451,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (constraintType.flags & TypeFlags.TypeParameter) {
                 // We're inferring from some source type S to a mapped type { [P in K]: X }, where K is a type
                 // parameter. First infer from 'keyof S' to K.
-                inferWithPriority(getIndexType(source), constraintType, InferencePriority.MappedTypeConstraint);
+                inferWithPriority(getIndexType(source, /*stringsOnly*/ undefined, /*noIndexSignatures*/ !!source.pattern), constraintType, InferencePriority.MappedTypeConstraint);
                 // If K is constrained to a type C, also infer to C. Thus, for a mapped type { [P in K]: X },
                 // where K extends keyof T, we make the same inferences as for a homomorphic mapped type
                 // { [P in keyof T]: X }. This enables us to make meaningful inferences when the target is a

--- a/tests/baselines/reference/objectRestBindingContextualInference.symbols
+++ b/tests/baselines/reference/objectRestBindingContextualInference.symbols
@@ -1,0 +1,76 @@
+=== tests/cases/compiler/objectRestBindingContextualInference.ts ===
+// slimmed-down repro from #52629
+
+type ImageHolder<K extends string> = {
+>ImageHolder : Symbol(ImageHolder, Decl(objectRestBindingContextualInference.ts, 0, 0))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 2, 17))
+
+  [P in K]: string;
+>P : Symbol(P, Decl(objectRestBindingContextualInference.ts, 3, 3))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 2, 17))
+
+};
+
+type SetupImageRefs<K extends string> = {
+>SetupImageRefs : Symbol(SetupImageRefs, Decl(objectRestBindingContextualInference.ts, 4, 2))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 6, 20))
+
+  [P in K]: File;
+>P : Symbol(P, Decl(objectRestBindingContextualInference.ts, 7, 3))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 6, 20))
+>File : Symbol(File, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+};
+
+type SetupImages<K extends string> = SetupImageRefs<K> & {
+>SetupImages : Symbol(SetupImages, Decl(objectRestBindingContextualInference.ts, 8, 2))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 10, 17))
+>SetupImageRefs : Symbol(SetupImageRefs, Decl(objectRestBindingContextualInference.ts, 4, 2))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 10, 17))
+
+  prepare: () => { type: K };
+>prepare : Symbol(prepare, Decl(objectRestBindingContextualInference.ts, 10, 58))
+>type : Symbol(type, Decl(objectRestBindingContextualInference.ts, 11, 18))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 10, 17))
+
+};
+
+interface TestInterface {
+>TestInterface : Symbol(TestInterface, Decl(objectRestBindingContextualInference.ts, 12, 2))
+
+  name: string;
+>name : Symbol(TestInterface.name, Decl(objectRestBindingContextualInference.ts, 14, 25))
+
+  image: string;
+>image : Symbol(TestInterface.image, Decl(objectRestBindingContextualInference.ts, 15, 15))
+}
+
+declare function setupImages<R extends ImageHolder<K>, K extends string>(
+>setupImages : Symbol(setupImages, Decl(objectRestBindingContextualInference.ts, 17, 1))
+>R : Symbol(R, Decl(objectRestBindingContextualInference.ts, 19, 29))
+>ImageHolder : Symbol(ImageHolder, Decl(objectRestBindingContextualInference.ts, 0, 0))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 19, 54))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 19, 54))
+
+  item: R,
+>item : Symbol(item, Decl(objectRestBindingContextualInference.ts, 19, 73))
+>R : Symbol(R, Decl(objectRestBindingContextualInference.ts, 19, 29))
+
+  keys: K[]
+>keys : Symbol(keys, Decl(objectRestBindingContextualInference.ts, 20, 10))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 19, 54))
+
+): SetupImages<K>;
+>SetupImages : Symbol(SetupImages, Decl(objectRestBindingContextualInference.ts, 8, 2))
+>K : Symbol(K, Decl(objectRestBindingContextualInference.ts, 19, 54))
+
+declare const test: TestInterface;
+>test : Symbol(test, Decl(objectRestBindingContextualInference.ts, 24, 13))
+>TestInterface : Symbol(TestInterface, Decl(objectRestBindingContextualInference.ts, 12, 2))
+
+const { prepare, ...rest } = setupImages(test, ["image"]);
+>prepare : Symbol(prepare, Decl(objectRestBindingContextualInference.ts, 26, 7))
+>rest : Symbol(rest, Decl(objectRestBindingContextualInference.ts, 26, 16))
+>setupImages : Symbol(setupImages, Decl(objectRestBindingContextualInference.ts, 17, 1))
+>test : Symbol(test, Decl(objectRestBindingContextualInference.ts, 24, 13))
+

--- a/tests/baselines/reference/objectRestBindingContextualInference.types
+++ b/tests/baselines/reference/objectRestBindingContextualInference.types
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/objectRestBindingContextualInference.ts ===
+// slimmed-down repro from #52629
+
+type ImageHolder<K extends string> = {
+>ImageHolder : ImageHolder<K>
+
+  [P in K]: string;
+};
+
+type SetupImageRefs<K extends string> = {
+>SetupImageRefs : SetupImageRefs<K>
+
+  [P in K]: File;
+};
+
+type SetupImages<K extends string> = SetupImageRefs<K> & {
+>SetupImages : SetupImages<K>
+
+  prepare: () => { type: K };
+>prepare : () => {    type: K;}
+>type : K
+
+};
+
+interface TestInterface {
+  name: string;
+>name : string
+
+  image: string;
+>image : string
+}
+
+declare function setupImages<R extends ImageHolder<K>, K extends string>(
+>setupImages : <R extends ImageHolder<K>, K extends string>(item: R, keys: K[]) => SetupImages<K>
+
+  item: R,
+>item : R
+
+  keys: K[]
+>keys : K[]
+
+): SetupImages<K>;
+
+declare const test: TestInterface;
+>test : TestInterface
+
+const { prepare, ...rest } = setupImages(test, ["image"]);
+>prepare : () => { type: "image"; }
+>rest : { image: File; }
+>setupImages(test, ["image"]) : SetupImages<"image">
+>setupImages : <R extends ImageHolder<K>, K extends string>(item: R, keys: K[]) => SetupImages<K>
+>test : TestInterface
+>["image"] : "image"[]
+>"image" : "image"
+

--- a/tests/cases/compiler/objectRestBindingContextualInference.ts
+++ b/tests/cases/compiler/objectRestBindingContextualInference.ts
@@ -1,0 +1,30 @@
+// @strict: true
+// @noEmit: true
+
+// slimmed-down repro from #52629
+
+type ImageHolder<K extends string> = {
+  [P in K]: string;
+};
+
+type SetupImageRefs<K extends string> = {
+  [P in K]: File;
+};
+
+type SetupImages<K extends string> = SetupImageRefs<K> & {
+  prepare: () => { type: K };
+};
+
+interface TestInterface {
+  name: string;
+  image: string;
+}
+
+declare function setupImages<R extends ImageHolder<K>, K extends string>(
+  item: R,
+  keys: K[]
+): SetupImages<K>;
+
+declare const test: TestInterface;
+
+const { prepare, ...rest } = setupImages(test, ["image"]);


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/52629

cc @andrewbranch , it might be interesting to you given your work on https://github.com/microsoft/TypeScript/pull/49086