### PR TITLE
Make special intersections order-independent

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16649,12 +16649,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return reduceLeft(types, (n, t) => n + getConstituentCount(t), 0);
     }
 
+    function areIntersectedTypesAvoidingPrimitiveReduction(t1: Type, t2: Type) {
+        return !!(t1.flags & (TypeFlags.String | TypeFlags.Number | TypeFlags.BigInt)) && t2 === emptyTypeLiteralType;
+    }
+
     function getTypeFromIntersectionTypeNode(node: IntersectionTypeNode): Type {
         const links = getNodeLinks(node);
         if (!links.resolvedType) {
             const aliasSymbol = getAliasSymbolForTypeNode(node);
             const types = map(node.types, getTypeFromTypeNode);
-            const noSupertypeReduction = types.length === 2 && !!(types[0].flags & (TypeFlags.String | TypeFlags.Number | TypeFlags.BigInt)) && types[1] === emptyTypeLiteralType;
+            const noSupertypeReduction = types.length === 2 && (areIntersectedTypesAvoidingPrimitiveReduction(types[0], types[1]) || areIntersectedTypesAvoidingPrimitiveReduction(types[1], types[0]));
             links.resolvedType = getIntersectionType(types, aliasSymbol, getTypeArgumentsForAliasSymbol(aliasSymbol), noSupertypeReduction);
         }
         return links.resolvedType;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2163,6 +2163,10 @@ export function isStringOrRegularExpressionOrTemplateLiteral(kind: SyntaxKind): 
     return false;
 }
 
+function areIntersectedTypesAvoidingStringReduction(checker: TypeChecker, t1: Type, t2: Type) {
+    return !!(t1.flags & TypeFlags.String) && checker.isEmptyAnonymousObjectType(t2);
+}
+
 /** @internal */
 export function isStringAndEmptyAnonymousObjectIntersection(type: Type) {
     if (!type.isIntersection()) {
@@ -2170,8 +2174,8 @@ export function isStringAndEmptyAnonymousObjectIntersection(type: Type) {
     }
 
     const { types, checker } = type;
-    return types.length === 2
-        && (types[0].flags & TypeFlags.String) && checker.isEmptyAnonymousObjectType(types[1]);
+    return types.length === 2 &&
+        (areIntersectedTypesAvoidingStringReduction(checker, types[0], types[1]) || areIntersectedTypesAvoidingStringReduction(checker, types[1], types[0]));
 }
 
 /** @internal */

--- a/tests/baselines/reference/unknownControlFlow.errors.txt
+++ b/tests/baselines/reference/unknownControlFlow.errors.txt
@@ -6,7 +6,7 @@ tests/cases/conformance/types/unknown/unknownControlFlow.ts(293,5): error TS2345
 
 
 ==== tests/cases/conformance/types/unknown/unknownControlFlow.ts (5 errors) ====
-    type T01 = {} & string;  // string
+    type T01 = {} & string;  // {} & string
     type T02 = {} & 'a';  // 'a'
     type T03 = {} & object;  // object
     type T04 = {} & { x: number };  // { x: number }

--- a/tests/baselines/reference/unknownControlFlow.js
+++ b/tests/baselines/reference/unknownControlFlow.js
@@ -1,5 +1,5 @@
 //// [unknownControlFlow.ts]
-type T01 = {} & string;  // string
+type T01 = {} & string;  // {} & string
 type T02 = {} & 'a';  // 'a'
 type T03 = {} & object;  // object
 type T04 = {} & { x: number };  // { x: number }

--- a/tests/baselines/reference/unknownControlFlow.symbols
+++ b/tests/baselines/reference/unknownControlFlow.symbols
@@ -1,5 +1,5 @@
 === tests/cases/conformance/types/unknown/unknownControlFlow.ts ===
-type T01 = {} & string;  // string
+type T01 = {} & string;  // {} & string
 >T01 : Symbol(T01, Decl(unknownControlFlow.ts, 0, 0))
 
 type T02 = {} & 'a';  // 'a'

--- a/tests/baselines/reference/unknownControlFlow.types
+++ b/tests/baselines/reference/unknownControlFlow.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/types/unknown/unknownControlFlow.ts ===
-type T01 = {} & string;  // string
->T01 : string
+type T01 = {} & string;  // {} & string
+>T01 : {} & string
 
 type T02 = {} & 'a';  // 'a'
 >T02 : "a"

--- a/tests/cases/conformance/types/unknown/unknownControlFlow.ts
+++ b/tests/cases/conformance/types/unknown/unknownControlFlow.ts
@@ -1,7 +1,7 @@
 // @strict: true
 // @declaration: true
 
-type T01 = {} & string;  // string
+type T01 = {} & string;  // {} & string
 type T02 = {} & 'a';  // 'a'
 type T03 = {} & object;  // object
 type T04 = {} & { x: number };  // { x: number }

--- a/tests/cases/fourslash/specialIntersectionsOrderIndependent.ts
+++ b/tests/cases/fourslash/specialIntersectionsOrderIndependent.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+//
+//// declare function a(arg: 'test' | (string & {})): void
+//// a('/*1*/')
+//// declare function b(arg: 'test' | ({} & string)): void
+//// b('/*2*/')
+
+verify.completions({ marker: ["1", "2"], exact: ["test"] });


### PR DESCRIPTION
I understand that those special intersections are, well, special - they are a carveout in the logic and don't quite adhere to The Rules. So if you feel that it's unnecessary then feel free to just close this PR.

That being said... this is a regression from https://github.com/microsoft/TypeScript/pull/49119 and this worked OK in TS 4.7 ([TS 4.7 playground](https://www.typescriptlang.org/play?ts=4.7.4#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXygApYBzALngHIMQBnDS+AH3kPpi1RPgDJ4BvAL4BKYRQBuOLMABQMopUrC5oSLAQp02PPABGxGOSo16jFoSG947TiVESpsmQHpn8ACwA6ABx6YOAGsEKGQMHDAcAFsABwgQGngACxA4GX1FYSA)). I accidentally discovered this by using `{} & string` (even though usually I write `string & {}`). It took me some time to notice that I used a somewhat unusual order and that it broke my use case.

fixes https://github.com/microsoft/TypeScript/issues/53043