### PR TITLE
fix(53074): Functions with async keyword don't autocomplete

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -4500,6 +4500,8 @@ function tryGetObjectLikeCompletionContainer(contextToken: Node | undefined): Ob
                 break;
             case SyntaxKind.AsteriskToken:
                 return isMethodDeclaration(parent) ? tryCast(parent.parent, isObjectLiteralExpression) : undefined;
+            case SyntaxKind.AsyncKeyword:
+                return tryCast(parent.parent, isObjectLiteralExpression);
             case SyntaxKind.Identifier:
                 return (contextToken as Identifier).text === "async" && isShorthandPropertyAssignment(contextToken.parent)
                     ? contextToken.parent.parent : undefined;

--- a/tests/cases/fourslash/completionsObjectLiteralMethod6.ts
+++ b/tests/cases/fourslash/completionsObjectLiteralMethod6.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+////type T = {
+////    foo: () => Promise<void>;
+////}
+////const foo: T = {
+////    async f/**/
+////}
+
+verify.completions({
+    marker: "",
+    includes: [
+        {
+            name: "foo",
+            sortText: completion.SortText.LocationPriority,
+        },
+    ],
+});


### PR DESCRIPTION
Fixes #53074