### PR TITLE
fix(52852): "Move to a new file" refactoring does not maintain "import type" semantics

### DIFF
--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -762,7 +762,7 @@ function filterImport(i: SupportedImport, moduleSpecifier: StringLiteralLike, ke
             const defaultImport = clause.name && keep(clause.name) ? clause.name : undefined;
             const namedBindings = clause.namedBindings && filterNamedBindings(clause.namedBindings, keep);
             return defaultImport || namedBindings
-                ? factory.createImportDeclaration(/*modifiers*/ undefined, factory.createImportClause(/*isTypeOnly*/ false, defaultImport, namedBindings), moduleSpecifier, /*assertClause*/ undefined)
+                ? factory.createImportDeclaration(/*modifiers*/ undefined, factory.createImportClause(clause.isTypeOnly, defaultImport, namedBindings), moduleSpecifier, /*assertClause*/ undefined)
                 : undefined;
         }
         case SyntaxKind.ImportEqualsDeclaration:

--- a/tests/cases/fourslash/moveToNewFile_typeImport1.ts
+++ b/tests/cases/fourslash/moveToNewFile_typeImport1.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: /a.ts
+////export interface A {
+////    x: number;
+////}
+
+// @Filename: /b.ts
+////import type { A } from "./a";
+////[|function f(a: A) {}|]
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/b.ts": "",
+        "/f.ts":
+`import type { A } from "./a";
+
+function f(a: A) { }
+`,
+    },
+});

--- a/tests/cases/fourslash/moveToNewFile_typeImport2.ts
+++ b/tests/cases/fourslash/moveToNewFile_typeImport2.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: /a.ts
+////export interface A {
+////    x: number;
+////}
+
+// @Filename: /b.ts
+////import { type A } from "./a";
+////[|function f(a: A) {}|]
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/b.ts": "",
+        "/f.ts":
+`import { type A } from "./a";
+
+function f(a: A) { }
+`,
+    },
+});


### PR DESCRIPTION
Fixes #52852