### PR TITLE
Remove perf_hooks patch needed for old versions of Node

### DIFF
--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -1,7 +1,5 @@
 import {
     isNodeLikeSystem,
-    Version,
-    VersionRange,
 } from "./_namespaces/ts";
 
 // The following definitions provide the minimum compatible support for the Web Performance User Timings API
@@ -52,7 +50,6 @@ export type PerformanceObserverConstructor = new (callback: (list: PerformanceOb
 export type PerformanceEntryList = PerformanceEntry[];
 
 // Browser globals for the Web Performance User Timings API
-declare const process: any;
 declare const performance: Performance | undefined;
 declare const PerformanceObserver: PerformanceObserverConstructor | undefined;
 
@@ -86,35 +83,8 @@ function tryGetWebPerformanceHooks(): PerformanceHooks | undefined {
 function tryGetNodePerformanceHooks(): PerformanceHooks | undefined {
     if (isNodeLikeSystem()) {
         try {
-            let performance: Performance;
-            const { performance: nodePerformance, PerformanceObserver } = require("perf_hooks") as typeof import("perf_hooks");
-            if (hasRequiredAPI(nodePerformance as unknown as Performance, PerformanceObserver)) {
-                performance = nodePerformance as unknown as Performance;
-                // There is a bug in Node's performance.measure prior to 12.16.3/13.13.0 that does not
-                // match the Web Performance API specification. Node's implementation did not allow
-                // optional `start` and `end` arguments for `performance.measure`.
-                // See https://github.com/nodejs/node/pull/32651 for more information.
-                const version = new Version(process.versions.node);
-                const range = new VersionRange("<12.16.3 || 13 <13.13");
-                if (range.test(version)) {
-                    performance = {
-                        get timeOrigin() { return nodePerformance.timeOrigin; },
-                        now() { return nodePerformance.now(); },
-                        mark(name) { return nodePerformance.mark(name); },
-                        measure(name, start = "nodeStart", end?) {
-                            if (end === undefined) {
-                                end = "__performance.measure-fix__";
-                                nodePerformance.mark(end);
-                            }
-                            nodePerformance.measure(name, start, end);
-                            if (end === "__performance.measure-fix__") {
-                                nodePerformance.clearMarks("__performance.measure-fix__");
-                            }
-                        },
-                        clearMarks(name) { return nodePerformance.clearMarks(name); },
-                        clearMeasures(name) { return (nodePerformance as unknown as Performance).clearMeasures(name); },
-                    };
-                }
+            const { performance, PerformanceObserver } = require("perf_hooks") as typeof import("perf_hooks");
+            if (hasRequiredAPI(performance, PerformanceObserver)) {
                 return {
                     // By default, only write native events when generating a cpu profile or using the v8 profiler.
                     shouldWriteNativeEvents: false,


### PR DESCRIPTION
Splitting this out of #51590 for a narrower review.

This patch is only needed for `<12.16.3 || 13 <13.13`. Anyone who is still using Node 12 better be using Node 12.20 at this point, and nobody should be using Node 13.

Removing this is needed for #51590 to prevent this file from using `Version` and causing a cycle.