### PR TITLE
Switch let/const to var in the scanner & parser for top-levelish variables.

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1431,24 +1431,25 @@ namespace Parser {
 
     const factory = createNodeFactory(NodeFactoryFlags.NoParenthesizerRules | NodeFactoryFlags.NoNodeConverters | NodeFactoryFlags.NoOriginalNode, baseNodeFactory);
 
-    let fileName: string;
-    let sourceFlags: NodeFlags;
-    let sourceText: string;
-    let languageVersion: ScriptTarget;
-    let scriptKind: ScriptKind;
-    let languageVariant: LanguageVariant;
-    let parseDiagnostics: DiagnosticWithDetachedLocation[];
-    let jsDocDiagnostics: DiagnosticWithDetachedLocation[];
-    let syntaxCursor: IncrementalParser.SyntaxCursor | undefined;
+    /* eslint-disable no-var */
+    var fileName: string;
+    var sourceFlags: NodeFlags;
+    var sourceText: string;
+    var languageVersion: ScriptTarget;
+    var scriptKind: ScriptKind;
+    var languageVariant: LanguageVariant;
+    var parseDiagnostics: DiagnosticWithDetachedLocation[];
+    var jsDocDiagnostics: DiagnosticWithDetachedLocation[];
+    var syntaxCursor: IncrementalParser.SyntaxCursor | undefined;
 
-    let currentToken: SyntaxKind;
-    let nodeCount: number;
-    let identifiers: Map<string, string>;
-    let identifierCount: number;
+    var currentToken: SyntaxKind;
+    var nodeCount: number;
+    var identifiers: Map<string, string>;
+    var identifierCount: number;
 
-    let parsingContext: ParsingContext;
+    var parsingContext: ParsingContext;
 
-    let notParenthesizedArrow: Set<number> | undefined;
+    var notParenthesizedArrow: Set<number> | undefined;
 
     // Flags that dictate what parsing context we're in.  For example:
     // Whether or not we are in strict parsing mode.  All that changes in strict parsing mode is
@@ -1496,10 +1497,10 @@ namespace Parser {
     // Note: it should not be necessary to save/restore these flags during speculative/lookahead
     // parsing.  These context flags are naturally stored and restored through normal recursive
     // descent parsing and unwinding.
-    let contextFlags: NodeFlags;
+    var contextFlags: NodeFlags;
 
     // Indicates whether we are currently parsing top-level statements.
-    let topLevel = true;
+    var topLevel = true;
 
     // Whether or not we've had a parse error since creating the last AST node.  If we have
     // encountered an error, it will be stored on the next AST node we create.  Parse errors
@@ -1528,7 +1529,8 @@ namespace Parser {
     //
     // Note: any errors at the end of the file that do not precede a regular node, should get
     // attached to the EOF token.
-    let parseErrorBeforeNextFinishedNode = false;
+    var parseErrorBeforeNextFinishedNode = false;
+    /* eslint-enable no-var */
 
     export function parseSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, syntaxCursor: IncrementalParser.SyntaxCursor | undefined, setParentNodes = false, scriptKind?: ScriptKind, setExternalModuleIndicatorOverride?: (file: SourceFile) => void): SourceFile {
         scriptKind = ensureScriptKind(fileName, scriptKind);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1401,18 +1401,20 @@ export function parseJSDocTypeExpressionForTests(content: string, start?: number
 // parser instances can actually be expensive enough to impact us on projects with many source
 // files.
 namespace Parser {
+    /* eslint-disable no-var */
+
     // Share a single scanner across all calls to parse a source file.  This helps speed things
     // up by avoiding the cost of creating/compiling scanners over and over again.
-    const scanner = createScanner(ScriptTarget.Latest, /*skipTrivia*/ true);
+    var scanner = createScanner(ScriptTarget.Latest, /*skipTrivia*/ true);
 
-    const disallowInAndDecoratorContext = NodeFlags.DisallowInContext | NodeFlags.DecoratorContext;
+    var disallowInAndDecoratorContext = NodeFlags.DisallowInContext | NodeFlags.DecoratorContext;
 
     // capture constructors in 'initializeState' to avoid null checks
-    let NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
-    let TokenConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
-    let IdentifierConstructor: new (kind: SyntaxKind.Identifier, pos: number, end: number) => Identifier;
-    let PrivateIdentifierConstructor: new (kind: SyntaxKind.PrivateIdentifier, pos: number, end: number) => PrivateIdentifier;
-    let SourceFileConstructor: new (kind: SyntaxKind.SourceFile, pos: number, end: number) => SourceFile;
+    var NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
+    var TokenConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
+    var IdentifierConstructor: new (kind: SyntaxKind.Identifier, pos: number, end: number) => Identifier;
+    var PrivateIdentifierConstructor: new (kind: SyntaxKind.PrivateIdentifier, pos: number, end: number) => PrivateIdentifier;
+    var SourceFileConstructor: new (kind: SyntaxKind.SourceFile, pos: number, end: number) => SourceFile;
 
     function countNode(node: Node) {
         nodeCount++;
@@ -1421,7 +1423,7 @@ namespace Parser {
 
     // Rather than using `createBaseNodeFactory` here, we establish a `BaseNodeFactory` that closes over the
     // constructors above, which are reset each time `initializeState` is called.
-    const baseNodeFactory: BaseNodeFactory = {
+    var baseNodeFactory: BaseNodeFactory = {
         createBaseSourceFileNode: kind => countNode(new SourceFileConstructor(kind, /*pos*/ 0, /*end*/ 0)),
         createBaseIdentifierNode: kind => countNode(new IdentifierConstructor(kind, /*pos*/ 0, /*end*/ 0)),
         createBasePrivateIdentifierNode: kind => countNode(new PrivateIdentifierConstructor(kind, /*pos*/ 0, /*end*/ 0)),
@@ -1429,9 +1431,8 @@ namespace Parser {
         createBaseNode: kind => countNode(new NodeConstructor(kind, /*pos*/ 0, /*end*/ 0))
     };
 
-    const factory = createNodeFactory(NodeFactoryFlags.NoParenthesizerRules | NodeFactoryFlags.NoNodeConverters | NodeFactoryFlags.NoOriginalNode, baseNodeFactory);
+    var factory = createNodeFactory(NodeFactoryFlags.NoParenthesizerRules | NodeFactoryFlags.NoNodeConverters | NodeFactoryFlags.NoOriginalNode, baseNodeFactory);
 
-    /* eslint-disable no-var */
     var fileName: string;
     var sourceFlags: NodeFlags;
     var sourceText: string;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -961,31 +961,32 @@ export function createScanner(languageVersion: ScriptTarget,
     start?: number,
     length?: number): Scanner {
 
-    let text = textInitial!;
+    /* eslint-disable no-var */
+    var text = textInitial!;
 
     // Current position (end position of text of current token)
-    let pos: number;
+    var pos: number;
 
 
     // end of text
-    let end: number;
+    var end: number;
 
     // Start position of whitespace before current token
-    let startPos: number;
+    var startPos: number;
 
     // Start position of text of current token
-    let tokenPos: number;
+    var tokenPos: number;
 
-    let token: SyntaxKind;
-    let tokenValue!: string;
-    let tokenFlags: TokenFlags;
+    var token: SyntaxKind;
+    var tokenValue!: string;
+    var tokenFlags: TokenFlags;
 
-    let commentDirectives: CommentDirective[] | undefined;
-    let inJSDocType = 0;
+    var commentDirectives: CommentDirective[] | undefined;
+    var inJSDocType = 0;
 
     setText(text, start, length);
 
-    const scanner: Scanner = {
+    var scanner: Scanner = {
         getStartPos: () => startPos,
         getTextPos: () => pos,
         getToken: () => token,
@@ -1030,6 +1031,8 @@ export function createScanner(languageVersion: ScriptTarget,
         lookAhead,
         scanRange,
     };
+
+    /* eslint-disable no-var */
 
     if (Debug.isDebugging) {
         Object.defineProperty(scanner, "__debugShowCurrentPositionInText", {


### PR DESCRIPTION
This pull request regains some of the performance we lost in #51387 when we switched our emit from ES5 to ES2018 - a significant part due to TDZ checks that engines need to perform. These TDZ checks can often be eliminated, but engines probably have a hard time knowing whether a function can eliminate these checks.

By switching many of the top-level shared closure variables in the parser and scanner from `let`/`const` to `var`, we're able to eliminate those checks. Doing so should be fairly safe, since our functions follow the same initialization mechanism of declaring variables, and then calling the "workhorse" function afterwards.