### PR TITLE
Lower jsdoc comment state

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8571,13 +8571,14 @@ namespace Parser {
             let tags: JSDocTag[];
             let tagsPos: number;
             let tagsEnd: number;
-            let linkEnd: number;
-            let commentsPos: number | undefined;
-            let comments: string[] = [];
-            const parts: JSDocComment[] = [];
 
             // + 3 for leading /**, - 5 in total for /** */
             return scanner.scanRange(start + 3, length - 5, () => {
+                let linkEnd: number | undefined;
+                let commentsPos: number | undefined;
+                let comments: string[] = [];
+                const parts: JSDocComment[] = [];
+
                 // Initially we can parse out a tag.  We also have seen a starting asterisk.
                 // This is so that /** * @type */ doesn't parse.
                 let state = JSDocState.SawAsterisk;


### PR DESCRIPTION
Four frequently accessed variables are outside the closure passed to scanRange for no reason. I'm not sure this is going to help, but I want to run the perf tests on it without tying up my machine/having to get perf tests working again.

Small step toward addressing https://github.com/microsoft/TypeScript/issues/52959