### PR TITLE
Ensure call return() for an abrupt completion at for await of loop

### DIFF
--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -769,22 +769,24 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
         const binding = createForOfBindingStatement(factory, node.initializer, value);
         statements.push(visitNode(binding, visitor, isStatement));
 
+        let bodyLocation: TextRange | undefined;
         let statementsLocation: TextRange | undefined;
         const statement = visitIterationBody(node.statement, visitor, context);
         if (isBlock(statement)) {
             addRange(statements, statement.statements);
+            bodyLocation = statement;
             statementsLocation = statement.statements;
         }
         else {
             statements.push(statement);
         }
 
-        return setEmitFlags(
+        return setTextRange(
             factory.createBlock(
                 setTextRange(factory.createNodeArray(statements), statementsLocation),
                 /*multiLine*/ true
             ),
-            EmitFlags.NoSourceMap | EmitFlags.NoTokenSourceMaps
+            bodyLocation
         );
     }
 

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -767,7 +767,7 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
 
         const enterNonUserCodeExpression = factory.createAssignment(nonUserCode, factory.createTrue());
         const enterNonUserCodeStatement = factory.createExpressionStatement(enterNonUserCodeExpression);
-        setSourceMapRange(exitNonUserCodeStatement, node.expression);
+        setSourceMapRange(enterNonUserCodeStatement, node.expression);
 
         const statements: Statement[] = [];
         const binding = createForOfBindingStatement(factory, node.initializer, value);
@@ -799,13 +799,8 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
         return factory.createBlock([
             iteratorValueStatement,
             exitNonUserCodeStatement,
-            factory.createTryStatement(
-                body,
-                /*catchClause*/ undefined,
-                factory.createBlock([
-                    enterNonUserCodeStatement
-                ])
-            )
+            body,
+            enterNonUserCodeStatement
         ]);
     }
 

--- a/src/testRunner/unittests/evaluation/forAwaitOf.ts
+++ b/src/testRunner/unittests/evaluation/forAwaitOf.ts
@@ -106,6 +106,34 @@ describe("unittests:: evaluation:: forAwaitOfEvaluation", () => {
         assert.instanceOf(result.output[2], Promise);
     });
 
+    it("call return when user code throws (es2015)", async () => {
+        const result = evaluator.evaluateTypeScript(`
+        let returnCalled = false;
+        async function f() {
+            let i = 0;
+            const iterator = {
+                [Symbol.asyncIterator](): AsyncIterableIterator<any> { return this; },
+                async next() {
+                    i++;
+                    if (i < 2) return { value: undefined, done: false };
+                    throw new Error();
+                },
+                async return() {
+                    returnCalled = true;
+                }
+            };
+            for await (const item of iterator) {
+                throw new Error();
+            }
+        }
+        export async function main() {
+            try { await f(); } catch { }
+            return returnCalled;
+        }
+        `, { target: ts.ScriptTarget.ES2015 });
+        assert.isTrue(await result.main());
+    });
+
     it("don't call return when non-user code throws (es2015)", async () => {
         const result = evaluator.evaluateTypeScript(`
         let returnCalled = false;

--- a/tests/baselines/reference/emitter.forAwait(target=es2015).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es2015).js
@@ -72,13 +72,10 @@ function f1() {
     return __awaiter(this, void 0, void 0, function* () {
         let y;
         try {
-            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    const x = _c;
-                }
-                _d = true;
+                const x = _c;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -112,13 +109,10 @@ function f2() {
     return __awaiter(this, void 0, void 0, function* () {
         let x, y;
         try {
-            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    x = _c;
-                }
-                _d = true;
+                x = _c;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -155,13 +149,10 @@ function f3() {
         var _a, e_1, _b, _c;
         let y;
         try {
-            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    const x = _c;
-                }
-                _d = true;
+                const x = _c;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -198,13 +189,10 @@ function f4() {
         var _a, e_1, _b, _c;
         let x, y;
         try {
-            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    x = _c;
-                }
-                _d = true;
+                x = _c;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -239,14 +227,11 @@ function f5() {
     return __awaiter(this, void 0, void 0, function* () {
         let y;
         try {
-            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
+            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    const x = _c;
-                    continue outer;
-                }
-                _d = true;
+                const x = _c;
+                continue outer;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -284,14 +269,11 @@ function f6() {
         var _a, e_1, _b, _c;
         let y;
         try {
-            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    const x = _c;
-                    continue outer;
-                }
-                _d = true;
+                const x = _c;
+                continue outer;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -330,13 +312,10 @@ function f7() {
         let y;
         for (;;) {
             try {
-                for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                     _c = y_1_1.value;
                     _d = false;
-                    {
-                        const x = _c;
-                    }
-                    _d = true;
+                    const x = _c;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/emitter.forAwait(target=es2015).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es2015).js
@@ -75,12 +75,10 @@ function f1() {
             for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     const x = _c;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -117,12 +115,10 @@ function f2() {
             for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     x = _c;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -162,12 +158,10 @@ function f3() {
             for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     const x = _c;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -207,12 +201,10 @@ function f4() {
             for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     x = _c;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -250,13 +242,11 @@ function f5() {
             outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     const x = _c;
                     continue outer;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -297,13 +287,11 @@ function f6() {
             outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     const x = _c;
                     continue outer;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -345,12 +333,10 @@ function f7() {
                 for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                     _c = y_1_1.value;
                     _d = false;
-                    try {
+                    {
                         const x = _c;
                     }
-                    finally {
-                        _d = true;
-                    }
+                    _d = true;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/emitter.forAwait(target=es2017).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es2017).js
@@ -62,13 +62,10 @@ async function f1() {
     var _a, e_1, _b, _c;
     let y;
     try {
-        for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
+        for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a; _d = true) {
             _c = y_1_1.value;
             _d = false;
-            {
-                const x = _c;
-            }
-            _d = true;
+            const x = _c;
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -91,13 +88,10 @@ async function f2() {
     var _a, e_1, _b, _c;
     let x, y;
     try {
-        for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
+        for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a; _d = true) {
             _c = y_1_1.value;
             _d = false;
-            {
-                x = _c;
-            }
-            _d = true;
+            x = _c;
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -133,13 +127,10 @@ function f3() {
         var _a, e_1, _b, _c;
         let y;
         try {
-            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    const x = _c;
-                }
-                _d = true;
+                const x = _c;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -176,13 +167,10 @@ function f4() {
         var _a, e_1, _b, _c;
         let x, y;
         try {
-            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+            for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    x = _c;
-                }
-                _d = true;
+                x = _c;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -207,14 +195,11 @@ async function f5() {
     var _a, e_1, _b, _c;
     let y;
     try {
-        outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
+        outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a; _d = true) {
             _c = y_1_1.value;
             _d = false;
-            {
-                const x = _c;
-                continue outer;
-            }
-            _d = true;
+            const x = _c;
+            continue outer;
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -251,14 +236,11 @@ function f6() {
         var _a, e_1, _b, _c;
         let y;
         try {
-            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+            outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                 _c = y_1_1.value;
                 _d = false;
-                {
-                    const x = _c;
-                    continue outer;
-                }
-                _d = true;
+                const x = _c;
+                continue outer;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -297,13 +279,10 @@ function f7() {
         let y;
         for (;;) {
             try {
-                for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
+                for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a; _d = true) {
                     _c = y_1_1.value;
                     _d = false;
-                    {
-                        const x = _c;
-                    }
-                    _d = true;
+                    const x = _c;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/emitter.forAwait(target=es2017).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es2017).js
@@ -65,12 +65,10 @@ async function f1() {
         for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
             _c = y_1_1.value;
             _d = false;
-            try {
+            {
                 const x = _c;
             }
-            finally {
-                _d = true;
-            }
+            _d = true;
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -96,12 +94,10 @@ async function f2() {
         for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
             _c = y_1_1.value;
             _d = false;
-            try {
+            {
                 x = _c;
             }
-            finally {
-                _d = true;
-            }
+            _d = true;
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -140,12 +136,10 @@ function f3() {
             for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     const x = _c;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -185,12 +179,10 @@ function f4() {
             for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     x = _c;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -218,13 +210,11 @@ async function f5() {
         outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = await y_1.next(), _a = y_1_1.done, !_a;) {
             _c = y_1_1.value;
             _d = false;
-            try {
+            {
                 const x = _c;
                 continue outer;
             }
-            finally {
-                _d = true;
-            }
+            _d = true;
         }
     }
     catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -264,13 +254,11 @@ function f6() {
             outer: for (var _d = true, y_1 = __asyncValues(y), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                 _c = y_1_1.value;
                 _d = false;
-                try {
+                {
                     const x = _c;
                     continue outer;
                 }
-                finally {
-                    _d = true;
-                }
+                _d = true;
             }
         }
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -312,12 +300,10 @@ function f7() {
                 for (var _d = true, y_1 = (e_1 = void 0, __asyncValues(y)), y_1_1; y_1_1 = yield __await(y_1.next()), _a = y_1_1.done, !_a;) {
                     _c = y_1_1.value;
                     _d = false;
-                    try {
+                    {
                         const x = _c;
                     }
-                    finally {
-                        _d = true;
-                    }
+                    _d = true;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/emitter.forAwait(target=es5).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es5).js
@@ -109,12 +109,11 @@ function f1() {
                     if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
                     _c = y_1_1.value;
                     _d = false;
-                    {
-                        x = _c;
-                    }
-                    _d = true;
+                    x = _c;
                     _e.label = 3;
-                case 3: return [3 /*break*/, 1];
+                case 3:
+                    _d = true;
+                    return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
                     e_1_1 = _e.sent();
@@ -196,12 +195,11 @@ function f2() {
                     if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
                     _c = y_1_1.value;
                     _d = false;
-                    {
-                        x = _c;
-                    }
-                    _d = true;
+                    x = _c;
                     _e.label = 3;
-                case 3: return [3 /*break*/, 1];
+                case 3:
+                    _d = true;
+                    return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
                     e_1_1 = _e.sent();
@@ -286,12 +284,11 @@ function f3() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    {
-                        x = _d;
-                    }
-                    _a = true;
+                    x = _d;
                     _e.label = 3;
-                case 3: return [3 /*break*/, 1];
+                case 3:
+                    _a = true;
+                    return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
                     e_1_1 = _e.sent();
@@ -376,12 +373,11 @@ function f4() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    {
-                        x = _d;
-                    }
-                    _a = true;
+                    x = _d;
                     _e.label = 3;
-                case 3: return [3 /*break*/, 1];
+                case 3:
+                    _a = true;
+                    return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
                     e_1_1 = _e.sent();
@@ -464,13 +460,11 @@ function f5() {
                     if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
                     _c = y_1_1.value;
                     _d = false;
-                    {
-                        x = _c;
-                        return [3 /*break*/, 3];
-                    }
+                    x = _c;
+                    return [3 /*break*/, 3];
+                case 3:
                     _d = true;
-                    _e.label = 3;
-                case 3: return [3 /*break*/, 1];
+                    return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
                     e_1_1 = _e.sent();
@@ -556,13 +550,11 @@ function f6() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    {
-                        x = _d;
-                        return [3 /*break*/, 3];
-                    }
+                    x = _d;
+                    return [3 /*break*/, 3];
+                case 3:
                     _a = true;
-                    _e.label = 3;
-                case 3: return [3 /*break*/, 1];
+                    return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
                     e_1_1 = _e.sent();
@@ -648,12 +640,11 @@ function f7() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    {
-                        x = _d;
-                    }
-                    _a = true;
+                    x = _d;
                     _e.label = 3;
-                case 3: return [3 /*break*/, 1];
+                case 3:
+                    _a = true;
+                    return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
                 case 5:
                     e_1_1 = _e.sent();

--- a/tests/baselines/reference/emitter.forAwait(target=es5).js
+++ b/tests/baselines/reference/emitter.forAwait(target=es5).js
@@ -109,12 +109,10 @@ function f1() {
                     if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
                     _c = y_1_1.value;
                     _d = false;
-                    try {
+                    {
                         x = _c;
                     }
-                    finally {
-                        _d = true;
-                    }
+                    _d = true;
                     _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
@@ -198,12 +196,10 @@ function f2() {
                     if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
                     _c = y_1_1.value;
                     _d = false;
-                    try {
+                    {
                         x = _c;
                     }
-                    finally {
-                        _d = true;
-                    }
+                    _d = true;
                     _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
@@ -290,12 +286,10 @@ function f3() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    try {
+                    {
                         x = _d;
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                     _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
@@ -382,12 +376,10 @@ function f4() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    try {
+                    {
                         x = _d;
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                     _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
@@ -472,13 +464,11 @@ function f5() {
                     if (!(y_1_1 = _e.sent(), _a = y_1_1.done, !_a)) return [3 /*break*/, 4];
                     _c = y_1_1.value;
                     _d = false;
-                    try {
+                    {
                         x = _c;
                         return [3 /*break*/, 3];
                     }
-                    finally {
-                        _d = true;
-                    }
+                    _d = true;
                     _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
@@ -566,13 +556,11 @@ function f6() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    try {
+                    {
                         x = _d;
                         return [3 /*break*/, 3];
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                     _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];
@@ -660,12 +648,10 @@ function f7() {
                     if (!(y_1_1 = _e.sent(), _b = y_1_1.done, !_b)) return [3 /*break*/, 4];
                     _d = y_1_1.value;
                     _a = false;
-                    try {
+                    {
                         x = _d;
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                     _e.label = 3;
                 case 3: return [3 /*break*/, 1];
                 case 4: return [3 /*break*/, 11];

--- a/tests/baselines/reference/forAwaitPerIterationBindingDownlevel.js
+++ b/tests/baselines/reference/forAwaitPerIterationBindingDownlevel.js
@@ -114,30 +114,27 @@ var log = console.log;
                 _loop_1 = function () {
                     _f = _c.value;
                     _a = false;
-                    {
-                        var outer = _f;
-                        log("I'm loop ".concat(outer));
-                        (function () { return __awaiter(_this, void 0, void 0, function () {
-                            var inner;
-                            return __generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0:
-                                        inner = outer;
-                                        return [4 /*yield*/, sleep(2000)];
-                                    case 1:
-                                        _a.sent();
-                                        if (inner === outer) {
-                                            log("I'm loop ".concat(inner, " and I know I'm loop ").concat(outer));
-                                        }
-                                        else {
-                                            log("I'm loop ".concat(inner, ", but I think I'm loop ").concat(outer));
-                                        }
-                                        return [2 /*return*/];
-                                }
-                            });
-                        }); })();
-                    }
-                    _a = true;
+                    var outer = _f;
+                    log("I'm loop ".concat(outer));
+                    (function () { return __awaiter(_this, void 0, void 0, function () {
+                        var inner;
+                        return __generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0:
+                                    inner = outer;
+                                    return [4 /*yield*/, sleep(2000)];
+                                case 1:
+                                    _a.sent();
+                                    if (inner === outer) {
+                                        log("I'm loop ".concat(inner, " and I know I'm loop ").concat(outer));
+                                    }
+                                    else {
+                                        log("I'm loop ".concat(inner, ", but I think I'm loop ").concat(outer));
+                                    }
+                                    return [2 /*return*/];
+                            }
+                        });
+                    }); })();
                 };
                 _a = true, _b = __asyncValues(gen());
                 _g.label = 1;
@@ -146,7 +143,9 @@ var log = console.log;
                 if (!(_c = _g.sent(), _d = _c.done, !_d)) return [3 /*break*/, 4];
                 _loop_1();
                 _g.label = 3;
-            case 3: return [3 /*break*/, 1];
+            case 3:
+                _a = true;
+                return [3 /*break*/, 1];
             case 4: return [3 /*break*/, 11];
             case 5:
                 e_1_1 = _g.sent();

--- a/tests/baselines/reference/forAwaitPerIterationBindingDownlevel.js
+++ b/tests/baselines/reference/forAwaitPerIterationBindingDownlevel.js
@@ -114,7 +114,7 @@ var log = console.log;
                 _loop_1 = function () {
                     _f = _c.value;
                     _a = false;
-                    try {
+                    {
                         var outer = _f;
                         log("I'm loop ".concat(outer));
                         (function () { return __awaiter(_this, void 0, void 0, function () {
@@ -137,9 +137,7 @@ var log = console.log;
                             });
                         }); })();
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                 };
                 _a = true, _b = __asyncValues(gen());
                 _g.label = 1;

--- a/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=node16).js
+++ b/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=node16).js
@@ -37,13 +37,10 @@ exports.x = void 0;
 var x = await 1;
 exports.x = x;
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -66,13 +63,10 @@ var _a, e_1, _b, _c;
 var x = await 1;
 export { x };
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=node16).js
+++ b/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=node16).js
@@ -40,12 +40,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -71,12 +69,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=nodenext).js
@@ -37,13 +37,10 @@ exports.x = void 0;
 var x = await 1;
 exports.x = x;
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -66,13 +63,10 @@ var _a, e_1, _b, _c;
 var x = await 1;
 export { x };
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesAllowJsTopLevelAwait(module=nodenext).js
@@ -40,12 +40,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -71,12 +69,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/nodeModulesTopLevelAwait(module=node16).js
+++ b/tests/baselines/reference/nodeModulesTopLevelAwait(module=node16).js
@@ -37,13 +37,10 @@ exports.x = void 0;
 var x = await 1;
 exports.x = x;
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -66,13 +63,10 @@ var _a, e_1, _b, _c;
 var x = await 1;
 export { x };
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/nodeModulesTopLevelAwait(module=node16).js
+++ b/tests/baselines/reference/nodeModulesTopLevelAwait(module=node16).js
@@ -40,12 +40,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -71,12 +69,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/nodeModulesTopLevelAwait(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTopLevelAwait(module=nodenext).js
@@ -37,13 +37,10 @@ exports.x = void 0;
 var x = await 1;
 exports.x = x;
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -66,13 +63,10 @@ var _a, e_1, _b, _c;
 var x = await 1;
 export { x };
 try {
-    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
+    for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a; _d = true) {
         _c = _f.value;
         _d = false;
-        {
-            var y = _c;
-        }
-        _d = true;
+        var y = _c;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/nodeModulesTopLevelAwait(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesTopLevelAwait(module=nodenext).js
@@ -40,12 +40,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }
@@ -71,12 +69,10 @@ try {
     for (var _d = true, _e = __asyncValues([]), _f; _f = await _e.next(), _a = _f.done, !_a;) {
         _c = _f.value;
         _d = false;
-        try {
+        {
             var y = _c;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -114,12 +114,11 @@ function fn(a, b, c, d, e, f, g) {
                     if (!(c_1_1 = _e.sent(), _b = c_1_1.done, !_b)) return [3 /*break*/, 5];
                     _d = c_1_1.value;
                     _a = false;
-                    {
-                        s = _d;
-                    }
-                    _a = true;
+                    s = _d;
                     _e.label = 4;
-                case 4: return [3 /*break*/, 2];
+                case 4:
+                    _a = true;
+                    return [3 /*break*/, 2];
                 case 5: return [3 /*break*/, 12];
                 case 6:
                     e_1_1 = _e.sent();

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -114,12 +114,10 @@ function fn(a, b, c, d, e, f, g) {
                     if (!(c_1_1 = _e.sent(), _b = c_1_1.done, !_b)) return [3 /*break*/, 5];
                     _d = c_1_1.value;
                     _a = false;
-                    try {
+                    {
                         s = _d;
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                     _e.label = 4;
                 case 4: return [3 /*break*/, 2];
                 case 5: return [3 /*break*/, 12];

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).js
@@ -88,14 +88,11 @@ export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a; _d = true) {
         _c = arr_1_1.value;
         _d = false;
-        {
-            const item = _c;
-            item;
-        }
-        _d = true;
+        const item = _c;
+        item;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).js
@@ -91,13 +91,11 @@ try {
     for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
         _c = arr_1_1.value;
         _d = false;
-        try {
+        {
             const item = _c;
             item;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).js
@@ -88,14 +88,11 @@ export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a; _d = true) {
         _c = arr_1_1.value;
         _d = false;
-        {
-            const item = _c;
-            item;
-        }
-        _d = true;
+        const item = _c;
+        item;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).js
@@ -91,13 +91,11 @@ try {
     for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
         _c = arr_1_1.value;
         _d = false;
-        try {
+        {
             const item = _c;
             item;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
@@ -88,14 +88,11 @@ export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a; _d = true) {
         _c = arr_1_1.value;
         _d = false;
-        {
-            const item = _c;
-            item;
-        }
-        _d = true;
+        const item = _c;
+        item;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).js
@@ -91,13 +91,11 @@ try {
     for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
         _c = arr_1_1.value;
         _d = false;
-        try {
+        {
             const item = _c;
             item;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
@@ -88,14 +88,11 @@ export { _await as await };
 // for-await-of
 const arr = [Promise.resolve()];
 try {
-    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+    for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a; _d = true) {
         _c = arr_1_1.value;
         _d = false;
-        {
-            const item = _c;
-            item;
-        }
-        _d = true;
+        const item = _c;
+        item;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).js
@@ -91,13 +91,11 @@ try {
     for (var _d = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
         _c = arr_1_1.value;
         _d = false;
-        try {
+        {
             const item = _c;
             item;
         }
-        finally {
-            _d = true;
-        }
+        _d = true;
     }
 }
 catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
@@ -93,14 +93,11 @@ System.register([], function (exports_1, context_1) {
             // for-await-of
             arr = [Promise.resolve()];
             try {
-                for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+                for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a; _a = true) {
                     _c = arr_1_1.value;
                     _a = false;
-                    {
-                        const item = _c;
-                        item;
-                    }
-                    _a = true;
+                    const item = _c;
+                    item;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).js
@@ -96,13 +96,11 @@ System.register([], function (exports_1, context_1) {
                 for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
                     _c = arr_1_1.value;
                     _a = false;
-                    try {
+                    {
                         const item = _c;
                         item;
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
@@ -93,14 +93,11 @@ System.register([], function (exports_1, context_1) {
             // for-await-of
             arr = [Promise.resolve()];
             try {
-                for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
+                for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a; _a = true) {
                     _c = arr_1_1.value;
                     _a = false;
-                    {
-                        const item = _c;
-                        item;
-                    }
-                    _a = true;
+                    const item = _c;
+                    item;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).js
@@ -96,13 +96,11 @@ System.register([], function (exports_1, context_1) {
                 for (var _a = true, arr_1 = __asyncValues(arr), arr_1_1; arr_1_1 = await arr_1.next(), _a = arr_1_1.done, !_a;) {
                     _c = arr_1_1.value;
                     _a = false;
-                    try {
+                    {
                         const item = _c;
                         item;
                     }
-                    finally {
-                        _a = true;
-                    }
+                    _a = true;
                 }
             }
             catch (e_1_1) { e_1 = { error: e_1_1 }; }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

After #51297, early exit(e.g. `throw`) from `for await...of` statement body does not trigger `.return()` of the asyncIterator. This PR removes `try/finally` block to prevent a `nonUserCode` variable from being set `true` when code exit early.

**Before**
```ts
for (...) {
    _nonUserCode = false;
    try {
        const x = _value;
        // for statement body comes here
    }
    finally {
        // early exit at try block always reach this
        _nonUserCode = true;
    }
}
```

**After**
```ts
for (...) {
    _nonUserCode = false;
    {
        const x = _value;
        // for statement body comes here
    }
    // early exit at try block never reach this
    _nonUserCode = true;
}
```

It makes iterator call `.return()` after for loop exits early and fits more with the specification.

Fixes #53106
Fixes #52936