### PR TITLE
Include Default Parameter Values in Signature Help

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -292,6 +292,7 @@ import {
     getJSDocDeprecatedTag,
     getJSDocEnumTag,
     getJSDocHost,
+    getJSDocInitializerParameter,
     getJSDocParameterTags,
     getJSDocRoot,
     getJSDocSatisfiesExpressionType,
@@ -7355,6 +7356,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const parameterTypeNode = serializeTypeForDeclaration(context, parameterType, parameterSymbol, context.enclosingDeclaration, privateSymbolVisitor, bundledImports);
 
+            let { initializer } = parameterDeclaration as ParameterDeclaration;
+            if (parameterDeclaration) initializer ??= getJSDocInitializerParameter(parameterDeclaration as ParameterDeclaration);
+
             const modifiers = !(context.flags & NodeBuilderFlags.OmitParameterModifiers) && preserveModifierFlags && parameterDeclaration && canHaveModifiers(parameterDeclaration) ? map(getModifiers(parameterDeclaration), factory.cloneNode) : undefined;
             const isRest = parameterDeclaration && isRestParameter(parameterDeclaration) || getCheckFlags(parameterSymbol) & CheckFlags.RestParameter;
             const dotDotDotToken = isRest ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined;
@@ -7372,7 +7376,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 name,
                 questionToken,
                 parameterTypeNode,
-                /*initializer*/ undefined);
+                initializer);
             context.approximateLength += symbolName(parameterSymbol).length + 3;
             return parameterNode;
 
@@ -7389,7 +7393,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             visited.dotDotDotToken,
                             visited.propertyName,
                             visited.name,
-                            /*initializer*/ undefined);
+                            visited.initializer);
                     }
                     if (!nodeIsSynthesized(visited)) {
                         visited = factory.cloneNode(visited);

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -5127,12 +5127,13 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     }
 
     // @api
-    function createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocComment>): JSDocParameterTag {
+    function createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocComment>, initializer?: Expression): JSDocParameterTag {
         const node = createBaseJSDocTagDeclaration<JSDocParameterTag>(SyntaxKind.JSDocParameterTag, tagName ?? createIdentifier("param"), comment);
         node.typeExpression = typeExpression;
         node.name = name;
         node.isNameFirst = !!isNameFirst;
         node.isBracketed = isBracketed;
+        node.initializer = initializer;
         return node;
     }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8973,7 +8973,7 @@ namespace Parser {
                 return token() === SyntaxKind.OpenBraceToken ? parseJSDocTypeExpression() : undefined;
             }
 
-            function parseBracketNameInPropertyAndParamTag(): { name: EntityName, isBracketed: boolean } {
+            function parseBracketNameInPropertyAndParamTag(): { name: EntityName, isBracketed: boolean, initializer: ts.Expression | undefined } {
                 // Looking for something like '[foo]', 'foo', '[foo.bar]' or 'foo.bar'
                 const isBracketed = parseOptionalJsdoc(SyntaxKind.OpenBracketToken);
                 if (isBracketed) {
@@ -8985,17 +8985,18 @@ namespace Parser {
                 if (isBackquoted) {
                     parseExpectedTokenJSDoc(SyntaxKind.BacktickToken);
                 }
+                let initializer: ts.Expression | undefined;
                 if (isBracketed) {
                     skipWhitespace();
                     // May have an optional default, e.g. '[foo = 42]'
                     if (parseOptionalToken(SyntaxKind.EqualsToken)) {
-                        parseExpression();
+                        initializer = parseExpression();
                     }
 
                     parseExpected(SyntaxKind.CloseBracketToken);
                 }
 
-                return { name, isBracketed };
+                return { name, isBracketed, initializer };
             }
 
             function isObjectOrObjectArrayTypeReference(node: TypeNode): boolean {
@@ -9014,7 +9015,7 @@ namespace Parser {
                 let isNameFirst = !typeExpression;
                 skipWhitespaceOrAsterisk();
 
-                const { name, isBracketed } = parseBracketNameInPropertyAndParamTag();
+                const { name, isBracketed, initializer } = parseBracketNameInPropertyAndParamTag();
                 const indentText = skipWhitespaceOrAsterisk();
 
                 if (isNameFirst && !lookAhead(parseJSDocLinkPrefix)) {
@@ -9030,7 +9031,7 @@ namespace Parser {
                 }
                 const result = target === PropertyLikeParse.Property
                     ? factory.createJSDocPropertyTag(tagName, name, isBracketed, typeExpression, isNameFirst, comment)
-                    : factory.createJSDocParameterTag(tagName, name, isBracketed, typeExpression, isNameFirst, comment);
+                    : factory.createJSDocParameterTag(tagName, name, isBracketed, typeExpression, isNameFirst, comment, initializer);
                 return finishNode(result, start);
             }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4071,6 +4071,7 @@ export interface JSDocPropertyTag extends JSDocPropertyLikeTag {
 
 export interface JSDocParameterTag extends JSDocPropertyLikeTag {
     readonly kind: SyntaxKind.JSDocParameterTag;
+    readonly initializer?: Expression
 }
 
 export interface JSDocTypeLiteral extends JSDocType, Declaration {
@@ -8565,7 +8566,7 @@ export interface NodeFactory {
     updateJSDocTemplateTag(node: JSDocTemplateTag, tagName: Identifier | undefined, constraint: JSDocTypeExpression | undefined, typeParameters: readonly TypeParameterDeclaration[], comment: string | NodeArray<JSDocComment> | undefined): JSDocTemplateTag;
     createJSDocTypedefTag(tagName: Identifier | undefined, typeExpression?: JSDocTypeExpression | JSDocTypeLiteral, fullName?: Identifier | JSDocNamespaceDeclaration, comment?: string | NodeArray<JSDocComment>): JSDocTypedefTag;
     updateJSDocTypedefTag(node: JSDocTypedefTag, tagName: Identifier | undefined, typeExpression: JSDocTypeExpression | JSDocTypeLiteral | undefined, fullName: Identifier | JSDocNamespaceDeclaration | undefined, comment: string | NodeArray<JSDocComment> | undefined): JSDocTypedefTag;
-    createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocComment>): JSDocParameterTag;
+    createJSDocParameterTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocComment>, initializer?: Expression): JSDocParameterTag;
     updateJSDocParameterTag(node: JSDocParameterTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocComment> | undefined): JSDocParameterTag;
     createJSDocPropertyTag(tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression?: JSDocTypeExpression, isNameFirst?: boolean, comment?: string | NodeArray<JSDocComment>): JSDocPropertyTag;
     updateJSDocPropertyTag(node: JSDocPropertyTag, tagName: Identifier | undefined, name: EntityName, isBracketed: boolean, typeExpression: JSDocTypeExpression | undefined, isNameFirst: boolean, comment: string | NodeArray<JSDocComment> | undefined): JSDocPropertyTag;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -9761,6 +9761,15 @@ export function isJSDocOptionalParameter(node: ParameterDeclaration) {
 }
 
 /** @internal */
+export function getJSDocInitializerParameter(node: ParameterDeclaration) {
+    if (!isInJSFile(node)) return;
+    const bracketed = getJSDocParameterTags(node).find(({ isBracketed }) => isBracketed);
+    if (!bracketed) return;
+    const textAfter = (bracketed as any).getFullText().slice(bracketed.name.end - bracketed.pos);
+    return factory.createIdentifier(textAfter.slice(0, textAfter.indexOf("]")));
+}
+
+/** @internal */
 export function isOptionalDeclaration(declaration: Declaration): boolean {
     switch (declaration.kind) {
         case SyntaxKind.PropertyDeclaration:

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -9764,9 +9764,7 @@ export function isJSDocOptionalParameter(node: ParameterDeclaration) {
 export function getJSDocInitializerParameter(node: ParameterDeclaration) {
     if (!isInJSFile(node)) return;
     const bracketed = getJSDocParameterTags(node).find(({ isBracketed }) => isBracketed);
-    if (!bracketed) return;
-    const textAfter = (bracketed as any).getFullText().slice(bracketed.name.end - bracketed.pos);
-    return factory.createIdentifier(textAfter.slice(0, textAfter.indexOf("]")));
+    return bracketed?.initializer;
 }
 
 /** @internal */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #16665

Handled cases:

1. Parameter initialzer case eg `const a = (b = true) => {}`.

It was suspicious easy to fix for regular parameter initialzer. In some cases (I think it should be really rare) initialzer can be really long. So answering @a-tarasyuk https://github.com/microsoft/typescript/issues/16665#issuecomment-968356595 :

```ts
function fn(a = {
  b: () => {},
  c: 2,
  d: {
    e: [1, 3, 4]
  }
}) {}
```

Will be shown as

```
fn(a?: { b: () => void; c: number; d: { e: number[]; }; } = { b: () => { }, c: 2, d: { e: [1, 3, 4] } }): void
```

Is that okay? :shrug:

I don't like the idea of hiding information in this case, but trying to merge it to format like `{ c: number = 2 }` would be cool imo

2. Jsdoc [optional default](https://github.com/microsoft/TypeScript/blob/4def812b2f7d813cbe112c9ba334865a7c771ec5/src/compiler/parser.ts#L8991) case.

I changed parser.ts in order to store jsdoc optional default parsed expression in node.

Will add tests tomorrow.
