### PR TITLE
Replace all instances of `compilerOptions.isolatedModules` with function considering `verbatimModuleSyntax`

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -45,6 +45,7 @@ import {
     generateDjb2Hash,
     getDirectoryPath,
     getEmitDeclarations,
+    getIsolatedModules,
     getNormalizedAbsolutePath,
     getOptionsNameMap,
     getOwnKeys,
@@ -763,7 +764,7 @@ function handleDtsMayChangeOfReferencingExportOfAffectedFile(
 
     // Since isolated modules dont change js files, files affected by change in signature is itself
     // But we need to cleanup semantic diagnostics and queue dts emit for affected files
-    if (state.compilerOptions.isolatedModules) {
+    if (getIsolatedModules(state.compilerOptions)) {
         const seenFileNamesMap = new Map<Path, true>();
         seenFileNamesMap.set(affectedFile.resolvedPath, true);
         const queue = BuilderState.getReferencedByPaths(state, affectedFile.resolvedPath);

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -9,6 +9,7 @@ import {
     ExportedModulesFromDeclarationEmit,
     GetCanonicalFileName,
     getDirectoryPath,
+    getIsolatedModules,
     getSourceFileOfNode,
     HostForComputeHash,
     isDeclarationFileName,
@@ -635,7 +636,7 @@ export namespace BuilderState {
         }
 
         const compilerOptions = programOfThisState.getCompilerOptions();
-        if (compilerOptions && (compilerOptions.isolatedModules || outFile(compilerOptions))) {
+        if (compilerOptions && (getIsolatedModules(compilerOptions) || outFile(compilerOptions))) {
             return [sourceFileWithUpdatedShape];
         }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -118,6 +118,7 @@ import {
     getEmitScriptTarget,
     getErrorSpanForNode,
     getExternalModuleName,
+    getIsolatedModules,
     getJSXImplicitImportBase,
     getJSXRuntimeImport,
     getLineAndCharacterOfPosition,
@@ -3186,7 +3187,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
         // If we are importing helpers, we need to add a synthetic reference to resolve the
         // helpers library.
-        if ((options.isolatedModules || isExternalModuleFile)
+        if ((getIsolatedModules(options) || isExternalModuleFile)
             && !file.isDeclarationFile) {
             if (options.importHelpers) {
                 // synthesize 'import "tslib"' declaration
@@ -3992,13 +3993,13 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "exactOptionalPropertyTypes", "strictNullChecks");
         }
 
-        if (options.isolatedModules) {
+        if (options.isolatedModules || options.verbatimModuleSyntax) {
             if (options.out) {
-                createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "out", "isolatedModules");
+                createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "out", options.verbatimModuleSyntax ? "verbatimModuleSyntax" : "isolatedModules");
             }
 
             if (options.outFile) {
-                createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "outFile", "isolatedModules");
+                createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "outFile", options.verbatimModuleSyntax ? "verbatimModuleSyntax" : "isolatedModules");
             }
         }
 

--- a/src/compiler/transformers/module/esnextAnd2015.ts
+++ b/src/compiler/transformers/module/esnextAnd2015.ts
@@ -16,6 +16,7 @@ import {
     getEmitModuleKind,
     getEmitScriptTarget,
     getExternalModuleNameLiteral,
+    getIsolatedModules,
     hasSyntacticModifier,
     Identifier,
     idText,
@@ -76,7 +77,7 @@ export function transformECMAScriptModule(context: TransformationContext): (x: S
             return node;
         }
 
-        if (isExternalModule(node) || compilerOptions.isolatedModules) {
+        if (isExternalModule(node) || getIsolatedModules(compilerOptions)) {
             currentSourceFile = node;
             importRequireStatements = undefined;
             let result = updateExternalModule(node);
@@ -286,7 +287,7 @@ export function transformECMAScriptModule(context: TransformationContext): (x: S
      */
     function onEmitNode(hint: EmitHint, node: Node, emitCallback: (hint: EmitHint, node: Node) => void): void {
         if (isSourceFile(node)) {
-            if ((isExternalModule(node) || compilerOptions.isolatedModules) && compilerOptions.importHelpers) {
+            if ((isExternalModule(node) || getIsolatedModules(compilerOptions)) && compilerOptions.importHelpers) {
                 helperNameSubstitutions = new Map<string, Identifier>();
             }
             previousOnEmitNode(hint, node, emitCallback);

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -54,6 +54,7 @@ import {
     getEmitScriptTarget,
     getFirstConstructorWithBody,
     getInitializedVariables,
+    getIsolatedModules,
     getOriginalNode,
     getParseTreeNode,
     getProperties,
@@ -2706,7 +2707,7 @@ export function transformTypeScript(context: TransformationContext) {
     }
 
     function tryGetConstEnumValue(node: Node): string | number | undefined {
-        if (compilerOptions.isolatedModules) {
+        if (getIsolatedModules(compilerOptions)) {
             return undefined;
         }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1781,7 +1781,7 @@ function isCommonJSContainingModuleKind(kind: ModuleKind) {
 
 /** @internal */
 export function isEffectiveExternalModule(node: SourceFile, compilerOptions: CompilerOptions) {
-    return isExternalModule(node) || compilerOptions.isolatedModules || (isCommonJSContainingModuleKind(getEmitModuleKind(compilerOptions)) && !!node.commonJsModuleIndicator);
+    return isExternalModule(node) || getIsolatedModules(compilerOptions) || (isCommonJSContainingModuleKind(getEmitModuleKind(compilerOptions)) && !!node.commonJsModuleIndicator);
 }
 
 /**
@@ -1812,7 +1812,7 @@ export function isEffectiveStrictModeSourceFile(node: SourceFile, compilerOption
     if (startsWithUseStrict(node.statements)) {
         return true;
     }
-    if (isExternalModule(node) || compilerOptions.isolatedModules) {
+    if (isExternalModule(node) || getIsolatedModules(compilerOptions)) {
         // ECMAScript Modules are always strict.
         if (getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015) {
             return true;
@@ -8443,7 +8443,7 @@ export function getEmitDeclarations(compilerOptions: CompilerOptions): boolean {
 
 /** @internal */
 export function shouldPreserveConstEnums(compilerOptions: CompilerOptions): boolean {
-    return !!(compilerOptions.preserveConstEnums || compilerOptions.isolatedModules);
+    return !!(compilerOptions.preserveConstEnums || getIsolatedModules(compilerOptions));
 }
 
 /** @internal */

--- a/src/services/codefixes/fixImportNonExportedMember.ts
+++ b/src/services/codefixes/fixImportNonExportedMember.ts
@@ -9,6 +9,7 @@ import {
     findAncestor,
     findLast,
     firstOrUndefined,
+    getIsolatedModules,
     getResolvedModule,
     getTokenAtPosition,
     Identifier,
@@ -173,7 +174,7 @@ function tryGetExportDeclaration(sourceFile: SourceFile, isTypeOnly: boolean) {
 
 function updateExport(changes: textChanges.ChangeTracker, program: Program, sourceFile: SourceFile, node: ExportDeclaration, names: ExportName[]) {
     const namedExports = node.exportClause && isNamedExports(node.exportClause) ? node.exportClause.elements : factory.createNodeArray([]);
-    const allowTypeModifier = !node.isTypeOnly && !!(program.getCompilerOptions().isolatedModules || find(namedExports, e => e.isTypeOnly));
+    const allowTypeModifier = !node.isTypeOnly && !!(getIsolatedModules(program.getCompilerOptions()) || find(namedExports, e => e.isTypeOnly));
     changes.replaceNode(sourceFile, node,
         factory.updateExportDeclaration(node, node.modifiers, node.isTypeOnly,
             factory.createNamedExports(
@@ -183,7 +184,7 @@ function updateExport(changes: textChanges.ChangeTracker, program: Program, sour
 function createExport(changes: textChanges.ChangeTracker, program: Program, sourceFile: SourceFile, names: ExportName[]) {
     changes.insertNodeAtEndOfScope(sourceFile, sourceFile,
         factory.createExportDeclaration(/*modifiers*/ undefined, /*isTypeOnly*/ false,
-            factory.createNamedExports(createExportSpecifiers(names, /*allowTypeModifier*/ !!program.getCompilerOptions().isolatedModules)), /*moduleSpecifier*/ undefined, /*assertClause*/ undefined));
+            factory.createNamedExports(createExportSpecifiers(names, /*allowTypeModifier*/ getIsolatedModules(program.getCompilerOptions()))), /*moduleSpecifier*/ undefined, /*assertClause*/ undefined));
 }
 
 function createExportSpecifiers(names: ExportName[], allowTypeModifier: boolean) {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -57,6 +57,7 @@ import {
     ImportEqualsDeclaration,
     importFromModuleSpecifier,
     ImportKind,
+    importNameElisionDisabled,
     ImportsNotUsedAsValues,
     insertImports,
     InternalSymbolName,
@@ -676,7 +677,7 @@ function getAddAsTypeOnly(
         // Not writing a (top-level) type-only import here would create an error because the runtime dependency is unnecessary
         return AddAsTypeOnly.Required;
     }
-    if ((compilerOptions.isolatedModules && compilerOptions.preserveValueImports || compilerOptions.verbatimModuleSyntax) &&
+    if (importNameElisionDisabled(compilerOptions) &&
         (!(targetFlags & SymbolFlags.Value) || !!checker.getTypeOnlyAliasDeclaration(symbol))
     ) {
         // A type-only import is required for this symbol if under these settings if the symbol will
@@ -1276,7 +1277,7 @@ function getModuleSpecifierText(promotedDeclaration: ImportClause | ImportEquals
 
 function promoteFromTypeOnly(changes: textChanges.ChangeTracker, aliasDeclaration: TypeOnlyAliasDeclaration, compilerOptions: CompilerOptions, sourceFile: SourceFile, preferences: UserPreferences) {
     // See comment in `doAddExistingFix` on constant with the same name.
-    const convertExistingToTypeOnly = compilerOptions.preserveValueImports && compilerOptions.isolatedModules || compilerOptions.verbatimModuleSyntax;
+    const convertExistingToTypeOnly = importNameElisionDisabled(compilerOptions);
     switch (aliasDeclaration.kind) {
         case SyntaxKind.ImportSpecifier:
             if (aliasDeclaration.isTypeOnly) {
@@ -1362,8 +1363,7 @@ function doAddExistingFix(
     // never used in an emitting position). These are allowed to be imported without being type-only,
     // but the user has clearly already signified that they don't need them to be present at runtime
     // by placing them in a type-only import. So, just mark each specifier as type-only.
-    const convertExistingToTypeOnly = promoteFromTypeOnly
-        && (compilerOptions.preserveValueImports && compilerOptions.isolatedModules || compilerOptions.verbatimModuleSyntax);
+    const convertExistingToTypeOnly = promoteFromTypeOnly && importNameElisionDisabled(compilerOptions);
 
     if (defaultImport) {
         Debug.assert(!clause.name, "Cannot add a default import to an import clause that already has one");

--- a/tests/baselines/reference/verbatimModuleSyntaxConstEnum.js
+++ b/tests/baselines/reference/verbatimModuleSyntaxConstEnum.js
@@ -1,0 +1,11 @@
+//// [verbatimModuleSyntaxConstEnum.ts]
+export const enum E {
+    A = 1,
+}
+
+
+//// [verbatimModuleSyntaxConstEnum.js]
+export var E;
+(function (E) {
+    E[E["A"] = 1] = "A";
+})(E || (E = {}));

--- a/tests/baselines/reference/verbatimModuleSyntaxConstEnum.symbols
+++ b/tests/baselines/reference/verbatimModuleSyntaxConstEnum.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts ===
+export const enum E {
+>E : Symbol(E, Decl(verbatimModuleSyntaxConstEnum.ts, 0, 0))
+
+    A = 1,
+>A : Symbol(E.A, Decl(verbatimModuleSyntaxConstEnum.ts, 0, 21))
+}
+

--- a/tests/baselines/reference/verbatimModuleSyntaxConstEnum.types
+++ b/tests/baselines/reference/verbatimModuleSyntaxConstEnum.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts ===
+export const enum E {
+>E : E
+
+    A = 1,
+>A : E.A
+>1 : 1
+}
+

--- a/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
+++ b/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
@@ -1,0 +1,6 @@
+// @verbatimModuleSyntax: true
+// @module: esnext
+
+export const enum E {
+    A = 1,
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #52669. It looks like I forgot to do a search for `.isolatedModules` outside of the checker.
