### PR TITLE
Fix spurious circularity caused by removeOptionalityFromDeclaredType, cache result

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5997,6 +5997,7 @@ export interface NodeLinks {
     declarationRequiresScopeChange?: boolean; // Set by `useOuterVariableScopeInParameter` in checker when downlevel emit would change the name resolution scope inside of a parameter.
     serializedTypes?: Map<string, SerializedTypeEntry>; // Collection of types serialized at this location
     decoratorSignature?: Signature;     // Signature for decorator as if invoked by the runtime.
+    isParameterWithUndefinedInAnnotation?: boolean; // True if this is a parameter declaration whose type annotation contains "undefined".
 }
 
 /** @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5997,7 +5997,7 @@ export interface NodeLinks {
     declarationRequiresScopeChange?: boolean; // Set by `useOuterVariableScopeInParameter` in checker when downlevel emit would change the name resolution scope inside of a parameter.
     serializedTypes?: Map<string, SerializedTypeEntry>; // Collection of types serialized at this location
     decoratorSignature?: Signature;     // Signature for decorator as if invoked by the runtime.
-    isParameterWithUndefinedInAnnotation?: boolean; // True if this is a parameter declaration whose type annotation contains "undefined".
+    parameterInitializerContainsUndefined?: boolean; // True if this is a parameter declaration whose type annotation contains "undefined".
 }
 
 /** @internal */

--- a/src/testRunner/unittests/tsserver/inconsistentErrorInEditor.ts
+++ b/src/testRunner/unittests/tsserver/inconsistentErrorInEditor.ts
@@ -39,3 +39,35 @@ describe("unittests:: tsserver:: inconsistentErrorInEditor", () => {
         baselineTsserverLogs("inconsistentErrorInEditor", "should not error", session);
     });
 });
+
+describe("unittests:: tsserver:: inconsistentErrorInEditor2", () => {
+    it("should not error", () => {
+        const host = createServerHost([]);
+        const session = createSession(host, { canUseEvents: true, noGetErrOnBackgroundUpdate: true, logger: createLoggerWithInMemoryLogs(host) });
+        session.executeCommandSeq<ts.server.protocol.UpdateOpenRequest>({
+            command: ts.server.protocol.CommandTypes.UpdateOpen,
+            arguments: {
+                changedFiles: [],
+                closedFiles: [],
+                openFiles: [
+                    {
+                        file: "^/untitled/ts-nul-authority/Untitled-1",
+                        fileContent: "function fn(Foo: number) {\r\n     type Foo = typeof Foo;\r\n    return 0 as any as {x: Foo};\r\n}",
+                        scriptKindName: "TS"
+                    }
+                ]
+            }
+        });
+        session.executeCommandSeq<ts.server.protocol.EncodedSemanticClassificationsRequest>({
+            command: ts.server.protocol.CommandTypes.EncodedSemanticClassificationsFull,
+            arguments: {
+                file: "^/untitled/ts-nul-authority/Untitled-1",
+                start: 0,
+                length: 128,
+                format: "2020"
+            }
+        });
+        verifyGetErrRequest({ session, host, files: ["^/untitled/ts-nul-authority/Untitled-1"] });
+        baselineTsserverLogs("inconsistentErrorInEditor2", "should not error", session);
+    });
+});

--- a/tests/baselines/reference/tsserver/inconsistentErrorInEditor2/should-not-error.js
+++ b/tests/baselines/reference/tsserver/inconsistentErrorInEditor2/should-not-error.js
@@ -188,7 +188,7 @@ FsWatches::
 FsWatchesRecursive::
 
 Info 16   [00:00:24.000] event:
-    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"^/untitled/ts-nul-authority/Untitled-1","diagnostics":[{"start":{"line":1,"offset":13},"end":{"line":1,"offset":24},"text":"'Foo' is referenced directly or indirectly in its own type annotation.","code":2502,"category":"error"},{"start":{"line":2,"offset":11},"end":{"line":2,"offset":14},"text":"Type alias 'Foo' circularly references itself.","code":2456,"category":"error"}]}}
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"^/untitled/ts-nul-authority/Untitled-1","diagnostics":[]}}
 Before running immediate callbacks and checking length (1)
 
 PolledWatches::

--- a/tests/baselines/reference/tsserver/inconsistentErrorInEditor2/should-not-error.js
+++ b/tests/baselines/reference/tsserver/inconsistentErrorInEditor2/should-not-error.js
@@ -1,0 +1,224 @@
+Info 0    [00:00:02.000] Provided types map file "/a/lib/typesMap.json" doesn't exist
+Info 1    [00:00:03.000] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [],
+        "closedFiles": [],
+        "openFiles": [
+          {
+            "file": "^/untitled/ts-nul-authority/Untitled-1",
+            "fileContent": "function fn(Foo: number) {\r\n     type Foo = typeof Foo;\r\n    return 0 as any as {x: Foo};\r\n}",
+            "scriptKindName": "TS"
+          }
+        ]
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Before request
+
+PolledWatches::
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 2    [00:00:04.000] Search path: ^/untitled/ts-nul-authority
+Info 3    [00:00:05.000] For info: ^/untitled/ts-nul-authority/Untitled-1 :: No config files found.
+Info 4    [00:00:06.000] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info 5    [00:00:07.000] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Info 6    [00:00:08.000] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info 7    [00:00:09.000] Project '/dev/null/inferredProject1*' (Inferred)
+Info 8    [00:00:10.000] 	Files (1)
+	^/untitled/ts-nul-authority/Untitled-1
+
+
+	^/untitled/ts-nul-authority/Untitled-1
+	  Root file specified for compilation
+
+Info 9    [00:00:11.000] -----------------------------------------------
+Info 10   [00:00:12.000] Project '/dev/null/inferredProject1*' (Inferred)
+Info 10   [00:00:13.000] 	Files (1)
+
+Info 10   [00:00:14.000] -----------------------------------------------
+Info 10   [00:00:15.000] Open files: 
+Info 10   [00:00:16.000] 	FileName: ^/untitled/ts-nul-authority/Untitled-1 ProjectRootPath: undefined
+Info 10   [00:00:17.000] 		Projects: /dev/null/inferredProject1*
+After request
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 10   [00:00:18.000] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+Info 11   [00:00:19.000] request:
+    {
+      "command": "encodedSemanticClassifications-full",
+      "arguments": {
+        "file": "^/untitled/ts-nul-authority/Untitled-1",
+        "start": 0,
+        "length": 128,
+        "format": "2020"
+      },
+      "seq": 2,
+      "type": "request"
+    }
+Before request
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+After request
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 12   [00:00:20.000] response:
+    {
+      "response": {
+        "spans": [
+          9,
+          2,
+          2817,
+          12,
+          3,
+          1536,
+          38,
+          3,
+          1537,
+          51,
+          3,
+          1536,
+          81,
+          1,
+          2561,
+          84,
+          3,
+          1536
+        ],
+        "endOfLineState": 0
+      },
+      "responseRequired": true
+    }
+Info 13   [00:00:21.000] request:
+    {
+      "command": "geterr",
+      "arguments": {
+        "delay": 0,
+        "files": [
+          "^/untitled/ts-nul-authority/Untitled-1"
+        ]
+      },
+      "seq": 3,
+      "type": "request"
+    }
+Before request
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+After request
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 14   [00:00:22.000] response:
+    {
+      "responseRequired": false
+    }
+Before checking timeout queue length (1) and running
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 15   [00:00:23.000] event:
+    {"seq":0,"type":"event","event":"syntaxDiag","body":{"file":"^/untitled/ts-nul-authority/Untitled-1","diagnostics":[]}}
+After checking timeout queue length (1) and running
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Before running immediate callbacks and checking length (1)
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 16   [00:00:24.000] event:
+    {"seq":0,"type":"event","event":"semanticDiag","body":{"file":"^/untitled/ts-nul-authority/Untitled-1","diagnostics":[{"start":{"line":1,"offset":13},"end":{"line":1,"offset":24},"text":"'Foo' is referenced directly or indirectly in its own type annotation.","code":2502,"category":"error"},{"start":{"line":2,"offset":11},"end":{"line":2,"offset":14},"text":"Type alias 'Foo' circularly references itself.","code":2456,"category":"error"}]}}
+Before running immediate callbacks and checking length (1)
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Before running immediate callbacks and checking length (1)
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::
+
+Info 17   [00:00:25.000] event:
+    {"seq":0,"type":"event","event":"suggestionDiag","body":{"file":"^/untitled/ts-nul-authority/Untitled-1","diagnostics":[]}}
+Info 18   [00:00:26.000] event:
+    {"seq":0,"type":"event","event":"requestCompleted","body":{"request_seq":3}}
+Before running immediate callbacks and checking length (1)
+
+PolledWatches::
+/a/lib/lib.d.ts:
+  {"pollingInterval":500}
+
+FsWatches::
+
+FsWatchesRecursive::


### PR DESCRIPTION
Fixes #50795

The way the `pushTypeResolution` system works is that each `TypeSystemPropertyName` maps to a currently-being-computed property on a `NodeLinks`, `SymbolLinks`, `Type`, etc, with the expectation that the value is set once the resolution stack is popped. If you try to push the same `TypeSystemPropertyName` onto the stack for the same thing, you get a circularity error because the thing isn't ready yet.

#37023 added a `pushTypeResolution` to detect a circularity, but then used `TypeSystemPropertyName.DeclaredType` even though `removeOptionalityFromDeclaredType` never actually sets `declaredType`. This led to spurious circularity errors depending on the order in which we ask for the types. In this bug's case, if we ask for semantic tokens first, we end up hitting what the old code thought was a cycle but is in fact not.

This PR fixes the issue while still emitting the right circularity error added in #37023 by creating a new property on `NodeLinks` which caches the computation that determines whether or not a parameter's initializer contains `undefined`. Then, we can add a `TypeSystemPropertyName` that is associated with that value, which then lets us detect cycles specifically in this part of the code, without reusing an unrelated `TypeSystemPropertyName`.

It also has the benefit of being faster because this computation is now cached rather than being reevaluated each time, and I've also switched it to use `checkDeclarationInitializer` which is the "correct" way to grab the declaration's initializer type (uses `checkExpressionCached`, uses JSDoc when needed, and so on).