### PR TITLE
Exclude literal completions after closing quote and JSX attribute location

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2905,7 +2905,10 @@ function getCompletionData(
     log("getCompletionData: Semantic work: " + (timestamp() - semanticStart));
     const contextualType = previousToken && getContextualType(previousToken, position, sourceFile, typeChecker);
 
-    const literals = mapDefined(
+    // don't include literal suggestions after <input type="text" [||] /> (#51667) and after quote (#52675)
+    // for strings getStringLiteralCompletions handles completions
+    const isLiteralExpected = !isStringLiteralLike(previousToken) && !isJsxIdentifierExpected;
+    const literals = !isLiteralExpected ? [] : mapDefined(
         contextualType && (contextualType.isUnion() ? contextualType.types : [contextualType]),
         t => t.isLiteral() && !(t.flags & TypeFlags.EnumLiteral) ? t.value : undefined);
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2907,7 +2907,7 @@ function getCompletionData(
 
     // don't include literal suggestions after <input type="text" [||] /> (#51667) and after quote (#52675)
     // for strings getStringLiteralCompletions handles completions
-    const isLiteralExpected = !isStringLiteralLike(previousToken) && !isJsxIdentifierExpected;
+    const isLiteralExpected = !tryCast(previousToken, isStringLiteralLike) && !isJsxIdentifierExpected;
     const literals = !isLiteralExpected ? [] : mapDefined(
         contextualType && (contextualType.isUnion() ? contextualType.types : [contextualType]),
         t => t.isLiteral() && !(t.flags & TypeFlags.EnumLiteral) ? t.value : undefined);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2905,7 +2905,7 @@ function getCompletionData(
     log("getCompletionData: Semantic work: " + (timestamp() - semanticStart));
     const contextualType = previousToken && getContextualType(previousToken, position, sourceFile, typeChecker);
 
-    // don't include literal suggestions after <input type="text" [||] /> (#51667) and after quote (#52675)
+    // exclude literal suggestions after <input type="text" [||] /> (#51667) and after closing quote (#52675)
     // for strings getStringLiteralCompletions handles completions
     const isLiteralExpected = !tryCast(previousToken, isStringLiteralLike) && !isJsxIdentifierExpected;
     const literals = !isLiteralExpected ? [] : mapDefined(

--- a/tests/cases/fourslash/completionsLiterals.ts
+++ b/tests/cases/fourslash/completionsLiterals.ts
@@ -2,6 +2,7 @@
 
 ////const x: 0 | "one" = /**/;
 ////const y: 0 | "one" | 1n = /*1*/;
+////const y2: 0 | "one" | 1n = 'one'/*2*/;
 
 verify.completions({
     marker: "",
@@ -19,4 +20,10 @@ verify.completions({
         { name: "1n", kind: "string", text: "1n" },
     ],
     isNewIdentifierLocation: true,
+});
+verify.completions({
+    marker: "2",
+    excludes: [
+        '"one"'
+    ],
 });

--- a/tests/cases/fourslash/stringLiteralCompletionsInJsxAttributeInitializer.ts
+++ b/tests/cases/fourslash/stringLiteralCompletionsInJsxAttributeInitializer.ts
@@ -7,5 +7,8 @@
 ////
 ////const a1 = <Foo b={"/*1*/"} />
 ////const a2 = <Foo b="/*2*/" />
+////const a3 = <Foo b="somethingelse"/*3*/ />
+////const a4 = <Foo b={"somethingelse"} /*4*/ />
 
 verify.completions({ marker: ["1", "2"], exact: ["somethingelse"] });
+verify.completions({ marker: ["3", "4"], excludes: ['"somethingelse"'], });

--- a/tests/cases/fourslash/stringLiteralCompletionsInJsxAttributeInitializer.ts
+++ b/tests/cases/fourslash/stringLiteralCompletionsInJsxAttributeInitializer.ts
@@ -2,13 +2,15 @@
 
 // @jsx: preserve
 // @filename: /a.tsx
-////type Props = { a: number } | { b: "somethingelse" };
+////type Props = { a: number } | { b: "somethingelse", c: 0 | 1 };
 ////declare function Foo(args: Props): any
 ////
 ////const a1 = <Foo b={"/*1*/"} />
 ////const a2 = <Foo b="/*2*/" />
 ////const a3 = <Foo b="somethingelse"/*3*/ />
 ////const a4 = <Foo b={"somethingelse"} /*4*/ />
+////const a5 = <Foo b={"somethingelse"} c={0} /*5*/ />
 
 verify.completions({ marker: ["1", "2"], exact: ["somethingelse"] });
 verify.completions({ marker: ["3", "4"], excludes: ['"somethingelse"'], });
+verify.completions({ marker: ["5"], excludes: ["0", "1"], });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/51667
Fixes https://github.com/microsoft/TypeScript/issues/52675

`contextualType` is derived from previous token
