### PR TITLE
Fix completion details auto-imports crashes

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -882,18 +882,28 @@ export class TestState {
 
     public verifyCompletions(options: FourSlashInterface.VerifyCompletionsOptions) {
         if (options.marker === undefined) {
-            this.verifyCompletionsWorker(options);
+            return this.verifyCompletionsWorker(options);
         }
         else {
-            for (const marker of toArray(options.marker)) {
-                this.goToMarker(marker);
-                this.verifyCompletionsWorker({ ...options, marker });
+            if (ts.isArray(options.marker)) {
+                for (const marker of options.marker) {
+                    this.goToMarker(marker);
+                    this.verifyCompletionsWorker({ ...options, marker });
+                }
+                return {
+                    andApplyCodeAction: () => {
+                        this.raiseError(`Cannot apply code action when multiple markers are specified.`);
+                    }
+                };
             }
+            this.goToMarker(options.marker);
+            return this.verifyCompletionsWorker({ ...options, marker: options.marker });
         }
     }
 
-    private verifyCompletionsWorker(options: FourSlashInterface.VerifyCompletionsOptions): void {
-        const actualCompletions = this.getCompletionListAtCaret({ ...options.preferences, triggerCharacter: options.triggerCharacter })!;
+    private verifyCompletionsWorker(options: FourSlashInterface.VerifyCompletionsOptions) {
+        const preferences = options.preferences;
+        const actualCompletions = this.getCompletionListAtCaret({ ...preferences, triggerCharacter: options.triggerCharacter })!;
         if (!actualCompletions) {
             if (ts.hasProperty(options, "exact") && (options.exact === undefined || ts.isArray(options.exact) && !options.exact.length)) {
                 return;
@@ -917,6 +927,7 @@ export class TestState {
         }
 
         const nameToEntries = new Map<string, ts.CompletionEntry[]>();
+        const nameAndSourceToData = new Map<string, ts.CompletionEntryData | false>();
         for (const entry of actualCompletions.entries) {
             const entries = nameToEntries.get(entry.name);
             if (!entries) {
@@ -933,6 +944,15 @@ export class TestState {
                     this.raiseError(`Duplicate completions for ${entry.name}`);
                 }
                 entries.push(entry);
+            }
+            if (entry.data && entry.source) {
+                const key = `${entry.name}|${entry.source}`;
+                if (nameAndSourceToData.has(key)) {
+                    nameAndSourceToData.set(key, false);
+                }
+                else {
+                    nameAndSourceToData.set(key, entry.data);
+                }
             }
         }
 
@@ -975,6 +995,26 @@ export class TestState {
                         this.raiseError(`Excludes: unexpected completion '${exclude}' found.`);
                     }
                 }
+            }
+        }
+
+        return {
+            andApplyCodeAction: (options: {
+                name: string,
+                source: string,
+                description: string,
+                newFileContent?: string,
+                newRangeContent?: string,
+            }) => {
+                const { name, source, description, newFileContent, newRangeContent } = options;
+                const data = nameAndSourceToData.get(`${options.name}|${options.source}`);
+                if (data === false) {
+                    this.raiseError(`Multiple completion entries found for '${options.name}' from '${options.source}'. This API cannot be used. Use 'verify.applyCodeActionFromCompletion' instead.`);
+                }
+                if (data === undefined) {
+                    this.raiseError(`No completion entry found for '${options.name}' from '${options.source}'`);
+                }
+                this.applyCodeActionFromCompletion(/*markerName*/ undefined, { name, source, data, description, newFileContent, newRangeContent, preferences });
             }
         }
     }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -2102,7 +2102,11 @@ export class TestState {
                 }
             }
         }
-        Harness.Baseline.runBaseline(baselineFile, annotations + "\n\n" + stringify(result));
+        Harness.Baseline.runBaseline(baselineFile, annotations + "\n\n" + stringify(result, (key, value) => {
+            return key === "exportMapKey"
+                ? value.replace(/\|[0-9]+/g, "|*")
+                : value;
+        }));
     }
 
     private annotateContentWithTooltips<T extends ts.QuickInfo | ts.SignatureHelpItems | {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1016,7 +1016,7 @@ export class TestState {
                 }
                 this.applyCodeActionFromCompletion(/*markerName*/ undefined, { name, source, data, description, newFileContent, newRangeContent, preferences });
             }
-        }
+        };
     }
 
     private verifyCompletionEntry(actual: ts.CompletionEntry, expected: FourSlashInterface.ExpectedCompletionEntry) {

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -252,9 +252,17 @@ export class Verify extends VerifyNegatable {
     }
 
     public completions(...optionsArray: VerifyCompletionsOptions[]) {
+        if (optionsArray.length === 1) {
+            return this.state.verifyCompletions(optionsArray[0]);
+        }
         for (const options of optionsArray) {
             this.state.verifyCompletions(options);
         }
+        return {
+            andApplyCodeAction: () => {
+                throw new Error("Cannot call andApplyCodeAction on multiple completions requests");
+            },
+        };
     }
 
     public getInlayHints(expected: readonly VerifyInlayHintsOptions[], span: ts.TextSpan, preference?: ts.UserPreferences) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -461,7 +461,7 @@ interface SymbolOriginInfoResolvedExport extends SymbolOriginInfo {
     symbolName: string;
     moduleSymbol: Symbol;
     exportName: string;
-    exportMapKey: string;
+    exportMapKey?: string;
     moduleSpecifier: string;
 }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -3443,8 +3443,8 @@ function getCompletionData(
                         // module resolution modes, getting past this point guarantees that we'll be
                         // able to generate a suitable module specifier, so we can safely show a completion,
                         // even if we defer computing the module specifier.
-                        const firstImportableExportInfo = find(info, isImportableExportInfo);
-                        if (!firstImportableExportInfo) {
+                        info = filter(info, isImportableExportInfo);
+                        if (!info.length) {
                             return;
                         }
 
@@ -3461,9 +3461,9 @@ function getCompletionData(
                         // it should be identical regardless of which one is used. During the subsequent
                         // `CompletionEntryDetails` request, we'll get all the ExportInfos again and pick
                         // the best one based on the module specifier it produces.
-                        let exportInfo = firstImportableExportInfo, moduleSpecifier;
+                        let exportInfo = info[0], moduleSpecifier;
                         if (result !== "skipped") {
-                            ({ exportInfo = firstImportableExportInfo, moduleSpecifier } = result);
+                            ({ exportInfo = info[0], moduleSpecifier } = result);
                         }
 
                         const isDefaultExport = exportInfo.exportKind === ExportKind.Default;

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -461,6 +461,7 @@ interface SymbolOriginInfoResolvedExport extends SymbolOriginInfo {
     symbolName: string;
     moduleSymbol: Symbol;
     exportName: string;
+    exportMapKey: string;
     moduleSpecifier: string;
 }
 
@@ -1924,6 +1925,7 @@ function originToCompletionEntryData(origin: SymbolOriginInfoExport | SymbolOrig
     if (originIsResolvedExport(origin)) {
         const resolvedData: CompletionEntryDataResolved = {
             exportName: origin.exportName,
+            exportMapKey: origin.exportMapKey,
             moduleSpecifier: origin.moduleSpecifier,
             ambientModuleName,
             fileName: origin.fileName,
@@ -1948,6 +1950,7 @@ function completionEntryDataToSymbolOriginInfo(data: CompletionEntryData, comple
         const resolvedOrigin: SymbolOriginInfoResolvedExport = {
             kind: SymbolOriginInfoKind.ResolvedExport,
             exportName: data.exportName,
+            exportMapKey: data.exportMapKey,
             moduleSpecifier: data.moduleSpecifier,
             symbolName: completionName,
             fileName: data.fileName,
@@ -2454,6 +2457,7 @@ function getCompletionEntryCodeActionsAndSourceDisplay(
     const { moduleSpecifier, codeAction } = codefix.getImportCompletionAction(
         targetSymbol,
         moduleSymbol,
+        data?.exportMapKey,
         sourceFile,
         name,
         isJsxOpeningTagName,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1337,7 +1337,7 @@ export interface CompletionEntryDataAutoImport {
      * in the case of InternalSymbolName.ExportEquals and InternalSymbolName.Default.
      */
     exportName: string;
-    exportMapKey: string;
+    exportMapKey?: string;
     moduleSpecifier?: string;
     /** The file name declaring the export's module symbol, if it was an external module */
     fileName?: string;
@@ -1348,6 +1348,7 @@ export interface CompletionEntryDataAutoImport {
 }
 
 export interface CompletionEntryDataUnresolved extends CompletionEntryDataAutoImport {
+    exportMapKey: string;
 }
 
 export interface CompletionEntryDataResolved extends CompletionEntryDataAutoImport {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1337,6 +1337,7 @@ export interface CompletionEntryDataAutoImport {
      * in the case of InternalSymbolName.ExportEquals and InternalSymbolName.Default.
      */
     exportName: string;
+    exportMapKey: string;
     moduleSpecifier?: string;
     /** The file name declaring the export's module symbol, if it was an external module */
     fileName?: string;
@@ -1347,8 +1348,6 @@ export interface CompletionEntryDataAutoImport {
 }
 
 export interface CompletionEntryDataUnresolved extends CompletionEntryDataAutoImport {
-    /** The key in the `ExportMapCache` where the completion entry's `SymbolExportInfo[]` is found */
-    exportMapKey: string;
 }
 
 export interface CompletionEntryDataResolved extends CompletionEntryDataAutoImport {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -10590,6 +10590,7 @@ declare namespace ts {
          * in the case of InternalSymbolName.ExportEquals and InternalSymbolName.Default.
          */
         exportName: string;
+        exportMapKey?: string;
         moduleSpecifier?: string;
         /** The file name declaring the export's module symbol, if it was an external module */
         fileName?: string;
@@ -10599,7 +10600,6 @@ declare namespace ts {
         isPackageJsonImport?: true;
     }
     interface CompletionEntryDataUnresolved extends CompletionEntryDataAutoImport {
-        /** The key in the `ExportMapCache` where the completion entry's `SymbolExportInfo[]` is found */
         exportMapKey: string;
     }
     interface CompletionEntryDataResolved extends CompletionEntryDataAutoImport {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6688,6 +6688,7 @@ declare namespace ts {
          * in the case of InternalSymbolName.ExportEquals and InternalSymbolName.Default.
          */
         exportName: string;
+        exportMapKey?: string;
         moduleSpecifier?: string;
         /** The file name declaring the export's module symbol, if it was an external module */
         fileName?: string;
@@ -6697,7 +6698,6 @@ declare namespace ts {
         isPackageJsonImport?: true;
     }
     interface CompletionEntryDataUnresolved extends CompletionEntryDataAutoImport {
-        /** The key in the `ExportMapCache` where the completion entry's `SymbolExportInfo[]` is found */
         exportMapKey: string;
     }
     interface CompletionEntryDataResolved extends CompletionEntryDataAutoImport {

--- a/tests/baselines/reference/importStatementCompletions3.baseline
+++ b/tests/baselines/reference/importStatementCompletions3.baseline
@@ -49,7 +49,7 @@
           "isImportStatementCompletion": true,
           "data": {
             "exportName": "foo",
-            "exportMapKey": "foo|19|",
+            "exportMapKey": "foo|*|",
             "moduleSpecifier": "./$foo",
             "fileName": "/tests/cases/fourslash/$foo.ts"
           },

--- a/tests/baselines/reference/importStatementCompletions3.baseline
+++ b/tests/baselines/reference/importStatementCompletions3.baseline
@@ -49,6 +49,7 @@
           "isImportStatementCompletion": true,
           "data": {
             "exportName": "foo",
+            "exportMapKey": "foo|19|",
             "moduleSpecifier": "./$foo",
             "fileName": "/tests/cases/fourslash/$foo.ts"
           },

--- a/tests/baselines/reference/tsserver/moduleSpecifierCache/caches-module-specifiers-within-a-file.js
+++ b/tests/baselines/reference/tsserver/moduleSpecifierCache/caches-module-specifiers-within-a-file.js
@@ -961,6 +961,7 @@ Info 67   [00:02:07.000] response:
             "isImportStatementCompletion": true,
             "data": {
               "exportName": "foo",
+              "exportMapKey": "foo|*|",
               "moduleSpecifier": "./a",
               "fileName": "/src/a.ts"
             }
@@ -993,6 +994,7 @@ Info 67   [00:02:07.000] response:
             "isImportStatementCompletion": true,
             "data": {
               "exportName": "observable",
+              "exportMapKey": "observable|*|",
               "moduleSpecifier": "mobx",
               "fileName": "/node_modules/mobx/index.d.ts",
               "isPackageJsonImport": true

--- a/tests/baselines/reference/tsserver/moduleSpecifierCache/invalidates-module-specifiers-when-changes-happen-in-contained-node_modules-directories.js
+++ b/tests/baselines/reference/tsserver/moduleSpecifierCache/invalidates-module-specifiers-when-changes-happen-in-contained-node_modules-directories.js
@@ -961,6 +961,7 @@ Info 67   [00:02:07.000] response:
             "isImportStatementCompletion": true,
             "data": {
               "exportName": "foo",
+              "exportMapKey": "foo|*|",
               "moduleSpecifier": "./a",
               "fileName": "/src/a.ts"
             }
@@ -993,6 +994,7 @@ Info 67   [00:02:07.000] response:
             "isImportStatementCompletion": true,
             "data": {
               "exportName": "observable",
+              "exportMapKey": "observable|*|",
               "moduleSpecifier": "mobx",
               "fileName": "/node_modules/mobx/index.d.ts",
               "isPackageJsonImport": true

--- a/tests/cases/fourslash/completionsImport_named_didNotExistBefore.ts
+++ b/tests/cases/fourslash/completionsImport_named_didNotExistBefore.ts
@@ -31,9 +31,7 @@ verify.completions({
         },
     ], { noLib: true }),
     preferences: { includeCompletionsForModuleExports: true },
-});
-
-verify.applyCodeActionFromCompletion("", {
+}).andApplyCodeAction({
     name: "Test1",
     source: "/a",
     description: `Update import from "./a"`,

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -284,7 +284,13 @@ declare namespace FourSlashInterface {
     class verify extends verifyNegatable {
         assertHasRanges(ranges: Range[]): void;
         caretAtMarker(markerName?: string): void;
-        completions(...options: CompletionsOptions[]): void;
+        completions(...options: CompletionsOptions[]): { andApplyCodeAction(options: {
+            name: string,
+            source: string,
+            description: string,
+            newFileContent?: string,
+            newRangeContent?: string,
+        }): void };
         applyCodeActionFromCompletion(markerName: string | undefined, options: {
             name: string,
             source?: string,

--- a/tests/cases/fourslash/server/autoImportReExportFromAmbientModule.ts
+++ b/tests/cases/fourslash/server/autoImportReExportFromAmbientModule.ts
@@ -1,0 +1,52 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "commonjs"
+////   }
+//// }
+
+// @Filename: /node_modules/@types/node/index.d.ts
+//// declare module "fs" {
+////   export function accessSync(path: string): void;
+//// }
+
+// @Filename: /node_modules/@types/fs-extra/index.d.ts
+//// export * from "fs";
+
+// @Filename: /index.ts
+//// access/**/
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "accessSync",
+    source: "fs",
+    sourceDisplay: "fs",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }, {
+    name: "accessSync",
+    source: "fs-extra",
+    sourceDisplay: "fs-extra",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true
+  }
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "accessSync",
+  source: "fs-extra",
+  description: `Add import from "fs-extra"`,
+  newFileContent: `import { accessSync } from "fs-extra";\r\n\r\naccess`,
+  data: {
+    exportName: "accessSync",
+    fileName: "/node_modules/@types/fs-extra/index.d.ts",
+    moduleSpecifier: "fs-extra",
+  }
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #52661

The ExportInfoMap is a multimap that contains information about every way that every export is re-exported from different places. Usually, a single symbol that gets re-exported multiple times has a single key pointing to an array of each place it’s exported from. When auto-imports are displayed in completions, we show one completion per key, and we simply pick the “best” re-exporting location out of that array. This lets us prefer short import paths over deep imports. (When and whether this is actually a good heuristic is beside the point.)

The exception is when a single symbol is exported by an ambient module. Ambient modules are considered a stronger signal that the name of the module is significant. For example, when `"node:fs"` re-exports everything from `"fs"`, we don’t want to be forced to pick which module is the “better” place to import `readFile` from—we’d rather show a completion for both, even though the exported symbol is the same in both. So each of these get their own keys in the multimap.

When `completionEntryDetails` is called and we have to re-find the export we showed in the previous `completionInfo` request, we never used to check the module symbol when searching the ExportInfoMap—instead, we asserted on it later, issuing the message seen in the telemetry bug. The fix is simply to check that the module symbol matches as part of our search instead of returning the first export info where just the export symbol itself matches.

The fix sounds obvious, so why was this not _more_ broken before? Well, when `completionEntryDetails` is called for an import from an ambient module, we were able to take shortcut that skips this search through the ExportInfoMap containing the faulty code. So the only way for the bug to manifest is when we request details for a symbol that a _non-ambient_ module re-exports from an ambient module, _and_ the iteration order mattered—it could have been correct by coincidence sometimes.