### PR TITLE
Don't allow everything to be assignable to string within string mappings like Uppercase/Lowercase

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23872,10 +23872,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isMemberOfStringMapping(source: Type, target: Type): boolean {
-        if (target.flags & (TypeFlags.String | TypeFlags.Any)) {
+        if (target.flags & TypeFlags.Any) {
             return true;
         }
-        if (target.flags & TypeFlags.TemplateLiteral) {
+        if (target.flags & (TypeFlags.String & TypeFlags.TemplateLiteral)) {
             return isTypeAssignableTo(source, target);
         }
         if (target.flags & TypeFlags.StringMapping) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23875,7 +23875,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (target.flags & TypeFlags.Any) {
             return true;
         }
-        if (target.flags & (TypeFlags.String & TypeFlags.TemplateLiteral)) {
+        if (target.flags & (TypeFlags.String | TypeFlags.TemplateLiteral)) {
             return isTypeAssignableTo(source, target);
         }
         if (target.flags & TypeFlags.StringMapping) {

--- a/tests/baselines/reference/stringMappingAssignability.errors.txt
+++ b/tests/baselines/reference/stringMappingAssignability.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/stringMappingAssignability.ts(1,7): error TS2322: Type 'number' is not assignable to type 'Uppercase<string>'.
+tests/cases/compiler/stringMappingAssignability.ts(2,7): error TS2322: Type '{ foo: string; }' is not assignable to type 'Uppercase<string>'.
+
+
+==== tests/cases/compiler/stringMappingAssignability.ts (2 errors) ====
+    const x: Uppercase<string> = 42;
+          ~
+!!! error TS2322: Type 'number' is not assignable to type 'Uppercase<string>'.
+    const y: Uppercase<string> = { foo: "bar" };
+          ~
+!!! error TS2322: Type '{ foo: string; }' is not assignable to type 'Uppercase<string>'.
+    

--- a/tests/baselines/reference/stringMappingAssignability.js
+++ b/tests/baselines/reference/stringMappingAssignability.js
@@ -1,0 +1,9 @@
+//// [stringMappingAssignability.ts]
+const x: Uppercase<string> = 42;
+const y: Uppercase<string> = { foo: "bar" };
+
+
+//// [stringMappingAssignability.js]
+"use strict";
+var x = 42;
+var y = { foo: "bar" };

--- a/tests/baselines/reference/stringMappingAssignability.symbols
+++ b/tests/baselines/reference/stringMappingAssignability.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/stringMappingAssignability.ts ===
+const x: Uppercase<string> = 42;
+>x : Symbol(x, Decl(stringMappingAssignability.ts, 0, 5))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+
+const y: Uppercase<string> = { foo: "bar" };
+>y : Symbol(y, Decl(stringMappingAssignability.ts, 1, 5))
+>Uppercase : Symbol(Uppercase, Decl(lib.es5.d.ts, --, --))
+>foo : Symbol(foo, Decl(stringMappingAssignability.ts, 1, 30))
+

--- a/tests/baselines/reference/stringMappingAssignability.types
+++ b/tests/baselines/reference/stringMappingAssignability.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/stringMappingAssignability.ts ===
+const x: Uppercase<string> = 42;
+>x : Uppercase<string>
+>42 : 42
+
+const y: Uppercase<string> = { foo: "bar" };
+>y : Uppercase<string>
+>{ foo: "bar" } : { foo: string; }
+>foo : string
+>"bar" : "bar"
+

--- a/tests/cases/compiler/stringMappingAssignability.ts
+++ b/tests/cases/compiler/stringMappingAssignability.ts
@@ -1,0 +1,4 @@
+// @strict: true
+
+const x: Uppercase<string> = 42;
+const y: Uppercase<string> = { foo: "bar" };


### PR DESCRIPTION
Fixes #52731
