### PR TITLE
Add an extra test case for inferring return type of generic class without a constructor

### DIFF
--- a/tests/baselines/reference/inferringReturnTypeFromConstructSignatureGeneric.js
+++ b/tests/baselines/reference/inferringReturnTypeFromConstructSignatureGeneric.js
@@ -29,6 +29,11 @@ const g3 = g(GenericNumberOrString);
 g3.give(1);
 g3.give('1');
 
+// repro from #35636
+class C<T> {}
+const g4 = g(C);
+
+
 //// [inferringReturnTypeFromConstructSignatureGeneric.js]
 var GenericObject = /** @class */ (function () {
     function GenericObject() {
@@ -64,3 +69,10 @@ g2.give(1);
 var g3 = g(GenericNumberOrString);
 g3.give(1);
 g3.give('1');
+// repro from #35636
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+var g4 = g(C);

--- a/tests/baselines/reference/inferringReturnTypeFromConstructSignatureGeneric.symbols
+++ b/tests/baselines/reference/inferringReturnTypeFromConstructSignatureGeneric.symbols
@@ -85,3 +85,13 @@ g3.give('1');
 >g3 : Symbol(g3, Decl(inferringReturnTypeFromConstructSignatureGeneric.ts, 26, 5))
 >give : Symbol(GenericNumberOrString.give, Decl(inferringReturnTypeFromConstructSignatureGeneric.ts, 10, 56))
 
+// repro from #35636
+class C<T> {}
+>C : Symbol(C, Decl(inferringReturnTypeFromConstructSignatureGeneric.ts, 28, 13))
+>T : Symbol(T, Decl(inferringReturnTypeFromConstructSignatureGeneric.ts, 31, 8))
+
+const g4 = g(C);
+>g4 : Symbol(g4, Decl(inferringReturnTypeFromConstructSignatureGeneric.ts, 32, 5))
+>g : Symbol(g, Decl(inferringReturnTypeFromConstructSignatureGeneric.ts, 14, 1))
+>C : Symbol(C, Decl(inferringReturnTypeFromConstructSignatureGeneric.ts, 28, 13))
+

--- a/tests/baselines/reference/inferringReturnTypeFromConstructSignatureGeneric.types
+++ b/tests/baselines/reference/inferringReturnTypeFromConstructSignatureGeneric.types
@@ -88,3 +88,13 @@ g3.give('1');
 >give : (value: string | number) => string | number
 >'1' : "1"
 
+// repro from #35636
+class C<T> {}
+>C : C<T>
+
+const g4 = g(C);
+>g4 : C<unknown>
+>g(C) : C<unknown>
+>g : <T>(type: new () => T) => T
+>C : typeof C
+

--- a/tests/cases/compiler/inferringReturnTypeFromConstructSignatureGeneric.ts
+++ b/tests/cases/compiler/inferringReturnTypeFromConstructSignatureGeneric.ts
@@ -27,3 +27,7 @@ g2.give(1);
 const g3 = g(GenericNumberOrString);
 g3.give(1);
 g3.give('1');
+
+// repro from #35636
+class C<T> {}
+const g4 = g(C);


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/35636
it was fixed by https://github.com/microsoft/TypeScript/pull/47750