### PR TITLE
Added link of TypeScript Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ with any additional questions or comments.
 
 ## Roadmap
 
+*  [TypeScript Roadmap](https://roadmap.sh/typescript)
+
 For details on our planned features and future direction please refer to our [roadmap](https://github.com/microsoft/TypeScript/wiki/Roadmap).


### PR DESCRIPTION
Hi,

This repository is no doubt a valuable resource for TypeScript enthusiasts. However it is missing links to any structured guides such as the famous ["TypeScript Roadmap"](https://roadmap.sh/typescript). I took the initiative to submit a pull request adding it in roadmap section.

Best,
Mouaaz