### PR TITLE
Prefer top-level type-only imports in verbatimModuleSyntax

### DIFF
--- a/tests/cases/fourslash/autoImportTypeOnlyPreferred1.ts
+++ b/tests/cases/fourslash/autoImportTypeOnlyPreferred1.ts
@@ -1,0 +1,43 @@
+/// <reference path="fourslash.ts" />
+
+// @verbatimModuleSyntax: true
+// @module: esnext
+// @moduleResolution: bundler
+
+// @Filename: /ts.d.ts
+//// declare namespace ts {
+////   interface SourceFile {
+////       text: string;
+////   }
+////   function createSourceFile(): SourceFile;
+//// }
+//// export = ts;
+
+// @Filename: /types.ts
+//// export interface VFS {
+////   getSourceFile(path: string): ts/**/
+//// }
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "ts",
+    source: "./ts",
+    sourceDisplay: "./ts",
+    hasAction: true,
+    sortText: completion.SortText.AutoImportSuggestions,
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+  },
+}).andApplyCodeAction({
+    name: "ts",
+    source: "./ts",
+    description: `Add import from "./ts"`,
+    newFileContent: `import type ts from "./ts";
+
+export interface VFS {
+  getSourceFile(path: string): ts
+}`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Auto-imports under `verbatimModuleSyntax` should prefer top-level `import type` when possible. Even though adding a non-type-only import of a namespace is not an error (as it would be in `--importsNotUsedAsValue error`), it would add unnecessary runtime emit.
