### PR TITLE
Uncomment gitlens option in template

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -8,10 +8,10 @@
     // "typescript.tsdk": "built/local"
 
     // To ignore commits listed in .git-blame-ignore-revs in GitLens:
-    // "gitlens.advanced.blame.customArguments": [
-    //     "--ignore-revs-file",
-    //     ".git-blame-ignore-revs"
-    // ]
+    "gitlens.advanced.blame.customArguments": [
+        "--ignore-revs-file",
+        ".git-blame-ignore-revs"
+    ],
 
     // Match eslint-plugin-simple-import-sort in organize/auto-imports.
     "typescript.unstable": {


### PR DESCRIPTION
As requested in https://github.com/microsoft/TypeScript/pull/53047#discussion_r1122174343

This is harmless to have if you don't have the extension installed.