### PR TITLE
infer from usages: support short-circuiting assignment operators

### DIFF
--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -871,6 +871,9 @@ function inferTypeFromReferences(program: Program, references: readonly Identifi
             case SyntaxKind.EqualsEqualsEqualsToken:
             case SyntaxKind.ExclamationEqualsEqualsToken:
             case SyntaxKind.ExclamationEqualsToken:
+            case SyntaxKind.AmpersandAmpersandEqualsToken:
+            case SyntaxKind.QuestionQuestionEqualsToken:
+            case SyntaxKind.BarBarEqualsToken:
                 addCandidateType(usage, checker.getTypeAtLocation(parent.left === node ? parent.right : parent.left));
                 break;
 

--- a/tests/cases/fourslash/codeFixInferFromUsageAllAssignments.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageAllAssignments.ts
@@ -7,7 +7,6 @@
 ////x ||= "2"
 ////x &&= true
 
-// verify.rangeAfterCodeFix("let x: string | number | boolean;", /*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);
 verify.codeFix({
     description: "Infer type of 'x' from usage",
     index: 0,

--- a/tests/cases/fourslash/codeFixInferFromUsageAllAssignments.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageAllAssignments.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: false
+////[|let x
+////|]
+////x ??= 1
+////x ||= "2"
+////x &&= true
+
+// verify.rangeAfterCodeFix("let x: string | number | boolean;", /*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);
+verify.codeFix({
+    description: "Infer type of 'x' from usage",
+    index: 0,
+    newRangeContent: 'let x: string | number | boolean\n',
+})


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

This case is supported:

```ts
let x

if (x === undefined || x === null) x = 1
if (!x) x = "2"
if (x) x = true
```

So why don't support this:

```ts
let x

x ??= 1
x ||= "2"
x &&= true
```

[TypeScript docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#short-circuiting-assignment-operators)

Real world pattern:

```ts
let x

function workWithX() {
  // init lazily
  x ??= ...
}
```
