### PR TITLE
Don't parse out a name for JSX fragments

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6151,10 +6151,7 @@ namespace Parser {
     function parseJsxClosingFragment(inExpressionContext: boolean): JsxClosingFragment {
         const pos = getNodePos();
         parseExpected(SyntaxKind.LessThanSlashToken);
-        if (tokenIsIdentifierOrKeyword(token())) {
-            parseErrorAtRange(parseJsxElementName(), Diagnostics.Expected_corresponding_closing_tag_for_JSX_fragment);
-        }
-        if (parseExpected(SyntaxKind.GreaterThanToken, /*diagnostic*/ undefined, /*shouldAdvance*/ false)) {
+        if (parseExpected(SyntaxKind.GreaterThanToken, Diagnostics.Expected_corresponding_closing_tag_for_JSX_fragment, /*shouldAdvance*/ false)) {
             // manually advance the scanner in order to look for jsx text inside jsx
             if (inExpressionContext) {
                 nextToken();

--- a/tests/baselines/reference/tsxFragmentErrors.errors.txt
+++ b/tests/baselines/reference/tsxFragmentErrors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(9,1): error TS2657: JSX expressions must have one parent element.
+tests/cases/conformance/jsx/file.tsx(9,7): error TS2304: Cannot find name 'div'.
 tests/cases/conformance/jsx/file.tsx(9,7): error TS17015: Expected corresponding closing tag for JSX fragment.
 tests/cases/conformance/jsx/file.tsx(9,11): error TS17014: JSX fragment has no corresponding closing tag.
 tests/cases/conformance/jsx/file.tsx(11,17): error TS1005: '</' expected.
@@ -14,16 +14,14 @@ tests/cases/conformance/jsx/file.tsx(11,17): error TS1005: '</' expected.
     declare var React: any;
     
     <>hi</div> // Error
-    ~~~~~~~~~~~~~~~~~~~
+          ~~~
+!!! error TS2304: Cannot find name 'div'.
           ~~~
 !!! error TS17015: Expected corresponding closing tag for JSX fragment.
               ~~~~~~~~~
     
     
-    
     <>eof   // Error
-    ~~~~~~~~~~~~~~~~
-!!! error TS2657: JSX expressions must have one parent element.
     ~~
 !!! error TS17014: JSX fragment has no corresponding closing tag.
                     

--- a/tests/baselines/reference/tsxFragmentErrors.js
+++ b/tests/baselines/reference/tsxFragmentErrors.js
@@ -12,6 +12,6 @@ declare var React: any;
 <>eof   // Error
 
 //// [file.js]
-React.createElement(React.Fragment, null, "hi") // Error
-    , // Error
-        React.createElement(React.Fragment, null, "eof   // Error");
+React.createElement(React.Fragment, null, "hi");
+div > // Error
+    React.createElement(React.Fragment, null, "eof   // Error");

--- a/tests/baselines/reference/tsxFragmentErrors.types
+++ b/tests/baselines/reference/tsxFragmentErrors.types
@@ -10,8 +10,9 @@ declare var React: any;
 >React : any
 
 <>hi</div> // Error
-><>hi</div> // Error<>eof   // Error : JSX.Element
-><>hi</div> : JSX.Element
+><>hi</ : JSX.Element
+>div> // Error<>eof   // Error : boolean
+>div : any
 
 <>eof   // Error
 ><>eof   // Error : JSX.Element

--- a/tests/cases/fourslash/jsxElementMissingOpeningTagNoCrash.ts
+++ b/tests/cases/fourslash/jsxElementMissingOpeningTagNoCrash.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+//@Filename: file.tsx
+//// declare function Foo(): any;
+//// let x = <></Fo/*$*/o>;
+
+verify.quickInfoAt("$", "let Foo: any");


### PR DESCRIPTION
Fixes #44154

I don't know why I didn't think of doing this sooner; if we don't parse the name and then throw it away, we won't end up with the trivia problem. No weirdness happens at all, and we don't need to screw with the tree to try and recover.