### PR TITLE
Add an extra test case for an aliased mapped type inference

### DIFF
--- a/tests/baselines/reference/mappedTypeInferenceAliasSubstitution.symbols
+++ b/tests/baselines/reference/mappedTypeInferenceAliasSubstitution.symbols
@@ -1,0 +1,52 @@
+=== tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts ===
+// repro from #31616
+
+const v = { test: { smth: 5 } };
+>v : Symbol(v, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 5))
+>test : Symbol(test, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 11))
+>smth : Symbol(smth, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 19))
+
+type Field<A extends string, R> = { [K in A]: R }
+>Field : Symbol(Field, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 32))
+>A : Symbol(A, Decl(mappedTypeInferenceAliasSubstitution.ts, 4, 11))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 4, 28))
+>K : Symbol(K, Decl(mappedTypeInferenceAliasSubstitution.ts, 4, 37))
+>A : Symbol(A, Decl(mappedTypeInferenceAliasSubstitution.ts, 4, 11))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 4, 28))
+
+const f = <A extends string, B extends string, R>(x: { [K in A]: Field<B, R> }): R => ({} as any);
+>f : Symbol(f, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 5))
+>A : Symbol(A, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 11))
+>B : Symbol(B, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 28))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 46))
+>x : Symbol(x, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 50))
+>K : Symbol(K, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 56))
+>A : Symbol(A, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 11))
+>Field : Symbol(Field, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 32))
+>B : Symbol(B, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 28))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 46))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 46))
+
+const r1 = f(v);
+>r1 : Symbol(r1, Decl(mappedTypeInferenceAliasSubstitution.ts, 7, 5))
+>f : Symbol(f, Decl(mappedTypeInferenceAliasSubstitution.ts, 6, 5))
+>v : Symbol(v, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 5))
+
+const g = <A extends string, B extends string, R>(x: Field<A, Field<B, R>>): R => ({} as any);
+>g : Symbol(g, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 5))
+>A : Symbol(A, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 11))
+>B : Symbol(B, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 28))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 46))
+>x : Symbol(x, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 50))
+>Field : Symbol(Field, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 32))
+>A : Symbol(A, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 11))
+>Field : Symbol(Field, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 32))
+>B : Symbol(B, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 28))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 46))
+>R : Symbol(R, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 46))
+
+const r2 = g(v);
+>r2 : Symbol(r2, Decl(mappedTypeInferenceAliasSubstitution.ts, 10, 5))
+>g : Symbol(g, Decl(mappedTypeInferenceAliasSubstitution.ts, 9, 5))
+>v : Symbol(v, Decl(mappedTypeInferenceAliasSubstitution.ts, 2, 5))
+

--- a/tests/baselines/reference/mappedTypeInferenceAliasSubstitution.types
+++ b/tests/baselines/reference/mappedTypeInferenceAliasSubstitution.types
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts ===
+// repro from #31616
+
+const v = { test: { smth: 5 } };
+>v : { test: { smth: number; }; }
+>{ test: { smth: 5 } } : { test: { smth: number; }; }
+>test : { smth: number; }
+>{ smth: 5 } : { smth: number; }
+>smth : number
+>5 : 5
+
+type Field<A extends string, R> = { [K in A]: R }
+>Field : Field<A, R>
+
+const f = <A extends string, B extends string, R>(x: { [K in A]: Field<B, R> }): R => ({} as any);
+>f : <A extends string, B extends string, R>(x: { [K in A]: Field<B, R>; }) => R
+><A extends string, B extends string, R>(x: { [K in A]: Field<B, R> }): R => ({} as any) : <A extends string, B extends string, R>(x: { [K in A]: Field<B, R>; }) => R
+>x : { [K in A]: Field<B, R>; }
+>({} as any) : any
+>{} as any : any
+>{} : {}
+
+const r1 = f(v);
+>r1 : number
+>f(v) : number
+>f : <A extends string, B extends string, R>(x: { [K in A]: Field<B, R>; }) => R
+>v : { test: { smth: number; }; }
+
+const g = <A extends string, B extends string, R>(x: Field<A, Field<B, R>>): R => ({} as any);
+>g : <A extends string, B extends string, R>(x: Field<A, Field<B, R>>) => R
+><A extends string, B extends string, R>(x: Field<A, Field<B, R>>): R => ({} as any) : <A extends string, B extends string, R>(x: Field<A, Field<B, R>>) => R
+>x : Field<A, Field<B, R>>
+>({} as any) : any
+>{} as any : any
+>{} : {}
+
+const r2 = g(v);
+>r2 : number
+>g(v) : number
+>g : <A extends string, B extends string, R>(x: Field<A, Field<B, R>>) => R
+>v : { test: { smth: number; }; }
+

--- a/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
+++ b/tests/cases/compiler/mappedTypeInferenceAliasSubstitution.ts
@@ -1,0 +1,14 @@
+// @strict: true
+// @noEmit: true
+
+// repro from #31616
+
+const v = { test: { smth: 5 } };
+
+type Field<A extends string, R> = { [K in A]: R }
+
+const f = <A extends string, B extends string, R>(x: { [K in A]: Field<B, R> }): R => ({} as any);
+const r1 = f(v);
+
+const g = <A extends string, B extends string, R>(x: Field<A, Field<B, R>>): R => ({} as any);
+const r2 = g(v);


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/31616

this was fixed in `4.1.0-dev.20200816`, not a lot has changed then - so it was *likely* fixed by https://github.com/microsoft/TypeScript/pull/40002