### PR TITLE
Fix property completion in unions of object types and string mappings

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6052,8 +6052,6 @@ export const enum TypeFlags {
     PossiblyFalsy = DefinitelyFalsy | String | Number | BigInt | Boolean,
     /** @internal */
     Intrinsic = Any | Unknown | String | Number | BigInt | Boolean | BooleanLiteral | ESSymbol | Void | Undefined | Null | Never | NonPrimitive,
-    /** @internal */
-    Primitive = String | Number | BigInt | Boolean | Enum | EnumLiteral | ESSymbol | Void | Undefined | Null | Literal | UniqueESSymbol | TemplateLiteral | StringMapping,
     StringLike = String | StringLiteral | TemplateLiteral | StringMapping,
     NumberLike = Number | NumberLiteral | Enum,
     BigIntLike = BigInt | BigIntLiteral,
@@ -6061,6 +6059,8 @@ export const enum TypeFlags {
     EnumLike = Enum | EnumLiteral,
     ESSymbolLike = ESSymbol | UniqueESSymbol,
     VoidLike = Void | Undefined,
+    /** @internal */
+    Primitive = StringLike | NumberLike | BigIntLike | BooleanLike | EnumLike | ESSymbolLike | VoidLike | Null,
     /** @internal */
     DefinitelyNonNullable = StringLike | NumberLike | BigIntLike | BooleanLike | EnumLike | ESSymbolLike | Object | NonPrimitive,
     /** @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6053,7 +6053,7 @@ export const enum TypeFlags {
     /** @internal */
     Intrinsic = Any | Unknown | String | Number | BigInt | Boolean | BooleanLiteral | ESSymbol | Void | Undefined | Null | Never | NonPrimitive,
     /** @internal */
-    Primitive = String | Number | BigInt | Boolean | Enum | EnumLiteral | ESSymbol | Void | Undefined | Null | Literal | UniqueESSymbol | TemplateLiteral,
+    Primitive = String | Number | BigInt | Boolean | Enum | EnumLiteral | ESSymbol | Void | Undefined | Null | Literal | UniqueESSymbol | TemplateLiteral | StringMapping,
     StringLike = String | StringLiteral | TemplateLiteral | StringMapping,
     NumberLike = Number | NumberLiteral | Enum,
     BigIntLike = BigInt | BigIntLiteral,

--- a/tests/cases/fourslash/completionsObjectLiteralUnionStringMappingType.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralUnionStringMappingType.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+////type UnionType = {
+////  key1: string;
+////} | {
+////  key2: number;
+////} | Uppercase<string>;
+////
+////const obj1: UnionType = {
+////  /*1*/
+////};
+////
+////const obj2: UnionType = {
+////  key1: "abc",
+////  /*2*/
+////};
+
+verify.completions({
+    marker: '1',
+    exact: [{ name: 'key1' }, { name: 'key2' }]
+})
+
+verify.completions({
+    marker: '2',
+    exact: [{ name: 'key2' }]
+})


### PR DESCRIPTION
followup to https://github.com/microsoft/TypeScript/pull/52196 since I noticed that `StringMapping` was also not covered