### PR TITLE
Fix mixin functions with 'this' type having 'any' type in dts file

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6651,6 +6651,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             // The specified symbol flags need to be reinterpreted as type flags
                             return symbolToTypeNode(typeAlias, context, SymbolFlags.Type);
                         }
+                        else if ((type as { target?: GenericType})?.target?.thisType && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral) {
+                            return factory.createThisTypeNode();
+                        }
                         else {
                             return createElidedInformationPlaceholder(context);
                         }

--- a/tests/baselines/reference/commonJSImportNestedClassTypeReference.js
+++ b/tests/baselines/reference/commonJSImportNestedClassTypeReference.js
@@ -41,8 +41,28 @@ function f(k) {
 //// [mod1.d.ts]
 export var K: {
     new (): {
-        values(): any;
+        values(): this;
     };
 };
 //// [main.d.ts]
 export {};
+
+
+//// [DtsFileErrors]
+
+
+out/mod1.d.ts(3,19): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+
+
+==== out/main.d.ts (0 errors) ====
+    export {};
+    
+==== out/mod1.d.ts (1 errors) ====
+    export var K: {
+        new (): {
+            values(): this;
+                      ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+        };
+    };
+    

--- a/tests/baselines/reference/emitClassExpressionInDeclarationFile.js
+++ b/tests/baselines/reference/emitClassExpressionInDeclarationFile.js
@@ -105,12 +105,12 @@ export declare var simpleExample: {
 };
 export declare var circularReference: {
     new (): {
-        tags(c: any): any;
+        tags(c: this): this;
     };
     getTags(c: {
-        tags(c: any): any;
+        tags(c: this): this;
     }): {
-        tags(c: any): any;
+        tags(c: this): this;
     };
 };
 export declare class FooItem {
@@ -137,3 +137,70 @@ declare const Test_base: {
 export declare class Test extends Test_base {
 }
 export {};
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/compiler/emitClassExpressionInDeclarationFile.d.ts(9,17): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+tests/cases/compiler/emitClassExpressionInDeclarationFile.d.ts(9,24): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+tests/cases/compiler/emitClassExpressionInDeclarationFile.d.ts(12,17): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+tests/cases/compiler/emitClassExpressionInDeclarationFile.d.ts(12,24): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+tests/cases/compiler/emitClassExpressionInDeclarationFile.d.ts(14,17): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+tests/cases/compiler/emitClassExpressionInDeclarationFile.d.ts(14,24): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+
+
+==== tests/cases/compiler/emitClassExpressionInDeclarationFile.d.ts (6 errors) ====
+    export declare var simpleExample: {
+        new (): {
+            tags(): void;
+        };
+        getTags(): void;
+    };
+    export declare var circularReference: {
+        new (): {
+            tags(c: this): this;
+                    ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+                           ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+        };
+        getTags(c: {
+            tags(c: this): this;
+                    ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+                           ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+        }): {
+            tags(c: this): this;
+                    ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+                           ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+        };
+    };
+    export declare class FooItem {
+        foo(): void;
+        name?: string;
+    }
+    export type Constructor<T> = new (...args: any[]) => T;
+    export declare function WithTags<T extends Constructor<FooItem>>(Base: T): {
+        new (...args: any[]): {
+            tags(): void;
+            foo(): void;
+            name?: string;
+        };
+        getTags(): void;
+    } & T;
+    declare const Test_base: {
+        new (...args: any[]): {
+            tags(): void;
+            foo(): void;
+            name?: string;
+        };
+        getTags(): void;
+    } & typeof FooItem;
+    export declare class Test extends Test_base {
+    }
+    export {};
+    

--- a/tests/baselines/reference/mixinFunctionReturningThis.js
+++ b/tests/baselines/reference/mixinFunctionReturningThis.js
@@ -1,0 +1,86 @@
+//// [mixinFunctionReturningThis.ts]
+class A {
+  constructor(name: string) {}
+}
+
+type Constructor = new (...args: any[]) => {};
+ 
+function MixB<TBase extends Constructor>(Base: TBase) {
+  return class extends Base {
+    getThis(): this {
+      return this;
+    }
+  };
+}
+
+export default MixB(A);
+
+//// [mixinFunctionReturningThis.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+var A = /** @class */ (function () {
+    function A(name) {
+    }
+    return A;
+}());
+function MixB(Base) {
+    return /** @class */ (function (_super) {
+        __extends(class_1, _super);
+        function class_1() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        class_1.prototype.getThis = function () {
+            return this;
+        };
+        return class_1;
+    }(Base));
+}
+exports.default = MixB(A);
+
+
+//// [mixinFunctionReturningThis.d.ts]
+declare class A {
+    constructor(name: string);
+}
+declare const _default: {
+    new (...args: any[]): {
+        getThis(): this;
+    };
+} & typeof A;
+export default _default;
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/compiler/mixinFunctionReturningThis.d.ts(6,20): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+
+
+==== tests/cases/compiler/mixinFunctionReturningThis.d.ts (1 errors) ====
+    declare class A {
+        constructor(name: string);
+    }
+    declare const _default: {
+        new (...args: any[]): {
+            getThis(): this;
+                       ~~~~
+!!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
+        };
+    } & typeof A;
+    export default _default;
+    

--- a/tests/baselines/reference/mixinFunctionReturningThis.symbols
+++ b/tests/baselines/reference/mixinFunctionReturningThis.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/mixinFunctionReturningThis.ts ===
+class A {
+>A : Symbol(A, Decl(mixinFunctionReturningThis.ts, 0, 0))
+
+  constructor(name: string) {}
+>name : Symbol(name, Decl(mixinFunctionReturningThis.ts, 1, 14))
+}
+
+type Constructor = new (...args: any[]) => {};
+>Constructor : Symbol(Constructor, Decl(mixinFunctionReturningThis.ts, 2, 1))
+>args : Symbol(args, Decl(mixinFunctionReturningThis.ts, 4, 24))
+ 
+function MixB<TBase extends Constructor>(Base: TBase) {
+>MixB : Symbol(MixB, Decl(mixinFunctionReturningThis.ts, 4, 46))
+>TBase : Symbol(TBase, Decl(mixinFunctionReturningThis.ts, 6, 14))
+>Constructor : Symbol(Constructor, Decl(mixinFunctionReturningThis.ts, 2, 1))
+>Base : Symbol(Base, Decl(mixinFunctionReturningThis.ts, 6, 41))
+>TBase : Symbol(TBase, Decl(mixinFunctionReturningThis.ts, 6, 14))
+
+  return class extends Base {
+>Base : Symbol(Base, Decl(mixinFunctionReturningThis.ts, 6, 41))
+
+    getThis(): this {
+>getThis : Symbol((Anonymous class).getThis, Decl(mixinFunctionReturningThis.ts, 7, 29))
+
+      return this;
+>this : Symbol((Anonymous class), Decl(mixinFunctionReturningThis.ts, 7, 8))
+    }
+  };
+}
+
+export default MixB(A);
+>MixB : Symbol(MixB, Decl(mixinFunctionReturningThis.ts, 4, 46))
+>A : Symbol(A, Decl(mixinFunctionReturningThis.ts, 0, 0))
+

--- a/tests/baselines/reference/mixinFunctionReturningThis.types
+++ b/tests/baselines/reference/mixinFunctionReturningThis.types
@@ -1,0 +1,34 @@
+=== tests/cases/compiler/mixinFunctionReturningThis.ts ===
+class A {
+>A : A
+
+  constructor(name: string) {}
+>name : string
+}
+
+type Constructor = new (...args: any[]) => {};
+>Constructor : new (...args: any[]) => {}
+>args : any[]
+ 
+function MixB<TBase extends Constructor>(Base: TBase) {
+>MixB : <TBase extends Constructor>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: MixB<any>.(Anonymous class); } & TBase
+>Base : TBase
+
+  return class extends Base {
+>class extends Base {    getThis(): this {      return this;    }  } : { new (...args: any[]): (Anonymous class); prototype: MixB<any>.(Anonymous class); } & TBase
+>Base : {}
+
+    getThis(): this {
+>getThis : () => this
+
+      return this;
+>this : this
+    }
+  };
+}
+
+export default MixB(A);
+>MixB(A) : { new (...args: any[]): MixB<typeof A>.(Anonymous class); prototype: MixB<any>.(Anonymous class); } & typeof A
+>MixB : <TBase extends Constructor>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: MixB<any>.(Anonymous class); } & TBase
+>A : typeof A
+

--- a/tests/baselines/reference/varianceAnnotations.js
+++ b/tests/baselines/reference/varianceAnnotations.js
@@ -326,11 +326,11 @@ declare const qq: ActionObject<{
 }>;
 declare let Anon: {
     new <out T>(): {
-        foo(): any;
+        foo(): this;
     };
 };
 declare let OuterC: {
     new <out T>(): {
-        foo(): any;
+        foo(): this;
     };
 };

--- a/tests/cases/compiler/mixinFunctionReturningThis.ts
+++ b/tests/cases/compiler/mixinFunctionReturningThis.ts
@@ -1,0 +1,16 @@
+// @declaration: true
+class A {
+  constructor(name: string) {}
+}
+
+type Constructor = new (...args: any[]) => {};
+ 
+function MixB<TBase extends Constructor>(Base: TBase) {
+  return class extends Base {
+    getThis(): this {
+      return this;
+    }
+  };
+}
+
+export default MixB(A);


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/51206

i'm very unsure that this is the right fix, but seems like all the baseline test changes are valid. There are a bunch of `TS2526: A 'this' type is available only in a non-static member of a class or interface.` errors, but I'm able to call chained methods returning `this` (e.g. `setX().setY()`) from a DTS file generated locally without any errors, so I'm not sure that these errors are correct