### PR TITLE
Call getUnionOrIntersectionProperty in getAllPossiblePropertiesOfTypes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13339,7 +13339,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         for (const memberType of types) {
             for (const { escapedName } of getAugmentedPropertiesOfType(memberType)) {
                 if (!props.has(escapedName)) {
-                    const prop = createUnionOrIntersectionProperty(unionType as UnionType, escapedName);
+                    const prop = getUnionOrIntersectionProperty(unionType as UnionType, escapedName);
                     // May be undefined if the property is private
                     if (prop) props.set(escapedName, prop);
                 }
@@ -13717,6 +13717,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return getReducedType(getApparentType(getReducedType(type)));
     }
 
+    /** Note: consider calling getUnionOrIntersectionProperty instead of this function directly. */
     function createUnionOrIntersectionProperty(containingType: UnionOrIntersectionType, name: __String, skipObjectFunctionPropertyAugment?: boolean): Symbol | undefined {
         let singleProp: Symbol | undefined;
         let propSet: Map<SymbolId, Symbol> | undefined;


### PR DESCRIPTION
I noticed this at some point while doing some perf investigation; this was something I thought mattered for my problem but didn't.

Currently, all calls to `createUnionOrIntersectionProperty` go through `getUnionOrIntersectionProperty` as the latter has a cache. But `getAllPossiblePropertiesOfTypes` bypassed this and created the property instead. It's probably advisable to always go through the cache, and probably improves the performance of completions (the only place `getAllPossiblePropertiesOfTypes` is used). But, I doubt we have a perf test that covers this case specifically.