### PR TITLE
Run lint in parallel with runtests-parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     - run:  npm ci
 
     - name: Tests
+      # run tests, but lint separately
       run:  npm run test -- --no-lint --bundle=${{ matrix.bundle }}
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - run:  npm ci
 
     - name: Tests
-      run:  npm run test -- --bundle=${{ matrix.bundle }}
+      run:  npm run test -- --no-lint --bundle=${{ matrix.bundle }}
 
   lint:
     runs-on: ubuntu-latest

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -569,12 +569,19 @@ export const watchLocal = task({
 
 const runtestsDeps = [tests, generateLibs].concat(cmdLineOptions.typecheck ? [dts] : []);
 
-export const runTests = task({
-    name: "runtests",
+const runTests = task({
+    name: "runtests-nolint",
     description: "Runs the tests using the built run.js file.",
     dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "mocha-fivemat-progress-reporter", /*runInParallel*/ false),
 });
+
+export const runTestsAndLint = task({
+    name: "runtests",
+    description: "Runs the tests using the built run.js file, linting in parallel if --lint=true.",
+    dependencies: [runTests].concat(cmdLineOptions.lint ? [lint] : []),
+});
+
 // task("runtests").flags = {
 //     "-t --tests=<regex>": "Pattern for tests to run.",
 //     "   --failed": "Runs tests listed in '.failed-tests'.",
@@ -702,12 +709,19 @@ export const runTestsAndWatch = task({
     },
 });
 
-export const runTestsParallel = task({
-    name: "runtests-parallel",
+const runTestsParallel = task({
+    name: "runtests-parallel-nolint",
     description: "Runs all the tests in parallel using the built run.js file.",
     dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "min", /*runInParallel*/ cmdLineOptions.workers > 1),
 });
+
+export const runTestsParallelAndLint = task({
+    name: "runtests-parallel",
+    description: "Runs all the tests in parallel using the built run.js file, linting in parallel if --lint=true.",
+    dependencies: [runTestsParallel].concat(cmdLineOptions.lint ? [lint] : []),
+});
+
 // task("runtests-parallel").flags = {
 //     "   --light": "Run tests in light mode (fewer verifications, but tests run faster).",
 //     "   --keepFailed": "Keep tests in .failed-tests even if they pass.",

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -575,7 +575,6 @@ export const runTests = task({
     dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "mocha-fivemat-progress-reporter", /*runInParallel*/ false),
 });
-
 // task("runtests").flags = {
 //     "-t --tests=<regex>": "Pattern for tests to run.",
 //     "   --failed": "Runs tests listed in '.failed-tests'.",

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -569,17 +569,17 @@ export const watchLocal = task({
 
 const runtestsDeps = [tests, generateLibs].concat(cmdLineOptions.typecheck ? [dts] : []);
 
-const runTests = task({
-    name: "runtests-nolint",
+const doRunTests = task({
+    name: "do-runtests",
     description: "Runs the tests using the built run.js file.",
     dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "mocha-fivemat-progress-reporter", /*runInParallel*/ false),
 });
 
-export const runTestsAndLint = task({
+export const runTests = task({
     name: "runtests",
     description: "Runs the tests using the built run.js file, linting in parallel if --lint=true.",
-    dependencies: [runTests].concat(cmdLineOptions.lint ? [lint] : []),
+    dependencies: [doRunTests].concat(cmdLineOptions.lint ? [lint] : []),
 });
 
 // task("runtests").flags = {
@@ -709,17 +709,17 @@ export const runTestsAndWatch = task({
     },
 });
 
-const runTestsParallel = task({
-    name: "runtests-parallel-nolint",
+const doRunTestsParallel = task({
+    name: "do-runtests-parallel",
     description: "Runs all the tests in parallel using the built run.js file.",
     dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "min", /*runInParallel*/ cmdLineOptions.workers > 1),
 });
 
-export const runTestsParallelAndLint = task({
+export const runTestsParallel = task({
     name: "runtests-parallel",
     description: "Runs all the tests in parallel using the built run.js file, linting in parallel if --lint=true.",
-    dependencies: [runTestsParallel].concat(cmdLineOptions.lint ? [lint] : []),
+    dependencies: [doRunTestsParallel].concat(cmdLineOptions.lint ? [lint] : []),
 });
 
 // task("runtests-parallel").flags = {

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -569,17 +569,11 @@ export const watchLocal = task({
 
 const runtestsDeps = [tests, generateLibs].concat(cmdLineOptions.typecheck ? [dts] : []);
 
-const doRunTests = task({
-    name: "do-runtests",
+export const runTests = task({
+    name: "runtests",
     description: "Runs the tests using the built run.js file.",
     dependencies: runtestsDeps,
     run: () => runConsoleTests(testRunner, "mocha-fivemat-progress-reporter", /*runInParallel*/ false),
-});
-
-export const runTests = task({
-    name: "runtests",
-    description: "Runs the tests using the built run.js file, linting in parallel if --lint=true.",
-    dependencies: [doRunTests].concat(cmdLineOptions.lint ? [lint] : []),
 });
 
 // task("runtests").flags = {

--- a/scripts/build/options.mjs
+++ b/scripts/build/options.mjs
@@ -4,7 +4,7 @@ import os from "os";
 const ci = ["1", "true"].includes(process.env.CI ?? "");
 
 const parsed = minimist(process.argv.slice(2), {
-    boolean: ["dirty", "light", "colors", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built", "ci", "bundle", "typecheck"],
+    boolean: ["dirty", "light", "colors", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built", "ci", "bundle", "typecheck", "lint"],
     string: ["browser", "tests", "break", "host", "reporter", "stackTraceLimit", "timeout", "shards", "shardId"],
     alias: {
         /* eslint-disable quote-props */
@@ -41,6 +41,7 @@ const parsed = minimist(process.argv.slice(2), {
         ci,
         bundle: true,
         typecheck: true,
+        lint: true,
     }
 });
 
@@ -86,5 +87,6 @@ export default options;
  * @property {string} break
  * @property {boolean} bundle
  * @property {boolean} typecheck
+ * @property {boolean} lint
  */
 void 0;


### PR DESCRIPTION
This effectively reverts #50597, except that instead of running the linter after tests have finished, we'll instead run them in parallel. This works because hereby won't exit early when a task fails but a sibling task has not yet finished.

I still prefer getting these in my editor where possible, but, I've heard from multiple people ambiently that they keep committing code that fails the lint task. At least we can do it in parallel in the new build.