### PR TITLE
Avoid using temporary array for getExpandedParameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12604,15 +12604,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return result;
     }
 
-    function getExpandedParameters(sig: Signature): readonly (readonly Symbol[])[]
-    function getExpandedParameters(sig: Signature, skipUnionExpanding: true): readonly Symbol[]
+    function getExpandedParameters(sig: Signature): readonly (readonly Symbol[])[];
+    function getExpandedParameters(sig: Signature, skipUnionExpanding: true): readonly Symbol[];
     function getExpandedParameters(sig: Signature, skipUnionExpanding?: boolean): readonly Symbol[] | readonly (readonly Symbol[])[] {
         if (signatureHasRestParameter(sig)) {
             const restIndex = sig.parameters.length - 1;
             const restType = getTypeOfSymbol(sig.parameters[restIndex]);
             if (isTupleType(restType)) {
                 const expanded = expandSignatureParametersWithTupleMembers(restType, restIndex);
-                return skipUnionExpanding ? expanded : [expanded]
+                return skipUnionExpanding ? expanded : [expanded];
             }
             else if (!skipUnionExpanding && restType.flags & TypeFlags.Union && every((restType as UnionType).types, isTupleType)) {
                 return map((restType as UnionType).types, t => expandSignatureParametersWithTupleMembers(t as TupleTypeReference, restIndex));


### PR DESCRIPTION
It was noted during review of #49627 that this function seemingly always returns an array with one item.

It looks like that in the checker, we always pass `skipUnionExpanding=true`. Only in services for signature help do we want expanding (for just a couple tests).

It seems wasteful to allocate an array and then throw it away to serializing any signature. Let's see if it helps to avoid it.