### PR TITLE
Fix auto-imports of redirected packages while making ExportInfoMap smaller?

### DIFF
--- a/tests/cases/fourslash/server/autoImportRedirect.ts
+++ b/tests/cases/fourslash/server/autoImportRedirect.ts
@@ -1,0 +1,76 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "module": "commonjs"
+////     }
+//// }
+
+// @Filename: /node_modules/foo/package.json
+//// {
+////     "name": "foo",
+////     "version": "1.0.0"
+//// }
+
+// @Filename: /node_modules/foo/index.d.ts
+//// import "duplicate";
+//// export declare const foo: number;
+
+// @Filename: /node_modules/foo/node_modules/duplicate/package.json
+//// {
+////     "name": "duplicate",
+////     "version": "1.0.0"
+//// }
+
+// @Filename: /node_modules/foo/node_modules/duplicate/index.d.ts
+//// export declare const duplicate: number;
+
+// @Filename: /node_modules/bar/package.json
+//// {
+////     "name": "bar",
+////     "version": "1.0.0"
+//// }
+
+// @Filename: /node_modules/bar/index.d.ts
+//// import "duplicate";
+//// export declare const bar: number;
+
+// @Filename: /node_modules/bar/node_modules/duplicate/package.json
+//// {
+////     "name": "duplicate",
+////     "version": "1.0.0"
+//// }
+
+// @Filename: /node_modules/bar/node_modules/duplicate/index.d.ts
+//// export declare const duplicate: number;
+
+// This seems far-fetched but I don't know how else to test this
+
+// @link: /node_modules/bar/node_modules/duplicate -> /node_modules/duplicate
+
+// @Filename: /utils.ts
+//// import {} from "duplicate";
+
+// @Filename: /index.ts
+//// import { foo } from "foo";
+//// import { bar } from "bar";
+//// duplicate/**/
+
+goTo.file("/index.ts");
+verify.completions({
+    marker: "",
+    includes: [{
+        name: "duplicate",
+        source: "duplicate",
+        sourceDisplay: "duplicate",
+        hasAction: true,
+        sortText: completion.SortText.AutoImportSuggestions
+    }],
+    preferences: {
+        includeCompletionsForModuleExports: true,
+        allowIncompleteCompletions: true
+    }
+});
+
+verify.importFixModuleSpecifiers("", ["duplicate"]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

I noticed while investigating #52661 that redirected packages might not be behaving as intended in the ExportInfoMap. Exports from redirected source files are present in the ExportInfoMap, but later `forEachFileNameOfModule` fetches redirects and considers them in its logic, so there’s definitely some amount of redundant work and storage. Currently, however, there are a couple places where we get the redirect target instead of the source for a module specifier computation, so there are cases where auto-imports that should be available via a redirect don’t work at all.
