### PR TITLE
Do not report errors when inference is partially blocked

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1423,6 +1423,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     let inlineLevel = 0;
     let currentNode: Node | undefined;
     let varianceTypeParameter: TypeParameter | undefined;
+    let isInferencePartiallyBlocked = false;
 
     const emptySymbols = createSymbolTable();
     const arrayVariances = [VarianceFlags.Covariant];
@@ -1824,7 +1825,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             } while (toMarkSkip && toMarkSkip !== containingCall);
             getNodeLinks(containingCall).resolvedSignature = undefined;
         }
+        isInferencePartiallyBlocked = true;
         const result = fn();
+        isInferencePartiallyBlocked = false;
         if (containingCall) {
             let toMarkSkip = node!;
             do {
@@ -32601,7 +32604,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const isTaggedTemplate = node.kind === SyntaxKind.TaggedTemplateExpression;
         const isDecorator = node.kind === SyntaxKind.Decorator;
         const isJsxOpeningOrSelfClosingElement = isJsxOpeningLikeElement(node);
-        const reportErrors = !candidatesOutArray;
+        const reportErrors = !isInferencePartiallyBlocked && !candidatesOutArray;
 
         let typeArguments: NodeArray<TypeNode> | undefined;
 

--- a/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction1.ts
+++ b/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction1.ts
@@ -1,0 +1,9 @@
+///<reference path="fourslash.ts"/>
+// @strict: true
+////
+//// declare function func<T extends { foo: 1 }>(arg: T): void;
+//// func({ foo: 1, bar/*1*/: 1 });
+
+goTo.marker("1");
+verify.completions({ exact: undefined });
+verify.noErrors();

--- a/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction2.ts
+++ b/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction2.ts
@@ -1,0 +1,12 @@
+///<reference path="fourslash.ts"/>
+// @strict: true
+////
+//// // repro from #50818#issuecomment-1278324638
+////
+//// declare function func<T extends { foo: 1 }>(arg: T): void;
+//// func({ foo: 1, bar/*1*/: 1 });
+
+goTo.marker("1");
+edit.insert("2");
+verify.completions({ exact: undefined });
+verify.noErrors();

--- a/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction3.ts
+++ b/tests/cases/fourslash/noErrorsAfterCompletionsRequestWithinGenericFunction3.ts
@@ -1,0 +1,25 @@
+///<reference path="fourslash.ts"/>
+// @strict: true
+////
+//// // repro from #52580#issuecomment-1416131055
+////
+//// type Funcs<A, B extends Record<string, unknown>> = {
+////   [K in keyof B]: {
+////     fn: (a: A, b: B) => void;
+////     thing: B[K];
+////   }
+//// }
+////
+//// function foo<A, B extends Record<string, unknown>>(fns: Funcs<A, B>) {}
+////
+//// foo({
+////   bar: { fn: (a: string, b) => {}, thing: "asd" },
+////   /*1*/
+//// });
+
+goTo.marker("1");
+const markerPosition = test.markers()[0].position;
+edit.paste(`bar: { fn: (a: string, b) => {}, thing: "asd" },`)
+edit.replace(markerPosition + 4, 1, 'z')
+verify.completions({ isNewIdentifierLocation: true });
+verify.noErrors();


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/50818
sort of supersedes https://github.com/microsoft/TypeScript/pull/52393

cc @andrewbranch @weswigham 