### PR TITLE
Remove most direct uses of `factory` from `src/compilers/transformers`

### DIFF
--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -41,7 +41,6 @@ import {
     Expression,
     ExpressionStatement,
     ExpressionWithTypeArguments,
-    factory,
     filter,
     find,
     findComputedPropertyNameCacheAssignment,
@@ -153,6 +152,7 @@ import {
     newPrivateEnvironment,
     Node,
     NodeCheckFlags,
+    NodeFactory,
     nodeIsSynthesized,
     ObjectLiteralElement,
     OmittedExpression,
@@ -2457,6 +2457,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 if (privateIdentifierInfo.kind === PrivateIdentifierKind.Field) {
                     if (!privateIdentifierInfo.isStatic) {
                         return createPrivateInstanceFieldInitializer(
+                            factory,
                             receiver,
                             visitNode(property.initializer, initializerVisitor, isExpression),
                             privateIdentifierInfo.brandCheckIdentifier
@@ -2464,6 +2465,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
                     }
                     else {
                         return createPrivateStaticFieldInitializer(
+                            factory,
                             privateIdentifierInfo.variableName,
                             visitNode(property.initializer, initializerVisitor, isExpression)
                         );
@@ -2575,7 +2577,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
         Debug.assert(weakSetName, "weakSetName should be set in private identifier environment");
         statements.push(
             factory.createExpressionStatement(
-                createPrivateInstanceMethodInitializer(receiver, weakSetName)
+                createPrivateInstanceMethodInitializer(factory, receiver, weakSetName)
             )
         );
     }
@@ -3213,7 +3215,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
     }
 }
 
-function createPrivateStaticFieldInitializer(variableName: Identifier, initializer: Expression | undefined) {
+function createPrivateStaticFieldInitializer(factory: NodeFactory, variableName: Identifier, initializer: Expression | undefined) {
     return factory.createAssignment(
         variableName,
         factory.createObjectLiteralExpression([
@@ -3222,7 +3224,7 @@ function createPrivateStaticFieldInitializer(variableName: Identifier, initializ
     );
 }
 
-function createPrivateInstanceFieldInitializer(receiver: LeftHandSideExpression, initializer: Expression | undefined, weakMapName: Identifier) {
+function createPrivateInstanceFieldInitializer(factory: NodeFactory, receiver: LeftHandSideExpression, initializer: Expression | undefined, weakMapName: Identifier) {
     return factory.createCallExpression(
         factory.createPropertyAccessExpression(weakMapName, "set"),
         /*typeArguments*/ undefined,
@@ -3230,7 +3232,7 @@ function createPrivateInstanceFieldInitializer(receiver: LeftHandSideExpression,
     );
 }
 
-function createPrivateInstanceMethodInitializer(receiver: LeftHandSideExpression, weakSetName: Identifier) {
+function createPrivateInstanceMethodInitializer(factory: NodeFactory, receiver: LeftHandSideExpression, weakSetName: Identifier) {
     return factory.createCallExpression(
         factory.createPropertyAccessExpression(weakSetName, "add"),
         /*typeArguments*/ undefined,

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -166,6 +166,7 @@ import {
     Node,
     NodeArray,
     NodeBuilderFlags,
+    NodeFactory,
     NodeFlags,
     NodeId,
     normalizeSlashes,
@@ -724,7 +725,7 @@ export function transformDeclarations(context: TransformationContext) {
         }
         const newParam = factory.updateParameterDeclaration(
             p,
-            maskModifiers(p, modifierMask),
+            maskModifiers(factory, p, modifierMask),
             p.dotDotDotToken,
             filterBindingPatternInitializersAndRenamings(p.name),
             resolver.isOptionalParameter(p) ? (p.questionToken || factory.createToken(SyntaxKind.QuestionToken)) : undefined,
@@ -1856,7 +1857,7 @@ function isAlwaysType(node: Node) {
 }
 
 // Elide "public" modifier, as it is the default
-function maskModifiers(node: Node, modifierMask?: ModifierFlags, modifierAdditions?: ModifierFlags): Modifier[] | undefined {
+function maskModifiers(factory: NodeFactory, node: Node, modifierMask?: ModifierFlags, modifierAdditions?: ModifierFlags): Modifier[] | undefined {
     return factory.createModifiersFromModifierFlags(maskModifierFlags(node, modifierMask, modifierAdditions));
 }
 

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -12,7 +12,6 @@ import {
     ElementAccessExpression,
     every,
     Expression,
-    factory,
     forEach,
     getElementsOfBindingOrAssignmentPattern,
     getInitializerOfBindingOrAssignmentElement,
@@ -543,6 +542,7 @@ function createDefaultValueCheck(flattenContext: FlattenContext, value: Expressi
  * @param propertyName The destructuring property name.
  */
 function createDestructuringPropertyAccess(flattenContext: FlattenContext, value: Expression, propertyName: PropertyName): LeftHandSideExpression {
+    const { factory } = flattenContext.context;
     if (isComputedPropertyName(propertyName)) {
         const argumentExpression = ensureIdentifier(flattenContext, Debug.checkDefined(visitNode(propertyName.expression, flattenContext.visitor, isExpression)), /*reuseIdentifierExpressions*/ false, /*location*/ propertyName);
         return flattenContext.context.factory.createElementAccessExpression(value, argumentExpression);

--- a/src/compiler/transformers/typeSerializer.ts
+++ b/src/compiler/transformers/typeSerializer.ts
@@ -11,7 +11,6 @@ import {
     Debug,
     EntityName,
     Expression,
-    factory,
     findAncestor,
     FunctionLikeDeclaration,
     getAllAccessorDeclarations,
@@ -137,6 +136,7 @@ export interface RuntimeTypeSerializer {
 /** @internal */
 export function createRuntimeTypeSerializer(context: TransformationContext): RuntimeTypeSerializer {
     const {
+        factory,
         hoistVariableDeclaration
     } = context;
 


### PR DESCRIPTION
Mentioned in https://github.com/microsoft/TypeScript/issues/43423, so I casually looked over who was still doing this. We have one function that I left as-is, which was `getDeclarationDiagnostics` in `declarations.ts`.