### PR TITLE
Add tests for inferring contextual generic mapped types

### DIFF
--- a/tests/baselines/reference/genericContextualTypes2.symbols
+++ b/tests/baselines/reference/genericContextualTypes2.symbols
@@ -1,0 +1,123 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts ===
+type LowInfer<T> = T & {};
+>LowInfer : Symbol(LowInfer, Decl(genericContextualTypes2.ts, 0, 0))
+>T : Symbol(T, Decl(genericContextualTypes2.ts, 0, 14))
+>T : Symbol(T, Decl(genericContextualTypes2.ts, 0, 14))
+
+type PartialAssigner<TContext, TKey extends keyof TContext> = (
+>PartialAssigner : Symbol(PartialAssigner, Decl(genericContextualTypes2.ts, 0, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 2, 21))
+>TKey : Symbol(TKey, Decl(genericContextualTypes2.ts, 2, 30))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 2, 21))
+
+  context: TContext
+>context : Symbol(context, Decl(genericContextualTypes2.ts, 2, 63))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 2, 21))
+
+) => TContext[TKey];
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 2, 21))
+>TKey : Symbol(TKey, Decl(genericContextualTypes2.ts, 2, 30))
+
+type PropertyAssigner<TContext> = {
+>PropertyAssigner : Symbol(PropertyAssigner, Decl(genericContextualTypes2.ts, 4, 20))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 6, 22))
+
+  [K in keyof TContext]?: PartialAssigner<TContext, K> | TContext[K];
+>K : Symbol(K, Decl(genericContextualTypes2.ts, 7, 3))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 6, 22))
+>PartialAssigner : Symbol(PartialAssigner, Decl(genericContextualTypes2.ts, 0, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 6, 22))
+>K : Symbol(K, Decl(genericContextualTypes2.ts, 7, 3))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 6, 22))
+>K : Symbol(K, Decl(genericContextualTypes2.ts, 7, 3))
+
+};
+
+type Meta<TContext> = {
+>Meta : Symbol(Meta, Decl(genericContextualTypes2.ts, 8, 2))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 10, 10))
+
+  action: (ctx: TContext) => void
+>action : Symbol(action, Decl(genericContextualTypes2.ts, 10, 23))
+>ctx : Symbol(ctx, Decl(genericContextualTypes2.ts, 11, 11))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 10, 10))
+}
+
+interface AssignAction<TContext> {
+>AssignAction : Symbol(AssignAction, Decl(genericContextualTypes2.ts, 12, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 14, 23))
+
+  type: "xstate.assign";
+>type : Symbol(AssignAction.type, Decl(genericContextualTypes2.ts, 14, 34))
+
+  exec: (arg: TContext, meta: Meta<TContext>) => void;
+>exec : Symbol(AssignAction.exec, Decl(genericContextualTypes2.ts, 15, 24))
+>arg : Symbol(arg, Decl(genericContextualTypes2.ts, 16, 9))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 14, 23))
+>meta : Symbol(meta, Decl(genericContextualTypes2.ts, 16, 23))
+>Meta : Symbol(Meta, Decl(genericContextualTypes2.ts, 8, 2))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 14, 23))
+}
+
+declare function assign<TContext>(
+>assign : Symbol(assign, Decl(genericContextualTypes2.ts, 17, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 19, 24))
+
+  assignment: PropertyAssigner<LowInfer<TContext>>
+>assignment : Symbol(assignment, Decl(genericContextualTypes2.ts, 19, 34))
+>PropertyAssigner : Symbol(PropertyAssigner, Decl(genericContextualTypes2.ts, 4, 20))
+>LowInfer : Symbol(LowInfer, Decl(genericContextualTypes2.ts, 0, 0))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 19, 24))
+
+): AssignAction<TContext>;
+>AssignAction : Symbol(AssignAction, Decl(genericContextualTypes2.ts, 12, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 19, 24))
+
+type Config<TContext> = {
+>Config : Symbol(Config, Decl(genericContextualTypes2.ts, 21, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 23, 12))
+
+  context: TContext;
+>context : Symbol(context, Decl(genericContextualTypes2.ts, 23, 25))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 23, 12))
+
+  entry?: AssignAction<TContext>;
+>entry : Symbol(entry, Decl(genericContextualTypes2.ts, 24, 20))
+>AssignAction : Symbol(AssignAction, Decl(genericContextualTypes2.ts, 12, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 23, 12))
+
+};
+
+declare function createMachine<TContext>(config: Config<TContext>): void;
+>createMachine : Symbol(createMachine, Decl(genericContextualTypes2.ts, 26, 2))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 28, 31))
+>config : Symbol(config, Decl(genericContextualTypes2.ts, 28, 41))
+>Config : Symbol(Config, Decl(genericContextualTypes2.ts, 21, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes2.ts, 28, 31))
+
+createMachine<{ count: number }>({
+>createMachine : Symbol(createMachine, Decl(genericContextualTypes2.ts, 26, 2))
+>count : Symbol(count, Decl(genericContextualTypes2.ts, 30, 15))
+
+  context: {
+>context : Symbol(context, Decl(genericContextualTypes2.ts, 30, 34))
+
+    count: 0,
+>count : Symbol(count, Decl(genericContextualTypes2.ts, 31, 12))
+
+  },
+  entry: assign({
+>entry : Symbol(entry, Decl(genericContextualTypes2.ts, 33, 4))
+>assign : Symbol(assign, Decl(genericContextualTypes2.ts, 17, 1))
+
+    count: (ctx: { count: number }) => ++ctx.count,
+>count : Symbol(count, Decl(genericContextualTypes2.ts, 34, 17))
+>ctx : Symbol(ctx, Decl(genericContextualTypes2.ts, 35, 12))
+>count : Symbol(count, Decl(genericContextualTypes2.ts, 35, 18))
+>ctx.count : Symbol(count, Decl(genericContextualTypes2.ts, 35, 18))
+>ctx : Symbol(ctx, Decl(genericContextualTypes2.ts, 35, 12))
+>count : Symbol(count, Decl(genericContextualTypes2.ts, 35, 18))
+
+  }),
+});
+

--- a/tests/baselines/reference/genericContextualTypes2.types
+++ b/tests/baselines/reference/genericContextualTypes2.types
@@ -1,0 +1,93 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts ===
+type LowInfer<T> = T & {};
+>LowInfer : LowInfer<T>
+
+type PartialAssigner<TContext, TKey extends keyof TContext> = (
+>PartialAssigner : PartialAssigner<TContext, TKey>
+
+  context: TContext
+>context : TContext
+
+) => TContext[TKey];
+
+type PropertyAssigner<TContext> = {
+>PropertyAssigner : PropertyAssigner<TContext>
+
+  [K in keyof TContext]?: PartialAssigner<TContext, K> | TContext[K];
+};
+
+type Meta<TContext> = {
+>Meta : Meta<TContext>
+
+  action: (ctx: TContext) => void
+>action : (ctx: TContext) => void
+>ctx : TContext
+}
+
+interface AssignAction<TContext> {
+  type: "xstate.assign";
+>type : "xstate.assign"
+
+  exec: (arg: TContext, meta: Meta<TContext>) => void;
+>exec : (arg: TContext, meta: Meta<TContext>) => void
+>arg : TContext
+>meta : Meta<TContext>
+}
+
+declare function assign<TContext>(
+>assign : <TContext>(assignment: PropertyAssigner<LowInfer<TContext>>) => AssignAction<TContext>
+
+  assignment: PropertyAssigner<LowInfer<TContext>>
+>assignment : PropertyAssigner<LowInfer<TContext>>
+
+): AssignAction<TContext>;
+
+type Config<TContext> = {
+>Config : Config<TContext>
+
+  context: TContext;
+>context : TContext
+
+  entry?: AssignAction<TContext>;
+>entry : AssignAction<TContext> | undefined
+
+};
+
+declare function createMachine<TContext>(config: Config<TContext>): void;
+>createMachine : <TContext>(config: Config<TContext>) => void
+>config : Config<TContext>
+
+createMachine<{ count: number }>({
+>createMachine<{ count: number }>({  context: {    count: 0,  },  entry: assign({    count: (ctx: { count: number }) => ++ctx.count,  }),}) : void
+>createMachine : <TContext>(config: Config<TContext>) => void
+>count : number
+>{  context: {    count: 0,  },  entry: assign({    count: (ctx: { count: number }) => ++ctx.count,  }),} : { context: { count: number; }; entry: AssignAction<{ count: number; }>; }
+
+  context: {
+>context : { count: number; }
+>{    count: 0,  } : { count: number; }
+
+    count: 0,
+>count : number
+>0 : 0
+
+  },
+  entry: assign({
+>entry : AssignAction<{ count: number; }>
+>assign({    count: (ctx: { count: number }) => ++ctx.count,  }) : AssignAction<{ count: number; }>
+>assign : <TContext>(assignment: PropertyAssigner<LowInfer<TContext>>) => AssignAction<TContext>
+>{    count: (ctx: { count: number }) => ++ctx.count,  } : { count: (ctx: {    count: number;}) => number; }
+
+    count: (ctx: { count: number }) => ++ctx.count,
+>count : (ctx: {    count: number;}) => number
+>(ctx: { count: number }) => ++ctx.count : (ctx: {    count: number;}) => number
+>ctx : { count: number; }
+>count : number
+>++ctx.count : number
+>ctx.count : number
+>ctx : { count: number; }
+>count : number
+
+  }),
+});
+

--- a/tests/baselines/reference/genericContextualTypes3.symbols
+++ b/tests/baselines/reference/genericContextualTypes3.symbols
@@ -1,0 +1,122 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts ===
+type LowInfer<T> = T & {};
+>LowInfer : Symbol(LowInfer, Decl(genericContextualTypes3.ts, 0, 0))
+>T : Symbol(T, Decl(genericContextualTypes3.ts, 0, 14))
+>T : Symbol(T, Decl(genericContextualTypes3.ts, 0, 14))
+
+type PartialAssigner<TContext, TKey extends keyof TContext> = (
+>PartialAssigner : Symbol(PartialAssigner, Decl(genericContextualTypes3.ts, 0, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 2, 21))
+>TKey : Symbol(TKey, Decl(genericContextualTypes3.ts, 2, 30))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 2, 21))
+
+  context: TContext
+>context : Symbol(context, Decl(genericContextualTypes3.ts, 2, 63))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 2, 21))
+
+) => TContext[TKey];
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 2, 21))
+>TKey : Symbol(TKey, Decl(genericContextualTypes3.ts, 2, 30))
+
+type PropertyAssigner<TContext> = {
+>PropertyAssigner : Symbol(PropertyAssigner, Decl(genericContextualTypes3.ts, 4, 20))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 6, 22))
+
+  [K in keyof TContext]?: PartialAssigner<TContext, K> | TContext[K];
+>K : Symbol(K, Decl(genericContextualTypes3.ts, 7, 3))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 6, 22))
+>PartialAssigner : Symbol(PartialAssigner, Decl(genericContextualTypes3.ts, 0, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 6, 22))
+>K : Symbol(K, Decl(genericContextualTypes3.ts, 7, 3))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 6, 22))
+>K : Symbol(K, Decl(genericContextualTypes3.ts, 7, 3))
+
+};
+
+type Meta<TContext> = {
+>Meta : Symbol(Meta, Decl(genericContextualTypes3.ts, 8, 2))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 10, 10))
+
+  action: (ctx: TContext) => void
+>action : Symbol(action, Decl(genericContextualTypes3.ts, 10, 23))
+>ctx : Symbol(ctx, Decl(genericContextualTypes3.ts, 11, 11))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 10, 10))
+}
+
+interface AssignAction<TContext> {
+>AssignAction : Symbol(AssignAction, Decl(genericContextualTypes3.ts, 12, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 14, 23))
+
+  type: "xstate.assign";
+>type : Symbol(AssignAction.type, Decl(genericContextualTypes3.ts, 14, 34))
+
+  (arg: TContext, meta: Meta<TContext>): void;
+>arg : Symbol(arg, Decl(genericContextualTypes3.ts, 16, 3))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 14, 23))
+>meta : Symbol(meta, Decl(genericContextualTypes3.ts, 16, 17))
+>Meta : Symbol(Meta, Decl(genericContextualTypes3.ts, 8, 2))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 14, 23))
+}
+
+declare function assign<TContext>(
+>assign : Symbol(assign, Decl(genericContextualTypes3.ts, 17, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 19, 24))
+
+  assignment: PropertyAssigner<LowInfer<TContext>>
+>assignment : Symbol(assignment, Decl(genericContextualTypes3.ts, 19, 34))
+>PropertyAssigner : Symbol(PropertyAssigner, Decl(genericContextualTypes3.ts, 4, 20))
+>LowInfer : Symbol(LowInfer, Decl(genericContextualTypes3.ts, 0, 0))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 19, 24))
+
+): AssignAction<TContext>;
+>AssignAction : Symbol(AssignAction, Decl(genericContextualTypes3.ts, 12, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 19, 24))
+
+type Config<TContext> = {
+>Config : Symbol(Config, Decl(genericContextualTypes3.ts, 21, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 23, 12))
+
+  context: TContext;
+>context : Symbol(context, Decl(genericContextualTypes3.ts, 23, 25))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 23, 12))
+
+  entry?: AssignAction<TContext>;
+>entry : Symbol(entry, Decl(genericContextualTypes3.ts, 24, 20))
+>AssignAction : Symbol(AssignAction, Decl(genericContextualTypes3.ts, 12, 1))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 23, 12))
+
+};
+
+declare function createMachine<TContext>(config: Config<TContext>): void;
+>createMachine : Symbol(createMachine, Decl(genericContextualTypes3.ts, 26, 2))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 28, 31))
+>config : Symbol(config, Decl(genericContextualTypes3.ts, 28, 41))
+>Config : Symbol(Config, Decl(genericContextualTypes3.ts, 21, 26))
+>TContext : Symbol(TContext, Decl(genericContextualTypes3.ts, 28, 31))
+
+createMachine<{ count: number }>({
+>createMachine : Symbol(createMachine, Decl(genericContextualTypes3.ts, 26, 2))
+>count : Symbol(count, Decl(genericContextualTypes3.ts, 30, 15))
+
+  context: {
+>context : Symbol(context, Decl(genericContextualTypes3.ts, 30, 34))
+
+    count: 0,
+>count : Symbol(count, Decl(genericContextualTypes3.ts, 31, 12))
+
+  },
+  entry: assign({
+>entry : Symbol(entry, Decl(genericContextualTypes3.ts, 33, 4))
+>assign : Symbol(assign, Decl(genericContextualTypes3.ts, 17, 1))
+
+    count: (ctx: { count: number }) => ++ctx.count,
+>count : Symbol(count, Decl(genericContextualTypes3.ts, 34, 17))
+>ctx : Symbol(ctx, Decl(genericContextualTypes3.ts, 35, 12))
+>count : Symbol(count, Decl(genericContextualTypes3.ts, 35, 18))
+>ctx.count : Symbol(count, Decl(genericContextualTypes3.ts, 35, 18))
+>ctx : Symbol(ctx, Decl(genericContextualTypes3.ts, 35, 12))
+>count : Symbol(count, Decl(genericContextualTypes3.ts, 35, 18))
+
+  }),
+});
+

--- a/tests/baselines/reference/genericContextualTypes3.types
+++ b/tests/baselines/reference/genericContextualTypes3.types
@@ -1,0 +1,92 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts ===
+type LowInfer<T> = T & {};
+>LowInfer : LowInfer<T>
+
+type PartialAssigner<TContext, TKey extends keyof TContext> = (
+>PartialAssigner : PartialAssigner<TContext, TKey>
+
+  context: TContext
+>context : TContext
+
+) => TContext[TKey];
+
+type PropertyAssigner<TContext> = {
+>PropertyAssigner : PropertyAssigner<TContext>
+
+  [K in keyof TContext]?: PartialAssigner<TContext, K> | TContext[K];
+};
+
+type Meta<TContext> = {
+>Meta : Meta<TContext>
+
+  action: (ctx: TContext) => void
+>action : (ctx: TContext) => void
+>ctx : TContext
+}
+
+interface AssignAction<TContext> {
+  type: "xstate.assign";
+>type : "xstate.assign"
+
+  (arg: TContext, meta: Meta<TContext>): void;
+>arg : TContext
+>meta : Meta<TContext>
+}
+
+declare function assign<TContext>(
+>assign : <TContext>(assignment: PropertyAssigner<LowInfer<TContext>>) => AssignAction<TContext>
+
+  assignment: PropertyAssigner<LowInfer<TContext>>
+>assignment : PropertyAssigner<LowInfer<TContext>>
+
+): AssignAction<TContext>;
+
+type Config<TContext> = {
+>Config : Config<TContext>
+
+  context: TContext;
+>context : TContext
+
+  entry?: AssignAction<TContext>;
+>entry : AssignAction<TContext> | undefined
+
+};
+
+declare function createMachine<TContext>(config: Config<TContext>): void;
+>createMachine : <TContext>(config: Config<TContext>) => void
+>config : Config<TContext>
+
+createMachine<{ count: number }>({
+>createMachine<{ count: number }>({  context: {    count: 0,  },  entry: assign({    count: (ctx: { count: number }) => ++ctx.count,  }),}) : void
+>createMachine : <TContext>(config: Config<TContext>) => void
+>count : number
+>{  context: {    count: 0,  },  entry: assign({    count: (ctx: { count: number }) => ++ctx.count,  }),} : { context: { count: number; }; entry: AssignAction<{ count: number; }>; }
+
+  context: {
+>context : { count: number; }
+>{    count: 0,  } : { count: number; }
+
+    count: 0,
+>count : number
+>0 : 0
+
+  },
+  entry: assign({
+>entry : AssignAction<{ count: number; }>
+>assign({    count: (ctx: { count: number }) => ++ctx.count,  }) : AssignAction<{ count: number; }>
+>assign : <TContext>(assignment: PropertyAssigner<LowInfer<TContext>>) => AssignAction<TContext>
+>{    count: (ctx: { count: number }) => ++ctx.count,  } : { count: (ctx: {    count: number;}) => number; }
+
+    count: (ctx: { count: number }) => ++ctx.count,
+>count : (ctx: {    count: number;}) => number
+>(ctx: { count: number }) => ++ctx.count : (ctx: {    count: number;}) => number
+>ctx : { count: number; }
+>count : number
+>++ctx.count : number
+>ctx.count : number
+>ctx : { count: number; }
+>count : number
+
+  }),
+});
+

--- a/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
@@ -1,0 +1,41 @@
+// @strict: true
+// @noEmit: true
+
+type LowInfer<T> = T & {};
+
+type PartialAssigner<TContext, TKey extends keyof TContext> = (
+  context: TContext
+) => TContext[TKey];
+
+type PropertyAssigner<TContext> = {
+  [K in keyof TContext]?: PartialAssigner<TContext, K> | TContext[K];
+};
+
+type Meta<TContext> = {
+  action: (ctx: TContext) => void
+}
+
+interface AssignAction<TContext> {
+  type: "xstate.assign";
+  exec: (arg: TContext, meta: Meta<TContext>) => void;
+}
+
+declare function assign<TContext>(
+  assignment: PropertyAssigner<LowInfer<TContext>>
+): AssignAction<TContext>;
+
+type Config<TContext> = {
+  context: TContext;
+  entry?: AssignAction<TContext>;
+};
+
+declare function createMachine<TContext>(config: Config<TContext>): void;
+
+createMachine<{ count: number }>({
+  context: {
+    count: 0,
+  },
+  entry: assign({
+    count: (ctx: { count: number }) => ++ctx.count,
+  }),
+});

--- a/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
@@ -1,0 +1,41 @@
+// @strict: true
+// @noEmit: true
+
+type LowInfer<T> = T & {};
+
+type PartialAssigner<TContext, TKey extends keyof TContext> = (
+  context: TContext
+) => TContext[TKey];
+
+type PropertyAssigner<TContext> = {
+  [K in keyof TContext]?: PartialAssigner<TContext, K> | TContext[K];
+};
+
+type Meta<TContext> = {
+  action: (ctx: TContext) => void
+}
+
+interface AssignAction<TContext> {
+  type: "xstate.assign";
+  (arg: TContext, meta: Meta<TContext>): void;
+}
+
+declare function assign<TContext>(
+  assignment: PropertyAssigner<LowInfer<TContext>>
+): AssignAction<TContext>;
+
+type Config<TContext> = {
+  context: TContext;
+  entry?: AssignAction<TContext>;
+};
+
+declare function createMachine<TContext>(config: Config<TContext>): void;
+
+createMachine<{ count: number }>({
+  context: {
+    count: 0,
+  },
+  entry: assign({
+    count: (ctx: { count: number }) => ++ctx.count,
+  }),
+});


### PR DESCRIPTION
This PR only introduces some tests. We started relying on this in [XState](https://github.com/statelyai/xstate) and it turned out that this doesn't work pre-4.8.

I tracked down the PR that enabled this use case: https://github.com/microsoft/TypeScript/pull/49696 (cc @ahejlsberg ). It wasn't fixing any case like that (no similar tests introduced there) so I figured out that it's best for us to provide tests for this here - to ensure that this won't accidentally regress (as long as you believe that this should continue to work, of course)