### PR TITLE
Stricter relational comparisons checking `valueOf`

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -2169,7 +2169,7 @@ export function equateStringsCaseSensitive(a: string, b: string) {
 
 function compareComparableValues(a: string | undefined, b: string | undefined): Comparison;
 function compareComparableValues(a: number | undefined, b: number | undefined): Comparison;
-function compareComparableValues(a: string | number | undefined, b: string | number | undefined) {
+function compareComparableValues(a: any, b: any) {
     return a === b ? Comparison.EqualTo :
         a === undefined ? Comparison.LessThan :
         b === undefined ? Comparison.GreaterThan :

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalObjects.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalObjects.errors.txt
@@ -1,0 +1,365 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(61,12): error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(62,12): error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(63,12): error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(64,12): error TS2365: Operator '<' cannot be applied to types 'A3' and 'B3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(65,12): error TS2365: Operator '<' cannot be applied to types 'A4' and 'B4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(66,12): error TS2365: Operator '<' cannot be applied to types 'A5' and 'B5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(67,12): error TS2365: Operator '<' cannot be applied to types 'A6' and 'B6'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(69,12): error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(70,12): error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(71,12): error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(72,12): error TS2365: Operator '<' cannot be applied to types 'B3' and 'A3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(73,12): error TS2365: Operator '<' cannot be applied to types 'B4' and 'A4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(74,12): error TS2365: Operator '<' cannot be applied to types 'B5' and 'A5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(75,12): error TS2365: Operator '<' cannot be applied to types 'B6' and 'A6'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(78,12): error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(79,12): error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(80,12): error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(81,12): error TS2365: Operator '>' cannot be applied to types 'A3' and 'B3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(82,12): error TS2365: Operator '>' cannot be applied to types 'A4' and 'B4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(83,12): error TS2365: Operator '>' cannot be applied to types 'A5' and 'B5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(84,12): error TS2365: Operator '>' cannot be applied to types 'A6' and 'B6'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(86,12): error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(87,12): error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(88,12): error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(89,12): error TS2365: Operator '>' cannot be applied to types 'B3' and 'A3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(90,12): error TS2365: Operator '>' cannot be applied to types 'B4' and 'A4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(91,12): error TS2365: Operator '>' cannot be applied to types 'B5' and 'A5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(92,12): error TS2365: Operator '>' cannot be applied to types 'B6' and 'A6'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(95,12): error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(96,12): error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(97,12): error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(98,12): error TS2365: Operator '<=' cannot be applied to types 'A3' and 'B3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(99,12): error TS2365: Operator '<=' cannot be applied to types 'A4' and 'B4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(100,12): error TS2365: Operator '<=' cannot be applied to types 'A5' and 'B5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(101,12): error TS2365: Operator '<=' cannot be applied to types 'A6' and 'B6'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(103,12): error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(104,12): error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(105,12): error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(106,12): error TS2365: Operator '<=' cannot be applied to types 'B3' and 'A3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(107,12): error TS2365: Operator '<=' cannot be applied to types 'B4' and 'A4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(108,12): error TS2365: Operator '<=' cannot be applied to types 'B5' and 'A5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(109,12): error TS2365: Operator '<=' cannot be applied to types 'B6' and 'A6'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(112,12): error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(113,12): error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(114,12): error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(115,12): error TS2365: Operator '>=' cannot be applied to types 'A3' and 'B3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(116,12): error TS2365: Operator '>=' cannot be applied to types 'A4' and 'B4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(117,12): error TS2365: Operator '>=' cannot be applied to types 'A5' and 'B5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(118,12): error TS2365: Operator '>=' cannot be applied to types 'A6' and 'B6'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(120,12): error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(121,12): error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(122,12): error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(123,12): error TS2365: Operator '>=' cannot be applied to types 'B3' and 'A3'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(124,12): error TS2365: Operator '>=' cannot be applied to types 'B4' and 'A4'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(125,12): error TS2365: Operator '>=' cannot be applied to types 'B5' and 'A5'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts(126,12): error TS2365: Operator '>=' cannot be applied to types 'B6' and 'A6'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts (56 errors) ====
+    class A1 {
+        public a: string;
+        public b: number;
+        public c: boolean;
+        public d: any;
+        public e: Object;
+        public fn(a: string): string {
+            return null;
+        }
+    }
+    class B1 {
+        public a: string;
+        public b: number;
+        public c: boolean;
+        public d: any;
+        public e: Object;
+        public fn(b: string): string {
+            return null;
+        }
+    }
+    
+    class Base {
+        private a: string;
+        private fn(b: string): string {
+            return null;
+        }
+    }
+    class A2 extends Base { }
+    class B2 extends Base { }
+    
+    interface A3 { f(a: number): string; }
+    interface B3 { f(a: number): string; }
+    
+    interface A4 { new (a: string): A1; }
+    interface B4 { new (a: string): B1; }
+    
+    interface A5 { [x: number]: number; }
+    interface B5 { [x: number]: number; }
+    
+    interface A6 { [x: string]: string; }
+    interface B6 { [x: string]: string; }
+    
+    var a1: A1;
+    var a2: A2;
+    var a3: A3;
+    var a4: A4;
+    var a5: A5;
+    var a6: A6;
+    
+    var b1: B1;
+    var b2: B2;
+    var b3: B3;
+    var b4: B4;
+    var b5: B5;
+    var b6: B6;
+    
+    var base1: Base;
+    var base2: Base;
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+    var r1a2 = base1 < base2;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+    var r1a3 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+    var r1a4 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A3' and 'B3'.
+    var r1a5 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A4' and 'B4'.
+    var r1a6 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A5' and 'B5'.
+    var r1a7 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A6' and 'B6'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+    var r1b2 = base2 < base1;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+    var r1b3 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+    var r1b4 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B3' and 'A3'.
+    var r1b5 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B4' and 'A4'.
+    var r1b6 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B5' and 'A5'.
+    var r1b7 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+    var r2a2 = base1 > base2;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+    var r2a3 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+    var r2a4 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A3' and 'B3'.
+    var r2a5 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A4' and 'B4'.
+    var r2a6 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A5' and 'B5'.
+    var r2a7 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A6' and 'B6'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+    var r2b2 = base2 > base1;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+    var r2b3 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+    var r2b4 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B3' and 'A3'.
+    var r2b5 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B4' and 'A4'.
+    var r2b6 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B5' and 'A5'.
+    var r2b7 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+    var r3a2 = base1 <= base2;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+    var r3a3 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+    var r3a4 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A3' and 'B3'.
+    var r3a5 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A4' and 'B4'.
+    var r3a6 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A5' and 'B5'.
+    var r3a7 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A6' and 'B6'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+    var r3b2 = base2 <= base1;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+    var r3b3 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+    var r3b4 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B3' and 'A3'.
+    var r3b5 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B4' and 'A4'.
+    var r3b6 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B5' and 'A5'.
+    var r3b7 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+    var r4a2 = base1 >= base2;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+    var r4a3 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+    var r4a4 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A3' and 'B3'.
+    var r4a5 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A4' and 'B4'.
+    var r4a6 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A5' and 'B5'.
+    var r4a7 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A6' and 'B6'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+    var r4b2 = base2 >= base1;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+    var r4b3 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+    var r4b4 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B3' and 'A3'.
+    var r4b5 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B4' and 'A4'.
+    var r4b6 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B5' and 'A5'.
+    var r4b7 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = base1 == base2;
+    var r5a3 = a2 == b2;
+    var r5a4 = a3 == b3;
+    var r5a5 = a4 == b4;
+    var r5a6 = a5 == b5;
+    var r5a7 = a6 == b6;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = base2 == base1;
+    var r5b3 = b2 == a2;
+    var r5b4 = b3 == a3;
+    var r5b5 = b4 == a4;
+    var r5b6 = b5 == a5;
+    var r5b7 = b6 == a6;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = base1 != base2;
+    var r6a3 = a2 != b2;
+    var r6a4 = a3 != b3;
+    var r6a5 = a4 != b4;
+    var r6a6 = a5 != b5;
+    var r6a7 = a6 != b6;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = base2 != base1;
+    var r6b3 = b2 != a2;
+    var r6b4 = b3 != a3;
+    var r6b5 = b4 != a4;
+    var r6b6 = b5 != a5;
+    var r6b7 = b6 != a6;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = base1 === base2;
+    var r7a3 = a2 === b2;
+    var r7a4 = a3 === b3;
+    var r7a5 = a4 === b4;
+    var r7a6 = a5 === b5;
+    var r7a7 = a6 === b6;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = base2 === base1;
+    var r7b3 = b2 === a2;
+    var r7b4 = b3 === a3;
+    var r7b5 = b4 === a4;
+    var r7b6 = b5 === a5;
+    var r7b7 = b6 === a6;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = base1 !== base2;
+    var r8a3 = a2 !== b2;
+    var r8a4 = a3 !== b3;
+    var r8a5 = a4 !== b4;
+    var r8a6 = a5 !== b5;
+    var r8a7 = a6 !== b6;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = base2 !== base1;
+    var r8b3 = b2 !== a2;
+    var r8b4 = b3 !== a3;
+    var r8b5 = b4 !== a4;
+    var r8b6 = b5 !== a5;
+    var r8b7 = b6 !== a6;

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
@@ -1,22 +1,30 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(11,11): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(13,11): error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,11): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,18): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,11): error TS18050: The value 'undefined' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,23): error TS18050: The value 'undefined' cannot be used here.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(20,11): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(22,11): error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,11): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,18): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,11): error TS18050: The value 'undefined' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,23): error TS18050: The value 'undefined' cannot be used here.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(29,11): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(31,11): error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,11): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,19): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,11): error TS18050: The value 'undefined' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,24): error TS18050: The value 'undefined' cannot be used here.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(38,11): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(40,11): error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,11): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,19): error TS18050: The value 'null' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,11): error TS18050: The value 'undefined' cannot be used here.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value 'undefined' cannot be used here.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts (16 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts (24 errors) ====
     enum E { a, b, c }
     
     var a: number;
@@ -28,8 +36,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator <
     var ra1 = a < a;
     var ra2 = b < b;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
     var ra3 = c < c;
     var ra4 = d < d;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
     var ra5 = e < e;
     var ra6 = null < null;
               ~~~~
@@ -45,8 +57,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator >
     var rb1 = a > a;
     var rb2 = b > b;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
     var rb3 = c > c;
     var rb4 = d > d;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
     var rb5 = e > e;
     var rb6 = null > null;
               ~~~~
@@ -62,8 +78,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator <=
     var rc1 = a <= a;
     var rc2 = b <= b;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
     var rc3 = c <= c;
     var rc4 = d <= d;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
     var rc5 = e <= e;
     var rc6 = null <= null;
               ~~~~
@@ -79,8 +99,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator >=
     var rd1 = a >= a;
     var rd2 = b >= b;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
     var rd3 = c >= c;
     var rd4 = d >= d;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
     var rd5 = e >= e;
     var rd6 = null >= null;
               ~~~~

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalTypeParameter.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalTypeParameter.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts(2,14): error TS2365: Operator '<' cannot be applied to types 'T' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts(3,14): error TS2365: Operator '>' cannot be applied to types 'T' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts(4,14): error TS2365: Operator '<=' cannot be applied to types 'T' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts(5,14): error TS2365: Operator '>=' cannot be applied to types 'T' and 'T'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts (4 errors) ====
+    function foo<T>(t: T) {
+        var r1 = t < t;
+                 ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'T'.
+        var r2 = t > t;
+                 ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and 'T'.
+        var r3 = t <= t;
+                 ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and 'T'.
+        var r4 = t >= t;
+                 ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and 'T'.
+        var r5 = t == t;
+        var r6 = t != t;
+        var r7 = t === t;
+        var r8 = t !== t;
+    }

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.errors.txt
@@ -4,48 +4,56 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(38,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(45,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(49,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(62,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(63,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(64,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(65,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(66,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(79,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(80,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(81,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(82,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(83,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(96,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(97,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(98,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(99,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(100,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(103,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(): Base; }' and 'new () => Base' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(104,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(105,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }' have no overlap.
@@ -96,7 +104,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }' have no overlap.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts (96 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts (104 errors) ====
     class Base {
         public a: string;
     }
@@ -150,6 +158,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r1b1 = b1 < a1;
                ~~~~~~~
@@ -170,6 +180,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator >
     var r2a1 = a1 > b1;
@@ -191,6 +203,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r2b1 = b1 > a1;
                ~~~~~~~
@@ -211,6 +225,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator <=
     var r3a1 = a1 <= b1;
@@ -232,6 +248,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r3b1 = b1 <= a1;
                ~~~~~~~~
@@ -252,6 +270,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator >=
     var r4a1 = a1 >= b1;
@@ -273,6 +293,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r4b1 = b1 >= a1;
                ~~~~~~~~
@@ -293,6 +315,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator ==
     var r5a1 = a1 == b1;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.errors.txt
@@ -4,48 +4,56 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(38,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => C'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(45,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types 'new () => C' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(49,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => C'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(62,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(63,12): error TS2365: Operator '>' cannot be applied to types 'new () => C' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(64,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(65,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(66,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => C'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(79,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(80,12): error TS2365: Operator '<=' cannot be applied to types 'new () => C' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(81,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(82,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(83,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => C'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(96,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(97,12): error TS2365: Operator '>=' cannot be applied to types 'new () => C' and 'new () => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(98,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(99,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(100,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(103,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(): Base; }' and 'new () => Base' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(104,12): error TS2367: This comparison appears to be unintentional because the types 'new (a: number, b: string) => Base' and 'new (a: string) => Base' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(105,12): error TS2367: This comparison appears to be unintentional because the types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base' have no overlap.
@@ -96,7 +104,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): error TS2367: This comparison appears to be unintentional because the types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base' have no overlap.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts (96 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts (104 errors) ====
     class Base {
         public a: string;
     }
@@ -150,6 +158,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r1b1 = b1 < a1;
                ~~~~~~~
@@ -170,6 +180,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator >
     var r2a1 = a1 > b1;
@@ -191,6 +203,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r2b1 = b1 > a1;
                ~~~~~~~
@@ -211,6 +225,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator <=
     var r3a1 = a1 <= b1;
@@ -232,6 +248,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r3b1 = b1 <= a1;
                ~~~~~~~~
@@ -252,6 +270,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator >=
     var r4a1 = a1 >= b1;
@@ -273,6 +293,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r4b1 = b1 >= a1;
                ~~~~~~~~
@@ -293,6 +315,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator ==
     var r5a1 = a1 == b1;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.errors.txt
@@ -1,27 +1,35 @@
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(26,12): error TS2365: Operator '<' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(27,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(28,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(29,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(31,12): error TS2365: Operator '<' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(37,12): error TS2365: Operator '>' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(38,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(39,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(40,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(42,12): error TS2365: Operator '>' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(43,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(44,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(45,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(48,12): error TS2365: Operator '<=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(49,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(50,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(51,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(53,12): error TS2365: Operator '<=' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(54,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(55,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(56,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(59,12): error TS2365: Operator '>=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(60,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(61,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(62,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(64,12): error TS2365: Operator '>=' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(65,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(66,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(67,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(70,12): error TS2367: This comparison appears to be unintentional because the types '{ [a: string]: string; }' and '{ [b: string]: number; }' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(71,12): error TS2367: This comparison appears to be unintentional because the types '{ [index: string]: Base; }' and '{ [index: string]: C; }' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(72,12): error TS2367: This comparison appears to be unintentional because the types '{ [index: number]: Base; }' and '{ [index: number]: C; }' have no overlap.
@@ -48,7 +56,7 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS2367: This comparison appears to be unintentional because the types '{ [index: number]: C; }' and '{ [index: number]: Base; }' have no overlap.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts (48 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts (56 errors) ====
     class Base {
         public a: string;
     }
@@ -84,6 +92,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r1b1 = b1 < a1;
                ~~~~~~~
@@ -95,6 +105,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator >
     var r2a1 = a1 > b1;
@@ -107,6 +119,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r2b1 = b1 > a1;
                ~~~~~~~
@@ -118,6 +132,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator <=
     var r3a1 = a1 <= b1;
@@ -130,6 +146,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r3b1 = b1 <= a1;
                ~~~~~~~~
@@ -141,6 +159,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator >=
     var r4a1 = a1 >= b1;
@@ -153,6 +173,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r4b1 = b1 >= a1;
                ~~~~~~~~
@@ -164,6 +186,8 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator ==
     var r5a1 = a1 == b1;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.errors.txt
@@ -1,0 +1,296 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(37,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(47,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(62,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(63,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(64,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(77,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(78,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(79,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(80,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(81,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    class C {
+        public c: string;
+    }
+    
+    var a1: { fn<T>(x: T): T };
+    var b1: { fn(): string };
+    
+    var a2: { fn<T>(x: T): T };
+    var b2: { fn(x: string): number };
+    
+    var a3: { fn<T>(x?: T): T };
+    var b3: { fn(x?: string): number };
+    
+    var a4: { fn<T>(...x: T[]): T };
+    var b4: { fn(...x: string[]): number };
+    
+    var a5: { fn<T>(x: T, y: T): T };
+    var b5: { fn(x: string, y: number): string };
+    
+    var a6: { fn<T, U extends T>(x: T, y: U): T };
+    var b6: { fn(x: Base, y: C): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.errors.txt
@@ -1,0 +1,296 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(37,12): error TS2365: Operator '<' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(47,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(62,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(63,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(64,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(77,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(78,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(79,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(80,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(81,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    class C {
+        public c: string;
+    }
+    
+    var a1: { new <T>(x: T): T };
+    var b1: { new (): string };
+    
+    var a2: { new <T>(x: T): T };
+    var b2: { new (x: string): number };
+    
+    var a3: { new <T>(x?: T): T };
+    var b3: { new (x?: string): number };
+    
+    var a4: { new <T>(...x: T[]): T };
+    var b4: { new (...x: string[]): number };
+    
+    var a5: { new <T>(x: T, y: T): T };
+    var b5: { new (x: string, y: number): string };
+    
+    var a6: { new <T, U extends T>(x: T, y: U): T };
+    var b6: { new (x: Base, y: C): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipTypeParameter.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipTypeParameter.errors.txt
@@ -6,41 +6,121 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(17,14): error TS2367: This comparison appears to be unintentional because the types 'T' and 'U' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(18,14): error TS2367: This comparison appears to be unintentional because the types 'T' and 'U' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(19,14): error TS2367: This comparison appears to be unintentional because the types 'T' and 'U' have no overlap.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(22,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(23,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(24,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(25,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(26,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(27,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(28,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(30,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(31,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(32,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(33,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(34,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(35,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(36,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(39,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(40,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(41,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(42,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(43,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(44,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(45,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(47,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(48,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(49,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(50,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(51,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(52,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(53,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(56,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(57,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(58,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(59,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(60,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(61,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(62,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(64,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(65,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(66,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(67,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(68,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(69,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(70,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(73,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(74,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(75,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(76,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(77,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(78,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(79,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(81,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(82,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(83,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(84,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(85,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(86,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(87,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(90,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(91,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(92,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(93,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(94,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(95,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(96,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(98,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(99,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(100,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(101,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(102,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(103,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(104,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(107,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(108,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(109,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(110,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(111,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(112,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(113,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(115,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(116,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(117,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(118,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(119,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(120,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(121,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(124,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(125,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(126,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(127,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(128,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(129,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(130,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(132,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(133,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(134,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(135,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(136,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(137,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(138,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(141,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(142,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(143,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(144,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(145,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(146,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(147,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(149,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(150,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(151,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(152,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(153,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(154,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts(155,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts (40 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts (120 errors) ====
     enum E { a, b, c }
     
     var a: boolean;
@@ -79,201 +159,361 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     
         // operator <
         var r1a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r1a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r1a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r1a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r1a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r1a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r1a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r1b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r1b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r1b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r1b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r1b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r1b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r1b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator >
         var r2a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r2a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r2a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r2a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r2a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r2a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r2a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r2b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r2b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r2b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r2b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r2b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r2b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r2b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator <=
         var r3a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r3a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r3a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r3a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r3a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r3a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r3a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r3b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r3b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r3b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r3b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r3b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r3b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r3b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator >=
         var r4a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r4a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r4a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r4a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r4a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r4a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r4a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r4b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r4b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r4b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r4b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r4b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r4b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r4b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator ==
         var r5a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r5a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r5a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r5a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r5a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r5a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r5a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r5b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r5b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r5b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r5b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r5b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r5b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r5b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator !=
         var r6a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r6a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r6a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r6a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r6a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r6a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r6a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r6b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r6b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r6b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r6b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r6b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r6b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r6b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator ===
         var r7a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r7a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r7a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r7a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r7a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r7a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r7a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r7b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r7b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r7b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r7b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r7b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r7b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r7b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator !==
         var r8a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r8a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r8a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r8a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r8a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r8a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r8a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r8b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r8b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r8b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r8b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r8b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r8b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r8b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     }

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnCallSignature.errors.txt
@@ -1,0 +1,526 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(49,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(50,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(51,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(52,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(53,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(54,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(55,13): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(56,13): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(59,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(60,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(61,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(62,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(63,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(64,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(65,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(66,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(67,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(68,13): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(69,13): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(73,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(74,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(75,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(76,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(77,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(78,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(79,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(80,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(81,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(82,13): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(83,13): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(86,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(87,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(88,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(89,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(90,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(91,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(92,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(93,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(94,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(95,13): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(96,13): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(100,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(101,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(102,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(103,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(104,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(105,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(106,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(107,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(108,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(109,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(110,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(113,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(114,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(115,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(116,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(117,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(118,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(119,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(120,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(121,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(122,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(123,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(127,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(128,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(129,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(130,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(131,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(132,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(133,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(134,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(135,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(136,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(137,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(140,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(141,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(142,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(143,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(144,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(145,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(146,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(147,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(148,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(149,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts(150,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnCallSignature.ts (88 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { fn(): void };
+    var b1: { fn(): void };
+    
+    var a2: { fn(a: number, b: string): void };
+    var b2: { fn(a: number, b: string): void };
+    
+    var a3: { fn(a: number, b: string): void };
+    var b3: { fn(a: number): void };
+    
+    var a4: { fn(a: number, b: string): void };
+    var b4: { fn(): void };
+    
+    var a5: { fn(a: Base): void };
+    var b5: { fn(a: Derived): void };
+    
+    var a6: { fn(a: Derived, b: Base): void };
+    var b6: { fn(a: Base, b: Derived): void };
+    
+    var a7: { fn(): void };
+    var b7: { fn(): Base };
+    
+    var a8: { fn(): Base };
+    var b8: { fn(): Base };
+    
+    var a9: { fn(): Base };
+    var b9: { fn(): Derived };
+    
+    var a10: { fn(a?: Base): void };
+    var b10: { fn(a?: Derived): void };
+    
+    var a11: { fn(...a: Base[]): void };
+    var b11: { fn(...a: Derived[]): void };
+    
+    //var a12: { fn<T, U extends T>(t: T, u: U): T[] };
+    //var b12: { fn<A, B extends A>(a: A, b: B): A[] };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r1a8 = a8 < b8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r1a9 = a9 < b9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r1a10 = a10 < b10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r1a11 = a11 < b11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r1a12 = a12 < b12;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r1b8 = b8 < a8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r1b9 = b9 < a9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r1b10 = b10 < a10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r1b11 = b11 < a11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r1b12 = b12 < a12;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r2a8 = a8 > b8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r2a9 = a9 > b9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r2a10 = a10 > b10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r2a11 = a11 > b11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r2a12 = a12 > b12;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r2b8 = b8 > a8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r2b9 = b9 > a9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r2b10 = b10 > a10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r2b11 = b11 > a11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r2b12 = b12 > a12;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r3a8 = a8 <= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r3a9 = a9 <= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r3a10 = a10 <= b10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r3a11 = a11 <= b11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r3a12 = a12 <= b12;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r3b8 = b8 <= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r3b9 = b9 <= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r3b10 = b10 <= a10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r3b11 = b11 <= a11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r3b12 = b12 <= a12;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r4a8 = a8 >= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r4a9 = a9 >= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r4a10 = a10 >= b10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r4a11 = a11 >= b11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r4a12 = a12 >= b12;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r4b8 = b8 >= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r4b9 = b9 >= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r4b10 = b10 >= a10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r4b11 = b11 >= a11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r4b12 = b12 >= a12;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    var r5a7 = a7 == b7;
+    var r5a8 = a8 == b8;
+    var r5a9 = a9 == b9;
+    var r5a10 = a10 == b10;
+    var r5a11 = a11 == b11;
+    //var r5a12 = a12 == b12;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    var r5b7 = b7 == a7;
+    var r5b8 = b8 == a8;
+    var r5b9 = b9 == a9;
+    var r5b10 = b10 == a10;
+    var r5b11 = b11 == a11;
+    //var r5b12 = b12 == a12;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    var r6a7 = a7 != b7;
+    var r6a8 = a8 != b8;
+    var r6a9 = a9 != b9;
+    var r6a10 = a10 != b10;
+    var r6a11 = a11 != b11;
+    //var r6a12 = a12 != b12;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    var r6b7 = b7 != a7;
+    var r6b8 = b8 != a8;
+    var r6b9 = b9 != a9;
+    var r6b10 = b10 != a10;
+    var r6b11 = b11 != a11;
+    //var r6b12 = b12 != a12;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    var r7a7 = a7 === b7;
+    var r7a8 = a8 === b8;
+    var r7a9 = a9 === b9;
+    var r7a10 = a10 === b10;
+    var r7a11 = a11 === b11;
+    //var r7a12 = a12 === b12;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    var r7b7 = b7 === a7;
+    var r7b8 = b8 === a8;
+    var r7b9 = b9 === a9;
+    var r7b10 = b10 === a10;
+    var r7b11 = b11 === a11;
+    //var r7b12 = b12 === a12;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    var r8a7 = a7 !== b7;
+    var r8a8 = a8 !== b8;
+    var r8a9 = a9 !== b9;
+    var r8a10 = a10 !== b10;
+    var r8a11 = a11 !== b11;
+    //var r8a12 = a12 !== b12;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    var r8b7 = b7 !== a7;
+    var r8b8 = b8 !== a8;
+    var r8b9 = b9 !== a9;
+    var r8b10 = b10 !== a10;
+    var r8b11 = b11 !== a11;
+    //var r8b12 = b12 !== a12;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnConstructorSignature.errors.txt
@@ -1,0 +1,440 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(45,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(51,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(52,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(53,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(54,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(55,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(56,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(57,12): error TS2365: Operator '<' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(58,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(59,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(63,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(64,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(65,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(66,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(67,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(68,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(69,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(70,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(71,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(74,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(75,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(76,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(77,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(78,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(79,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(80,12): error TS2365: Operator '>' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(81,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(82,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(86,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(87,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(88,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(89,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(90,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(91,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(92,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(93,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(94,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(97,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(98,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(99,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(100,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(101,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(102,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(103,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(104,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(105,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(109,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(110,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(111,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(112,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(113,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(114,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(115,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(116,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(117,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(120,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(121,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(122,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(123,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(124,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(125,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(126,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(127,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(128,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts (72 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { new (): Base };
+    var b1: { new (): Base };
+    
+    var a2: { new (a: number, b: string): Base };
+    var b2: { new (a: number, b: string): Base };
+    
+    var a3: { new (a: number, b: string): Base };
+    var b3: { new (a: number): Base };
+    
+    var a4: { new (a: number, b: string): Base };
+    var b4: { new (): Base };
+    
+    var a5: { new (a: Base): Base };
+    var b5: { new (a: Derived): Base };
+    
+    var a6: { new (a: Derived, b: Base): Base };
+    var b6: { new (a: Base, b: Derived): Base };
+    
+    var a7: { new (): Base };
+    var b7: { new (): Derived };
+    
+    var a8: { new (a?: Base): Base };
+    var b8: { new (a?: Derived): Base };
+    
+    var a9: { new (...a: Base[]): Base };
+    var b9: { new (...a: Derived[]): Base };
+    
+    //var a10: { <T, U extends T>(t: T, u: U): T[] };
+    //var b10: { <A, B extends A>(a: A, b: B): A[] };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r1a8 = a8 < b8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r1a9 = a9 < b9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r1a10 = a10 < b10;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r1b8 = b8 < a8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r1b9 = b9 < a9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r1b10 = b10 < a10;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r2a8 = a8 > b8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r2a9 = a9 > b9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r2a10 = a10 > b10;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r2b8 = b8 > a8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r2b9 = b9 > a9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r2b10 = b10 > a10;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r3a8 = a8 <= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r3a9 = a9 <= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r3a10 = a10 <= b10;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r3b8 = b8 <= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r3b9 = b9 <= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r3b10 = b10 <= a10;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r4a8 = a8 >= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r4a9 = a9 >= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r4a10 = a10 >= b10;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r4b8 = b8 >= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r4b9 = b9 >= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r4b10 = b10 >= a10;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    var r5a7 = a7 == b7;
+    var r5a8 = a8 == b8;
+    var r5a9 = a9 == b9;
+    //var r5a10 = a10 == b10;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    var r5b7 = b7 == a7;
+    var r5b8 = b8 == a8;
+    var r5b9 = b9 == a9;
+    //var r5b10 = b10 == a10;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    var r6a7 = a7 != b7;
+    var r6a8 = a8 != b8;
+    var r6a9 = a9 != b9;
+    //var r6a10 = a10 != b10;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    var r6b7 = b7 != a7;
+    var r6b8 = b8 != a8;
+    var r6b9 = b9 != a9;
+    //var r6b10 = b10 != a10;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    var r7a7 = a7 === b7;
+    var r7a8 = a8 === b8;
+    var r7a9 = a9 === b9;
+    //var r7a10 = a10 === b10;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    var r7b7 = b7 === a7;
+    var r7b8 = b8 === a8;
+    var r7b9 = b9 === a9;
+    //var r7b10 = b10 === a10;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    var r8a7 = a7 !== b7;
+    var r8a8 = a8 !== b8;
+    var r8a9 = a9 !== b9;
+    //var r8a10 = a10 !== b10;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    var r8b7 = b7 !== a7;
+    var r8b8 = b8 !== a8;
+    var r8b9 = b9 !== a9;
+    //var r8b10 = b10 !== a10;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnIndexSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnIndexSignature.errors.txt
@@ -1,0 +1,206 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(22,12): error TS2365: Operator '<' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(23,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(24,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(25,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(27,12): error TS2365: Operator '<' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(28,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(29,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(30,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(33,12): error TS2365: Operator '>' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(34,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(35,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(36,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(38,12): error TS2365: Operator '>' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(39,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(40,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(41,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(44,12): error TS2365: Operator '<=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(45,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(46,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(47,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(49,12): error TS2365: Operator '<=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(50,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(51,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(52,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(55,12): error TS2365: Operator '>=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(56,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(57,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(58,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(60,12): error TS2365: Operator '>=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(61,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(62,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(63,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnIndexSignature.ts (32 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { [a: string]: string };
+    var b1: { [b: string]: string };
+    
+    var a2: { [index: string]: Base };
+    var b2: { [index: string]: Derived };
+    
+    var a3: { [index: number]: string };
+    var b3: { [index: number]: string };
+    
+    var a4: { [index: number]: Base };
+    var b4: { [index: string]: Derived };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r1a1 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r1a1 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r1a1 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r1b1 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r1b1 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r1b1 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r2a1 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r2a1 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r2a1 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r2b1 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r2b1 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r2b1 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r3a1 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r3a1 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r3a1 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r3b1 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r3b1 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r3b1 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r4a1 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r4a1 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r4a1 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r4b1 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r4b1 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r4b1 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a1 = a2 == b2;
+    var r5a1 = a3 == b3;
+    var r5a1 = a4 == b4;
+    
+    var r5b1 = b1 == a1;
+    var r5b1 = b2 == a2;
+    var r5b1 = b3 == a3;
+    var r5b1 = b4 == a4;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a1 = a2 != b2;
+    var r6a1 = a3 != b3;
+    var r6a1 = a4 != b4;
+    
+    var r6b1 = b1 != a1;
+    var r6b1 = b2 != a2;
+    var r6b1 = b3 != a3;
+    var r6b1 = b4 != a4;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a1 = a2 === b2;
+    var r7a1 = a3 === b3;
+    var r7a1 = a4 === b4;
+    
+    var r7b1 = b1 === a1;
+    var r7b1 = b2 === a2;
+    var r7b1 = b3 === a3;
+    var r7b1 = b4 === a4;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a1 = a2 !== b2;
+    var r8a1 = a3 !== b3;
+    var r8a1 = a4 !== b4;
+    
+    var r8b1 = b1 !== a1;
+    var r8b1 = b2 !== a2;
+    var r8b1 = b3 !== a3;
+    var r8b1 = b4 !== a4;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.errors.txt
@@ -1,0 +1,311 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(31,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(68,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(76,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(83,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(93,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { fn<T>(x: T): T };
+    var b1: { fn(x: string): string };
+    
+    var a2: { fn<T>(x: T): T };
+    var b2: { fn(x: string, y: number): string };
+    
+    var a3: { fn<T, U>(x: T, y: U): T };
+    var b3: { fn(x: string, y: number): string };
+    
+    var a4: { fn<T>(x?: T): T };
+    var b4: { fn(x?: string): string };
+    
+    var a5: { fn<T>(...x: T[]): T };
+    var b5: { fn(...x: string[]): string };
+    
+    var a6: { fn<T>(x: T, y: T): T };
+    var b6: { fn(x: string, y: number): {} };
+    
+    //var a7: { fn<T, U extends T>(x: T, y: U): T };
+    var b7: { fn(x: Base, y: Derived): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r1a7 = a7 < b7;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r1b7 = b7 < a7;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r2a7 = a7 > b7;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r2b7 = b7 > a7;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r3a7 = a7 <= b7;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r3b7 = b7 <= a7;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r4a7 = a7 >= b7;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r4b7 = b7 >= a7;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    //var r5a7 = a7 == b7;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    //var r5b7 = b7 == a7;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    //var r6a7 = a7 != b7;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    //var r6b7 = b7 != a7;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    //var r7a7 = a7 === b7;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    //var r7b7 = b7 === a7;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    //var r8a7 = a7 !== b7;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    //var r8b7 = b7 !== a7;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.errors.txt
@@ -1,0 +1,311 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(31,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(68,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(76,12): error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(83,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(93,12): error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { new <T>(x: T): T };
+    var b1: { new (x: string): string };
+    
+    var a2: { new <T>(x: T): T };
+    var b2: { new (x: string, y: number): string };
+    
+    var a3: { new <T, U>(x: T, y: U): T };
+    var b3: { new (x: string, y: number): string };
+    
+    var a4: { new <T>(x?: T): T };
+    var b4: { new (x?: string): string };
+    
+    var a5: { new <T>(...x: T[]): T };
+    var b5: { new (...x: string[]): string };
+    
+    var a6: { new <T>(x: T, y: T): T };
+    var b6: { new (x: string, y: number): {} };
+    
+    //var a7: { new <T, U extends T>(x: T, y: U): T };
+    var b7: { new (x: Base, y: Derived): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r1a7 = a7 < b7;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r1b7 = b7 < a7;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r2a7 = a7 > b7;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r2b7 = b7 > a7;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r3a7 = a7 <= b7;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r3b7 = b7 <= a7;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r4a7 = a7 >= b7;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r4b7 = b7 >= a7;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    //var r5a7 = a7 == b7;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    //var r5b7 = b7 == a7;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    //var r6a7 = a7 != b7;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    //var r6b7 = b7 != a7;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    //var r7a7 = a7 === b7;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    //var r7b7 = b7 === a7;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    //var r8a7 = a7 !== b7;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    //var r8b7 = b7 !== a7;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnOptionalProperty.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnOptionalProperty.errors.txt
@@ -1,0 +1,70 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(14,11): error TS2365: Operator '<' cannot be applied to types 'I' and 'J'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(15,11): error TS2365: Operator '<' cannot be applied to types 'J' and 'I'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(18,11): error TS2365: Operator '>' cannot be applied to types 'I' and 'J'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(19,11): error TS2365: Operator '>' cannot be applied to types 'J' and 'I'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(22,11): error TS2365: Operator '<=' cannot be applied to types 'I' and 'J'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(23,11): error TS2365: Operator '<=' cannot be applied to types 'J' and 'I'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(26,11): error TS2365: Operator '>=' cannot be applied to types 'I' and 'J'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(27,11): error TS2365: Operator '>=' cannot be applied to types 'J' and 'I'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts (8 errors) ====
+    interface I {
+        a: string;
+        b?: number;
+    }
+    
+    interface J {
+        a: string;
+    }
+    
+    var a: I;
+    var b: J;
+    
+    // operator <
+    var ra1 = a < b;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'I' and 'J'.
+    var ra2 = b < a;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'J' and 'I'.
+    
+    // operator >
+    var rb1 = a > b;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'I' and 'J'.
+    var rb2 = b > a;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'J' and 'I'.
+    
+    // operator <=
+    var rc1 = a <= b;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'I' and 'J'.
+    var rc2 = b <= a;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'J' and 'I'.
+    
+    // operator >=
+    var rd1 = a >= b;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'I' and 'J'.
+    var rd2 = b >= a;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'J' and 'I'.
+    
+    // operator ==
+    var re1 = a == b;
+    var re2 = b == a;
+    
+    // operator !=
+    var rf1 = a != b;
+    var rf2 = b != a;
+    
+    // operator ===
+    var rg1 = a === b;
+    var rg2 = b === a;
+    
+    // operator !==
+    var rh1 = a !== b;
+    var rh2 = b !== a;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnProperty.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnProperty.errors.txt
@@ -1,0 +1,129 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(33,11): error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(34,11): error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(35,11): error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(36,11): error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(39,11): error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(40,11): error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(41,11): error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(42,11): error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(45,11): error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(46,11): error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(47,11): error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(48,11): error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(51,11): error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(52,11): error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(53,11): error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts(54,11): error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts (16 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    class A1 {
+        public a: Base;
+        public b: Base;
+    }
+    
+    class B1 {
+        public a: Base;
+        public b: Derived;
+    }
+    
+    class A2 {
+        private a;
+    }
+    
+    class B2 extends A2 {
+        private b;
+    }
+    
+    var a1: A1;
+    var a2: A2;
+    var b1: B1;
+    var b2: B2;
+    
+    // operator <
+    var ra1 = a1 < b1;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+    var ra2 = a2 < b2;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+    var ra3 = b1 < a1;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+    var ra4 = b2 < a2;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator >
+    var rb1 = a1 > b1;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+    var rb2 = a2 > b2;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+    var rb3 = b1 > a1;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+    var rb4 = b2 > a2;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator <=
+    var rc1 = a1 <= b1;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+    var rc2 = a2 <= b2;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+    var rc3 = b1 <= a1;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+    var rc4 = b2 <= a2;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator >=
+    var rd1 = a1 >= b1;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+    var rd2 = a2 >= b2;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+    var rd3 = b1 >= a1;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+    var rd4 = b2 >= a2;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator ==
+    var re1 = a1 == b1;
+    var re2 = a2 == b2;
+    var re3 = b1 == a1;
+    var re4 = b2 == a2;
+    
+    // operator !=
+    var rf1 = a1 != b1;
+    var rf2 = a2 != b2;
+    var rf3 = b1 != a1;
+    var rf4 = b2 != a2;
+    
+    // operator ===
+    var rg1 = a1 === b1;
+    var rg2 = a2 === b2;
+    var rg3 = b1 === a1;
+    var rg4 = b2 === a2;
+    
+    // operator !==
+    var rh1 = a1 !== b1;
+    var rh2 = a2 !== b2;
+    var rh3 = b1 !== a1;
+    var rh4 = b2 !== a2;

--- a/tests/baselines/reference/comparisonOperatorWithTypeParameter.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithTypeParameter.errors.txt
@@ -30,9 +30,25 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(38,15): error TS2367: This comparison appears to be unintentional because the types 'V' and 'T' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(39,15): error TS2367: This comparison appears to be unintentional because the types 'V' and 'T' have no overlap.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(40,15): error TS2367: This comparison appears to be unintentional because the types 'V' and 'T' have no overlap.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(43,15): error TS2365: Operator '<' cannot be applied to types 'T' and '{}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(44,15): error TS2365: Operator '>' cannot be applied to types 'T' and '{}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(45,15): error TS2365: Operator '<=' cannot be applied to types 'T' and '{}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(46,15): error TS2365: Operator '>=' cannot be applied to types 'T' and '{}'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(52,15): error TS2365: Operator '<' cannot be applied to types '{}' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(53,15): error TS2365: Operator '>' cannot be applied to types '{}' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(54,15): error TS2365: Operator '<=' cannot be applied to types '{}' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(55,15): error TS2365: Operator '>=' cannot be applied to types '{}' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(61,15): error TS2365: Operator '<' cannot be applied to types 'T' and 'Object'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(62,15): error TS2365: Operator '>' cannot be applied to types 'T' and 'Object'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(63,15): error TS2365: Operator '<=' cannot be applied to types 'T' and 'Object'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(64,15): error TS2365: Operator '>=' cannot be applied to types 'T' and 'Object'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(70,15): error TS2365: Operator '<' cannot be applied to types 'Object' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(71,15): error TS2365: Operator '>' cannot be applied to types 'Object' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(72,15): error TS2365: Operator '<=' cannot be applied to types 'Object' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts(73,15): error TS2365: Operator '>=' cannot be applied to types 'Object' and 'T'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts (32 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts (48 errors) ====
     var a: {};
     var b: Object;
     
@@ -140,36 +156,68 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     
         // ok
         var re1 = t < a;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{}'.
         var re2 = t > a;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and '{}'.
         var re3 = t <= a;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and '{}'.
         var re4 = t >= a;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and '{}'.
         var re5 = t == a;
         var re6 = t != a;
         var re7 = t === a;
         var re8 = t !== a;
     
         var rf1 = a < t;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{}' and 'T'.
         var rf2 = a > t;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{}' and 'T'.
         var rf3 = a <= t;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{}' and 'T'.
         var rf4 = a >= t;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{}' and 'T'.
         var rf5 = a == t;
         var rf6 = a != t;
         var rf7 = a === t;
         var rf8 = a !== t;
     
         var rg1 = t < b;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'Object'.
         var rg2 = t > b;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and 'Object'.
         var rg3 = t <= b;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and 'Object'.
         var rg4 = t >= b;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and 'Object'.
         var rg5 = t == b;
         var rg6 = t != b;
         var rg7 = t === b;
         var rg8 = t !== b;
     
         var rh1 = b < t;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Object' and 'T'.
         var rh2 = b > t;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Object' and 'T'.
         var rh3 = b <= t;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Object' and 'T'.
         var rh4 = b >= t;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Object' and 'T'.
         var rh5 = b == t;
         var rh6 = b != t;
         var rh7 = b === t;

--- a/tests/baselines/reference/instantiationExpressionErrors.errors.txt
+++ b/tests/baselines/reference/instantiationExpressionErrors.errors.txt
@@ -10,13 +10,14 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpr
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(26,24): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(39,2): error TS2554: Expected 0 arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(43,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(43,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(44,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(45,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts(45,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
 
 
-==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts (16 errors) ====
+==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressionErrors.ts (17 errors) ====
     declare let f: { <T>(): T, g<U>(): U };
     
     // Type arguments in member expressions
@@ -84,6 +85,8 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpr
     const r1 = f < true > true;
                ~~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+               ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
     const r2 = f < true > +1;
                ~~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.

--- a/tests/baselines/reference/relationalComparisons.errors.txt
+++ b/tests/baselines/reference/relationalComparisons.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/relationalComparisons.ts(15,5): error TS2365: Operator '>' cannot be applied to types 'any[]' and 'any[]'.
+
+
+==== tests/cases/compiler/relationalComparisons.ts (1 errors) ====
+    type Moment = {
+        valueOf(): number;
+    };
+    
+    declare const m1: Moment, m2: Moment;
+    declare const d1: Date, d2: Date;
+    
+    if (m1 > 0) { }
+    if (m1 > m2) { }
+    if (0 > m2) { }
+    
+    if (d1 > d2) { }
+    
+    declare const arr1: any[], arr2: any[];
+    if (arr1 > arr2) { }
+        ~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any[]' and 'any[]'.
+    

--- a/tests/baselines/reference/relationalComparisons.symbols
+++ b/tests/baselines/reference/relationalComparisons.symbols
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/relationalComparisons.ts ===
+type Moment = {
+>Moment : Symbol(Moment, Decl(relationalComparisons.ts, 0, 0))
+
+    valueOf(): number;
+>valueOf : Symbol(valueOf, Decl(relationalComparisons.ts, 0, 15))
+
+};
+
+declare const m1: Moment, m2: Moment;
+>m1 : Symbol(m1, Decl(relationalComparisons.ts, 4, 13))
+>Moment : Symbol(Moment, Decl(relationalComparisons.ts, 0, 0))
+>m2 : Symbol(m2, Decl(relationalComparisons.ts, 4, 25))
+>Moment : Symbol(Moment, Decl(relationalComparisons.ts, 0, 0))
+
+declare const d1: Date, d2: Date;
+>d1 : Symbol(d1, Decl(relationalComparisons.ts, 5, 13))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+>d2 : Symbol(d2, Decl(relationalComparisons.ts, 5, 23))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+if (m1 > 0) { }
+>m1 : Symbol(m1, Decl(relationalComparisons.ts, 4, 13))
+
+if (m1 > m2) { }
+>m1 : Symbol(m1, Decl(relationalComparisons.ts, 4, 13))
+>m2 : Symbol(m2, Decl(relationalComparisons.ts, 4, 25))
+
+if (0 > m2) { }
+>m2 : Symbol(m2, Decl(relationalComparisons.ts, 4, 25))
+
+if (d1 > d2) { }
+>d1 : Symbol(d1, Decl(relationalComparisons.ts, 5, 13))
+>d2 : Symbol(d2, Decl(relationalComparisons.ts, 5, 23))
+
+declare const arr1: any[], arr2: any[];
+>arr1 : Symbol(arr1, Decl(relationalComparisons.ts, 13, 13))
+>arr2 : Symbol(arr2, Decl(relationalComparisons.ts, 13, 26))
+
+if (arr1 > arr2) { }
+>arr1 : Symbol(arr1, Decl(relationalComparisons.ts, 13, 13))
+>arr2 : Symbol(arr2, Decl(relationalComparisons.ts, 13, 26))
+

--- a/tests/baselines/reference/relationalComparisons.types
+++ b/tests/baselines/reference/relationalComparisons.types
@@ -1,0 +1,46 @@
+=== tests/cases/compiler/relationalComparisons.ts ===
+type Moment = {
+>Moment : { valueOf(): number; }
+
+    valueOf(): number;
+>valueOf : () => number
+
+};
+
+declare const m1: Moment, m2: Moment;
+>m1 : Moment
+>m2 : Moment
+
+declare const d1: Date, d2: Date;
+>d1 : Date
+>d2 : Date
+
+if (m1 > 0) { }
+>m1 > 0 : boolean
+>m1 : Moment
+>0 : 0
+
+if (m1 > m2) { }
+>m1 > m2 : boolean
+>m1 : Moment
+>m2 : Moment
+
+if (0 > m2) { }
+>0 > m2 : boolean
+>0 : 0
+>m2 : Moment
+
+if (d1 > d2) { }
+>d1 > d2 : boolean
+>d1 : Date
+>d2 : Date
+
+declare const arr1: any[], arr2: any[];
+>arr1 : any[]
+>arr2 : any[]
+
+if (arr1 > arr2) { }
+>arr1 > arr2 : boolean
+>arr1 : any[]
+>arr2 : any[]
+

--- a/tests/baselines/reference/stringLiteralTypesWithVariousOperators01.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesWithVariousOperators01.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators01.ts(24,9): error TS2365: Operator '<' cannot be applied to types 'string | number' and 'string | number'.
+tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators01.ts(25,9): error TS2365: Operator '>=' cannot be applied to types 'string | number' and 'string'.
+
+
+==== tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators01.ts (2 errors) ====
+    let abc: "ABC" = "ABC";
+    let xyz: "XYZ" = "XYZ";
+    let abcOrXyz: "ABC" | "XYZ" = abc || xyz;
+    let abcOrXyzOrNumber: "ABC" | "XYZ" | number = abcOrXyz || 100;
+    
+    let a = "" + abc;
+    let b = abc + "";
+    let c = 10 + abc;
+    let d = abc + 10;
+    let e = xyz + abc;
+    let f = abc + xyz;
+    let g = true + abc;
+    let h = abc + true;
+    let i = abc + abcOrXyz + xyz;
+    let j = abcOrXyz + abcOrXyz;
+    let k = +abcOrXyz;
+    let l = -abcOrXyz;
+    let m = abcOrXyzOrNumber + "";
+    let n = "" + abcOrXyzOrNumber;
+    let o = abcOrXyzOrNumber + abcOrXyz;
+    let p = abcOrXyz + abcOrXyzOrNumber;
+    let q = !abcOrXyzOrNumber;
+    let r = ~abcOrXyzOrNumber;
+    let s = abcOrXyzOrNumber < abcOrXyzOrNumber;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string | number' and 'string | number'.
+    let t = abcOrXyzOrNumber >= abcOrXyz;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'string | number' and 'string'.
+    let u = abc === abcOrXyz;
+    let v = abcOrXyz === abcOrXyzOrNumber;

--- a/tests/cases/compiler/relationalComparisons.ts
+++ b/tests/cases/compiler/relationalComparisons.ts
@@ -1,0 +1,18 @@
+// @strict: true
+// @noEmit: true
+
+type Moment = {
+    valueOf(): number;
+};
+
+declare const m1: Moment, m2: Moment;
+declare const d1: Date, d2: Date;
+
+if (m1 > 0) { }
+if (m1 > m2) { }
+if (0 > m2) { }
+
+if (d1 > d2) { }
+
+declare const arr1: any[], arr2: any[];
+if (arr1 > arr2) { }


### PR DESCRIPTION
Per discussion in #52790, this implements the following ruleset for `>`, `<`, `>=`, and `<=`:

For each operand expressions, let the "operand type" be:
* The base primitive type of expression's type, if one exists
* Otherwise, the return type of the `valueOf` property of the expression's type, if that exists
* Otherwise, the expression type

One of the following must be true:
* Either operand type is any
* Both operand types are assignable to string
* Both operand types are assignable to number

Otherwise an error is issued