### PR TITLE
[experiment] Don't relate primitives to their wrappers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21574,7 +21574,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 const sourceIsPrimitive = !!(sourceFlags & TypeFlags.Primitive);
                 if (relation !== identityRelation) {
-                    const originalSource = source
+                    const originalSource = source;
                     const originalFlags = sourceFlags;
                     source = getApparentType(source);
                     sourceFlags = source.flags;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6100,6 +6100,8 @@ export const enum TypeFlags {
     IncludesInstantiable = Substitution,
     /** @internal */
     NotPrimitiveUnion = Any | Unknown | Enum | Void | Never | Object | Intersection | IncludesInstantiable,
+    /** @internal */
+    HasWrapper = StringLike | NumberLike | BigIntLike | BooleanLike | ESSymbolLike,
 }
 
 export type DestructuringPattern = BindingPattern | ObjectLiteralExpression | ArrayLiteralExpression;

--- a/tests/baselines/reference/apparentTypeSubtyping.errors.txt
+++ b/tests/baselines/reference/apparentTypeSubtyping.errors.txt
@@ -1,9 +1,11 @@
+tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(9,31): error TS2344: Type 'string' does not satisfy the constraint 'String'.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts(10,5): error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'Base<string>'.
   Type 'String' is not assignable to type 'string'.
     'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
-==== tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts (1 errors) ====
+==== tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts (2 errors) ====
     // subtype checks use the apparent type of the target type
     // S is a subtype of a type T, and T is a supertype of S, if one of the following is true, where S' denotes the apparent type (section 3.8.1) of S:
     
@@ -13,6 +15,9 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtypi
     
     // is String (S) a subtype of U extends String (T)? Would only be true if we used the apparent type of U (T)
     class Derived<U> extends Base<string> { // error
+                                  ~~~~~~
+!!! error TS2344: Type 'string' does not satisfy the constraint 'String'.
+!!! error TS2344:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
         x: String;
         ~
 !!! error TS2416: Property 'x' in type 'Derived<U>' is not assignable to the same property in base type 'Base<string>'.

--- a/tests/baselines/reference/arrayLiterals2ES5.errors.txt
+++ b/tests/baselines/reference/arrayLiterals2ES5.errors.txt
@@ -1,0 +1,73 @@
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts(50,5): error TS2322: Type 'number[]' is not assignable to type 'myArray'.
+  Type 'number' is not assignable to type 'Number'.
+    'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts(51,5): error TS2322: Type '(string | number)[]' is not assignable to type 'myArray2'.
+  Type 'string | number' is not assignable to type 'String | Number'.
+    Type 'string' is not assignable to type 'String | Number'.
+
+
+==== tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts (2 errors) ====
+    // ElementList:  ( Modified )
+    //      Elisionopt   AssignmentExpression
+    //      Elisionopt   SpreadElement
+    //      ElementList, Elisionopt   AssignmentExpression
+    //      ElementList, Elisionopt   SpreadElement
+    
+    // SpreadElement:
+    //      ...   AssignmentExpression
+    
+    var a0 = [,, 2, 3, 4]
+    var a1 = ["hello", "world"]
+    var a2 = [, , , ...a0, "hello"];
+    var a3 = [,, ...a0]
+    var a4 = [() => 1, ];
+    var a5 = [...a0, , ]
+    
+    // Each element expression in a non-empty array literal is processed as follows:
+    //    - If the array literal contains no spread elements, and if the array literal is contextually typed (section 4.19)
+    //      by a type T and T has a property with the numeric name N, where N is the index of the element expression in the array literal,
+    //      the element expression is contextually typed by the type of that property.
+    
+    // The resulting type an array literal expression is determined as follows:
+    //     - If the array literal contains no spread elements and is contextually typed by a tuple-like type,
+    //       the resulting type is a tuple type constructed from the types of the element expressions.
+    
+    var b0: [any, any, any] = [undefined, null, undefined];
+    var b1: [number[], string[]] = [[1, 2, 3], ["hello", "string"]];
+    
+    // The resulting type an array literal expression is determined as follows:
+    //     - If the array literal contains no spread elements and is an array assignment pattern in a destructuring assignment (section 4.17.1),
+    //       the resulting type is a tuple type constructed from the types of the element expressions.
+    
+    var [c0, c1] = [1, 2];        // tuple type [number, number]
+    var [c2, c3] = [1, 2, true];  // tuple type [number, number, boolean]
+    
+    // The resulting type an array literal expression is determined as follows:
+    //      - the resulting type is an array type with an element type that is the union of the types of the
+    //        non - spread element expressions and the numeric index signature types of the spread element expressions
+    var temp = ["s", "t", "r"];
+    var temp1 = [1, 2, 3];
+    var temp2: [number[], string[]] = [[1, 2, 3], ["hello", "string"]];
+    var temp3 = [undefined, null, undefined];
+    var temp4 = [];
+    
+    interface myArray extends Array<Number> { }
+    interface myArray2 extends Array<Number|String> { }
+    var d0 = [1, true, ...temp,];  // has type (string|number|boolean)[]
+    var d1 = [...temp];            // has type string[]
+    var d2: number[] = [...temp1];
+    var d3: myArray = [...temp1];
+        ~~
+!!! error TS2322: Type 'number[]' is not assignable to type 'myArray'.
+!!! error TS2322:   Type 'number' is not assignable to type 'Number'.
+!!! error TS2322:     'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+    var d4: myArray2 = [...temp, ...temp1];
+        ~~
+!!! error TS2322: Type '(string | number)[]' is not assignable to type 'myArray2'.
+!!! error TS2322:   Type 'string | number' is not assignable to type 'String | Number'.
+!!! error TS2322:     Type 'string' is not assignable to type 'String | Number'.
+    var d5 = [...temp3];
+    var d6 = [...temp4];
+    var d7 = [...[...temp1]];
+    var d8: number[][] = [[...temp1]]
+    var d9 = [[...temp1], ...["hello"]];

--- a/tests/baselines/reference/arrayLiterals2ES6.errors.txt
+++ b/tests/baselines/reference/arrayLiterals2ES6.errors.txt
@@ -1,0 +1,71 @@
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts(48,5): error TS2322: Type 'number[]' is not assignable to type 'myArray'.
+  Type 'number' is not assignable to type 'Number'.
+    'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts(49,5): error TS2322: Type '(string | number)[]' is not assignable to type 'myArray2'.
+  Type 'string | number' is not assignable to type 'String | Number'.
+    Type 'string' is not assignable to type 'String | Number'.
+
+
+==== tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts (2 errors) ====
+    // ElementList:  ( Modified )
+    //      Elisionopt   AssignmentExpression
+    //      Elisionopt   SpreadElement
+    //      ElementList, Elisionopt   AssignmentExpression
+    //      ElementList, Elisionopt   SpreadElement
+    
+    // SpreadElement:
+    //      ...   AssignmentExpression
+    
+    var a0 = [, , 2, 3, 4]
+    var a1 = ["hello", "world"]
+    var a2 = [, , , ...a0, "hello"];
+    var a3 = [, , ...a0]
+    var a4 = [() => 1, ];
+    var a5 = [...a0, , ]
+    
+    // Each element expression in a non-empty array literal is processed as follows:
+    //    - If the array literal contains no spread elements, and if the array literal is contextually typed (section 4.19)
+    //      by a type T and T has a property with the numeric name N, where N is the index of the element expression in the array literal,
+    //      the element expression is contextually typed by the type of that property.
+    
+    // The resulting type an array literal expression is determined as follows:
+    //     - If the array literal contains no spread elements and is contextually typed by a tuple-like type,
+    //       the resulting type is a tuple type constructed from the types of the element expressions.
+    
+    var b0: [any, any, any] = [undefined, null, undefined];
+    var b1: [number[], string[]] = [[1, 2, 3], ["hello", "string"]];
+    
+    // The resulting type an array literal expression is determined as follows:
+    //     - If the array literal contains no spread elements and is an array assignment pattern in a destructuring assignment (section 4.17.1),
+    //       the resulting type is a tuple type constructed from the types of the element expressions.
+    
+    var [c0, c1] = [1, 2];        // tuple type [number, number]
+    var [c2, c3] = [1, 2, true];  // tuple type [number, number, boolean]
+    
+    // The resulting type an array literal expression is determined as follows:
+    //      - the resulting type is an array type with an element type that is the union of the types of the
+    //        non - spread element expressions and the numeric index signature types of the spread element expressions
+    var temp = ["s", "t", "r"];
+    var temp1 = [1, 2, 3];
+    var temp2: [number[], string[]] = [[1, 2, 3], ["hello", "string"]];
+    
+    interface myArray extends Array<Number> { }
+    interface myArray2 extends Array<Number|String> { }
+    var d0 = [1, true, ...temp, ];  // has type (string|number|boolean)[]
+    var d1 = [...temp];            // has type string[]
+    var d2: number[] = [...temp1];
+    var d3: myArray = [...temp1];
+        ~~
+!!! error TS2322: Type 'number[]' is not assignable to type 'myArray'.
+!!! error TS2322:   Type 'number' is not assignable to type 'Number'.
+!!! error TS2322:     'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+    var d4: myArray2 = [...temp, ...temp1];
+        ~~
+!!! error TS2322: Type '(string | number)[]' is not assignable to type 'myArray2'.
+!!! error TS2322:   Type 'string | number' is not assignable to type 'String | Number'.
+!!! error TS2322:     Type 'string' is not assignable to type 'String | Number'.
+    var d5 = [...a2];
+    var d6 = [...a3];
+    var d7 = [...a4];
+    var d8: number[][] = [[...temp1]]
+    var d9 = [[...temp1], ...["hello"]];

--- a/tests/baselines/reference/assignFromBooleanInterface.errors.txt
+++ b/tests/baselines/reference/assignFromBooleanInterface.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts(3,1): error TS2322: Type 'Boolean' is not assignable to type 'boolean'.
   'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
+tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts(4,1): error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+  'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
 
 
-==== tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts (1 errors) ====
+==== tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts (2 errors) ====
     var x = true;
     var a: Boolean;
     x = a;
@@ -10,3 +12,6 @@ tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts(3
 !!! error TS2322: Type 'Boolean' is not assignable to type 'boolean'.
 !!! error TS2322:   'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
     a = x;
+    ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+!!! error TS2322:   'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.

--- a/tests/baselines/reference/assignFromBooleanInterface2.errors.txt
+++ b/tests/baselines/reference/assignFromBooleanInterface2.errors.txt
@@ -1,12 +1,14 @@
+tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts(13,1): error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
 tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts(14,1): error TS2322: Type 'NotBoolean' is not assignable to type 'Boolean'.
   The types returned by 'valueOf()' are incompatible between these types.
     Type 'Object' is not assignable to type 'boolean'.
+      The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts(19,1): error TS2322: Type 'Boolean' is not assignable to type 'boolean'.
   'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
 tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts(20,1): error TS2322: Type 'NotBoolean' is not assignable to type 'boolean'.
 
 
-==== tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts (3 errors) ====
+==== tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts (4 errors) ====
     interface Boolean {
         doStuff(): string;
     }
@@ -20,11 +22,14 @@ tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts(
     var b: NotBoolean;
     
     a = x;
+    ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
     a = b;
     ~
 !!! error TS2322: Type 'NotBoolean' is not assignable to type 'Boolean'.
 !!! error TS2322:   The types returned by 'valueOf()' are incompatible between these types.
 !!! error TS2322:     Type 'Object' is not assignable to type 'boolean'.
+!!! error TS2322:       The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     b = a;
     b = x;

--- a/tests/baselines/reference/assignFromNumberInterface.errors.txt
+++ b/tests/baselines/reference/assignFromNumberInterface.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts(3,1): error TS2322: Type 'Number' is not assignable to type 'number'.
   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts(4,1): error TS2322: Type 'number' is not assignable to type 'Number'.
+  'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
 
 
-==== tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts (1 errors) ====
+==== tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts (2 errors) ====
     var x = 1;
     var a: Number;
     x = a;
@@ -10,3 +12,6 @@ tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts(3,1
 !!! error TS2322: Type 'Number' is not assignable to type 'number'.
 !!! error TS2322:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
     a = x;
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'Number'.
+!!! error TS2322:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.

--- a/tests/baselines/reference/assignFromNumberInterface2.errors.txt
+++ b/tests/baselines/reference/assignFromNumberInterface2.errors.txt
@@ -1,9 +1,11 @@
+tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts(18,1): error TS2322: Type 'number' is not assignable to type 'Number'.
+  'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
 tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts(24,1): error TS2322: Type 'Number' is not assignable to type 'number'.
   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
 tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts(25,1): error TS2322: Type 'NotNumber' is not assignable to type 'number'.
 
 
-==== tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts (2 errors) ====
+==== tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts (3 errors) ====
     interface Number {
         doStuff(): string;
     }
@@ -22,6 +24,9 @@ tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts(25
     var b: NotNumber;
     
     a = x; 
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'Number'.
+!!! error TS2322:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
     a = b; 
     
     b = a; 

--- a/tests/baselines/reference/assignFromStringInterface.errors.txt
+++ b/tests/baselines/reference/assignFromStringInterface.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts(3,1): error TS2322: Type 'String' is not assignable to type 'string'.
   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts(4,1): error TS2322: Type 'string' is not assignable to type 'String'.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
-==== tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts (1 errors) ====
+==== tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts (2 errors) ====
     var x = '';
     var a: String;
     x = a;
@@ -10,3 +12,6 @@ tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts(3,1
 !!! error TS2322: Type 'String' is not assignable to type 'string'.
 !!! error TS2322:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
     a = x;
+    ~
+!!! error TS2322: Type 'string' is not assignable to type 'String'.
+!!! error TS2322:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.

--- a/tests/baselines/reference/assignFromStringInterface2.errors.txt
+++ b/tests/baselines/reference/assignFromStringInterface2.errors.txt
@@ -1,9 +1,11 @@
+tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts(41,1): error TS2322: Type 'string' is not assignable to type 'String'.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts(47,1): error TS2322: Type 'String' is not assignable to type 'string'.
   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts(48,1): error TS2322: Type 'NotString' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts (2 errors) ====
+==== tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts (3 errors) ====
     interface String {
         doStuff(): string;
     }
@@ -45,6 +47,9 @@ tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts(48
     var b: NotString;
     
     a = x;
+    ~
+!!! error TS2322: Type 'string' is not assignable to type 'String'.
+!!! error TS2322:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
     a = b;
     
     b = a;

--- a/tests/baselines/reference/bigintWithoutLib.errors.txt
+++ b/tests/baselines/reference/bigintWithoutLib.errors.txt
@@ -6,6 +6,7 @@ tests/cases/compiler/bigintWithoutLib.ts(7,30): error TS2737: BigInt literals ar
 tests/cases/compiler/bigintWithoutLib.ts(8,13): error TS2583: Cannot find name 'BigInt'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2020' or later.
 tests/cases/compiler/bigintWithoutLib.ts(8,31): error TS2737: BigInt literals are not available when targeting lower than ES2020.
 tests/cases/compiler/bigintWithoutLib.ts(9,1): error TS2322: Type 'Object' is not assignable to type 'bigint'.
+  The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/bigintWithoutLib.ts(11,32): error TS2554: Expected 0 arguments, but got 1.
 tests/cases/compiler/bigintWithoutLib.ts(13,38): error TS2554: Expected 0 arguments, but got 1.
 tests/cases/compiler/bigintWithoutLib.ts(14,38): error TS2554: Expected 0 arguments, but got 2.
@@ -77,6 +78,7 @@ tests/cases/compiler/bigintWithoutLib.ts(56,36): error TS2345: Argument of type 
     bigintVal = bigintVal.valueOf(); // should error - bigintVal inferred as {}
     ~~~~~~~~~
 !!! error TS2322: Type 'Object' is not assignable to type 'bigint'.
+!!! error TS2322:   The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     let stringVal: string = bigintVal.toString(); // should not error - bigintVal inferred as {}
     stringVal = bigintVal.toString(2); // should error - bigintVal inferred as {}
                                    ~

--- a/tests/baselines/reference/booleanAssignment.errors.txt
+++ b/tests/baselines/reference/booleanAssignment.errors.txt
@@ -3,9 +3,13 @@ tests/cases/compiler/booleanAssignment.ts(3,1): error TS2322: Type 'string' is n
 tests/cases/compiler/booleanAssignment.ts(4,1): error TS2322: Type '{}' is not assignable to type 'Boolean'.
   The types returned by 'valueOf()' are incompatible between these types.
     Type 'Object' is not assignable to type 'boolean'.
+      The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
+tests/cases/compiler/booleanAssignment.ts(9,1): error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+tests/cases/compiler/booleanAssignment.ts(12,1): error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+  'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
 
 
-==== tests/cases/compiler/booleanAssignment.ts (3 errors) ====
+==== tests/cases/compiler/booleanAssignment.ts (5 errors) ====
     var b = new Boolean();
     b = 1; // Error
     ~
@@ -18,11 +22,17 @@ tests/cases/compiler/booleanAssignment.ts(4,1): error TS2322: Type '{}' is not a
 !!! error TS2322: Type '{}' is not assignable to type 'Boolean'.
 !!! error TS2322:   The types returned by 'valueOf()' are incompatible between these types.
 !!! error TS2322:     Type 'Object' is not assignable to type 'boolean'.
+!!! error TS2322:       The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     var o = {};
     o = b; // OK
     
     b = true; // OK
+    ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
     
     var b2:boolean;
     b = b2; // OK
+    ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+!!! error TS2322:   'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.

--- a/tests/baselines/reference/computedPropertyNames3_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames3_ES5.errors.txt
@@ -6,9 +6,11 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts(5,1
 tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts(6,9): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts(7,16): error TS2378: A 'get' accessor must return a value.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts(7,16): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts(7,17): error TS2352: Conversion of type 'string' to type 'String' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
-==== tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts (8 errors) ====
+==== tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts (9 errors) ====
     var id;
     class C {
         [0 + 1]() { }
@@ -32,5 +34,8 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts(7,1
 !!! error TS2378: A 'get' accessor must return a value.
                    ~~~~~~~~~~~~
 !!! error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+                    ~~~~~~~~~~
+!!! error TS2352: Conversion of type 'string' to type 'String' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+!!! error TS2352:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
         static set [id.toString()](v) { }
     }

--- a/tests/baselines/reference/computedPropertyNames3_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames3_ES6.errors.txt
@@ -6,9 +6,11 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts(5,1
 tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts(6,9): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts(7,16): error TS2378: A 'get' accessor must return a value.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts(7,16): error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts(7,17): error TS2352: Conversion of type 'string' to type 'String' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
 
 
-==== tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts (8 errors) ====
+==== tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts (9 errors) ====
     var id;
     class C {
         [0 + 1]() { }
@@ -32,5 +34,8 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts(7,1
 !!! error TS2378: A 'get' accessor must return a value.
                    ~~~~~~~~~~~~
 !!! error TS2464: A computed property name must be of type 'string', 'number', 'symbol', or 'any'.
+                    ~~~~~~~~~~
+!!! error TS2352: Conversion of type 'string' to type 'String' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+!!! error TS2352:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
         static set [id.toString()](v) { }
     }

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.errors.txt
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.errors.txt
@@ -4,6 +4,11 @@ tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAss
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(3,12): error TS2493: Tuple type '[]' of length '0' has no element at index '1'.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(4,5): error TS2461: Type 'undefined' is not an array type.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(9,51): error TS2322: Type 'number' is not assignable to type 'boolean'.
+tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(11,5): error TS2411: Property '2' of type 'number' is not assignable to 'number' index type 'Number'.
+tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(15,5): error TS2322: Type '[number, number, number]' is not assignable to type 'J'.
+  The types returned by 'pop()' are incompatible between these types.
+    Type 'number' is not assignable to type 'Number'.
+      'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(22,5): error TS2322: Type 'number[]' is not assignable to type '[number, number]'.
   Target requires 2 element(s) but source may have fewer.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(23,5): error TS2322: Type 'number[]' is not assignable to type '[string, string]'.
@@ -11,7 +16,7 @@ tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAss
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(34,5): error TS2461: Type 'F' is not an array type.
 
 
-==== tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts (9 errors) ====
+==== tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts (11 errors) ====
     // V is an array assignment pattern, S is the type Any or an array-like type (section 3.3.2), and, for each assignment element E in V,
     //      S is the type Any, or
     var [[a0], [[a1]]] = []         // Error
@@ -35,10 +40,17 @@ tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAss
 !!! error TS2322: Type 'number' is not assignable to type 'boolean'.
     interface J extends Array<Number> {
         2: number;
+        ~
+!!! error TS2411: Property '2' of type 'number' is not assignable to 'number' index type 'Number'.
     }
     
     function bar(): J {
         return <[number, number, number]>[1, 2, 3];
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '[number, number, number]' is not assignable to type 'J'.
+!!! error TS2322:   The types returned by 'pop()' are incompatible between these types.
+!!! error TS2322:     Type 'number' is not assignable to type 'Number'.
+!!! error TS2322:       'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
     }
     var [b3 = "string", b4, b5] = bar();  // Error
     

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES5.errors.txt
@@ -3,9 +3,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts(29,12): error TS2322: Type 'number' is not assignable to type '[[any]]'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts(30,5): error TS2345: Argument of type '[number, number]' is not assignable to parameter of type '[any, any, [[any]], ...any[]]'.
   Source has 2 element(s) but target requires 3.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts(41,6): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts(42,6): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
 
 
-==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts (3 errors) ====
+==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.ts (5 errors) ====
     // If the parameter is a rest parameter, the parameter type is any[]
     // A type annotation for a rest parameter must denote an array type.
     
@@ -55,7 +57,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5.
     const enum E1 { a, b }
     function foo1<T extends Number>(...a: T[]) { }
     foo1(1, 2, 3, E.a);
+         ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
     foo1(1, 2, 3, E1.a, E.b);
+         ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
     
     
     

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.errors.txt
@@ -3,9 +3,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5i
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5iterable.ts(29,12): error TS2322: Type 'number' is not assignable to type '[[any]]'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5iterable.ts(30,5): error TS2345: Argument of type '[number, number]' is not assignable to parameter of type '[any, any, [[any]], ...any[]]'.
   Source has 2 element(s) but target requires 3.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5iterable.ts(41,6): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5iterable.ts(42,6): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
 
 
-==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5iterable.ts (3 errors) ====
+==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5iterable.ts (5 errors) ====
     // If the parameter is a rest parameter, the parameter type is any[]
     // A type annotation for a rest parameter must denote an array type.
     
@@ -55,7 +57,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES5i
     const enum E1 { a, b }
     function foo1<T extends Number>(...a: T[]) { }
     foo1(1, 2, 3, E.a);
+         ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
     foo1(1, 2, 3, E1.a, E.b);
+         ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
     
     
     

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES6.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES6.errors.txt
@@ -3,9 +3,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts(29,12): error TS2322: Type 'number' is not assignable to type '[[any]]'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts(30,5): error TS2345: Argument of type '[number, number]' is not assignable to parameter of type '[any, any, [[any]], ...any[]]'.
   Source has 2 element(s) but target requires 3.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts(41,6): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts(42,6): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
 
 
-==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts (3 errors) ====
+==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.ts (5 errors) ====
     // If the parameter is a rest parameter, the parameter type is any[]
     // A type annotation for a rest parameter must denote an array type.
     
@@ -55,7 +57,11 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration3ES6.
     const enum E1 { a, b }
     function foo1<T extends Number>(...a: T[]) { }
     foo1(1, 2, 3, E.a);
+         ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
     foo1(1, 2, 3, E1.a, E.b);
+         ~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
     
     
     

--- a/tests/baselines/reference/enumAssignability.errors.txt
+++ b/tests/baselines/reference/enumAssignability.errors.txt
@@ -14,6 +14,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssi
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(41,9): error TS2322: Type 'E' is not assignable to type 'number[]'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(42,9): error TS2322: Type 'E' is not assignable to type '{ foo: string; }'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(43,9): error TS2322: Type 'E' is not assignable to type '<T>(x: T) => T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(44,9): error TS2322: Type 'E' is not assignable to type 'Number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(45,9): error TS2322: Type 'E' is not assignable to type 'String'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(48,9): error TS2322: Type 'E' is not assignable to type 'T'.
   'T' could be instantiated with an arbitrary type which could be unrelated to 'E'.
@@ -22,12 +23,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssi
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(50,9): error TS2322: Type 'E' is not assignable to type 'V'.
   'V' could be instantiated with an arbitrary type which could be unrelated to 'E'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(51,13): error TS2322: Type 'E' is not assignable to type 'A'.
-  'E' is assignable to the constraint of type 'A', but 'A' could be instantiated with a different subtype of constraint 'Number'.
+  'A' could be instantiated with an arbitrary type which could be unrelated to 'E'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts(52,13): error TS2322: Type 'E' is not assignable to type 'B'.
   'E' is assignable to the constraint of type 'B', but 'B' could be instantiated with a different subtype of constraint 'E'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts (22 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssignability.ts (23 errors) ====
     // enums assignable to number, any, Object, errors unless otherwise noted
     
     enum E { A }
@@ -104,6 +105,8 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssi
             ~
 !!! error TS2322: Type 'E' is not assignable to type '<T>(x: T) => T'.
         var p: Number = e;
+            ~
+!!! error TS2322: Type 'E' is not assignable to type 'Number'.
         var q: String = e;
             ~
 !!! error TS2322: Type 'E' is not assignable to type 'String'.
@@ -124,7 +127,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/enumAssi
             var a: A = e;
                 ~
 !!! error TS2322: Type 'E' is not assignable to type 'A'.
-!!! error TS2322:   'E' is assignable to the constraint of type 'A', but 'A' could be instantiated with a different subtype of constraint 'Number'.
+!!! error TS2322:   'A' could be instantiated with an arbitrary type which could be unrelated to 'E'.
             var b: B = e;
                 ~
 !!! error TS2322: Type 'E' is not assignable to type 'B'.

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndInitializers.errors.txt
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndInitializers.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts(5,33): error TS2322: Type 'number' is not assignable to type 'T'.
-  'number' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Number'.
+  'T' could be instantiated with an arbitrary type which could be unrelated to 'number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts(6,37): error TS2322: Type 'T' is not assignable to type 'U'.
   'U' could be instantiated with an arbitrary type which could be unrelated to 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts(8,56): error TS2322: Type 'U' is not assignable to type 'V'.
@@ -14,7 +14,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericC
     function foo3<T extends Number>(x: T = 1) { } // error
                                     ~~~~~~~~
 !!! error TS2322: Type 'number' is not assignable to type 'T'.
-!!! error TS2322:   'number' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'Number'.
+!!! error TS2322:   'T' could be instantiated with an arbitrary type which could be unrelated to 'number'.
     function foo4<T, U extends T>(x: T, y: U = x) { } // error
                                         ~~~~~~~~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.

--- a/tests/baselines/reference/genericConstraintOnExtendedBuiltinTypes2.errors.txt
+++ b/tests/baselines/reference/genericConstraintOnExtendedBuiltinTypes2.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts(22,19): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
+  'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+
+
+==== tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts (1 errors) ====
+    module EndGate {
+        export interface ICloneable {
+            Clone(): any;
+        }
+    }
+    
+    interface Number extends EndGate.ICloneable { }
+    
+    module EndGate.Tweening {
+        export class Tween<T extends ICloneable>{
+            private _from: T;
+    
+            constructor(from: T) {
+                this._from = from.Clone();
+            }
+        }
+    }
+    
+    module EndGate.Tweening {
+        export class NumberTween extends Tween<Number>{
+            constructor(from: number) {
+                super(from);
+                      ~~~~
+!!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'Number'.
+!!! error TS2345:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+            }
+        }
+    }

--- a/tests/baselines/reference/nonPrimitiveAssignError.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveAssignError.errors.txt
@@ -5,9 +5,12 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(15,1): err
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(17,1): error TS2322: Type 'object' is not assignable to type 'number'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(18,1): error TS2322: Type 'object' is not assignable to type 'boolean'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(19,1): error TS2322: Type 'object' is not assignable to type 'string'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(21,5): error TS2322: Type 'number' is not assignable to type 'Number'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(22,5): error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(23,5): error TS2322: Type 'string' is not assignable to type 'String'.
 
 
-==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts (7 errors) ====
+==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts (10 errors) ====
     var x = {};
     var y = {foo: "bar"};
     var a: object;
@@ -44,8 +47,14 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(19,1): err
 !!! error TS2322: Type 'object' is not assignable to type 'string'.
     
     var numObj: Number = 123;
+        ~~~~~~
+!!! error TS2322: Type 'number' is not assignable to type 'Number'.
     var boolObj: Boolean = true;
+        ~~~~~~~
+!!! error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
     var strObj: String = "string";
+        ~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type 'String'.
     
     a = numObj; // ok
     a = boolObj; // ok

--- a/tests/baselines/reference/numberWrapper.errors.txt
+++ b/tests/baselines/reference/numberWrapper.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/compiler/numberWrapper.ts(5,5): error TS2322: Type 'Number' is not assignable to type 'number'.
+  'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+
+
+==== tests/cases/compiler/numberWrapper.ts (1 errors) ====
+    declare let aNumber: number;
+    declare let aNumberWrapper: Number;
+    
+    function a() {
+        aNumber = aNumberWrapper;
+        ~~~~~~~
+!!! error TS2322: Type 'Number' is not assignable to type 'number'.
+!!! error TS2322:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+    }
+    
+    function b() {
+        aNumberWrapper = aNumber;
+    }
+    

--- a/tests/baselines/reference/numberWrapper.errors.txt
+++ b/tests/baselines/reference/numberWrapper.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/compiler/numberWrapper.ts(5,5): error TS2322: Type 'Number' is not assignable to type 'number'.
   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+tests/cases/compiler/numberWrapper.ts(9,5): error TS2322: Type 'number' is not assignable to type 'Number'.
+  'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
 
 
-==== tests/cases/compiler/numberWrapper.ts (1 errors) ====
+==== tests/cases/compiler/numberWrapper.ts (2 errors) ====
     declare let aNumber: number;
     declare let aNumberWrapper: Number;
     
@@ -15,5 +17,8 @@ tests/cases/compiler/numberWrapper.ts(5,5): error TS2322: Type 'Number' is not a
     
     function b() {
         aNumberWrapper = aNumber;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'number' is not assignable to type 'Number'.
+!!! error TS2322:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
     }
     

--- a/tests/baselines/reference/numberWrapper.js
+++ b/tests/baselines/reference/numberWrapper.js
@@ -1,0 +1,21 @@
+//// [numberWrapper.ts]
+declare let aNumber: number;
+declare let aNumberWrapper: Number;
+
+function a() {
+    aNumber = aNumberWrapper;
+}
+
+function b() {
+    aNumberWrapper = aNumber;
+}
+
+
+//// [numberWrapper.js]
+"use strict";
+function a() {
+    aNumber = aNumberWrapper;
+}
+function b() {
+    aNumberWrapper = aNumber;
+}

--- a/tests/baselines/reference/numberWrapper.symbols
+++ b/tests/baselines/reference/numberWrapper.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/numberWrapper.ts ===
+declare let aNumber: number;
+>aNumber : Symbol(aNumber, Decl(numberWrapper.ts, 0, 11))
+
+declare let aNumberWrapper: Number;
+>aNumberWrapper : Symbol(aNumberWrapper, Decl(numberWrapper.ts, 1, 11))
+>Number : Symbol(Number, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+function a() {
+>a : Symbol(a, Decl(numberWrapper.ts, 1, 35))
+
+    aNumber = aNumberWrapper;
+>aNumber : Symbol(aNumber, Decl(numberWrapper.ts, 0, 11))
+>aNumberWrapper : Symbol(aNumberWrapper, Decl(numberWrapper.ts, 1, 11))
+}
+
+function b() {
+>b : Symbol(b, Decl(numberWrapper.ts, 5, 1))
+
+    aNumberWrapper = aNumber;
+>aNumberWrapper : Symbol(aNumberWrapper, Decl(numberWrapper.ts, 1, 11))
+>aNumber : Symbol(aNumber, Decl(numberWrapper.ts, 0, 11))
+}
+

--- a/tests/baselines/reference/numberWrapper.types
+++ b/tests/baselines/reference/numberWrapper.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/numberWrapper.ts ===
+declare let aNumber: number;
+>aNumber : number
+
+declare let aNumberWrapper: Number;
+>aNumberWrapper : Number
+
+function a() {
+>a : () => void
+
+    aNumber = aNumberWrapper;
+>aNumber = aNumberWrapper : Number
+>aNumber : number
+>aNumberWrapper : Number
+}
+
+function b() {
+>b : () => void
+
+    aNumberWrapper = aNumber;
+>aNumberWrapper = aNumber : number
+>aNumberWrapper : Number
+>aNumber : number
+}
+

--- a/tests/baselines/reference/overloadsWithConstraints.errors.txt
+++ b/tests/baselines/reference/overloadsWithConstraints.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/overloadsWithConstraints.ts(4,11): error TS2344: Type 'string' does not satisfy the constraint 'String'.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+
+
+==== tests/cases/compiler/overloadsWithConstraints.ts (1 errors) ====
+    declare function f<T extends Number>(x: T): T;
+    declare function f<T extends String>(x: T): T
+    
+    var v = f<string>("");
+              ~~~~~~
+!!! error TS2344: Type 'string' does not satisfy the constraint 'String'.
+!!! error TS2344:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.

--- a/tests/baselines/reference/primitiveMembers.errors.txt
+++ b/tests/baselines/reference/primitiveMembers.errors.txt
@@ -1,9 +1,14 @@
 tests/cases/compiler/primitiveMembers.ts(5,3): error TS2339: Property 'toBAZ' does not exist on type 'number'.
 tests/cases/compiler/primitiveMembers.ts(11,1): error TS2322: Type 'Number' is not assignable to type 'number'.
   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+tests/cases/compiler/primitiveMembers.ts(12,1): error TS2322: Type 'number' is not assignable to type 'Number'.
+  'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
+tests/cases/compiler/primitiveMembers.ts(17,5): error TS2322: Type 'number' is not assignable to type 'Number'.
+tests/cases/compiler/primitiveMembers.ts(18,5): error TS2322: Type 'string' is not assignable to type 'String'.
+tests/cases/compiler/primitiveMembers.ts(19,5): error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
 
 
-==== tests/cases/compiler/primitiveMembers.ts (2 errors) ====
+==== tests/cases/compiler/primitiveMembers.ts (6 errors) ====
     var x = 5;
     var r = /yo/;
     r.source;
@@ -21,13 +26,22 @@ tests/cases/compiler/primitiveMembers.ts(11,1): error TS2322: Type 'Number' is n
 !!! error TS2322: Type 'Number' is not assignable to type 'number'.
 !!! error TS2322:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
     N = n; // should work
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'Number'.
+!!! error TS2322:   'number' is a primitive, but 'Number' is a wrapper object. Prefer using 'number' when possible.
     
     var o: Object = {}
     var f: Function = (x: string) => x.length;
     var r2: RegExp = /./g;
     var n2: Number = 34;
+        ~~
+!!! error TS2322: Type 'number' is not assignable to type 'Number'.
     var s: String = "yo";
+        ~
+!!! error TS2322: Type 'string' is not assignable to type 'String'.
     var b: Boolean = true;
+        ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
     
     var n3 = 5 || {};
     

--- a/tests/baselines/reference/strictFunctionTypesErrors.errors.txt
+++ b/tests/baselines/reference/strictFunctionTypesErrors.errors.txt
@@ -1,42 +1,59 @@
 tests/cases/compiler/strictFunctionTypesErrors.ts(10,1): error TS2322: Type '(x: string) => Object' is not assignable to type '(x: Object) => Object'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'Object' is not assignable to type 'string'.
+      The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(11,1): error TS2322: Type '(x: string) => string' is not assignable to type '(x: Object) => Object'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'Object' is not assignable to type 'string'.
+      The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(13,1): error TS2322: Type '(x: Object) => Object' is not assignable to type '(x: Object) => string'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(14,1): error TS2322: Type '(x: string) => Object' is not assignable to type '(x: Object) => string'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'Object' is not assignable to type 'string'.
+      The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(15,1): error TS2322: Type '(x: string) => string' is not assignable to type '(x: Object) => string'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'Object' is not assignable to type 'string'.
+      The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(21,1): error TS2322: Type '(x: Object) => Object' is not assignable to type '(x: string) => string'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(23,1): error TS2322: Type '(x: string) => Object' is not assignable to type '(x: string) => string'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(33,1): error TS2322: Type 'Func<string, Object>' is not assignable to type 'Func<Object, Object>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(34,1): error TS2322: Type 'Func<string, string>' is not assignable to type 'Func<Object, Object>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(36,1): error TS2322: Type 'Func<Object, Object>' is not assignable to type 'Func<Object, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(37,1): error TS2322: Type 'Func<string, Object>' is not assignable to type 'Func<Object, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(38,1): error TS2322: Type 'Func<string, string>' is not assignable to type 'Func<Object, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(44,1): error TS2322: Type 'Func<Object, Object>' is not assignable to type 'Func<string, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(46,1): error TS2322: Type 'Func<string, Object>' is not assignable to type 'Func<string, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(57,1): error TS2322: Type 'Func<Func<Object, void>, Object>' is not assignable to type 'Func<Func<Object, void>, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(58,1): error TS2322: Type 'Func<Func<string, void>, Object>' is not assignable to type 'Func<Func<Object, void>, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(61,1): error TS2322: Type 'Func<Func<Object, void>, Object>' is not assignable to type 'Func<Func<string, void>, Object>'.
   Type 'Func<string, void>' is not assignable to type 'Func<Object, void>'.
     Type 'Object' is not assignable to type 'string'.
+      The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(62,1): error TS2322: Type 'Func<Func<Object, void>, string>' is not assignable to type 'Func<Func<string, void>, Object>'.
   Type 'Func<string, void>' is not assignable to type 'Func<Object, void>'.
 tests/cases/compiler/strictFunctionTypesErrors.ts(65,1): error TS2322: Type 'Func<Func<Object, void>, Object>' is not assignable to type 'Func<Func<string, void>, string>'.
@@ -45,16 +62,21 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(66,1): error TS2322: Type 'Fun
   Type 'Func<string, void>' is not assignable to type 'Func<Object, void>'.
 tests/cases/compiler/strictFunctionTypesErrors.ts(67,1): error TS2322: Type 'Func<Func<string, void>, Object>' is not assignable to type 'Func<Func<string, void>, string>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(74,1): error TS2322: Type 'Func<Object, Func<string, void>>' is not assignable to type 'Func<Object, Func<Object, void>>'.
   Type 'Func<string, void>' is not assignable to type 'Func<Object, void>'.
 tests/cases/compiler/strictFunctionTypesErrors.ts(75,1): error TS2322: Type 'Func<string, Func<Object, void>>' is not assignable to type 'Func<Object, Func<Object, void>>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(76,1): error TS2322: Type 'Func<string, Func<string, void>>' is not assignable to type 'Func<Object, Func<Object, void>>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(79,1): error TS2322: Type 'Func<string, Func<Object, void>>' is not assignable to type 'Func<Object, Func<string, void>>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(80,1): error TS2322: Type 'Func<string, Func<string, void>>' is not assignable to type 'Func<Object, Func<string, void>>'.
   Type 'Object' is not assignable to type 'string'.
+    The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/strictFunctionTypesErrors.ts(83,1): error TS2322: Type 'Func<Object, Func<string, void>>' is not assignable to type 'Func<string, Func<Object, void>>'.
   Type 'Func<string, void>' is not assignable to type 'Func<Object, void>'.
 tests/cases/compiler/strictFunctionTypesErrors.ts(84,1): error TS2322: Type 'Func<string, Func<string, void>>' is not assignable to type 'Func<string, Func<Object, void>>'.
@@ -100,26 +122,31 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
 !!! error TS2322: Type '(x: string) => Object' is not assignable to type '(x: Object) => Object'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2322:     Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:       The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     f1 = f4;  // Error
     ~~
 !!! error TS2322: Type '(x: string) => string' is not assignable to type '(x: Object) => Object'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2322:     Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:       The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     f2 = f1;  // Error
     ~~
 !!! error TS2322: Type '(x: Object) => Object' is not assignable to type '(x: Object) => string'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     f2 = f3;  // Error
     ~~
 !!! error TS2322: Type '(x: string) => Object' is not assignable to type '(x: Object) => string'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2322:     Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:       The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     f2 = f4;  // Error
     ~~
 !!! error TS2322: Type '(x: string) => string' is not assignable to type '(x: Object) => string'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2322:     Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:       The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     f3 = f1;  // Ok
     f3 = f2;  // Ok
@@ -129,11 +156,13 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
     ~~
 !!! error TS2322: Type '(x: Object) => Object' is not assignable to type '(x: string) => string'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     f4 = f2;  // Ok
     f4 = f3;  // Error
     ~~
 !!! error TS2322: Type '(x: string) => Object' is not assignable to type '(x: string) => string'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     type Func<T, U> = (x: T) => U;
     
@@ -147,23 +176,28 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
     ~~
 !!! error TS2322: Type 'Func<string, Object>' is not assignable to type 'Func<Object, Object>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     g1 = g4;  // Error
     ~~
 !!! error TS2322: Type 'Func<string, string>' is not assignable to type 'Func<Object, Object>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     g2 = g1;  // Error
     ~~
 !!! error TS2322: Type 'Func<Object, Object>' is not assignable to type 'Func<Object, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     g2 = g3;  // Error
     ~~
 !!! error TS2322: Type 'Func<string, Object>' is not assignable to type 'Func<Object, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     g2 = g4;  // Error
     ~~
 !!! error TS2322: Type 'Func<string, string>' is not assignable to type 'Func<Object, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     g3 = g1;  // Ok
     g3 = g2;  // Ok
@@ -173,11 +207,13 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
     ~~
 !!! error TS2322: Type 'Func<Object, Object>' is not assignable to type 'Func<string, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     g4 = g2;  // Ok
     g4 = g3;  // Error
     ~~
 !!! error TS2322: Type 'Func<string, Object>' is not assignable to type 'Func<string, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     declare let h1: Func<Func<Object, void>, Object>;
     declare let h2: Func<Func<Object, void>, string>;
@@ -192,10 +228,12 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
     ~~
 !!! error TS2322: Type 'Func<Func<Object, void>, Object>' is not assignable to type 'Func<Func<Object, void>, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     h2 = h3;  // Error
     ~~
 !!! error TS2322: Type 'Func<Func<string, void>, Object>' is not assignable to type 'Func<Func<Object, void>, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     h2 = h4;  // Ok
     
     h3 = h1;  // Error
@@ -203,6 +241,7 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
 !!! error TS2322: Type 'Func<Func<Object, void>, Object>' is not assignable to type 'Func<Func<string, void>, Object>'.
 !!! error TS2322:   Type 'Func<string, void>' is not assignable to type 'Func<Object, void>'.
 !!! error TS2322:     Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:       The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     h3 = h2;  // Error
     ~~
 !!! error TS2322: Type 'Func<Func<Object, void>, string>' is not assignable to type 'Func<Func<string, void>, Object>'.
@@ -221,6 +260,7 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
     ~~
 !!! error TS2322: Type 'Func<Func<string, void>, Object>' is not assignable to type 'Func<Func<string, void>, string>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     declare let i1: Func<Object, Func<Object, void>>;
     declare let i2: Func<Object, Func<string, void>>;
@@ -235,20 +275,24 @@ tests/cases/compiler/strictFunctionTypesErrors.ts(155,5): error TS2322: Type '(c
     ~~
 !!! error TS2322: Type 'Func<string, Func<Object, void>>' is not assignable to type 'Func<Object, Func<Object, void>>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     i1 = i4;  // Error
     ~~
 !!! error TS2322: Type 'Func<string, Func<string, void>>' is not assignable to type 'Func<Object, Func<Object, void>>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     i2 = i1;  // Ok
     i2 = i3;  // Error
     ~~
 !!! error TS2322: Type 'Func<string, Func<Object, void>>' is not assignable to type 'Func<Object, Func<string, void>>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     i2 = i4;  // Error
     ~~
 !!! error TS2322: Type 'Func<string, Func<string, void>>' is not assignable to type 'Func<Object, Func<string, void>>'.
 !!! error TS2322:   Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:     The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     
     i3 = i1;  // Ok
     i3 = i2;  // Error

--- a/tests/baselines/reference/superAccessCastedCall.errors.txt
+++ b/tests/baselines/reference/superAccessCastedCall.errors.txt
@@ -1,0 +1,26 @@
+tests/cases/compiler/superAccessCastedCall.ts(10,9): error TS2322: Type 'number' is not assignable to type 'Number'.
+
+
+==== tests/cases/compiler/superAccessCastedCall.ts (1 errors) ====
+    class Foo {
+        bar(): void {}
+    }
+    
+    class Bar extends Foo {
+        x: Number;
+    
+        constructor() {
+            super();
+            this.x = 2;
+            ~~~~~~
+!!! error TS2322: Type 'number' is not assignable to type 'Number'.
+        }
+    
+        bar() {
+            super.bar();
+            (super.bar as any)();
+        }
+    } 
+    
+    let b = new Bar();
+    b.bar()

--- a/tests/baselines/reference/symbolType15.errors.txt
+++ b/tests/baselines/reference/symbolType15.errors.txt
@@ -1,12 +1,17 @@
+tests/cases/conformance/es6/Symbols/symbolType15.ts(4,1): error TS2322: Type 'symbol' is not assignable to type 'Symbol'.
+  'symbol' is a primitive, but 'Symbol' is a wrapper object. Prefer using 'symbol' when possible.
 tests/cases/conformance/es6/Symbols/symbolType15.ts(5,1): error TS2322: Type 'Symbol' is not assignable to type 'symbol'.
   'symbol' is a primitive, but 'Symbol' is a wrapper object. Prefer using 'symbol' when possible.
 
 
-==== tests/cases/conformance/es6/Symbols/symbolType15.ts (1 errors) ====
+==== tests/cases/conformance/es6/Symbols/symbolType15.ts (2 errors) ====
     var sym: symbol;
     var symObj: Symbol;
     
     symObj = sym;
+    ~~~~~~
+!!! error TS2322: Type 'symbol' is not assignable to type 'Symbol'.
+!!! error TS2322:   'symbol' is a primitive, but 'Symbol' is a wrapper object. Prefer using 'symbol' when possible.
     sym = symObj;
     ~~~
 !!! error TS2322: Type 'Symbol' is not assignable to type 'symbol'.

--- a/tests/baselines/reference/templateLiteralTypes2.errors.txt
+++ b/tests/baselines/reference/templateLiteralTypes2.errors.txt
@@ -1,9 +1,10 @@
 tests/cases/conformance/types/literal/templateLiteralTypes2.ts(23,11): error TS2322: Type 'string' is not assignable to type '`abc${string}`'.
 tests/cases/conformance/types/literal/templateLiteralTypes2.ts(29,11): error TS2322: Type 'string' is not assignable to type '`foo${string}` | `bar${string}`'.
 tests/cases/conformance/types/literal/templateLiteralTypes2.ts(32,11): error TS2322: Type 'string' is not assignable to type '`foo${string}` | `bar${string}` | `baz${string}`'.
+tests/cases/conformance/types/literal/templateLiteralTypes2.ts(67,9): error TS2322: Type '`foo${number}`' is not assignable to type 'String'.
 
 
-==== tests/cases/conformance/types/literal/templateLiteralTypes2.ts (3 errors) ====
+==== tests/cases/conformance/types/literal/templateLiteralTypes2.ts (4 errors) ====
     function ft1<T extends string>(s: string, n: number, u: 'foo' | 'bar' | 'baz', t: T) {
         const c1 = `abc${s}`;
         const c2 = `abc${n}`;
@@ -77,6 +78,8 @@ tests/cases/conformance/types/literal/templateLiteralTypes2.ts(32,11): error TS2
     function ft14(t: `foo${number}`) {
         let x1: string = t;
         let x2: String = t;
+            ~~
+!!! error TS2322: Type '`foo${number}`' is not assignable to type 'String'.
         let x3: Object = t;
         let x4: {} = t;
         let x6: { length: number } = t;

--- a/tests/baselines/reference/typeCheckingInsideFunctionExpressionInArray.errors.txt
+++ b/tests/baselines/reference/typeCheckingInsideFunctionExpressionInArray.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts(2,7): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts(3,5): error TS2322: Type 'Object' is not assignable to type 'string'.
+  The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
 tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts(4,15): error TS2339: Property 'NonexistantMethod' does not exist on type 'number[]'.
 tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts(5,5): error TS2304: Cannot find name 'derp'.
 
@@ -12,6 +13,7 @@ tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts(5,5): error 
         k = new Object();
         ~
 !!! error TS2322: Type 'Object' is not assignable to type 'string'.
+!!! error TS2322:   The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
         [1, 2, 3].NonexistantMethod();
                   ~~~~~~~~~~~~~~~~~
 !!! error TS2339: Property 'NonexistantMethod' does not exist on type 'number[]'.

--- a/tests/baselines/reference/typeGuardConstructorNarrowPrimitivesInUnion.types
+++ b/tests/baselines/reference/typeGuardConstructorNarrowPrimitivesInUnion.types
@@ -13,7 +13,7 @@ if (var1.constructor === Number) {
 >Number : NumberConstructor
 
     var1; // number
->var1 : number
+>var1 : never
 }
 
 if (var1.constructor === String) {
@@ -24,7 +24,7 @@ if (var1.constructor === String) {
 >String : StringConstructor
 
     var1; // "hello" | "world"
->var1 : "hello" | "world"
+>var1 : never
 }
 
 if (var1.constructor === Boolean) {
@@ -35,7 +35,7 @@ if (var1.constructor === Boolean) {
 >Boolean : BooleanConstructor
 
     var1; // boolean
->var1 : boolean
+>var1 : never
 }
 
 if (var1.constructor === Array) {

--- a/tests/baselines/reference/typeGuardConstructorPrimitiveTypes.types
+++ b/tests/baselines/reference/typeGuardConstructorPrimitiveTypes.types
@@ -11,7 +11,7 @@ if (var1.constructor === String) {
 >String : StringConstructor
 
     var1; // string
->var1 : string
+>var1 : never
 }
 if (var1.constructor === Number) {
 >var1.constructor === Number : boolean
@@ -21,7 +21,7 @@ if (var1.constructor === Number) {
 >Number : NumberConstructor
 
     var1; // number
->var1 : number
+>var1 : never
 }
 if (var1.constructor === Boolean) {
 >var1.constructor === Boolean : boolean
@@ -31,7 +31,7 @@ if (var1.constructor === Boolean) {
 >Boolean : BooleanConstructor
 
     var1; // boolean
->var1 : boolean
+>var1 : never
 }
 if (var1.constructor === Array) {
 >var1.constructor === Array : boolean
@@ -51,7 +51,7 @@ if (var1.constructor === Symbol) {
 >Symbol : SymbolConstructor
 
     var1; // symbol
->var1 : symbol
+>var1 : never
 }
 if (var1.constructor === BigInt) {
 >var1.constructor === BigInt : boolean
@@ -61,7 +61,7 @@ if (var1.constructor === BigInt) {
 >BigInt : BigIntConstructor
 
     var1; // bigint
->var1 : bigint
+>var1 : never
 }
 
 // Narrow a union of primitive object types

--- a/tests/baselines/reference/validBooleanAssignments.errors.txt
+++ b/tests/baselines/reference/validBooleanAssignments.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts(5,5): error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+
+
+==== tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts (1 errors) ====
+    var x = true;
+    
+    var a: any = x;
+    var b: Object = x;
+    var c: Boolean = x;
+        ~
+!!! error TS2322: Type 'boolean' is not assignable to type 'Boolean'.
+    var d: boolean = x;

--- a/tests/baselines/reference/validStringAssignments.errors.txt
+++ b/tests/baselines/reference/validStringAssignments.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/types/primitives/string/validStringAssignments.ts(6,5): error TS2322: Type 'string' is not assignable to type 'String'.
+  'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
+
+
+==== tests/cases/conformance/types/primitives/string/validStringAssignments.ts (1 errors) ====
+    var x = '';
+    
+    var a: any = x;
+    var b: Object = x;
+    var c: string = x;
+    var d: String = x;
+        ~
+!!! error TS2322: Type 'string' is not assignable to type 'String'.
+!!! error TS2322:   'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.

--- a/tests/cases/compiler/numberWrapper.ts
+++ b/tests/cases/compiler/numberWrapper.ts
@@ -1,0 +1,12 @@
+// @strict: true
+
+declare let aNumber: number;
+declare let aNumberWrapper: Number;
+
+function a() {
+    aNumber = aNumberWrapper;
+}
+
+function b() {
+    aNumberWrapper = aNumber;
+}


### PR DESCRIPTION
Basically, I was trying to understand why we allow `const x: Number = 1` when the latter is a wrapper object. e.g. `1 === new Number(1)` will yield false and `typeof new Number(1) === "object"`, not `number`.

@DanielRosenwasser said this might be an interesting experiment. Might as well try.