### PR TITLE
Fix debug assert for type assertions / JSX

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6167,7 +6167,7 @@ namespace Parser {
     }
 
     function parseTypeAssertion(): TypeAssertion {
-        Debug.assert(scriptKind === ScriptKind.TS, "Type assertions should never be parsed outside of TS; they should either be comparisons or JSX.");
+        Debug.assert(languageVariant !== LanguageVariant.JSX, "Type assertions should never be parsed in JSX; they should be parsed as comparisons or JSX elements/fragments.");
         const pos = getNodePos();
         parseExpected(SyntaxKind.LessThanToken);
         const type = parseType();


### PR DESCRIPTION
For https://github.com/vuejs/language-tools/issues/2434

Plugins can have their own script kinds / extensions / variants, which means that `LanguageVariant.JSX` and `ScriptKind.TS` are not mutually exclusive.

Just fix the assert to check the language variant, which is what we actually use to determine if a file should contain JSX elements (and therefore cannot contain old style type assertions).

I'd write a test for this, but, there don't appear to be any tests for external script kinds and this is supposed to be best-effort to prevent potential oddities / crashes in the checker anyway.