### PR TITLE
Remove the specialcase intended for `strictNullChecks: false` in `Awaited`

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1522,12 +1522,11 @@ interface Promise<T> {
  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
  */
 type Awaited<T> =
-    T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
-        T extends object & { then(onfulfilled: infer F, ...args: infer _): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
-            F extends ((value: infer V, ...args: infer _) => any) ? // if the argument to `then` is callable, extracts the first argument
-                Awaited<V> : // recursively unwrap the value
-                never : // the argument to `then` was not callable
-        T; // non-object or non-thenable
+    T extends object & { then(onfulfilled: infer F, ...args: infer _): any } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+        F extends ((value: infer V, ...args: infer _) => any) ? // if the argument to `then` is callable, extracts the first argument
+            Awaited<V> : // recursively unwrap the value
+            never : // the argument to `then` was not callable
+    T; // non-object or non-thenable
 
 interface ArrayLike<T> {
     readonly length: number;


### PR DESCRIPTION
A colleague of mine asked me why this branch is needed here. I couldn't figure it out so I decided to run the TS test suite without this to learn more about it... but the whole thing just passed. 

There are two possible situations here:
- this is redundant
- the test suite lacks the appropriate test case

If it's the second situation - then I would appreciate if somebody could provide that test case so I could add it, cause I don't know what that would look like. 

This type was added [here](https://github.com/microsoft/TypeScript/pull/45350) with this special branch there, right from the start. cc @rbuckton 