### PR TITLE
Also set javascript.unstable for organize imports in settings.json

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -20,6 +20,12 @@
         "organizeImportsIgnoreCase": false,
         "organizeImportsNumericCollation": true
     },
+    "javascript.unstable": {
+        "organizeImportsCollation": "unicode",
+        "organizeImportsCaseFirst": "upper",
+        "organizeImportsIgnoreCase": false,
+        "organizeImportsNumericCollation": true
+    },
 
     // These options search the repo recursively and slow down
     // the build task menu. We define our own in tasks.json.


### PR DESCRIPTION
Turns out there are two of these sections and I had no idea. You have to set both because which is used depends on the current file type. Bleh.

https://github.com/microsoft/vscode/blob/5676aff0f8e959e887c57142d525f2aebcd325df/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts#L168