### PR TITLE
[Move to new file] Update named re-exports in other files

### DIFF
--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -116,6 +116,7 @@ import {
     mapDefined,
     MethodSignature,
     Modifier,
+    NamedExports,
     NamedImportBindings,
     NamedImports,
     NamespaceImport,
@@ -1669,8 +1670,9 @@ namespace deleteDeclaration {
                 break;
 
             case SyntaxKind.ImportSpecifier:
-                const namedImports = (node as ImportSpecifier).parent;
-                if (namedImports.elements.length === 1) {
+            case SyntaxKind.ExportSpecifier:
+                const namedImports = (node as ImportSpecifier | NamedExports).parent;
+                if (isNamedImports(namedImports) && namedImports.elements.length === 1) {
                     deleteImportBinding(changes, sourceFile, namedImports);
                 }
                 else {

--- a/tests/cases/fourslash/moveToNewFile_reexports.ts
+++ b/tests/cases/fourslash/moveToNewFile_reexports.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @target: esnext
+// @module: esnext
+// @Filename: /a.ts
+////[|const x = 0;
+////export default x;|]
+////
+// @Filename: /b.ts
+////export { B, default as default, C } from "./a";
+////
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/x.ts":
+            `const x = 0;
+export default x;
+`,
+        "/b.ts":
+            `export { B, C } from "./a";
+export { default as default } from "./x";
+`,
+    }
+})


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/32885

I deicded to not create another `deleteUnusedImports` and `filterImport` for re-export handling (they need to updated only in updating files) and handle removing / returning new node in one place instead (`filterImportOrReexport`).