### PR TITLE
Modify ignoreDeprecation diagnostic to be copy/pastable

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4289,7 +4289,7 @@
         "category": "Error",
         "code": 5100
     },
-    "Flag '{0}' is deprecated and will stop functioning in TypeScript {1}. Specify 'ignoreDeprecations: \"{2}\"' to silence this error.": {
+    "Flag '{0}' is deprecated and will stop functioning in TypeScript {1}. Specify compilerOption '\"ignoreDeprecations\": \"{2}\"' to silence this error.": {
         "category": "Error",
         "code": 5101
     },

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -4404,7 +4404,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             createDiagnostic(Diagnostics.Flag_0_is_deprecated_Please_remove_it_from_your_configuration, value || name);
         }
         else {
-            createDiagnostic(Diagnostics.Flag_0_is_deprecated_and_will_stop_functioning_in_TypeScript_1_Specify_ignoreDeprecations_Colon_2_to_silence_this_error, value || name, DeprecationVersion.v5_5, DeprecationVersion.v5_0);
+            createDiagnostic(Diagnostics.Flag_0_is_deprecated_and_will_stop_functioning_in_TypeScript_1_Specify_compilerOption_ignoreDeprecations_Colon_2_to_silence_this_error, value || name, DeprecationVersion.v5_5, DeprecationVersion.v5_0);
         }
     }
 

--- a/tests/baselines/reference/ES3For-ofTypeCheck1.errors.txt
+++ b/tests/baselines/reference/ES3For-ofTypeCheck1.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck1.ts(1,15): error TS2494: Using a string in a 'for...of' statement is only supported in ECMAScript 5 and higher.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck1.ts (1 errors) ====
     for (var v of "") { }
                   ~~

--- a/tests/baselines/reference/ES3For-ofTypeCheck2.errors.txt
+++ b/tests/baselines/reference/ES3For-ofTypeCheck2.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck2.ts (0 errors) ====
     for (var v of [true]) { }

--- a/tests/baselines/reference/ES3For-ofTypeCheck4.errors.txt
+++ b/tests/baselines/reference/ES3For-ofTypeCheck4.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck4.ts(2,17): error TS2494: Using a string in a 'for...of' statement is only supported in ECMAScript 5 and higher.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck4.ts (1 errors) ====
     var union: string | string[];
     for (const v of union) { }

--- a/tests/baselines/reference/ES3For-ofTypeCheck6.errors.txt
+++ b/tests/baselines/reference/ES3For-ofTypeCheck6.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck6.ts (0 errors) ====
     var union: string[] | number[];
     for (var v of union) { }

--- a/tests/baselines/reference/accessorWithES3.errors.txt
+++ b/tests/baselines/reference/accessorWithES3.errors.txt
@@ -1,11 +1,11 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithES3.ts(4,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithES3.ts(10,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithES3.ts(15,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithES3.ts(19,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithES3.ts (4 errors) ====
     // error to use accessors in ES3 mode
     

--- a/tests/baselines/reference/accessorsNotAllowedInES3.errors.txt
+++ b/tests/baselines/reference/accessorsNotAllowedInES3.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/accessorsNotAllowedInES3.ts(2,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/accessorsNotAllowedInES3.ts(4,15): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/accessorsNotAllowedInES3.ts (2 errors) ====
     class C {
         get x(): number { return 1; }

--- a/tests/baselines/reference/alwaysStrictNoImplicitUseStrict.errors.txt
+++ b/tests/baselines/reference/alwaysStrictNoImplicitUseStrict.errors.txt
@@ -1,10 +1,10 @@
 error TS5053: Option 'noImplicitUseStrict' cannot be specified with option 'alwaysStrict'.
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts(3,13): error TS1100: Invalid use of 'arguments' in strict mode.
 
 
 !!! error TS5053: Option 'noImplicitUseStrict' cannot be specified with option 'alwaysStrict'.
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts (1 errors) ====
     module M {
         export function f() {

--- a/tests/baselines/reference/ambientAccessors(target=es3).errors.txt
+++ b/tests/baselines/reference/ambientAccessors(target=es3).errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts (0 errors) ====
     // ok to use accessors in ambient class in ES3
     declare class C {

--- a/tests/baselines/reference/amdDeclarationEmitNoExtraDeclare.errors.txt
+++ b/tests/baselines/reference/amdDeclarationEmitNoExtraDeclare.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/Class.ts (0 errors) ====
     import { Configurable } from "./Configurable"
     

--- a/tests/baselines/reference/bigIntWithTargetES3.errors.txt
+++ b/tests/baselines/reference/bigIntWithTargetES3.errors.txt
@@ -1,11 +1,11 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/bigIntWithTargetES3.ts(5,22): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigIntWithTargetES3.ts(5,29): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigIntWithTargetES3.ts(5,39): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigIntWithTargetES3.ts(5,48): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/bigIntWithTargetES3.ts (4 errors) ====
     const normalNumber = 123; // should not error
     let bigintType: bigint; // should not error

--- a/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.errors.txt
+++ b/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.errors.txt
@@ -1,10 +1,10 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/weird.js(1,1): error TS2552: Cannot find name 'someFunction'. Did you mean 'Function'?
 tests/cases/compiler/weird.js(1,23): error TS7006: Parameter 'BaseClass' implicitly has an 'any' type.
 tests/cases/compiler/weird.js(9,17): error TS7006: Parameter 'error' implicitly has an 'any' type.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/weird.js (3 errors) ====
     someFunction(function(BaseClass) {
     ~~~~~~~~~~~~

--- a/tests/baselines/reference/checkJsdocReturnTag1.errors.txt
+++ b/tests/baselines/reference/checkJsdocReturnTag1.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/jsdoc/returns.js (0 errors) ====
     // @ts-check
     /**

--- a/tests/baselines/reference/checkJsdocReturnTag2.errors.txt
+++ b/tests/baselines/reference/checkJsdocReturnTag2.errors.txt
@@ -1,10 +1,10 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/jsdoc/returns.js(6,5): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsdoc/returns.js(13,5): error TS2322: Type 'number | boolean' is not assignable to type 'string | number'.
   Type 'boolean' is not assignable to type 'string | number'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/jsdoc/returns.js (2 errors) ====
     // @ts-check
     /**

--- a/tests/baselines/reference/compilerOptionsOutAndNoEmit.errors.txt
+++ b/tests/baselines/reference/compilerOptionsOutAndNoEmit.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/computedPropertyNames52(target=es2015).errors.txt
+++ b/tests/baselines/reference/computedPropertyNames52(target=es2015).errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNames52.js (0 errors) ====
     const array = [];
     for (let i = 0; i < 10; ++i) {

--- a/tests/baselines/reference/computedPropertyNames52(target=es5).errors.txt
+++ b/tests/baselines/reference/computedPropertyNames52(target=es5).errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/computedProperties/computedPropertyNames52.js (0 errors) ====
     const array = [];
     for (let i = 0; i < 10; ++i) {

--- a/tests/baselines/reference/constDeclarations-useBeforeDefinition2.errors.txt
+++ b/tests/baselines/reference/constDeclarations-useBeforeDefinition2.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/file1.ts(1,1): error TS2448: Block-scoped variable 'c' used before its declaration.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/file1.ts (1 errors) ====
     c;
     ~

--- a/tests/baselines/reference/controlFlowJavascript.errors.txt
+++ b/tests/baselines/reference/controlFlowJavascript.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/controlFlowJavascript.js (0 errors) ====
     let cond = true;
     

--- a/tests/baselines/reference/declFileWithErrorsInInputDeclarationFileWithOut.errors.txt
+++ b/tests/baselines/reference/declFileWithErrorsInInputDeclarationFileWithOut.errors.txt
@@ -1,11 +1,11 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/declFile.d.ts(2,5): error TS1038: A 'declare' modifier cannot be used in an already ambient context.
 tests/cases/compiler/declFile.d.ts(3,5): error TS1038: A 'declare' modifier cannot be used in an already ambient context.
 tests/cases/compiler/declFile.d.ts(5,5): error TS1038: A 'declare' modifier cannot be used in an already ambient context.
 tests/cases/compiler/declFile.d.ts(7,5): error TS1038: A 'declare' modifier cannot be used in an already ambient context.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/client.ts (0 errors) ====
     ///<reference path="declFile.d.ts"/>
     var x = new M.C(); // Declaration file wont get emitted because there are errors in declaration file

--- a/tests/baselines/reference/declarationFileOverwriteErrorWithOut.errors.txt
+++ b/tests/baselines/reference/declarationFileOverwriteErrorWithOut.errors.txt
@@ -1,11 +1,11 @@
 error TS5055: Cannot write file 'tests/cases/compiler/out.d.ts' because it would overwrite input file.
   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS5055: Cannot write file 'tests/cases/compiler/out.d.ts' because it would overwrite input file.
 !!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/out.d.ts (0 errors) ====
     declare class c {
     }

--- a/tests/baselines/reference/definePropertyOutputES3.errors.txt
+++ b/tests/baselines/reference/definePropertyOutputES3.errors.txt
@@ -1,9 +1,9 @@
 error TS5048: Option 'useDefineForClassFields' cannot be specified when option 'target' is 'ES3'.
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS5048: Option 'useDefineForClassFields' cannot be specified when option 'target' is 'ES3'.
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/classes/propertyMemberDeclarations/definePropertyOutputES3.ts (0 errors) ====
     class A {
         a = 12

--- a/tests/baselines/reference/deprecatedCompilerOptions1.errors.txt
+++ b/tests/baselines/reference/deprecatedCompilerOptions1.errors.txt
@@ -1,11 +1,11 @@
-/foo/tsconfig.json(3,19): error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-/foo/tsconfig.json(4,9): error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-/foo/tsconfig.json(5,9): error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-/foo/tsconfig.json(6,9): error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-/foo/tsconfig.json(7,9): error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-/foo/tsconfig.json(8,9): error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-/foo/tsconfig.json(9,9): error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-/foo/tsconfig.json(10,9): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+/foo/tsconfig.json(3,19): error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+/foo/tsconfig.json(4,9): error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+/foo/tsconfig.json(5,9): error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+/foo/tsconfig.json(6,9): error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+/foo/tsconfig.json(7,9): error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+/foo/tsconfig.json(8,9): error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+/foo/tsconfig.json(9,9): error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+/foo/tsconfig.json(10,9): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 ==== /foo/tsconfig.json (8 errors) ====
@@ -13,28 +13,28 @@
         "compilerOptions": {
             "target": "ES3",
                       ~~~~~
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
             "noImplicitUseStrict": true,
             ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
             "keyofStringsOnly": true,
             ~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
             "suppressExcessPropertyErrors": true,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
             "suppressImplicitAnyIndexErrors": true,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
             "noStrictGenericChecks": true,
             ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
             "charset": "utf8",
             ~~~~~~~~~
-!!! error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
             "out": "dist.js"
             ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
         }
     }
     

--- a/tests/baselines/reference/dynamicRequire.errors.txt
+++ b/tests/baselines/reference/dynamicRequire.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.js (0 errors) ====
     function foo(name) {
         var s = require("t/" + name)

--- a/tests/baselines/reference/emptyFile-declaration.errors.txt
+++ b/tests/baselines/reference/emptyFile-declaration.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/emptyFile-declaration.ts (0 errors) ====
     

--- a/tests/baselines/reference/emptyFile-souremap.errors.txt
+++ b/tests/baselines/reference/emptyFile-souremap.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/emptyFile-souremap.ts (0 errors) ====
     

--- a/tests/baselines/reference/es3-amd.errors.txt
+++ b/tests/baselines/reference/es3-amd.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-amd.ts (0 errors) ====
     class A
     {

--- a/tests/baselines/reference/es3-declaration-amd.errors.txt
+++ b/tests/baselines/reference/es3-declaration-amd.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-declaration-amd.ts (0 errors) ====
     class A
     {

--- a/tests/baselines/reference/es3-jsx-preserve.errors.txt
+++ b/tests/baselines/reference/es3-jsx-preserve.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-jsx-preserve.tsx (0 errors) ====
     const React: any = null;
     

--- a/tests/baselines/reference/es3-jsx-react-native.errors.txt
+++ b/tests/baselines/reference/es3-jsx-react-native.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-jsx-react-native.tsx (0 errors) ====
     const React: any = null;
     

--- a/tests/baselines/reference/es3-jsx-react.errors.txt
+++ b/tests/baselines/reference/es3-jsx-react.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-jsx-react.tsx (0 errors) ====
     const React: any = null;
     

--- a/tests/baselines/reference/es3-oldStyleOctalLiteralInEnums.errors.txt
+++ b/tests/baselines/reference/es3-oldStyleOctalLiteralInEnums.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/es3-oldStyleOctalLiteralInEnums.ts(2,7): error TS8018: Octal literals are not allowed in enums members initializer. Use the syntax '-0o1'.
 tests/cases/compiler/es3-oldStyleOctalLiteralInEnums.ts(3,7): error TS8018: Octal literals are not allowed in enums members initializer. Use the syntax '0o2'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-oldStyleOctalLiteralInEnums.ts (2 errors) ====
     enum E {
       x = -01,

--- a/tests/baselines/reference/es3-oldStyleOctalLiteralTypes.errors.txt
+++ b/tests/baselines/reference/es3-oldStyleOctalLiteralTypes.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/es3-oldStyleOctalLiteralTypes.ts(1,8): error TS8017: Octal literal types must use ES2015 syntax. Use the syntax '0o10'.
 tests/cases/compiler/es3-oldStyleOctalLiteralTypes.ts(2,8): error TS8017: Octal literal types must use ES2015 syntax. Use the syntax '-0o20'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-oldStyleOctalLiteralTypes.ts (2 errors) ====
     let x: 010;
            ~~~

--- a/tests/baselines/reference/es3-sourcemap-amd.errors.txt
+++ b/tests/baselines/reference/es3-sourcemap-amd.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3-sourcemap-amd.ts (0 errors) ====
     class A
     {

--- a/tests/baselines/reference/es3defaultAliasIsQuoted.errors.txt
+++ b/tests/baselines/reference/es3defaultAliasIsQuoted.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/es3defaultAliasQuoted_file0.ts (0 errors) ====
     export class Foo {
         static CONSTANT = "Foo";

--- a/tests/baselines/reference/esModuleInteropWithExportStar(target=es3).errors.txt
+++ b/tests/baselines/reference/esModuleInteropWithExportStar(target=es3).errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/fs.d.ts (0 errors) ====
     export const x: number;
 ==== tests/cases/compiler/mjts.ts (0 errors) ====

--- a/tests/baselines/reference/excessPropertyErrorsSuppressed.errors.txt
+++ b/tests/baselines/reference/excessPropertyErrorsSuppressed.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/excessPropertyErrorsSuppressed.ts (0 errors) ====
     var x: { a: string } = { a: "hello", b: 42 };  // No error
     

--- a/tests/baselines/reference/exportAndImport-es3-amd.errors.txt
+++ b/tests/baselines/reference/exportAndImport-es3-amd.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
     export default function f1() {
     }

--- a/tests/baselines/reference/exportAndImport-es3.errors.txt
+++ b/tests/baselines/reference/exportAndImport-es3.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
     export default function f1() {
     }

--- a/tests/baselines/reference/exportDefaultInJsFile01.errors.txt
+++ b/tests/baselines/reference/exportDefaultInJsFile01.errors.txt
@@ -1,10 +1,10 @@
 error TS5055: Cannot write file 'tests/cases/conformance/salsa/myFile01.js' because it would overwrite input file.
   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS5055: Cannot write file 'tests/cases/conformance/salsa/myFile01.js' because it would overwrite input file.
 !!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/salsa/myFile01.js (0 errors) ====
     export default "hello";

--- a/tests/baselines/reference/exportsAndImportsWithUnderscores1.errors.txt
+++ b/tests/baselines/reference/exportsAndImportsWithUnderscores1.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/es6/modules/m1.ts(5,5): error TS1005: ',' expected.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/modules/m1.ts (1 errors) ====
     var R: any
     export default R = {

--- a/tests/baselines/reference/exportsAndImportsWithUnderscores2.errors.txt
+++ b/tests/baselines/reference/exportsAndImportsWithUnderscores2.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
     var R: any
     export default R = {

--- a/tests/baselines/reference/exportsAndImportsWithUnderscores3.errors.txt
+++ b/tests/baselines/reference/exportsAndImportsWithUnderscores3.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
     var R: any
     export default R = {

--- a/tests/baselines/reference/exportsAndImportsWithUnderscores4.errors.txt
+++ b/tests/baselines/reference/exportsAndImportsWithUnderscores4.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
     declare var console: any;
     export function _() {

--- a/tests/baselines/reference/filesEmittingIntoSameOutputWithOutOption.errors.txt
+++ b/tests/baselines/reference/filesEmittingIntoSameOutputWithOutOption.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     export class c {
     }

--- a/tests/baselines/reference/genericSetterInClassTypeJsDoc.errors.txt
+++ b/tests/baselines/reference/genericSetterInClassTypeJsDoc.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/classes/members/classTypes/genericSetterInClassTypeJsDoc.js (0 errors) ====
     /**
      * @template T

--- a/tests/baselines/reference/globalThisVarDeclaration.errors.txt
+++ b/tests/baselines/reference/globalThisVarDeclaration.errors.txt
@@ -1,11 +1,11 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/es2019/actual.ts(12,5): error TS2339: Property 'a' does not exist on type 'Window'.
 tests/cases/conformance/es2019/actual.ts(13,5): error TS2339: Property 'b' does not exist on type 'Window'.
 tests/cases/conformance/es2019/b.js(12,5): error TS2339: Property 'a' does not exist on type 'Window'.
 tests/cases/conformance/es2019/b.js(13,5): error TS2339: Property 'b' does not exist on type 'Window'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/es2019/b.js (2 errors) ====
     var a = 10;
     this.a;

--- a/tests/baselines/reference/importCallExpressionAsyncES3AMD.errors.txt
+++ b/tests/baselines/reference/importCallExpressionAsyncES3AMD.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/dynamicImport/test.ts (0 errors) ====
     export async function fn() {
         const req = await import('./test') // ONE

--- a/tests/baselines/reference/importCallExpressionAsyncES3CJS.errors.txt
+++ b/tests/baselines/reference/importCallExpressionAsyncES3CJS.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/dynamicImport/test.ts (0 errors) ====
     export async function fn() {
         const req = await import('./test') // ONE

--- a/tests/baselines/reference/importCallExpressionAsyncES3System.errors.txt
+++ b/tests/baselines/reference/importCallExpressionAsyncES3System.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/dynamicImport/test.ts (0 errors) ====
     export async function fn() {
         const req = await import('./test') // ONE

--- a/tests/baselines/reference/importCallExpressionAsyncES3UMD.errors.txt
+++ b/tests/baselines/reference/importCallExpressionAsyncES3UMD.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/dynamicImport/test.ts (0 errors) ====
     export async function fn() {
         const req = await import('./test') // ONE

--- a/tests/baselines/reference/importsNotUsedAsValues_error.errors.txt
+++ b/tests/baselines/reference/importsNotUsedAsValues_error.errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 /b.ts(1,1): error TS1371: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.
 /c.ts(1,1): error TS1371: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.
@@ -7,7 +7,7 @@ error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop function
 /i.ts(1,1): error TS1371: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.
 
 
-!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== /a.ts (0 errors) ====
     export default class {}

--- a/tests/baselines/reference/incrementalOut.errors.txt
+++ b/tests/baselines/reference/incrementalOut.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/incrementalOut.ts (0 errors) ====
     const x = 10;
     

--- a/tests/baselines/reference/inferringClassMembersFromAssignments.errors.txt
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments.errors.txt
@@ -1,10 +1,10 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/salsa/a.js(14,13): error TS7008: Member 'inMethodNullable' implicitly has an 'any' type.
 tests/cases/conformance/salsa/a.js(20,9): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/salsa/a.js(39,9): error TS2322: Type 'boolean' is not assignable to type 'number'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/salsa/a.js (3 errors) ====
     class C {
         constructor() {

--- a/tests/baselines/reference/inlineSourceMap.errors.txt
+++ b/tests/baselines/reference/inlineSourceMap.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/inlineSourceMap.ts (0 errors) ====
     var x = 0;
     console.log(x);

--- a/tests/baselines/reference/inlineSourceMap2.errors.txt
+++ b/tests/baselines/reference/inlineSourceMap2.errors.txt
@@ -1,13 +1,13 @@
 error TS5053: Option 'mapRoot' cannot be specified with option 'inlineSourceMap'.
 error TS5053: Option 'sourceMap' cannot be specified with option 'inlineSourceMap'.
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS5053: Option 'mapRoot' cannot be specified with option 'inlineSourceMap'.
 !!! error TS5053: Option 'sourceMap' cannot be specified with option 'inlineSourceMap'.
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/inlineSourceMap2.ts (0 errors) ====
     // configuration errors
     

--- a/tests/baselines/reference/inlineSources.errors.txt
+++ b/tests/baselines/reference/inlineSources.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     var a = 0;
     console.log(a);

--- a/tests/baselines/reference/inlineSources2.errors.txt
+++ b/tests/baselines/reference/inlineSources2.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     var a = 0;
     console.log(a);

--- a/tests/baselines/reference/isLiteral2.errors.txt
+++ b/tests/baselines/reference/isLiteral2.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/isLiteral2.ts (0 errors) ====
     var x: number = 02343

--- a/tests/baselines/reference/isolatedModulesOut.errors.txt
+++ b/tests/baselines/reference/isolatedModulesOut.errors.txt
@@ -1,10 +1,10 @@
 error TS5053: Option 'out' cannot be specified with option 'isolatedModules'.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/file1.ts(1,1): error TS6131: Cannot compile modules using option 'out' unless the '--module' flag is 'amd' or 'system'.
 
 
 !!! error TS5053: Option 'out' cannot be specified with option 'isolatedModules'.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/file1.ts (1 errors) ====
     export var x;
     ~~~~~~~~~~~~~

--- a/tests/baselines/reference/jsFileCompilationClassMethodContainingArrowFunction.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationClassMethodContainingArrowFunction.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.js (0 errors) ====
     class c {
         method(a) {

--- a/tests/baselines/reference/jsFileCompilationDuplicateFunctionImplementation.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationDuplicateFunctionImplementation.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/a.ts(1,10): error TS2393: Duplicate function implementation.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/b.js (0 errors) ====
     function foo() {
         return 10;

--- a/tests/baselines/reference/jsFileCompilationDuplicateFunctionImplementationFileOrderReversed.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationDuplicateFunctionImplementationFileOrderReversed.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/a.ts(1,10): error TS2393: Duplicate function implementation.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (1 errors) ====
     function foo() {
              ~~~

--- a/tests/baselines/reference/jsFileCompilationDuplicateVariable.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationDuplicateVariable.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     var x = 10;
     

--- a/tests/baselines/reference/jsFileCompilationDuplicateVariableErrorReported.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationDuplicateVariableErrorReported.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/a.ts(1,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'number'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/b.js (0 errors) ====
     var x = "hello";
     

--- a/tests/baselines/reference/jsFileCompilationEmitDeclarations.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationEmitDeclarations.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsFileCompilationEmitTrippleSlashReference.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationEmitTrippleSlashReference.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsFileCompilationErrorOnDeclarationsWithJsFileReferenceWithOut.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationErrorOnDeclarationsWithJsFileReferenceWithOut.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsFileCompilationLetBeingRenamed.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationLetBeingRenamed.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.js (0 errors) ====
     function foo(a) {
         for (let a = 0; a < 10; a++) {

--- a/tests/baselines/reference/jsFileCompilationLetDeclarationOrder.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationLetDeclarationOrder.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/b.js (0 errors) ====
     let a = 10;
     b = 30;

--- a/tests/baselines/reference/jsFileCompilationLetDeclarationOrder2.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationLetDeclarationOrder2.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/a.ts(2,1): error TS2448: Block-scoped variable 'a' used before its declaration.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (1 errors) ====
     let b = 30;
     a = 10;

--- a/tests/baselines/reference/jsFileCompilationNoErrorWithoutDeclarationsWithJsFileReferenceWithOut.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationNoErrorWithoutDeclarationsWithJsFileReferenceWithOut.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsFileCompilationNonNullAssertion.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationNonNullAssertion.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 /src/a.js(1,1): error TS8013: Non-null assertions can only be used in TypeScript files.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== /src/a.js (1 errors) ====
     0!
     ~~

--- a/tests/baselines/reference/jsFileCompilationRestParamJsDocFunction.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationRestParamJsDocFunction.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/_apply.js (0 errors) ====
     /**
      * A faster alternative to `Function#apply`, this function invokes `func`

--- a/tests/baselines/reference/jsFileCompilationRestParameter.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationRestParameter.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.js (0 errors) ====
     function foo(...a) { }

--- a/tests/baselines/reference/jsFileCompilationShortHandProperty.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationShortHandProperty.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.js (0 errors) ====
     function foo() {
         var a = 10;

--- a/tests/baselines/reference/jsFileCompilationTypeAssertions.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationTypeAssertions.errors.txt
@@ -1,10 +1,10 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 /src/a.js(1,6): error TS8016: Type assertion expressions can only be used in TypeScript files.
 /src/a.js(2,10): error TS17008: JSX element 'string' has no corresponding closing tag.
 /src/a.js(3,1): error TS1005: '</' expected.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== /src/a.js (3 errors) ====
     0 as number;
          ~~~~~~

--- a/tests/baselines/reference/jsFileCompilationWithEnabledCompositeOption.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationWithEnabledCompositeOption.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsFileCompilationWithOut.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationWithOut.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsFileCompilationWithOutDeclarationFileNameSameAsInputJsFile.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationWithOutDeclarationFileNameSameAsInputJsFile.errors.txt
@@ -1,11 +1,11 @@
 error TS5055: Cannot write file 'tests/cases/compiler/b.d.ts' because it would overwrite input file.
   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS5055: Cannot write file 'tests/cases/compiler/b.d.ts' because it would overwrite input file.
 !!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsFileCompilationWithOutFileNameSameAsInputJsFile.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationWithOutFileNameSameAsInputJsFile.errors.txt
@@ -1,11 +1,11 @@
 error TS5055: Cannot write file 'tests/cases/compiler/b.js' because it would overwrite input file.
   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS5055: Cannot write file 'tests/cases/compiler/b.js' because it would overwrite input file.
 !!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     class c {
     }

--- a/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.errors.txt
+++ b/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/salsa/a.js (0 errors) ====
     var variable = {};
     variable.a = 0;

--- a/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.errors.txt
+++ b/tests/baselines/reference/jsdocAccessibilityTagsDeclarations.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/jsdoc/jsdocAccessibilityTagDeclarations.js (0 errors) ====
     class Protected {
         /** @protected */

--- a/tests/baselines/reference/jsdocLiteral.errors.txt
+++ b/tests/baselines/reference/jsdocLiteral.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/jsdoc/in.js (0 errors) ====
     /**
      * @param {'literal'} p1

--- a/tests/baselines/reference/jsdocNeverUndefinedNull.errors.txt
+++ b/tests/baselines/reference/jsdocNeverUndefinedNull.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/jsdoc/in.js (0 errors) ====
     /**
      * @param {never} p1

--- a/tests/baselines/reference/jsdocReadonlyDeclarations.errors.txt
+++ b/tests/baselines/reference/jsdocReadonlyDeclarations.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/jsdoc/jsdocReadonlyDeclarations.js (0 errors) ====
     class C {
         /** @readonly */

--- a/tests/baselines/reference/jsdocReturnTag1.errors.txt
+++ b/tests/baselines/reference/jsdocReturnTag1.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/jsdoc/returns.js (0 errors) ====
     /**
      * @returns {string} This comment is not currently exposed

--- a/tests/baselines/reference/keepImportsInDts3.errors.txt
+++ b/tests/baselines/reference/keepImportsInDts3.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== c:/test.ts (0 errors) ====
     export {};
 ==== c:/app/main.ts (0 errors) ====

--- a/tests/baselines/reference/keepImportsInDts4.errors.txt
+++ b/tests/baselines/reference/keepImportsInDts4.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/folder/test.ts (0 errors) ====
     export {};
 ==== tests/cases/compiler/main.ts (0 errors) ====

--- a/tests/baselines/reference/keyofDoesntContainSymbols.errors.txt
+++ b/tests/baselines/reference/keyofDoesntContainSymbols.errors.txt
@@ -1,10 +1,10 @@
-error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/keyofDoesntContainSymbols.ts(11,30): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
 tests/cases/compiler/keyofDoesntContainSymbols.ts(14,23): error TS2345: Argument of type 'unique symbol' is not assignable to parameter of type '"str" | "num"'.
 tests/cases/compiler/keyofDoesntContainSymbols.ts(17,23): error TS2345: Argument of type '0' is not assignable to parameter of type '"str" | "num"'.
 
 
-!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/keyofDoesntContainSymbols.ts (3 errors) ====
     const sym = Symbol();
     const num = 0;

--- a/tests/baselines/reference/lateBoundConstraintTypeChecksCorrectly.errors.txt
+++ b/tests/baselines/reference/lateBoundConstraintTypeChecksCorrectly.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts (0 errors) ====
     declare const fooProp: unique symbol;
     declare const barProp: unique symbol;

--- a/tests/baselines/reference/letDeclarations-useBeforeDefinition2.errors.txt
+++ b/tests/baselines/reference/letDeclarations-useBeforeDefinition2.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/file1.ts(1,1): error TS2448: Block-scoped variable 'l' used before its declaration.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/file1.ts (1 errors) ====
     l;
     ~

--- a/tests/baselines/reference/mappedTypeUnionConstraintInferences.errors.txt
+++ b/tests/baselines/reference/mappedTypeUnionConstraintInferences.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'keyofStringsOnly' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/mappedTypeUnionConstraintInferences.ts (0 errors) ====
     export declare type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
     export declare type PartialProperties<T, K extends keyof T> = Partial<Pick<T, K>> & Omit<T, K>;

--- a/tests/baselines/reference/methodsReturningThis.errors.txt
+++ b/tests/baselines/reference/methodsReturningThis.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/salsa/input.js (0 errors) ====
     function Class()
     {

--- a/tests/baselines/reference/moduleAugmentationsBundledOutput1.errors.txt
+++ b/tests/baselines/reference/moduleAugmentationsBundledOutput1.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/m1.ts (0 errors) ====
     export class Cls {
     }

--- a/tests/baselines/reference/moduleAugmentationsImports1.errors.txt
+++ b/tests/baselines/reference/moduleAugmentationsImports1.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     export class A {}
     

--- a/tests/baselines/reference/moduleAugmentationsImports2.errors.txt
+++ b/tests/baselines/reference/moduleAugmentationsImports2.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     export class A {}
     

--- a/tests/baselines/reference/moduleAugmentationsImports3.errors.txt
+++ b/tests/baselines/reference/moduleAugmentationsImports3.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/main.ts (0 errors) ====
     /// <reference path="d.d.ts"/>
     import {A} from "./a";

--- a/tests/baselines/reference/moduleAugmentationsImports4.errors.txt
+++ b/tests/baselines/reference/moduleAugmentationsImports4.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/main.ts (0 errors) ====
     /// <reference path="d.d.ts"/>
     /// <reference path="e.d.ts"/>

--- a/tests/baselines/reference/multipleDeclarations.errors.txt
+++ b/tests/baselines/reference/multipleDeclarations.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/salsa/input.js (0 errors) ====
     function C() {
         this.m = null;

--- a/tests/baselines/reference/noImplicitAnyIndexingSuppressed.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyIndexingSuppressed.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/noImplicitAnyIndexingSuppressed.ts(19,9): error TS2339: Property 'hi' does not exist on type '{}'.
 tests/cases/compiler/noImplicitAnyIndexingSuppressed.ts(22,9): error TS2339: Property '10' does not exist on type '{}'.
 
 
-!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/noImplicitAnyIndexingSuppressed.ts (2 errors) ====
     enum MyEmusEnum {
         emu

--- a/tests/baselines/reference/noImplicitUseStrict_amd.errors.txt
+++ b/tests/baselines/reference/noImplicitUseStrict_amd.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/noImplicitUseStrict_amd.ts (0 errors) ====
     export var x = 0;

--- a/tests/baselines/reference/noImplicitUseStrict_commonjs.errors.txt
+++ b/tests/baselines/reference/noImplicitUseStrict_commonjs.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/noImplicitUseStrict_commonjs.ts (0 errors) ====
     export var x = 0;

--- a/tests/baselines/reference/noImplicitUseStrict_es6.errors.txt
+++ b/tests/baselines/reference/noImplicitUseStrict_es6.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/noImplicitUseStrict_es6.ts (0 errors) ====
     export var x = 0;

--- a/tests/baselines/reference/noImplicitUseStrict_system.errors.txt
+++ b/tests/baselines/reference/noImplicitUseStrict_system.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/noImplicitUseStrict_system.ts (0 errors) ====
     export var x = 0;

--- a/tests/baselines/reference/noImplicitUseStrict_umd.errors.txt
+++ b/tests/baselines/reference/noImplicitUseStrict_umd.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/noImplicitUseStrict_umd.ts (0 errors) ====
     export var x = 0;

--- a/tests/baselines/reference/noStrictGenericChecks.errors.txt
+++ b/tests/baselines/reference/noStrictGenericChecks.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'noStrictGenericChecks' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/noStrictGenericChecks.ts (0 errors) ====
     type A = <T, U>(x: T, y: U) => [T, U];
     type B = <S>(x: S, y: S) => [S, S];

--- a/tests/baselines/reference/nonPrimitiveIndexingWithForInSupressError.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveIndexingWithForInSupressError.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInSupressError.ts (0 errors) ====
     var a: object;
     

--- a/tests/baselines/reference/numericUnderscoredSeparator(target=es3).errors.txt
+++ b/tests/baselines/reference/numericUnderscoredSeparator(target=es3).errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/numericUnderscoredSeparator.ts (0 errors) ====
     1_000_000_000_000
     0b1010_0001_1000_0101

--- a/tests/baselines/reference/objectLiteralErrorsES3.errors.txt
+++ b/tests/baselines/reference/objectLiteralErrorsES3.errors.txt
@@ -1,11 +1,11 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralErrorsES3.ts(1,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralErrorsES3.ts(2,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralErrorsES3.ts(3,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralErrorsES3.ts(3,40): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/expressions/objectLiterals/objectLiteralErrorsES3.ts (4 errors) ====
     var e1 = { get a() { return 4; } };
                    ~

--- a/tests/baselines/reference/objectTypeWithStringNamedNumericProperty.errors.txt
+++ b/tests/baselines/reference/objectTypeWithStringNamedNumericProperty.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/types/members/objectTypeWithStringNamedNumericProperty.ts (0 errors) ====
     // string named numeric properties are legal and distinct when indexed by string values
     // indexed numerically the value is converted to a number

--- a/tests/baselines/reference/optionsOutAndNoModuleGen.errors.txt
+++ b/tests/baselines/reference/optionsOutAndNoModuleGen.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/compiler/optionsOutAndNoModuleGen.ts(1,1): error TS6131: Cannot compile modules using option 'out' unless the '--module' flag is 'amd' or 'system'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/optionsOutAndNoModuleGen.ts (1 errors) ====
     export var x = 10;
     ~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/out-flag3.errors.txt
+++ b/tests/baselines/reference/out-flag3.errors.txt
@@ -1,10 +1,10 @@
 error TS5053: Option 'out' cannot be specified with option 'outFile'.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
 !!! error TS5053: Option 'out' cannot be specified with option 'outFile'.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     // --out and --outFile error

--- a/tests/baselines/reference/parserArrowFunctionExpression10(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression10(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,11): error TS2304: Cannot find name 'c'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,11): error TS8010: Type annotations can only be used in TypeScript files.
@@ -10,7 +10,7 @@ tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,27): error TS2304: Cannot find name 'f'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (5 errors) ====
     a ? (b) : c => (d) : e => f // Not legal JS; "Unexpected token ':'" at last colon
     ~

--- a/tests/baselines/reference/parserArrowFunctionExpression11(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression11(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,5): error TS2304: Cannot find name 'b'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,9): error TS2304: Cannot find name 'c'.
@@ -11,7 +11,7 @@ tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,24): error TS2304: Cannot find name 'f'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (5 errors) ====
     a ? b ? c : (d) : e => f // Legal JS
     ~

--- a/tests/baselines/reference/parserArrowFunctionExpression12(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression12(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,13): error TS2304: Cannot find name 'c'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,22): error TS2304: Cannot find name 'e'.
@@ -7,7 +7,7 @@ tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,22): error TS2304: Cannot find name 'e'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (3 errors) ====
     a ? (b) => (c): d => e // Legal JS
     ~

--- a/tests/baselines/reference/parserArrowFunctionExpression13(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression13(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,11): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,21): error TS8010: Type annotations can only be used in TypeScript files.
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,11): error TS2304: Cannot find name 'a'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (3 errors) ====
     a ? () => a() : (): any => null; // Not legal JS; "Unexpected token ')'" at last paren
     ~

--- a/tests/baselines/reference/parserArrowFunctionExpression14(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression14(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,11): error TS8010: Type annotations can only be used in TypeScript files.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,20): error TS8009: The '?' modifier can only be used in TypeScript files.
@@ -11,7 +11,7 @@ tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,46): error TS2304: Cannot find name 'e'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (7 errors) ====
     a() ? (b: number, c?: string): void => d() : e; // Not legal JS; "Unexpected token ':'" at first colon
     ~

--- a/tests/baselines/reference/parserArrowFunctionExpression15(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression15(target=es3).errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,18): error TS8010: Type annotations can only be used in TypeScript files.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (1 errors) ====
     false ? (param): string => param : null // Not legal JS; "Unexpected token ':'" at last colon
                      ~~~~~~

--- a/tests/baselines/reference/parserArrowFunctionExpression16(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression16(target=es3).errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,25): error TS8010: Type annotations can only be used in TypeScript files.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (1 errors) ====
     true ? false ? (param): string => param : null : null // Not legal JS; "Unexpected token ':'" at last colon
                             ~~~~~~

--- a/tests/baselines/reference/parserArrowFunctionExpression17(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression17(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,5): error TS2304: Cannot find name 'b'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,15): error TS2304: Cannot find name 'd'.
@@ -10,7 +10,7 @@ tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,20): error TS2304: Cannot find name 'e'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (5 errors) ====
     a ? b : (c) : d => e // Not legal JS; "Unexpected token ':'" at last colon
     ~

--- a/tests/baselines/reference/parserArrowFunctionExpression8(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression8(target=es3).errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'x'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,1): error TS2304: Cannot find name 'x'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (1 errors) ====
     x ? y => ({ y }) : z => ({ z }) // Legal JS
     ~

--- a/tests/baselines/reference/parserArrowFunctionExpression9(target=es3).errors.txt
+++ b/tests/baselines/reference/parserArrowFunctionExpression9(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,1): error TS2304: Cannot find name 'b'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,6): error TS2304: Cannot find name 'c'.
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js(1,16): error TS2304: Cannot find name 'e'.
@@ -7,7 +7,7 @@ tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,
 tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileTs.ts(1,16): error TS2304: Cannot find name 'e'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/fileJs.js (3 errors) ====
     b ? (c) : d => e // Legal JS
     ~

--- a/tests/baselines/reference/preserveUnusedImports.errors.txt
+++ b/tests/baselines/reference/preserveUnusedImports.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
-!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     export type A = {};

--- a/tests/baselines/reference/preserveValueImports(isolatedmodules=false).errors.txt
+++ b/tests/baselines/reference/preserveValueImports(isolatedmodules=false).errors.txt
@@ -1,11 +1,11 @@
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 tests/cases/conformance/externalModules/typeOnly/d.ts(1,1): error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
 tests/cases/conformance/externalModules/typeOnly/e.ts(1,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
 tests/cases/conformance/externalModules/typeOnly/e.ts(2,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
 
 
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
     export default {};

--- a/tests/baselines/reference/preserveValueImports(isolatedmodules=true).errors.txt
+++ b/tests/baselines/reference/preserveValueImports(isolatedmodules=true).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 tests/cases/conformance/externalModules/typeOnly/b.ts(1,19): error TS1444: 'D' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
 tests/cases/conformance/externalModules/typeOnly/d.ts(1,1): error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
@@ -6,7 +6,7 @@ tests/cases/conformance/externalModules/typeOnly/e.ts(1,1): error TS1202: Import
 tests/cases/conformance/externalModules/typeOnly/e.ts(2,1): error TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.
 
 
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
     export default {};

--- a/tests/baselines/reference/preserveValueImports_errors(isolatedmodules=false).errors.txt
+++ b/tests/baselines/reference/preserveValueImports_errors(isolatedmodules=false).errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
     export type A = {};

--- a/tests/baselines/reference/preserveValueImports_errors(isolatedmodules=true).errors.txt
+++ b/tests/baselines/reference/preserveValueImports_errors(isolatedmodules=true).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 tests/cases/conformance/externalModules/typeOnly/c.ts(1,8): error TS1444: 'DefaultA' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
 tests/cases/conformance/externalModules/typeOnly/c.ts(2,10): error TS1444: 'A' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
@@ -10,7 +10,7 @@ tests/cases/conformance/externalModules/typeOnly/e.ts(1,10): error TS1444: 'AA' 
 tests/cases/conformance/externalModules/typeOnly/e.ts(1,14): error TS1446: 'BB' resolves to a type-only declaration and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
 
 
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
     export type A = {};

--- a/tests/baselines/reference/preserveValueImports_importsNotUsedAsValues.errors.txt
+++ b/tests/baselines/reference/preserveValueImports_importsNotUsedAsValues.errors.txt
@@ -1,12 +1,12 @@
-error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
-!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== /mod.ts (0 errors) ====
     export type A = unknown;

--- a/tests/baselines/reference/preserveValueImports_mixedImports.errors.txt
+++ b/tests/baselines/reference/preserveValueImports_mixedImports.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 /index.ts(1,21): error TS1444: 'ComponentProps' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
 
 
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== /exports.ts (0 errors) ====
     export function Component() {}

--- a/tests/baselines/reference/preserveValueImports_module(module=amd).errors.txt
+++ b/tests/baselines/reference/preserveValueImports_module(module=amd).errors.txt
@@ -1,10 +1,10 @@
 error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
 !!! error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/preserveValueImports_module.ts (0 errors) ====
     export {};

--- a/tests/baselines/reference/preserveValueImports_module(module=commonjs).errors.txt
+++ b/tests/baselines/reference/preserveValueImports_module(module=commonjs).errors.txt
@@ -1,10 +1,10 @@
 error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
 !!! error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/preserveValueImports_module.ts (0 errors) ====
     export {};

--- a/tests/baselines/reference/preserveValueImports_module(module=es2015).errors.txt
+++ b/tests/baselines/reference/preserveValueImports_module(module=es2015).errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/preserveValueImports_module.ts (0 errors) ====
     export {};

--- a/tests/baselines/reference/preserveValueImports_module(module=system).errors.txt
+++ b/tests/baselines/reference/preserveValueImports_module(module=system).errors.txt
@@ -1,10 +1,10 @@
 error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
 !!! error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== tests/cases/conformance/externalModules/typeOnly/preserveValueImports_module.ts (0 errors) ====
     export {};

--- a/tests/baselines/reference/privateNameES5Ban(target=es3).errors.txt
+++ b/tests/baselines/reference/privateNameES5Ban(target=es3).errors.txt
@@ -1,4 +1,4 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/classes/members/privateNames/privateNameES5Ban.ts(3,5): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
 tests/cases/conformance/classes/members/privateNames/privateNameES5Ban.ts(4,5): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
 tests/cases/conformance/classes/members/privateNames/privateNameES5Ban.ts(5,12): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
@@ -9,7 +9,7 @@ tests/cases/conformance/classes/members/privateNames/privateNameES5Ban.ts(9,16):
 tests/cases/conformance/classes/members/privateNames/privateNameES5Ban.ts(10,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/classes/members/privateNames/privateNameES5Ban.ts (8 errors) ====
     class A {
         constructor() {}

--- a/tests/baselines/reference/project/declarationDir3/amd/declarationDir3.errors.txt
+++ b/tests/baselines/reference/project/declarationDir3/amd/declarationDir3.errors.txt
@@ -1,9 +1,9 @@
 error TS5053: Option 'declarationDir' cannot be specified with option 'out'.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS5053: Option 'declarationDir' cannot be specified with option 'out'.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== b.ts (0 errors) ====
     export class B {
         

--- a/tests/baselines/reference/project/declarationDir3/node/declarationDir3.errors.txt
+++ b/tests/baselines/reference/project/declarationDir3/node/declarationDir3.errors.txt
@@ -1,10 +1,10 @@
 error TS5053: Option 'declarationDir' cannot be specified with option 'out'.
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
 !!! error TS5053: Option 'declarationDir' cannot be specified with option 'out'.
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== b.ts (0 errors) ====
     export class B {

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecified/amd/jsFileCompilationDifferentNamesNotSpecified.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecified/amd/jsFileCompilationDifferentNamesNotSpecified.errors.txt
@@ -1,11 +1,11 @@
-DifferentNamesNotSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesNotSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 ==== DifferentNamesNotSpecified/tsconfig.json (1 errors) ====
     {
       "compilerOptions": { "out": "test.js" }
                            ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
     }
 ==== DifferentNamesNotSpecified/a.ts (0 errors) ====
     var test = 10;

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecified/node/jsFileCompilationDifferentNamesNotSpecified.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecified/node/jsFileCompilationDifferentNamesNotSpecified.errors.txt
@@ -1,4 +1,4 @@
-DifferentNamesNotSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesNotSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 DifferentNamesNotSpecified/tsconfig.json(2,24): error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
@@ -6,7 +6,7 @@ DifferentNamesNotSpecified/tsconfig.json(2,24): error TS6082: Only 'amd' and 'sy
     {
       "compilerOptions": { "out": "test.js" }
                            ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
                            ~~~~~
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
     }

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs/amd/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs/amd/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs.errors.txt
@@ -1,4 +1,4 @@
-DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 ==== DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json (1 errors) ====
@@ -6,7 +6,7 @@ DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'ou
       "compilerOptions": {
         "out": "test.js",
         ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
         "allowJs": true
       }
     }

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs/node/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs/node/jsFileCompilationDifferentNamesNotSpecifiedWithAllowJs.errors.txt
@@ -1,4 +1,4 @@
-DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json(3,5): error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
@@ -7,7 +7,7 @@ DifferentNamesNotSpecifiedWithAllowJs/tsconfig.json(3,5): error TS6082: Only 'am
       "compilerOptions": {
         "out": "test.js",
         ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
         ~~~~~
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
         "allowJs": true

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecified/amd/jsFileCompilationDifferentNamesSpecified.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecified/amd/jsFileCompilationDifferentNamesSpecified.errors.txt
@@ -1,7 +1,7 @@
 error TS6504: File 'DifferentNamesSpecified/b.js' is a JavaScript file. Did you mean to enable the 'allowJs' option?
   The file is in the program because:
     Part of 'files' list in tsconfig.json
-DifferentNamesSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 !!! error TS6504: File 'DifferentNamesSpecified/b.js' is a JavaScript file. Did you mean to enable the 'allowJs' option?
@@ -12,7 +12,7 @@ DifferentNamesSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is depreca
     {
       "compilerOptions": { "out": "test.js" },
                            ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
       "files": [ "a.ts", "b.js" ]
     }
 ==== DifferentNamesSpecified/a.ts (0 errors) ====

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecified/node/jsFileCompilationDifferentNamesSpecified.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecified/node/jsFileCompilationDifferentNamesSpecified.errors.txt
@@ -1,7 +1,7 @@
 error TS6504: File 'DifferentNamesSpecified/b.js' is a JavaScript file. Did you mean to enable the 'allowJs' option?
   The file is in the program because:
     Part of 'files' list in tsconfig.json
-DifferentNamesSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesSpecified/tsconfig.json(2,24): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 DifferentNamesSpecified/tsconfig.json(2,24): error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
@@ -13,7 +13,7 @@ DifferentNamesSpecified/tsconfig.json(2,24): error TS6082: Only 'amd' and 'syste
     {
       "compilerOptions": { "out": "test.js" },
                            ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
                            ~~~~~
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
       "files": [ "a.ts", "b.js" ]

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecifiedWithAllowJs/amd/jsFileCompilationDifferentNamesSpecifiedWithAllowJs.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecifiedWithAllowJs/amd/jsFileCompilationDifferentNamesSpecifiedWithAllowJs.errors.txt
@@ -1,4 +1,4 @@
-DifferentNamesSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 ==== DifferentNamesSpecifiedWithAllowJs/tsconfig.json (1 errors) ====
@@ -6,7 +6,7 @@ DifferentNamesSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' 
       "compilerOptions": {
         "out": "test.js",
         ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
         "allowJs": true
       },
       "files": [ "a.ts", "b.js" ]

--- a/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecifiedWithAllowJs/node/jsFileCompilationDifferentNamesSpecifiedWithAllowJs.errors.txt
+++ b/tests/baselines/reference/project/jsFileCompilationDifferentNamesSpecifiedWithAllowJs/node/jsFileCompilationDifferentNamesSpecifiedWithAllowJs.errors.txt
@@ -1,4 +1,4 @@
-DifferentNamesSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+DifferentNamesSpecifiedWithAllowJs/tsconfig.json(3,5): error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 DifferentNamesSpecifiedWithAllowJs/tsconfig.json(3,5): error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
@@ -7,7 +7,7 @@ DifferentNamesSpecifiedWithAllowJs/tsconfig.json(3,5): error TS6082: Only 'amd' 
       "compilerOptions": {
         "out": "test.js",
         ~~~~~
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
         ~~~~~
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
         "allowJs": true

--- a/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile/node/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile/node/mapRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/mapRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/node/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSimpleSpecifyOutputFile/node/mapRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/mapRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathMultifolderSpecifyOutputFile/node/mapRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathMultifolderSpecifyOutputFile/node/mapRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathSimpleSpecifyOutputFile/amd/mapRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathSimpleSpecifyOutputFile/amd/mapRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathSimpleSpecifyOutputFile/node/mapRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathSimpleSpecifyOutputFile/node/mapRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathSingleFileSpecifyOutputFile/amd/mapRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathSingleFileSpecifyOutputFile/amd/mapRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathSingleFileSpecifyOutputFile/node/mapRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathSingleFileSpecifyOutputFile/node/mapRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/mapRootAbsolutePathSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathSubfolderSpecifyOutputFile/amd/mapRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootAbsolutePathSubfolderSpecifyOutputFile/node/mapRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathSubfolderSpecifyOutputFile/node/mapRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFile/amd/mapRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFile/amd/mapRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFile/node/mapRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFile/node/mapRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/mapRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/mapRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/mapRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/node/mapRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/node/mapRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/amd/mapRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/amd/mapRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/node/mapRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSimpleSpecifyOutputFile/node/mapRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/amd/mapRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/amd/mapRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/node/mapRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleSubfolderSpecifyOutputFile/node/mapRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathMultifolderSpecifyOutputFile/amd/mapRootRelativePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathMultifolderSpecifyOutputFile/amd/mapRootRelativePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathMultifolderSpecifyOutputFile/node/mapRootRelativePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathMultifolderSpecifyOutputFile/node/mapRootRelativePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathSimpleSpecifyOutputFile/amd/mapRootRelativePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathSimpleSpecifyOutputFile/amd/mapRootRelativePathSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathSimpleSpecifyOutputFile/node/mapRootRelativePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathSimpleSpecifyOutputFile/node/mapRootRelativePathSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathSingleFileSpecifyOutputFile/amd/mapRootRelativePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathSingleFileSpecifyOutputFile/amd/mapRootRelativePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathSingleFileSpecifyOutputFile/node/mapRootRelativePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathSingleFileSpecifyOutputFile/node/mapRootRelativePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/mapRootRelativePathSubfolderSpecifyOutputFile/amd/mapRootRelativePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathSubfolderSpecifyOutputFile/amd/mapRootRelativePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/mapRootRelativePathSubfolderSpecifyOutputFile/node/mapRootRelativePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathSubfolderSpecifyOutputFile/node/mapRootRelativePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFile/amd/maprootUrlMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFile/amd/maprootUrlMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFile/node/maprootUrlMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFile/node/maprootUrlMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/maprootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlMultifolderSpecifyOutputFile/amd/maprootUrlMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlMultifolderSpecifyOutputFile/amd/maprootUrlMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlMultifolderSpecifyOutputFile/node/maprootUrlMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlMultifolderSpecifyOutputFile/node/maprootUrlMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlSimpleSpecifyOutputFile/amd/maprootUrlSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlSimpleSpecifyOutputFile/amd/maprootUrlSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlSimpleSpecifyOutputFile/node/maprootUrlSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlSimpleSpecifyOutputFile/node/maprootUrlSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlSingleFileSpecifyOutputFile/amd/maprootUrlSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlSingleFileSpecifyOutputFile/amd/maprootUrlSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/maprootUrlSingleFileSpecifyOutputFile/node/maprootUrlSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlSingleFileSpecifyOutputFile/node/maprootUrlSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlSubfolderSpecifyOutputFile/amd/maprootUrlSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlSubfolderSpecifyOutputFile/amd/maprootUrlSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlSubfolderSpecifyOutputFile/node/maprootUrlSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlSubfolderSpecifyOutputFile/node/maprootUrlSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/maprootUrlsourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile/node/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile/node/maprootUrlsourcerootUrlMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlSimpleSpecifyOutputFile/amd/maprootUrlsourcerootUrlSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlSimpleSpecifyOutputFile/amd/maprootUrlsourcerootUrlSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlSimpleSpecifyOutputFile/node/maprootUrlsourcerootUrlSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlSimpleSpecifyOutputFile/node/maprootUrlsourcerootUrlSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile/amd/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile/amd/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile/node/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile/node/maprootUrlsourcerootUrlSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile/node/maprootUrlsourcerootUrlSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFile/amd/outMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFile/amd/outMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFile/node/outMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFile/node/outMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/outMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/outMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/outMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/outMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/outMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/outModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/outModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/node/outModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/node/outModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/amd/outModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/amd/outModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/node/outModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outModuleSimpleSpecifyOutputFile/node/outModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/amd/outModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/amd/outModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/node/outModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outModuleSubfolderSpecifyOutputFile/node/outModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/outMultifolderSpecifyOutputFile/amd/outMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outMultifolderSpecifyOutputFile/amd/outMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/outMultifolderSpecifyOutputFile/node/outMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outMultifolderSpecifyOutputFile/node/outMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/outSimpleSpecifyOutputFile/amd/outSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outSimpleSpecifyOutputFile/amd/outSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/outSimpleSpecifyOutputFile/node/outSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outSimpleSpecifyOutputFile/node/outSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/outSingleFileSpecifyOutputFile/amd/outSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outSingleFileSpecifyOutputFile/amd/outSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/outSingleFileSpecifyOutputFile/node/outSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outSingleFileSpecifyOutputFile/node/outSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/outSubfolderSpecifyOutputFile/amd/outSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outSubfolderSpecifyOutputFile/amd/outSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/outSubfolderSpecifyOutputFile/node/outSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/outSubfolderSpecifyOutputFile/node/outSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/prologueEmit/amd/prologueEmit.errors.txt
+++ b/tests/baselines/reference/project/prologueEmit/amd/prologueEmit.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== globalThisCapture.ts (0 errors) ====
     // Add a lambda to ensure global 'this' capture is triggered
     (()=>this.window);

--- a/tests/baselines/reference/project/prologueEmit/node/prologueEmit.errors.txt
+++ b/tests/baselines/reference/project/prologueEmit/node/prologueEmit.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== globalThisCapture.ts (0 errors) ====
     // Add a lambda to ensure global 'this' capture is triggered

--- a/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourceRootAbsolutePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/node/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile/node/sourceRootAbsolutePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathMultifolderSpecifyOutputFile/node/sourceRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathMultifolderSpecifyOutputFile/node/sourceRootAbsolutePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathSimpleSpecifyOutputFile/amd/sourceRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathSimpleSpecifyOutputFile/amd/sourceRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathSimpleSpecifyOutputFile/node/sourceRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathSimpleSpecifyOutputFile/node/sourceRootAbsolutePathSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathSingleFileSpecifyOutputFile/amd/sourceRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathSingleFileSpecifyOutputFile/amd/sourceRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathSingleFileSpecifyOutputFile/node/sourceRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathSingleFileSpecifyOutputFile/node/sourceRootAbsolutePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathSubfolderSpecifyOutputFile/amd/sourceRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathSubfolderSpecifyOutputFile/node/sourceRootAbsolutePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFile/amd/sourceRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFile/amd/sourceRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFile/node/sourceRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFile/node/sourceRootRelativePathMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourceRootRelativePathMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/node/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/node/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/amd/sourceRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/amd/sourceRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/node/sourceRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSimpleSpecifyOutputFile/node/sourceRootRelativePathModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/amd/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/amd/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/node/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleSubfolderSpecifyOutputFile/node/sourceRootRelativePathModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathMultifolderSpecifyOutputFile/amd/sourceRootRelativePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathMultifolderSpecifyOutputFile/amd/sourceRootRelativePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathMultifolderSpecifyOutputFile/node/sourceRootRelativePathMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathMultifolderSpecifyOutputFile/node/sourceRootRelativePathMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathSimpleSpecifyOutputFile/amd/sourceRootRelativePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathSimpleSpecifyOutputFile/amd/sourceRootRelativePathSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathSimpleSpecifyOutputFile/node/sourceRootRelativePathSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathSimpleSpecifyOutputFile/node/sourceRootRelativePathSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathSingleFileSpecifyOutputFile/amd/sourceRootRelativePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathSingleFileSpecifyOutputFile/amd/sourceRootRelativePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathSingleFileSpecifyOutputFile/node/sourceRootRelativePathSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathSingleFileSpecifyOutputFile/node/sourceRootRelativePathSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/sourceRootRelativePathSubfolderSpecifyOutputFile/amd/sourceRootRelativePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathSubfolderSpecifyOutputFile/amd/sourceRootRelativePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourceRootRelativePathSubfolderSpecifyOutputFile/node/sourceRootRelativePathSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathSubfolderSpecifyOutputFile/node/sourceRootRelativePathSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFile/amd/sourcemapMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFile/amd/sourcemapMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFile/node/sourcemapMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFile/node/sourcemapMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourcemapMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/sourcemapModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/sourcemapModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/node/sourcemapModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/node/sourcemapModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/amd/sourcemapModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/amd/sourcemapModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/node/sourcemapModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapModuleSimpleSpecifyOutputFile/node/sourcemapModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/amd/sourcemapModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/amd/sourcemapModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/node/sourcemapModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapModuleSubfolderSpecifyOutputFile/node/sourcemapModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapMultifolderSpecifyOutputFile/amd/sourcemapMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapMultifolderSpecifyOutputFile/amd/sourcemapMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapMultifolderSpecifyOutputFile/node/sourcemapMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapMultifolderSpecifyOutputFile/node/sourcemapMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapSimpleSpecifyOutputFile/amd/sourcemapSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapSimpleSpecifyOutputFile/amd/sourcemapSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapSimpleSpecifyOutputFile/node/sourcemapSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapSimpleSpecifyOutputFile/node/sourcemapSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcemapSingleFileSpecifyOutputFile/amd/sourcemapSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapSingleFileSpecifyOutputFile/amd/sourcemapSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/sourcemapSingleFileSpecifyOutputFile/node/sourcemapSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapSingleFileSpecifyOutputFile/node/sourcemapSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/sourcemapSubfolderSpecifyOutputFile/amd/sourcemapSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapSubfolderSpecifyOutputFile/amd/sourcemapSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcemapSubfolderSpecifyOutputFile/node/sourcemapSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcemapSubfolderSpecifyOutputFile/node/sourcemapSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFile/amd/sourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFile/amd/sourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFile/node/sourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFile/node/sourcerootUrlMixedSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/amd/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory/node/sourcerootUrlMixedSubfolderSpecifyOutputFileAndOutputDirectory.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/sourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/sourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/node/sourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/node/sourcerootUrlModuleMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/amd/sourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/amd/sourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/node/sourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSimpleSpecifyOutputFile/node/sourcerootUrlModuleSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/amd/sourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/amd/sourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;
     export class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/node/sourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlModuleSubfolderSpecifyOutputFile/node/sourcerootUrlModuleSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     export var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlMultifolderSpecifyOutputFile/amd/sourcerootUrlMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlMultifolderSpecifyOutputFile/amd/sourcerootUrlMultifolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlMultifolderSpecifyOutputFile/node/sourcerootUrlMultifolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlMultifolderSpecifyOutputFile/node/sourcerootUrlMultifolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlSimpleSpecifyOutputFile/amd/sourcerootUrlSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlSimpleSpecifyOutputFile/amd/sourcerootUrlSimpleSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlSimpleSpecifyOutputFile/node/sourcerootUrlSimpleSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlSimpleSpecifyOutputFile/node/sourcerootUrlSimpleSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlSingleFileSpecifyOutputFile/amd/sourcerootUrlSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlSingleFileSpecifyOutputFile/amd/sourcerootUrlSingleFileSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== test.ts (0 errors) ====
     var a1 = 10;
     class c1 {

--- a/tests/baselines/reference/project/sourcerootUrlSingleFileSpecifyOutputFile/node/sourcerootUrlSingleFileSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlSingleFileSpecifyOutputFile/node/sourcerootUrlSingleFileSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== test.ts (0 errors) ====
     var a1 = 10;

--- a/tests/baselines/reference/project/sourcerootUrlSubfolderSpecifyOutputFile/amd/sourcerootUrlSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlSubfolderSpecifyOutputFile/amd/sourcerootUrlSubfolderSpecifyOutputFile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;
     class m1_c1 {

--- a/tests/baselines/reference/project/sourcerootUrlSubfolderSpecifyOutputFile/node/sourcerootUrlSubfolderSpecifyOutputFile.errors.txt
+++ b/tests/baselines/reference/project/sourcerootUrlSubfolderSpecifyOutputFile/node/sourcerootUrlSubfolderSpecifyOutputFile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6082: Only 'amd' and 'system' modules are supported alongside --out.
 ==== ref/m1.ts (0 errors) ====
     var m1_a1 = 10;

--- a/tests/baselines/reference/propertyAccessNumericLiterals.errors.txt
+++ b/tests/baselines/reference/propertyAccessNumericLiterals.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/expressions/propertyAccess/propertyAccessNumericLiterals.ts (0 errors) ====
     0xffffffff.toString();
     0o01234.toString();

--- a/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.errors.txt
+++ b/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/jsDocOptionality.js (0 errors) ====
     function MyClass() {
       this.prop = null;

--- a/tests/baselines/reference/sourceMap-Comment1.errors.txt
+++ b/tests/baselines/reference/sourceMap-Comment1.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-Comment1.ts (0 errors) ====
     // Comment

--- a/tests/baselines/reference/sourceMap-EmptyFile1.errors.txt
+++ b/tests/baselines/reference/sourceMap-EmptyFile1.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-EmptyFile1.ts (0 errors) ====
     

--- a/tests/baselines/reference/sourceMap-InterfacePrecedingVariableDeclaration1.errors.txt
+++ b/tests/baselines/reference/sourceMap-InterfacePrecedingVariableDeclaration1.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-InterfacePrecedingVariableDeclaration1.ts (0 errors) ====
     interface I {}
     var x = 0;

--- a/tests/baselines/reference/sourceMap-LineBreaks.errors.txt
+++ b/tests/baselines/reference/sourceMap-LineBreaks.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-LineBreaks.ts (0 errors) ====
     var endsWithlineSeparator = 10;  var endsWithParagraphSeparator = 10;  var endsWithNextLine = 1;var endsWithLineFeed = 1;
     var endsWithCarriageReturnLineFeed = 1;

--- a/tests/baselines/reference/sourceMap-NewLine1.errors.txt
+++ b/tests/baselines/reference/sourceMap-NewLine1.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-NewLine1.ts (0 errors) ====
     

--- a/tests/baselines/reference/sourceMap-SemiColon1.errors.txt
+++ b/tests/baselines/reference/sourceMap-SemiColon1.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-SemiColon1.ts (0 errors) ====
     ;
     

--- a/tests/baselines/reference/sourceMap-SingleSpace1.errors.txt
+++ b/tests/baselines/reference/sourceMap-SingleSpace1.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-SingleSpace1.ts (0 errors) ====
      

--- a/tests/baselines/reference/sourceMap-StringLiteralWithNewLine.errors.txt
+++ b/tests/baselines/reference/sourceMap-StringLiteralWithNewLine.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/sourceMap-StringLiteralWithNewLine.ts (0 errors) ====
     interface Document {
     }

--- a/tests/baselines/reference/sourceMapWithCaseSensitiveFileNames.errors.txt
+++ b/tests/baselines/reference/sourceMapWithCaseSensitiveFileNames.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/testFiles/app.ts (0 errors) ====
     // Note in the out result we are using same folder name only different in casing
     // Since this is case sensitive, the folders are different and hence the relative paths in sourcemap shouldn't be just app.ts or app2.ts

--- a/tests/baselines/reference/sourceMapWithMultipleFilesWithCopyright.errors.txt
+++ b/tests/baselines/reference/sourceMapWithMultipleFilesWithCopyright.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/b.ts (0 errors) ====
     /*--------------------------------------------------------------------------
     Copyright 

--- a/tests/baselines/reference/sourceMapWithMultipleFilesWithFileEndingWithInterface.errors.txt
+++ b/tests/baselines/reference/sourceMapWithMultipleFilesWithFileEndingWithInterface.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/a.ts (0 errors) ====
     module M {
         export var X = 1;

--- a/tests/baselines/reference/sourceMapWithNonCaseSensitiveFileNames.errors.txt
+++ b/tests/baselines/reference/sourceMapWithNonCaseSensitiveFileNames.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/testFiles/app.ts (0 errors) ====
     // Note in the out result we are using same folder name only different in casing
     // Since this is non case sensitive, the relative paths should be just app.ts and app2.ts in the sourcemap

--- a/tests/baselines/reference/taggedTemplateStringsWithCurriedFunction.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithCurriedFunction.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/taggedTemplateStringsWithCurriedFunction.ts (0 errors) ====
     // Originated from #38558
     

--- a/tests/baselines/reference/topLevelThisAssignment.errors.txt
+++ b/tests/baselines/reference/topLevelThisAssignment.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/salsa/a.js (0 errors) ====
     this.a = 10;
     this.a;

--- a/tests/baselines/reference/trailingCommasES3.errors.txt
+++ b/tests/baselines/reference/trailingCommasES3.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/compiler/trailingCommasES3.ts (0 errors) ====
     var o1 = { a: 1, b: 2 };
     var o2 = { a: 1, b: 2, };

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics.errors.txt
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x: string = 0;

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x: string = 0;

--- a/tests/baselines/reference/transpile/Elides import equals referenced only by export type.errors.txt
+++ b/tests/baselines/reference/transpile/Elides import equals referenced only by export type.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import IFoo = Namespace.IFoo;export type { IFoo };

--- a/tests/baselines/reference/transpile/Elides import equals referenced only by export type.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Elides import equals referenced only by export type.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import IFoo = Namespace.IFoo;export type { IFoo };

--- a/tests/baselines/reference/transpile/Elides import equals referenced only by type only export specifier.errors.txt
+++ b/tests/baselines/reference/transpile/Elides import equals referenced only by type only export specifier.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import IFoo = Namespace.IFoo;export { type IFoo };

--- a/tests/baselines/reference/transpile/Elides import equals referenced only by type only export specifier.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Elides import equals referenced only by type only export specifier.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import IFoo = Namespace.IFoo;export { type IFoo };

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash.errors.txt
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     
     var a;

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash.oldTranspile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     
     var a;

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.errors.txt
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 file.ts(1,1): error TS1434: Unexpected keyword or identifier.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (1 errors) ====
     a b
     ~

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.oldTranspile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 file.ts(1,1): error TS1434: Unexpected keyword or identifier.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (1 errors) ====
     a b
     ~

--- a/tests/baselines/reference/transpile/Generates module output.errors.txt
+++ b/tests/baselines/reference/transpile/Generates module output.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 0;

--- a/tests/baselines/reference/transpile/Generates module output.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates module output.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     /// <reference path="file2.ts" />
     var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.oldTranspile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     /// <reference path="file2.ts" />
     var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import {a} from "module2";

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import {a} from "module2";

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 0;

--- a/tests/baselines/reference/transpile/Infer correct file extension.errors.txt
+++ b/tests/baselines/reference/transpile/Infer correct file extension.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     const fn = <T>(a: T) => a

--- a/tests/baselines/reference/transpile/Infer correct file extension.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Infer correct file extension.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     const fn = <T>(a: T) => a

--- a/tests/baselines/reference/transpile/No extra errors for file without extension.errors.txt
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file (0 errors) ====
     "use strict";
     var x = 0;

--- a/tests/baselines/reference/transpile/No extra errors for file without extension.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension.oldTranspile.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file (0 errors) ====
     "use strict";
     var x = 0;

--- a/tests/baselines/reference/transpile/Rename dependencies - AMD.errors.txt
+++ b/tests/baselines/reference/transpile/Rename dependencies - AMD.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import {foo} from "SomeName";
     declare function use(a: any);

--- a/tests/baselines/reference/transpile/Rename dependencies - System.errors.txt
+++ b/tests/baselines/reference/transpile/Rename dependencies - System.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import {foo} from "SomeName";
     declare function use(a: any);

--- a/tests/baselines/reference/transpile/Rename dependencies - UMD.errors.txt
+++ b/tests/baselines/reference/transpile/Rename dependencies - UMD.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     import {foo} from "SomeName";
     declare function use(a: any);

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 ==== file.ts (0 errors) ====
     

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.oldTranspile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 ==== file.ts (0 errors) ====
     

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 ==== file.ts (0 errors) ====
     

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.oldTranspile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS6046: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.
 ==== file.ts (0 errors) ====
     

--- a/tests/baselines/reference/transpile/Sets module name.errors.txt
+++ b/tests/baselines/reference/transpile/Sets module name.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 1;

--- a/tests/baselines/reference/transpile/Sets module name.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Sets module name.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 1;

--- a/tests/baselines/reference/transpile/Support options with lib values.errors.txt
+++ b/tests/baselines/reference/transpile/Support options with lib values.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     const a = 10;

--- a/tests/baselines/reference/transpile/Support options with lib values.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Support options with lib values.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     const a = 10;

--- a/tests/baselines/reference/transpile/Support options with types values.errors.txt
+++ b/tests/baselines/reference/transpile/Support options with types values.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     const a = 10;

--- a/tests/baselines/reference/transpile/Support options with types values.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Support options with types values.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     const a = 10;

--- a/tests/baselines/reference/transpile/Supports as const arrays.errors.txt
+++ b/tests/baselines/reference/transpile/Supports as const arrays.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     ([] as const).forEach(k => console.log(k));

--- a/tests/baselines/reference/transpile/Supports as const arrays.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports as const arrays.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     ([] as const).forEach(k => console.log(k));

--- a/tests/baselines/reference/transpile/Supports backslashes in file name.errors.txt
+++ b/tests/baselines/reference/transpile/Supports backslashes in file name.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== a\b.ts (0 errors) ====
     var x

--- a/tests/baselines/reference/transpile/Supports backslashes in file name.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports backslashes in file name.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== a\b.ts (0 errors) ====
     var x

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays.errors.txt
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     let x: readonly string[];

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     let x: readonly string[];

--- a/tests/baselines/reference/transpile/Supports setting allowJs.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowJs.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting allowJs.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowJs.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting baseUrl.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting baseUrl.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting charset.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting charset.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting charset.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting charset.oldTranspile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting composite.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting composite.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting composite.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting composite.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting declaration.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declaration.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting declaration.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declaration.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting declarationDir.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting declarationDir.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting emitBOM.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting emitBOM.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting incremental.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting incremental.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting incremental.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting incremental.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting isolatedModules.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting isolatedModules.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting isolatedModules.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting isolatedModules.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting jsx.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsx.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting jsx.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsx.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting lib.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting lib.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting lib.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting lib.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting locale.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting locale.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting locale.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting locale.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting module.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting module.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting module.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting module.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting newLine.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting newLine.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting newLine.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting newLine.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noEmit.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmit.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noEmit.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmit.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict.oldTranspile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noLib.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noLib.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noLib.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noLib.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noResolve.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noResolve.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting noResolve.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noResolve.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting out.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting out.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting out.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting out.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting outDir.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outDir.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting outDir.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outDir.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting outFile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outFile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting outFile.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outFile.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting paths.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting paths.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting paths.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting paths.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting removeComments.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting removeComments.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting removeComments.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting removeComments.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting rootDir.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDir.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ./rootDir/input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting rootDir.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDir.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== ./rootDir/input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting rootDirs.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting rootDirs.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting stripInternal.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting stripInternal.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.oldTranspile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.oldTranspile.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
-!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5101: Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting tsbuildinfo.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting tsbuildinfo.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting tsbuildinfo.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting tsbuildinfo.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting typeRoots.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting typeRoots.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting types.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting types.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports setting types.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting types.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     x;

--- a/tests/baselines/reference/transpile/Supports urls in file name.errors.txt
+++ b/tests/baselines/reference/transpile/Supports urls in file name.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== http://somewhere/directory//directory2/file.ts (0 errors) ====
     var x

--- a/tests/baselines/reference/transpile/Supports urls in file name.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports urls in file name.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== http://somewhere/directory//directory2/file.ts (0 errors) ====
     var x

--- a/tests/baselines/reference/transpile/Uses correct newLine character.errors.txt
+++ b/tests/baselines/reference/transpile/Uses correct newLine character.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 0;

--- a/tests/baselines/reference/transpile/Uses correct newLine character.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Uses correct newLine character.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
     var x = 0;

--- a/tests/baselines/reference/transpile/transpile .js files.errors.txt
+++ b/tests/baselines/reference/transpile/transpile .js files.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     const a = 10;

--- a/tests/baselines/reference/transpile/transpile .js files.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/transpile .js files.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== input.js (0 errors) ====
     const a = 10;

--- a/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.errors.txt
+++ b/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.tsx (0 errors) ====
     var x = <div/>

--- a/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.oldTranspile.errors.txt
@@ -1,6 +1,6 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.tsx (0 errors) ====
     var x = <div/>

--- a/tests/baselines/reference/tsbuild/amdModulesWithOut/prepend-reports-deprecation-error.js
+++ b/tests/baselines/reference/tsbuild/amdModulesWithOut/prepend-reports-deprecation-error.js
@@ -82,7 +82,7 @@ Output::
 
 [[90m12:00:19 AM[0m] Building project '/src/app/tsconfig.json'...
 
-[96msrc/app/tsconfig.json[0m:[93m14[0m:[93m9[0m - [91merror[0m[90m TS5101: [0mFlag 'prepend' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96msrc/app/tsconfig.json[0m:[93m14[0m:[93m9[0m - [91merror[0m[90m TS5101: [0mFlag 'prepend' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 [7m14[0m         { "path": "../lib", "prepend": true }
 [7m  [0m [91m        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
@@ -500,7 +500,7 @@ Output::
 
 [[90m12:00:34 AM[0m] Building project '/src/app/tsconfig.json'...
 
-[96msrc/app/tsconfig.json[0m:[93m14[0m:[93m9[0m - [91merror[0m[90m TS5101: [0mFlag 'prepend' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96msrc/app/tsconfig.json[0m:[93m14[0m:[93m9[0m - [91merror[0m[90m TS5101: [0mFlag 'prepend' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 [7m14[0m         { "path": "../lib", "prepend": true }
 [7m  [0m [91m        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m

--- a/tests/baselines/reference/tsbuild/sample1/can-detect-when-and-what-to-rebuild.js
+++ b/tests/baselines/reference/tsbuild/sample1/can-detect-when-and-what-to-rebuild.js
@@ -714,7 +714,7 @@ Output::
 
 [[90m12:01:03 AM[0m] Building project '/src/tests/tsconfig.json'...
 
-[96msrc/tests/tsconfig.json[0m:[93m8[0m:[93m38[0m - [91merror[0m[90m TS5101: [0mFlag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96msrc/tests/tsconfig.json[0m:[93m8[0m:[93m38[0m - [91merror[0m[90m TS5101: [0mFlag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 [7m8[0m         "composite": true, "target": "es3",
 [7m [0m [91m                                     ~~~~~[0m

--- a/tests/baselines/reference/tsbuild/sample1/rebuilds-when-extended-config-file-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/rebuilds-when-extended-config-file-changes.js
@@ -131,7 +131,7 @@ Output::
 
 [[90m12:00:29 AM[0m] Building project '/src/tests/tsconfig.json'...
 
-[91merror[0m[90m TS5101: [0mFlag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[91merror[0m[90m TS5101: [0mFlag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
 Found 1 error.

--- a/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
+++ b/tests/baselines/reference/tscWatch/emit/emit-with-outFile-or-out-setting/config-has-out.js
@@ -27,7 +27,7 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-[96ma/tsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96ma/tsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 [7m1[0m {"compilerOptions":{"out":"/a/out.js"}}
 [7m [0m [91m                    ~~~~~[0m
@@ -85,7 +85,7 @@ Output::
 >> Screen clear
 [[90m12:00:22 AM[0m] File change detected. Starting incremental compilation...
 
-[96ma/tsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96ma/tsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 [7m1[0m {"compilerOptions":{"out":"/a/out.js"}}
 [7m [0m [91m                    ~~~~~[0m
@@ -143,7 +143,7 @@ Output::
 >> Screen clear
 [[90m12:00:30 AM[0m] File change detected. Starting incremental compilation...
 
-[96ma/tsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96ma/tsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 [7m1[0m {"compilerOptions":{"out":"/a/out.js"}}
 [7m [0m [91m                    ~~~~~[0m

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-diagnostics-and-emit-for-decorators.js
@@ -31,7 +31,7 @@ Output::
 >> Screen clear
 [[90m12:00:15 AM[0m] Starting compilation in watch mode...
 
-[96mtsconfig.json[0m:[93m1[0m:[93m36[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96mtsconfig.json[0m:[93m1[0m:[93m36[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 [7m1[0m {"compilerOptions":{"target":"es6","importsNotUsedAsValues":"error"}}
@@ -149,7 +149,7 @@ Output::
 >> Screen clear
 [[90m12:00:23 AM[0m] File change detected. Starting incremental compilation...
 
-[96mtsconfig.json[0m:[93m1[0m:[93m36[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96mtsconfig.json[0m:[93m1[0m:[93m36[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 [7m1[0m {"compilerOptions":{"target":"es6","importsNotUsedAsValues":"error","experimentalDecorators":true}}
@@ -219,7 +219,7 @@ Output::
 >> Screen clear
 [[90m12:00:33 AM[0m] File change detected. Starting incremental compilation...
 
-[96mtsconfig.json[0m:[93m1[0m:[93m36[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96mtsconfig.json[0m:[93m1[0m:[93m36[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 [7m1[0m {"compilerOptions":{"target":"es6","importsNotUsedAsValues":"error","experimentalDecorators":true,"emitDecoratorMetadata":true}}

--- a/tests/baselines/reference/tscWatch/programUpdates/updates-errors-and-emit-when-importsNotUsedAsValues-changes.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/updates-errors-and-emit-when-importsNotUsedAsValues-changes.js
@@ -155,7 +155,7 @@ Output::
 >> Screen clear
 [[90m12:00:43 AM[0m] File change detected. Starting incremental compilation...
 
-[96mtsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96mtsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 [7m1[0m {"compilerOptions":{"importsNotUsedAsValues":"error"}}
@@ -219,7 +219,7 @@ Output::
 >> Screen clear
 [[90m12:00:54 AM[0m] File change detected. Starting incremental compilation...
 
-[96mtsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+[96mtsconfig.json[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS5101: [0mFlag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 [7m1[0m {"compilerOptions":{"importsNotUsedAsValues":"preserve"}}

--- a/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.errors.txt
+++ b/tests/baselines/reference/typeFromPropertyAssignmentOutOfOrder.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/salsa/index.js (0 errors) ====
     First.Item = class I {}
     Common.Object = class extends First.Item {}

--- a/tests/baselines/reference/typeReferenceDirectives11.errors.txt
+++ b/tests/baselines/reference/typeReferenceDirectives11.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 /mod1.ts(1,17): error TS6131: Cannot compile modules using option 'out' unless the '--module' flag is 'amd' or 'system'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== /mod2.ts (0 errors) ====
     import {foo} from "./mod1";
     export const bar = foo();

--- a/tests/baselines/reference/typeReferenceDirectives12.errors.txt
+++ b/tests/baselines/reference/typeReferenceDirectives12.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 /main.ts(1,14): error TS6131: Cannot compile modules using option 'out' unless the '--module' flag is 'amd' or 'system'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== /mod2.ts (0 errors) ====
     import { Cls } from "./main";
     import "./mod1";

--- a/tests/baselines/reference/typeSatisfaction_js.errors.txt
+++ b/tests/baselines/reference/typeSatisfaction_js.errors.txt
@@ -1,8 +1,8 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 /src/a.js(1,29): error TS8037: Type satisfaction expressions can only be used in TypeScript files.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== /src/a.js (1 errors) ====
     var v = undefined satisfies 1;
                                 ~

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJs.errors.txt
@@ -1,7 +1,7 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJs.js (0 errors) ====
     // classes
     class C {

--- a/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolsDeclarationsInJsErrors.errors.txt
@@ -1,9 +1,9 @@
-error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js(5,12): error TS1331: A property of a class whose type is a 'unique symbol' type must be both 'static' and 'readonly'.
 tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js(14,12): error TS1331: A property of a class whose type is a 'unique symbol' type must be both 'static' and 'readonly'.
 
 
-!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'out' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsInJsErrors.js (2 errors) ====
     class C {
         /**

--- a/tests/baselines/reference/verbatimModuleSyntaxCompat.errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxCompat.errors.txt
@@ -1,7 +1,7 @@
 error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
 error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
@@ -10,9 +10,9 @@ error TS5105: Option 'verbatimModuleSyntax' cannot be used when 'module' is set 
 
 
 !!! error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 !!! error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
 !!! error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.

--- a/tests/baselines/reference/verbatimModuleSyntaxCompat2.errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxCompat2.errors.txt
@@ -1,9 +1,9 @@
 /tsconfig.json(4,9): error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
 /tsconfig.json(5,9): error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-/tsconfig.json(5,9): error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+/tsconfig.json(5,9): error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 /tsconfig.json(5,9): error TS5104: Option 'preserveValueImports' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
-/tsconfig.json(6,9): error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+/tsconfig.json(6,9): error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 /tsconfig.json(6,9): error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
 
@@ -19,13 +19,13 @@
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
             ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS5104: Option 'preserveValueImports' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
             "importsNotUsedAsValues": "error",
             ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
             ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.

--- a/tests/baselines/reference/verbatimModuleSyntaxCompat3.errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxCompat3.errors.txt
@@ -1,14 +1,14 @@
 error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
-error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 
 
 !!! error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
 ==== /tsconfig.json (0 errors) ====
     {

--- a/tests/baselines/reference/verbatimModuleSyntaxCompat4.errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxCompat4.errors.txt
@@ -1,9 +1,9 @@
 /tsconfig.json(4,9): error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
 /tsconfig.json(5,9): error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
-/tsconfig.json(5,9): error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+/tsconfig.json(5,9): error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 /tsconfig.json(5,9): error TS5104: Option 'preserveValueImports' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
-/tsconfig.json(6,9): error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+/tsconfig.json(6,9): error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
   Use 'verbatimModuleSyntax' instead.
 /tsconfig.json(6,9): error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
 
@@ -19,13 +19,13 @@
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS5095: Option 'preserveValueImports' can only be used when 'module' is set to 'es2015' or later.
             ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'preserveValueImports' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS5104: Option 'preserveValueImports' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
             "importsNotUsedAsValues": "error",
             ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify 'ignoreDeprecations: "5.0"' to silence this error.
+!!! error TS5101: Flag 'importsNotUsedAsValues' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 !!! error TS5101:   Use 'verbatimModuleSyntax' instead.
             ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.


### PR DESCRIPTION
After this change, you can copy and paste out of the error message, and it tells you which block it's supposed to be in (if you put it at the top level, it'll silently not work).