### PR TITLE
Fix crash on `addImportFromExportedSymbol` with default exported symbol

### DIFF
--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -906,9 +906,8 @@ export function getNonAssignedNameOfDeclaration(declaration: Declaration | Expre
         case SyntaxKind.JSDocEnumTag:
             return nameForNamelessJSDocTypedef(declaration as JSDocEnumTag);
         case SyntaxKind.ExportAssignment: {
-            const { expression } = declaration as ExportAssignment;
-            const skipExpression = skipOuterExpressions(expression);
-            return isIdentifier(skipExpression) ? skipExpression : undefined;
+            const expression = skipOuterExpressions((declaration as ExportAssignment).expression);
+            return isIdentifier(expression) ? expression : undefined;
         }
         case SyntaxKind.ElementAccessExpression:
             const expr = declaration as ElementAccessExpression;

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -906,7 +906,7 @@ export function getNonAssignedNameOfDeclaration(declaration: Declaration | Expre
         case SyntaxKind.JSDocEnumTag:
             return nameForNamelessJSDocTypedef(declaration as JSDocEnumTag);
         case SyntaxKind.ExportAssignment: {
-            const expression = skipOuterExpressions((declaration as ExportAssignment).expression);
+            const { expression } = declaration as ExportAssignment;
             return isIdentifier(expression) ? expression : undefined;
         }
         case SyntaxKind.ElementAccessExpression:

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -907,7 +907,8 @@ export function getNonAssignedNameOfDeclaration(declaration: Declaration | Expre
             return nameForNamelessJSDocTypedef(declaration as JSDocEnumTag);
         case SyntaxKind.ExportAssignment: {
             const { expression } = declaration as ExportAssignment;
-            return isIdentifier(expression) ? expression : undefined;
+            const skipExpression = skipOuterExpressions(expression);
+            return isIdentifier(skipExpression) ? skipExpression : undefined;
         }
         case SyntaxKind.ElementAccessExpression:
             const expr = declaration as ElementAccessExpression;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3960,7 +3960,11 @@ function needsNameFromDeclaration(symbol: Symbol) {
 }
 
 function getDefaultLikeExportNameFromDeclaration(symbol: Symbol): string | undefined {
-    return firstDefined(symbol.declarations, d => tryCast(getNameOfDeclaration(d), isIdentifier)?.text);
+    return firstDefined(symbol.declarations, d =>
+        isExportAssignment(d)
+            ? tryCast(skipOuterExpressions(d.expression), isIdentifier)?.text
+            : tryCast(getNameOfDeclaration(d), isIdentifier)?.text
+    );
 }
 
 function getSymbolParentOrFail(symbol: Symbol) {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3959,8 +3959,8 @@ function needsNameFromDeclaration(symbol: Symbol) {
     return !(symbol.flags & SymbolFlags.Transient) && (symbol.escapedName === InternalSymbolName.ExportEquals || symbol.escapedName === InternalSymbolName.Default);
 }
 
-function getDefaultLikeExportNameFromDeclaration(symbol: Symbol) {
-    return firstDefined(symbol.declarations, d => isExportAssignment(d) ? tryCast(skipOuterExpressions(d.expression), isIdentifier)?.text : undefined);
+function getDefaultLikeExportNameFromDeclaration(symbol: Symbol): string | undefined {
+    return firstDefined(symbol.declarations, d => tryCast(getNameOfDeclaration(d), isIdentifier)?.text);
 }
 
 function getSymbolParentOrFail(symbol: Symbol) {

--- a/tests/cases/fourslash/completionsOverridingMethodDefaultExported.ts
+++ b/tests/cases/fourslash/completionsOverridingMethodDefaultExported.ts
@@ -1,0 +1,38 @@
+/// <reference path="fourslash.ts" />
+
+// Issue #52662
+
+// @filename: other.ts
+//// export default class Other {}
+
+// @filename: base.ts
+//// import Other from "./other";
+//// export class Base {
+////     foo(): Other {
+////         throw new Error("");
+////     }
+//// }
+
+// @filename: derived.ts
+//// import { Base } from "./base";
+//// export class Derived extends Base {
+////     /**/
+//// }
+
+verify.completions({
+    marker: "",
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+    includes: [
+        {
+            name: "foo",
+            sortText: completion.SortText.ClassMemberSnippets,
+            insertText: "foo(): Other {\n}",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
+        }
+    ],
+})


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #52662.

The crash was happening because we were using a filename as the name of the default exported symbol when looking up its export info, and we couldn't find it in the export info map. We were using the filename as the name of the default exported symbol because we couldn't properly get its name from its declarations, so I fixed the logic of getting the symbol name for a default exported symbol.
