### PR TITLE
Fix crash in getAwaitedType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -38998,7 +38998,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
 
-        Debug.assert(getPromisedTypeOfPromise(type) === undefined, "type provided should not be a non-generic 'promise'-like.");
+        Debug.assert(isAwaitedTypeInstantiation(type) || getPromisedTypeOfPromise(type) === undefined, "type provided should not be a non-generic 'promise'-like.");
         return type;
     }
 

--- a/tests/baselines/reference/awaitedTypeCrash.js
+++ b/tests/baselines/reference/awaitedTypeCrash.js
@@ -1,0 +1,7 @@
+//// [awaitedTypeCrash.ts]
+// https://github.com/microsoft/TypeScript/issues/51984
+async function* f<T extends Promise<never>>(): AsyncGenerator<T, void, void> { }
+
+//// [awaitedTypeCrash.js]
+// https://github.com/microsoft/TypeScript/issues/51984
+async function* f() { }

--- a/tests/baselines/reference/awaitedTypeCrash.symbols
+++ b/tests/baselines/reference/awaitedTypeCrash.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/awaitedTypeCrash.ts ===
+// https://github.com/microsoft/TypeScript/issues/51984
+async function* f<T extends Promise<never>>(): AsyncGenerator<T, void, void> { }
+>f : Symbol(f, Decl(awaitedTypeCrash.ts, 0, 0))
+>T : Symbol(T, Decl(awaitedTypeCrash.ts, 1, 18))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>T : Symbol(T, Decl(awaitedTypeCrash.ts, 1, 18))
+

--- a/tests/baselines/reference/awaitedTypeCrash.types
+++ b/tests/baselines/reference/awaitedTypeCrash.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/awaitedTypeCrash.ts ===
+// https://github.com/microsoft/TypeScript/issues/51984
+async function* f<T extends Promise<never>>(): AsyncGenerator<T, void, void> { }
+>f : <T extends Promise<never>>() => AsyncGenerator<T, void, void>
+

--- a/tests/cases/compiler/awaitedTypeCrash.ts
+++ b/tests/cases/compiler/awaitedTypeCrash.ts
@@ -1,0 +1,4 @@
+// @target: esnext
+
+// https://github.com/microsoft/TypeScript/issues/51984
+async function* f<T extends Promise<never>>(): AsyncGenerator<T, void, void> { }


### PR DESCRIPTION
Fixes a debug assertion in `getAwaitedTypeIfNeeded` when the incoming type is a constructed `Awaited<T>`  (as opposed to one created by `await`) and `T` has a promise-like base constraint.

Fixes #51984
