### PR TITLE
Fix crash in private accessor emit

### DIFF
--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -1013,7 +1013,14 @@ export function transformClassFields(context: TransformationContext): (x: Source
             );
         }
 
-        return visitEachChild(node, visitor, context);
+        return factory.updatePropertyDeclaration(
+            node,
+            visitNodes(node.modifiers, modifierVisitor, isModifier),
+            visitNode(node.name, propertyNameVisitor, isPropertyName),
+            /*questionOrExclamationToken*/ undefined,
+            /*type*/ undefined,
+            visitNode(node.initializer, visitor, isExpression)
+        );
     }
 
     function transformPublicFieldInitializer(node: PropertyDeclaration) {

--- a/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.js
+++ b/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.js
@@ -1,0 +1,79 @@
+//// [tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorNoUseDefineForClassFields.ts] ////
+
+//// [file1.ts]
+// https://github.com/microsoft/TypeScript/issues/51528
+class C1 {
+    static accessor x = 0;
+}
+
+//// [file2.ts]
+class C2 {
+    static accessor #x = 0;
+}
+
+//// [file3.ts]
+class C3 {
+    static accessor #x = 0;
+    accessor #y = 0;
+}
+
+//// [file3.ts]
+class C3 {
+    accessor x = 0;
+}
+
+//// [file4.ts]
+class C4 {
+    accessor #x = 0;
+}
+
+//// [file5.ts]
+class C5 {
+    x = 0;
+    accessor #x = 1;
+}
+
+//// [file6.ts]
+class C6 {
+    accessor #x = 0;
+    x = 1;
+}
+
+
+//// [file1.js]
+// https://github.com/microsoft/TypeScript/issues/51528
+class C1 {
+    static accessor x = 0;
+}
+//// [file2.js]
+class C2 {
+    static accessor #x = 0;
+}
+//// [file3.js]
+class C3 {
+    accessor x = 0;
+}
+//// [file4.js]
+class C4 {
+    accessor #x = 0;
+}
+//// [file5.js]
+class C5 {
+    constructor() {
+        this.x = 0;
+        this.#x_accessor_storage = 1;
+    }
+    #x_accessor_storage;
+    get #x() { return this.#x_accessor_storage; }
+    set #x(value) { this.#x_accessor_storage = value; }
+}
+//// [file6.js]
+class C6 {
+    constructor() {
+        this.#x_accessor_storage = 0;
+        this.x = 1;
+    }
+    #x_accessor_storage;
+    get #x() { return this.#x_accessor_storage; }
+    set #x(value) { this.#x_accessor_storage = value; }
+}

--- a/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.symbols
+++ b/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.symbols
@@ -1,0 +1,65 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file1.ts ===
+// https://github.com/microsoft/TypeScript/issues/51528
+class C1 {
+>C1 : Symbol(C1, Decl(file1.ts, 0, 0))
+
+    static accessor x = 0;
+>x : Symbol(C1.x, Decl(file1.ts, 1, 10))
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file2.ts ===
+class C2 {
+>C2 : Symbol(C2, Decl(file2.ts, 0, 0))
+
+    static accessor #x = 0;
+>#x : Symbol(C2.#x, Decl(file2.ts, 0, 10))
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file3.ts ===
+class C3 {
+>C3 : Symbol(C3, Decl(file3.ts, 0, 0))
+
+    static accessor #x = 0;
+>x : Symbol(C3.x, Decl(file3.ts, 0, 10))
+
+    accessor #y = 0;
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file3.ts ===
+class C3 {
+>C3 : Symbol(C3, Decl(file3.ts, 0, 0))
+
+    accessor x = 0;
+>x : Symbol(C3.x, Decl(file3.ts, 0, 10))
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file4.ts ===
+class C4 {
+>C4 : Symbol(C4, Decl(file4.ts, 0, 0))
+
+    accessor #x = 0;
+>#x : Symbol(C4.#x, Decl(file4.ts, 0, 10))
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file5.ts ===
+class C5 {
+>C5 : Symbol(C5, Decl(file5.ts, 0, 0))
+
+    x = 0;
+>x : Symbol(C5.x, Decl(file5.ts, 0, 10))
+
+    accessor #x = 1;
+>#x : Symbol(C5.#x, Decl(file5.ts, 1, 10))
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file6.ts ===
+class C6 {
+>C6 : Symbol(C6, Decl(file6.ts, 0, 0))
+
+    accessor #x = 0;
+>#x : Symbol(C6.#x, Decl(file6.ts, 0, 10))
+
+    x = 1;
+>x : Symbol(C6.x, Decl(file6.ts, 1, 20))
+}
+

--- a/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.types
+++ b/tests/baselines/reference/autoAccessorNoUseDefineForClassFields.types
@@ -1,0 +1,74 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file1.ts ===
+// https://github.com/microsoft/TypeScript/issues/51528
+class C1 {
+>C1 : C1
+
+    static accessor x = 0;
+>x : number
+>0 : 0
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file2.ts ===
+class C2 {
+>C2 : C2
+
+    static accessor #x = 0;
+>#x : number
+>0 : 0
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file3.ts ===
+class C3 {
+>C3 : C3
+
+    static accessor #x = 0;
+>x : number
+>0 : 0
+
+    accessor #y = 0;
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file3.ts ===
+class C3 {
+>C3 : C3
+
+    accessor x = 0;
+>x : number
+>0 : 0
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file4.ts ===
+class C4 {
+>C4 : C4
+
+    accessor #x = 0;
+>#x : number
+>0 : 0
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file5.ts ===
+class C5 {
+>C5 : C5
+
+    x = 0;
+>x : number
+>0 : 0
+
+    accessor #x = 1;
+>#x : number
+>1 : 1
+}
+
+=== tests/cases/conformance/classes/propertyMemberDeclarations/file6.ts ===
+class C6 {
+>C6 : C6
+
+    accessor #x = 0;
+>#x : number
+>0 : 0
+
+    x = 1;
+>x : number
+>1 : 1
+}
+

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorNoUseDefineForClassFields.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorNoUseDefineForClassFields.ts
@@ -1,0 +1,41 @@
+// @target: esnext
+// @useDefineForClassFields: false
+
+// @filename: file1.ts
+// https://github.com/microsoft/TypeScript/issues/51528
+class C1 {
+    static accessor x = 0;
+}
+
+// @filename: file2.ts
+class C2 {
+    static accessor #x = 0;
+}
+
+// @filename: file3.ts
+class C3 {
+    static accessor #x = 0;
+    accessor #y = 0;
+}
+
+// @filename: file3.ts
+class C3 {
+    accessor x = 0;
+}
+
+// @filename: file4.ts
+class C4 {
+    accessor #x = 0;
+}
+
+// @filename: file5.ts
+class C5 {
+    x = 0;
+    accessor #x = 1;
+}
+
+// @filename: file6.ts
+class C6 {
+    accessor #x = 0;
+    x = 1;
+}


### PR DESCRIPTION
This fixes a crash when emitting private accessors when `useDefineForClassFields` is `false`. Prior to 5.0, this was not a crash but was emitting incorrectly.

Fixes #51528
