### PR TITLE
Fix RWC tests with errors in tsconfig

### DIFF
--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -609,8 +609,8 @@ export namespace Compiler {
             // do not count errors from lib.d.ts here, they are computed separately as numLibraryDiagnostics
             // if lib.d.ts is explicitly included in input files and there are some errors in it (i.e. because of duplicate identifiers)
             // then they will be added twice thus triggering 'total errors' assertion with condition
-            // 'totalErrorsReportedInNonLibraryFiles + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length
             // Similarly for tsconfig, which may be in the input files and contain errors.
+            // 'totalErrorsReportedInNonLibraryNonTsconfigFiles + numLibraryDiagnostics + numTsconfigDiagnostics + numTest262HarnessDiagnostics, diagnostics.length
 
             if (!error.file || !isDefaultLibraryFile(error.file.fileName) && !vpath.isTsConfigFile(error.file.fileName)) {
                 totalErrorsReportedInNonLibraryNonTsconfigFiles++;

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -567,7 +567,7 @@ export namespace Compiler {
         diagnostics = ts.sort(diagnostics, ts.compareDiagnostics);
         let outputLines = "";
         // Count up all errors that were found in files other than lib.d.ts so we don't miss any
-        let totalErrorsReportedInNonLibraryFiles = 0;
+        let totalErrorsReportedInNonLibraryNonTsconfigFiles = 0;
 
         let errorsReported = 0;
 
@@ -610,9 +610,10 @@ export namespace Compiler {
             // if lib.d.ts is explicitly included in input files and there are some errors in it (i.e. because of duplicate identifiers)
             // then they will be added twice thus triggering 'total errors' assertion with condition
             // 'totalErrorsReportedInNonLibraryFiles + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length
+            // Similarly for tsconfig, which may be in the input files and contain errors.
 
-            if (!error.file || !isDefaultLibraryFile(error.file.fileName)) {
-                totalErrorsReportedInNonLibraryFiles++;
+            if (!error.file || !isDefaultLibraryFile(error.file.fileName) && !vpath.isTsConfigFile(error.file.fileName)) {
+                totalErrorsReportedInNonLibraryNonTsconfigFiles++;
             }
         }
 
@@ -704,7 +705,7 @@ export namespace Compiler {
                 // Case-duplicated files on a case-insensitive build will have errors reported in both the dupe and the original
                 // thanks to the canse-insensitive path comparison on the error file path - We only want to count those errors once
                 // for the assert below, so we subtract them here.
-                totalErrorsReportedInNonLibraryFiles -= errorsReported;
+                totalErrorsReportedInNonLibraryNonTsconfigFiles -= errorsReported;
             }
             outputLines = "";
             errorsReported = 0;
@@ -714,13 +715,17 @@ export namespace Compiler {
             return !!diagnostic.file && (isDefaultLibraryFile(diagnostic.file.fileName) || isBuiltFile(diagnostic.file.fileName));
         });
 
+        const numTsconfigDiagnostics = ts.countWhere(diagnostics, diagnostic => {
+            return !!diagnostic.file && (vpath.isTsConfigFile(diagnostic.file.fileName));
+        });
+
         const numTest262HarnessDiagnostics = ts.countWhere(diagnostics, diagnostic => {
             // Count an error generated from tests262-harness folder.This should only apply for test262
             return !!diagnostic.file && diagnostic.file.fileName.indexOf("test262-harness") >= 0;
         });
 
         // Verify we didn't miss any errors in total
-        assert.equal(totalErrorsReportedInNonLibraryFiles + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length, "total number of errors");
+        assert.equal(totalErrorsReportedInNonLibraryNonTsconfigFiles + numLibraryDiagnostics + numTsconfigDiagnostics + numTest262HarnessDiagnostics, diagnostics.length, "total number of errors");
     }
 
     export function doErrorBaseline(baselinePath: string, inputFiles: readonly TestFile[], errors: readonly ts.Diagnostic[], pretty?: boolean) {


### PR DESCRIPTION
RWC tests currently fail because one of the tests includes tsconfig in the input file set, so the harness double-reports errors. This is brand new after our new deprecations, but we didn't seem to notice as the RWC tests were still reporting baseline differences.

This sort of thing appears to already be worked around for `lib.d.ts` files, so, do something similar to tsconfig to get RWC passing again.