### PR TITLE
Move to New File: Respect Quote Style in import updates

### DIFF
--- a/tests/cases/fourslash/moveToNewFile_inferQuoteStyle.ts
+++ b/tests/cases/fourslash/moveToNewFile_inferQuoteStyle.ts
@@ -3,8 +3,17 @@
 // @Filename: /a.ts
 ////import 'unrelated';
 ////
-////[|const x = 0;|]
+////[|export const x = 0;|]
 ////x;
+// @Filename: /b.ts
+////import { x } from './a'
+////
+////x;
+// @Filename: /c.ts
+//////The same import, but namespace variant
+////import * as A from './a'
+////
+////A.x;
 
 verify.moveToNewFile({
     newFileContents: {
@@ -15,7 +24,18 @@ import { x } from './x';
 x;`,
 
         "/x.ts":
-`export const x = 0;
+`
+export const x = 0;
 `,
+        "/b.ts":
+            `import { x } from './x';
+
+x;`,
+        "/c.ts":
+            `//The same import, but namespace variant
+import * as A from './a'
+import * as x from './x';
+
+x.x;`
     },
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #31915

As I understand `makeStringLiteral` should almost always be used instead of `factory.createStringLiteral`
