### PR TITLE
Move to new file: handle later exports in old file

### DIFF
--- a/tests/cases/fourslash/moveToNewFile_exportedLaterDefaultExports.ts
+++ b/tests/cases/fourslash/moveToNewFile_exportedLaterDefaultExports.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////[|const x = 0;|]
+////export default x;
+// @Filename: /b.ts
+////import x from "./a"
+////
+////x;
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts":
+`import { x } from "./x";
+
+export default x;`,
+
+        "/x.ts":
+`export const x = 0;
+`
+    },
+});

--- a/tests/cases/fourslash/moveToNewFile_exportedLaterNamedExports.ts
+++ b/tests/cases/fourslash/moveToNewFile_exportedLaterNamedExports.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////[|const x = 0;|]
+////export { x };
+// @Filename: /b.ts
+////import { x } from "./a"
+////
+////x;
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts":
+`import { x } from "./x";
+
+export { x };`,
+
+        "/x.ts":
+`export const x = 0;
+`
+    },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/32344

The idea is to not put symbols to `movedSymbols` that are exported later.

I came up with this idea since `movedSymbols` result is used:

- to add imports into old file from new file
- to update imports in other files

I added special handling for first case by introducing `symbolsExportedLaterInOldFile` Map (because symbols that are used in exports are different)

Current solution seems to work, but, probably code should be cleaned up in some cases (like getting symbol of default export), anyway, let me know if I'm going here into right direction.
