### PR TITLE
Add an extra test case for deferred conditional types

### DIFF
--- a/tests/baselines/reference/deferredConditionalTypes.js
+++ b/tests/baselines/reference/deferredConditionalTypes.js
@@ -40,6 +40,18 @@ type FilteredValuesMatchNever<O extends object>
 
 type FilteredRes1 = FilteredValuesMatchNever<[]>
 
+// repro from #46761
+
+type Bit = 0 | 1;
+
+type AndBit<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+
+type TestBit<A extends Bit, B extends Bit> = AndBit<
+  A extends 1 ? 0 : 1,
+  B extends 1 ? 0 : 1
+>;
+
+type TestBitRes = TestBit<1, 1>; 
 
 //// [deferredConditionalTypes.js]
 "use strict";

--- a/tests/baselines/reference/deferredConditionalTypes.symbols
+++ b/tests/baselines/reference/deferredConditionalTypes.symbols
@@ -155,3 +155,37 @@ type FilteredRes1 = FilteredValuesMatchNever<[]>
 >FilteredRes1 : Symbol(FilteredRes1, Decl(deferredConditionalTypes.ts, 37, 51))
 >FilteredValuesMatchNever : Symbol(FilteredValuesMatchNever, Decl(deferredConditionalTypes.ts, 34, 1))
 
+// repro from #46761
+
+type Bit = 0 | 1;
+>Bit : Symbol(Bit, Decl(deferredConditionalTypes.ts, 39, 48))
+
+type AndBit<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+>AndBit : Symbol(AndBit, Decl(deferredConditionalTypes.ts, 43, 17))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 45, 12))
+>Bit : Symbol(Bit, Decl(deferredConditionalTypes.ts, 39, 48))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 45, 26))
+>Bit : Symbol(Bit, Decl(deferredConditionalTypes.ts, 39, 48))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 45, 12))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 45, 26))
+
+type TestBit<A extends Bit, B extends Bit> = AndBit<
+>TestBit : Symbol(TestBit, Decl(deferredConditionalTypes.ts, 45, 74))
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 47, 13))
+>Bit : Symbol(Bit, Decl(deferredConditionalTypes.ts, 39, 48))
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 47, 27))
+>Bit : Symbol(Bit, Decl(deferredConditionalTypes.ts, 39, 48))
+>AndBit : Symbol(AndBit, Decl(deferredConditionalTypes.ts, 43, 17))
+
+  A extends 1 ? 0 : 1,
+>A : Symbol(A, Decl(deferredConditionalTypes.ts, 47, 13))
+
+  B extends 1 ? 0 : 1
+>B : Symbol(B, Decl(deferredConditionalTypes.ts, 47, 27))
+
+>;
+
+type TestBitRes = TestBit<1, 1>; 
+>TestBitRes : Symbol(TestBitRes, Decl(deferredConditionalTypes.ts, 50, 2))
+>TestBit : Symbol(TestBit, Decl(deferredConditionalTypes.ts, 45, 74))
+

--- a/tests/baselines/reference/deferredConditionalTypes.types
+++ b/tests/baselines/reference/deferredConditionalTypes.types
@@ -90,3 +90,21 @@ type FilteredValuesMatchNever<O extends object>
 type FilteredRes1 = FilteredValuesMatchNever<[]>
 >FilteredRes1 : true
 
+// repro from #46761
+
+type Bit = 0 | 1;
+>Bit : 0 | 1
+
+type AndBit<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+>AndBit : AndBit<A, B>
+
+type TestBit<A extends Bit, B extends Bit> = AndBit<
+>TestBit : TestBit<A, B>
+
+  A extends 1 ? 0 : 1,
+  B extends 1 ? 0 : 1
+>;
+
+type TestBitRes = TestBit<1, 1>; 
+>TestBitRes : 0
+

--- a/tests/cases/compiler/deferredConditionalTypes.ts
+++ b/tests/cases/compiler/deferredConditionalTypes.ts
@@ -40,3 +40,16 @@ type FilteredValuesMatchNever<O extends object>
   = Equals<Values<FilterByStringValue<[O]>>, never>
 
 type FilteredRes1 = FilteredValuesMatchNever<[]>
+
+// repro from #46761
+
+type Bit = 0 | 1;
+
+type AndBit<A extends Bit, B extends Bit> = [A, B] extends [1, 1] ? 1 : 0;
+
+type TestBit<A extends Bit, B extends Bit> = AndBit<
+  A extends 1 ? 0 : 1,
+  B extends 1 ? 0 : 1
+>;
+
+type TestBitRes = TestBit<1, 1>; 


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/46761
it was actually fixed in 4.9 by https://github.com/microsoft/TypeScript/pull/50397 