### PR TITLE
Fix crash in 'Wrap in JSX Fragment' quick fix

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -804,7 +804,7 @@ function formatSpanWorker(
             isFirstListItem?: boolean): number {
             Debug.assert(!nodeIsSynthesized(child));
 
-            if (nodeIsMissing(child)) {
+            if (nodeIsMissing(child) || isGrammarError(parent, child)) {
                 return inheritedIndentation;
             }
 
@@ -864,7 +864,7 @@ function formatSpanWorker(
                 // if child node is a token, it does not impact indentation, proceed it using parent indentation scope rules
                 const tokenInfo = formattingScanner.readTokenInfo(child);
                 // JSX text shouldn't affect indenting
-                if (child.kind !== SyntaxKind.JsxText && !isGrammarError(parent, child)) {
+                if (child.kind !== SyntaxKind.JsxText) {
                     Debug.assert(tokenInfo.token.end === child.end, "Token end is child end");
                     consumeTokenAndAdvanceScanner(tokenInfo, node, parentDynamicIndentation, child);
                     return inheritedIndentation;

--- a/tests/cases/fourslash/codeFixWrapJsxInFragmentWithGrammarError1.ts
+++ b/tests/cases/fourslash/codeFixWrapJsxInFragmentWithGrammarError1.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+// @jsx: react-jsxdev
+// @Filename: /a.tsx
+////[|<div abc={{ foo = 10 }}></div><div abc={{ foo = 10 }}></div>|]
+
+verify.rangeAfterCodeFix(`<><div abc={{ foo = 10 }}></div><div abc={{ foo = 10 }}></div></>`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);

--- a/tests/cases/fourslash/refactorExtractTypeRemoveGrammarError2.ts
+++ b/tests/cases/fourslash/refactorExtractTypeRemoveGrammarError2.ts
@@ -11,7 +11,7 @@ edit.applyRefactor({
     newContent:
 `type /*RENAME*/NewType = {
     x: string;
-    };
+};
 
 type Foo<T extends NewType> = T`,
 });


### PR DESCRIPTION
This amends #52803 so that we also address a crash in the "Wrap in JSX Fragment" quick fix.

Fixes #52137
