### PR TITLE
Remove unused eslint-disable directives

### DIFF
--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-globals */
-
 import { CancelError } from "@esfx/canceltoken";
 import assert from "assert";
 import chalk from "chalk";

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1633,7 +1633,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     // `structuralIsReused`, which would be a TDZ violation if it was not set in advance to `undefined`.
     let structureIsReused: StructureIsReused;
     tracing?.push(tracing.Phase.Program, "tryReuseStructureFromOldProgram", {});
-    structureIsReused = tryReuseStructureFromOldProgram(); // eslint-disable-line prefer-const
+    structureIsReused = tryReuseStructureFromOldProgram();
     tracing?.pop();
     if (structureIsReused !== StructureIsReused.Completely) {
         processingDefaultLibFiles = [];

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -103,7 +103,7 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
         return sourceIndex;
     }
 
-    /* eslint-disable local/boolean-trivia, no-null/no-null */
+    /* eslint-disable no-null/no-null */
     function setSourceContent(sourceIndex: number, content: string | null) {
         enter();
         if (content !== null) {
@@ -115,7 +115,7 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
         }
         exit();
     }
-    /* eslint-enable local/boolean-trivia, no-null/no-null */
+    /* eslint-enable no-null/no-null */
 
     function addName(name: string) {
         enter();

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -537,7 +537,7 @@ export function getFileWatcherEventKind(oldTime: number, newTime: number) {
 /** @internal */
 export const ignoredPaths = ["/node_modules/.", "/.git", "/.#"];
 
-let curSysLog: (s: string) => void = noop; // eslint-disable-line prefer-const
+let curSysLog: (s: string) => void = noop;
 
 /** @internal */
 export function sysLog(s: string) {
@@ -1465,7 +1465,6 @@ export function getNodeMajorVersion(): number | undefined {
 }
 
 // TODO: GH#18217 this is used as if it's certainly defined in many places.
-// eslint-disable-next-line prefer-const
 export let sys: System = (() => {
     // NodeJS detects "\uFEFF" at the start of the string and *replaces* it with the actual
     // byte order mark from the specified encoding. Using any other byte order mark does

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4723,7 +4723,7 @@ export interface Program extends ScriptReferenceHost {
      */
     emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult;
     /** @internal */
-    emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnly?: boolean | EmitOnly, customTransformers?: CustomTransformers, forceDtsEmit?: boolean): EmitResult; // eslint-disable-line @typescript-eslint/unified-signatures
+    emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnly?: boolean | EmitOnly, customTransformers?: CustomTransformers, forceDtsEmit?: boolean): EmitResult;
 
     getOptionsDiagnostics(cancellationToken?: CancellationToken): readonly Diagnostic[];
     getGlobalDiagnostics(cancellationToken?: CancellationToken): readonly Diagnostic[];
@@ -5915,7 +5915,7 @@ export const enum InternalSymbolName {
  * with a normal string (which is good, it cannot be misused on assignment or on usage),
  * while still being comparable with a normal string via === (also good) and castable from a string.
  */
-export type __String = (string & { __escapedIdentifier: void }) | (void & { __escapedIdentifier: void }) | InternalSymbolName; // eslint-disable-line @typescript-eslint/naming-convention
+export type __String = (string & { __escapedIdentifier: void }) | (void & { __escapedIdentifier: void }) | InternalSymbolName;
 
 /** ReadonlyMap where keys are `__String`s. */
 export interface ReadonlyUnderscoreEscapedMap<T> extends ReadonlyMap<__String, T> {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7936,7 +7936,6 @@ function SourceMapSource(this: SourceMapSource, fileName: string, text: string, 
     this.skipTrivia = skipTrivia || (pos => pos);
 }
 
-// eslint-disable-next-line prefer-const
 /** @internal */
 export const objectAllocator: ObjectAllocator = {
     getNodeConstructor: () => Node as any,

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -601,7 +601,7 @@ export function visitEachChild<T extends Node>(node: T, visitor: Visitor, contex
  */
 export function visitEachChild<T extends Node>(node: T | undefined, visitor: Visitor, context: TransformationContext, nodesVisitor?: typeof visitNodes, tokenVisitor?: Visitor): T | undefined;
 /** @internal */
-export function visitEachChild<T extends Node>(node: T | undefined, visitor: Visitor, context: TransformationContext, nodesVisitor?: NodesVisitor, tokenVisitor?: Visitor, nodeVisitor?: NodeVisitor): T | undefined; // eslint-disable-line @typescript-eslint/unified-signatures
+export function visitEachChild<T extends Node>(node: T | undefined, visitor: Visitor, context: TransformationContext, nodesVisitor?: NodesVisitor, tokenVisitor?: Visitor, nodeVisitor?: NodeVisitor): T | undefined;
 export function visitEachChild<T extends Node>(node: T | undefined, visitor: Visitor, context: TransformationContext, nodesVisitor = visitNodes, tokenVisitor?: Visitor, nodeVisitor: NodeVisitor = visitNode): T | undefined {
     if (node === undefined) {
         return undefined;

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -866,22 +866,18 @@ class SessionServerHost implements ts.server.ServerHost, ts.server.Logger {
     }
 
     setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): any {
-        // eslint-disable-next-line no-restricted-globals
         return setTimeout(callback, ms, ...args);
     }
 
     clearTimeout(timeoutId: any): void {
-        // eslint-disable-next-line no-restricted-globals
         clearTimeout(timeoutId);
     }
 
     setImmediate(callback: (...args: any[]) => void, _ms: number, ...args: any[]): any {
-        // eslint-disable-next-line no-restricted-globals
         return setImmediate(callback, args);
     }
 
     clearImmediate(timeoutId: any): void {
-        // eslint-disable-next-line no-restricted-globals
         clearImmediate(timeoutId);
     }
 

--- a/src/harness/runnerbase.ts
+++ b/src/harness/runnerbase.ts
@@ -9,10 +9,8 @@ export type TestRunnerKind = CompilerTestKind | FourslashTestKind | "project" | 
 export type CompilerTestKind = "conformance" | "compiler";
 export type FourslashTestKind = "fourslash" | "fourslash-shims" | "fourslash-shims-pp" | "fourslash-server";
 
-/* eslint-disable prefer-const */
 export let shards = 1;
 export let shardId = 1;
-/* eslint-enable prefer-const */
 
 // The following have setters as while they're read here in the harness, they're only set in the runner
 export function setShards(count: number) {

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -600,8 +600,7 @@ function compareModuleSpecifiersWorker(m1: Expression | undefined, m2: Expressio
     const name2 = m2 === undefined ? undefined : getExternalModuleName(m2);
     return compareBooleans(name1 === undefined, name2 === undefined) ||
         compareBooleans(isExternalModuleNameRelative(name1!), isExternalModuleNameRelative(name2!)) ||
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        comparer(name1!, name2!); // I don't know why eslint is wrong but this one is necessary
+        comparer(name1!, name2!);
 }
 
 function getModuleSpecifierExpression(declaration: AnyImportOrRequireStatement): Expression | undefined {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -567,10 +567,8 @@ export interface LanguageService {
     getSmartSelectionRange(fileName: string, position: number): SelectionRange;
 
     /** @internal */
-    // eslint-disable-next-line @typescript-eslint/unified-signatures
     getDefinitionAtPosition(fileName: string, position: number, searchOtherFilesOnly: false, stopAtAlias: boolean): readonly DefinitionInfo[] | undefined;
     /** @internal */
-    // eslint-disable-next-line @typescript-eslint/unified-signatures
     getDefinitionAtPosition(fileName: string, position: number, searchOtherFilesOnly: boolean, stopAtAlias: false): readonly DefinitionInfo[] | undefined;
     getDefinitionAtPosition(fileName: string, position: number): readonly DefinitionInfo[] | undefined;
     getDefinitionAndBoundSpan(fileName: string, position: number): DefinitionInfoAndBoundSpan | undefined;

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -318,14 +318,12 @@ export function start() {
                     }
                     case "timeout": {
                         if (worker.timer) {
-                            // eslint-disable-next-line no-restricted-globals
                             clearTimeout(worker.timer);
                         }
                         if (data.payload.duration === "reset") {
                             worker.timer = undefined;
                         }
                         else {
-                            // eslint-disable-next-line no-restricted-globals
                             worker.timer = setTimeout(killChild, data.payload.duration, data.payload);
                         }
                         break;
@@ -649,6 +647,5 @@ export function start() {
         shimNoopTestInterface(global);
     }
 
-    // eslint-disable-next-line no-restricted-globals
     setTimeout(() => startDelayed(perfData, totalCost), 0); // Do real startup on next tick, so all unit tests have been collected
 }

--- a/src/testRunner/unittests/services/preProcessFile.ts
+++ b/src/testRunner/unittests/services/preProcessFile.ts
@@ -350,7 +350,6 @@ describe("unittests:: services:: PreProcessFile:", () => {
         });
 
         it("Correctly returns empty importedFiles with incorrect template expression", () => {
-            /* eslint-disable no-template-curly-in-string */
             test("const foo = `${",
             /*readImportFile*/ true,
             /*detectJavaScriptImports*/ true,
@@ -362,7 +361,6 @@ describe("unittests:: services:: PreProcessFile:", () => {
                 ambientExternalModules: undefined,
                 isLibFile: false
             });
-            /* eslint-enable no-template-curly-in-string */
         });
 
         it("Correctly return ES6 exports", () => {


### PR DESCRIPTION
These are all no longer needed for one reason or another; found with `--report-unused-disable-directives`.