### PR TITLE
[WIP] Allow adding arbitrary extension files to program without d.ts files being on the disk

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -905,7 +905,7 @@ import {
     removeExtension,
     removePrefix,
     replaceElement,
-    resolutionExtensionIsTSOrJson,
+    resolutionExtensionIsTSOrJsonOrArbitrary,
     ResolutionMode,
     ResolvedModuleFull,
     ResolvedType,
@@ -4874,7 +4874,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             if (sourceFile.symbol) {
-                if (resolvedModule.isExternalLibraryImport && !resolutionExtensionIsTSOrJson(resolvedModule.extension)) {
+                if (resolvedModule.isExternalLibraryImport && !resolutionExtensionIsTSOrJsonOrArbitrary(resolvedModule.extension, compilerOptions)) {
                     errorOnImplicitAnyModule(/*isError*/ false, errorNode, currentSourceFile, mode, resolvedModule, moduleReference);
                 }
                 if (moduleResolutionKind === ModuleResolutionKind.Node16 || moduleResolutionKind === ModuleResolutionKind.NodeNext) {
@@ -4957,7 +4957,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         // May be an untyped module. If so, ignore resolutionDiagnostic.
-        if (resolvedModule && !resolutionExtensionIsTSOrJson(resolvedModule.extension) && resolutionDiagnostic === undefined || resolutionDiagnostic === Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type) {
+        if (resolvedModule && !resolutionExtensionIsTSOrJsonOrArbitrary(resolvedModule.extension, compilerOptions) && resolutionDiagnostic === undefined || resolutionDiagnostic === Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type) {
             if (isForAugmentation) {
                 const diag = Diagnostics.Invalid_module_name_in_augmentation_Module_0_resolves_to_an_untyped_module_at_1_which_cannot_be_augmented;
                 error(errorNode, diag, moduleReference, resolvedModule!.resolvedFileName);

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -57,7 +57,7 @@ import {
     Program,
     removeSuffix,
     removeTrailingDirectorySeparator,
-    resolutionExtensionIsTSOrJson,
+    resolutionExtensionIsTSOrJsonOrArbitrary,
     ResolutionLoader,
     ResolutionMode,
     ResolvedModuleWithFailedLookupLocations,
@@ -684,7 +684,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
                 options,
             ),
             getResolutionWithResolvedFileName: getResolvedModule,
-            shouldRetryResolution: resolution => !resolution.resolvedModule || !resolutionExtensionIsTSOrJson(resolution.resolvedModule.extension),
+            shouldRetryResolution: resolution => !resolution.resolvedModule || !resolutionExtensionIsTSOrJsonOrArbitrary(resolution.resolvedModule.extension, options),
             logChanges: logChangesWhenResolvingModule,
         });
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7647,6 +7647,7 @@ export type HasInvalidatedResolutions = (sourceFile: Path) => boolean;
 export type HasChangedAutomaticTypeDirectiveNames = () => boolean;
 
 export interface CompilerHost extends ModuleResolutionHost {
+    getDeclarationFileForArbitraryExtension?(arbitraryExtensionFileName: string, languageVersionOrOptions: ScriptTarget | CreateSourceFileOptions, onError?: (message: string) => void, shouldCreateNewSourceFile?: boolean): SourceFile | undefined;
     getSourceFile(fileName: string, languageVersionOrOptions: ScriptTarget | CreateSourceFileOptions, onError?: (message: string) => void, shouldCreateNewSourceFile?: boolean): SourceFile | undefined;
     getSourceFileByPath?(fileName: string, path: Path, languageVersionOrOptions: ScriptTarget | CreateSourceFileOptions, onError?: (message: string) => void, shouldCreateNewSourceFile?: boolean): SourceFile | undefined;
     getCancellationToken?(): CancellationToken;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8465,6 +8465,14 @@ export function getResolveJsonModule(compilerOptions: CompilerOptions) {
 }
 
 /** @internal */
+export function getAllowArbitraryExtensions(compilerOptions: CompilerOptions) {
+    if (compilerOptions.allowArbitraryExtensions !== undefined) {
+        return compilerOptions.allowArbitraryExtensions;
+    }
+    return getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Bundler;
+}
+
+/** @internal */
 export function getEmitDeclarations(compilerOptions: CompilerOptions): boolean {
     return !!(compilerOptions.declaration || compilerOptions.composite);
 }
@@ -9298,9 +9306,17 @@ export function extensionIsTS(ext: string): boolean {
     return ext === Extension.Ts || ext === Extension.Tsx || ext === Extension.Dts || ext === Extension.Cts || ext === Extension.Mts || ext === Extension.Dmts || ext === Extension.Dcts || (startsWith(ext, ".d.") && endsWith(ext, ".ts"));
 }
 
+export function hasArbitraryExtension(ext: string) {
+    return !some(supportedTSExtensionsFlat, tsExt => endsWith(ext, tsExt)) &&
+        !some(supportedJSExtensionsFlat, jsExt => endsWith(ext, jsExt)) &&
+        !endsWith(ext, Extension.Json);
+}
+
 /** @internal */
-export function resolutionExtensionIsTSOrJson(ext: string) {
-    return extensionIsTS(ext) || ext === Extension.Json;
+export function resolutionExtensionIsTSOrJsonOrArbitrary(ext: string, options: CompilerOptions) {
+    return extensionIsTS(ext) ||
+        ext === Extension.Json ||
+        getAllowArbitraryExtensions(options) && !some(supportedJSExtensionsFlat, jsExt => endsWith(ext, jsExt));
 }
 
 /**

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -644,7 +644,7 @@ export class TestState {
             if (!ts.isAnySupportedFileExtension(fileName)
                 || Harness.getConfigNameFromFileName(fileName)
                 // Can't get a Program in Server tests
-                || this.testType !== FourSlashTestType.Server && !ts.getAllowJSCompilerOption(this.getProgram().getCompilerOptions()) && !ts.resolutionExtensionIsTSOrJson(ts.extensionFromPath(fileName))
+                || this.testType !== FourSlashTestType.Server && !ts.getAllowJSCompilerOption(this.getProgram().getCompilerOptions()) && !ts.resolutionExtensionIsTSOrJsonOrArbitrary(ts.extensionFromPath(fileName))
                 || ts.getBaseFileName(fileName) === "package.json") return;
             const errors = this.getDiagnostics(fileName).filter(e => e.category !== ts.DiagnosticCategory.Suggestion);
             if (errors.length) {

--- a/src/testRunner/tests.ts
+++ b/src/testRunner/tests.ts
@@ -99,6 +99,7 @@ import "./unittests/tsbuildWatch/projectsBuilding";
 import "./unittests/tsbuildWatch/publicApi";
 import "./unittests/tsbuildWatch/reexport";
 import "./unittests/tsbuildWatch/watchEnvironment";
+import "./unittests/tsc/arbitraryExtensions";
 import "./unittests/tsc/cancellationToken";
 import "./unittests/tsc/composite";
 import "./unittests/tsc/declarationEmit";

--- a/src/testRunner/unittests/tsc/arbitraryExtensions.ts
+++ b/src/testRunner/unittests/tsc/arbitraryExtensions.ts
@@ -1,0 +1,34 @@
+import {
+    loadProjectFromFiles,
+    verifyTsc,
+} from "./helpers";
+
+describe("unittests:: tsc:: arbitraryExtensions::", () => {
+
+    verifyTsc({
+        scenario: "arbitraryExtensions",
+        subScenario: "reports error for css resolution",
+        fs: () => loadProjectFromFiles({
+            "/src/a.ts": `import {} from "./b.css";`,
+            "/src/b.css": "random content",
+        }),
+        commandLineArgs: ["/src/a.ts", "--explainFiles", "--traceResolution"],
+        baselinePrograms: true,
+    });
+
+    verifyTsc({
+        scenario: "arbitraryExtensions",
+        subScenario: "resolves to css file",
+        fs: () => loadProjectFromFiles({
+            "/src/a.ts": `import {} from "./b.css";`,
+            "/src/b.css": "random content",
+        }),
+        commandLineArgs: ["/src/a.ts", "--explainFiles", "--traceResolution", "--allowArbitraryExtensions"],
+        baselinePrograms: true,
+    });
+
+    // May be always try arbitraryextension and report error depending on options ?
+
+    // TODO:: try other flags, watchMode, incremental, program reuse, host.getDeclarationForArbitraryExtensionFile
+    // editor scenarios, module specifier
+});

--- a/tests/baselines/reference/tsc/arbitraryExtensions/reports-error-for-css-resolution.js
+++ b/tests/baselines/reference/tsc/arbitraryExtensions/reports-error-for-css-resolution.js
@@ -1,0 +1,67 @@
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/src/a.ts]
+import {} from "./b.css";
+
+//// [/src/b.css]
+random content
+
+
+
+Output::
+/lib/tsc /src/a.ts --explainFiles --traceResolution
+======== Resolving module './b.css' from '/src/a.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module as file / folder, candidate module location '/src/b.css', target file types: TypeScript, Declaration.
+File name '/src/b.css' has a '.css' extension - stripping it.
+File '/src/b.d.css.ts' does not exist.
+File '/src/b.css.ts' does not exist.
+File '/src/b.css.tsx' does not exist.
+File '/src/b.css.d.ts' does not exist.
+Directory '/src/b.css' does not exist, skipping all lookups in it.
+Loading module as file / folder, candidate module location '/src/b.css', target file types: JavaScript.
+File name '/src/b.css' has a '.css' extension - stripping it.
+File '/src/b.css.js' does not exist.
+File '/src/b.css.jsx' does not exist.
+Directory '/src/b.css' does not exist, skipping all lookups in it.
+======== Module name './b.css' was not resolved. ========
+[96msrc/a.ts[0m:[93m1[0m:[93m16[0m - [91merror[0m[90m TS2307: [0mCannot find module './b.css' or its corresponding type declarations.
+
+[7m1[0m import {} from "./b.css";
+[7m [0m [91m               ~~~~~~~~~[0m
+
+lib/lib.d.ts
+  Default library for target 'es5'
+src/a.ts
+  Root file specified for compilation
+
+Found 1 error in src/a.ts[90m:1[0m
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+Program root files: ["/src/a.ts"]
+Program options: {"explainFiles":true,"traceResolution":true}
+Program structureReused: Not
+Program files::
+/lib/lib.d.ts
+/src/a.ts
+
+
+//// [/src/a.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+

--- a/tests/baselines/reference/tsc/arbitraryExtensions/resolves-to-css-file.js
+++ b/tests/baselines/reference/tsc/arbitraryExtensions/resolves-to-css-file.js
@@ -1,0 +1,65 @@
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/src/a.ts]
+import {} from "./b.css";
+
+//// [/src/b.css]
+random content
+
+
+
+Output::
+/lib/tsc /src/a.ts --explainFiles --traceResolution --allowArbitraryExtensions
+======== Resolving module './b.css' from '/src/a.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module as file / folder, candidate module location '/src/b.css', target file types: TypeScript, Declaration.
+File name '/src/b.css' has a '.css' extension - stripping it.
+File '/src/b.d.css.ts' does not exist.
+File '/src/b.css.ts' does not exist.
+File '/src/b.css.tsx' does not exist.
+File '/src/b.css.d.ts' does not exist.
+Directory '/src/b.css' does not exist, skipping all lookups in it.
+Loading module as file / folder, candidate module location '/src/b.css', target file types: JavaScript.
+File name '/src/b.css' has a '.css' extension - stripping it.
+File '/src/b.css.js' does not exist.
+File '/src/b.css.jsx' does not exist.
+Directory '/src/b.css' does not exist, skipping all lookups in it.
+Loading module as file / folder, candidate module location '/src/b.css', target file types: Arbitrary.
+File name '/src/b.css' has a '.css' extension - stripping it.
+File '/src/b.css' exists - use it as a name resolution result.
+======== Module name './b.css' was successfully resolved to '/src/b.css'. ========
+lib/lib.d.ts
+  Default library for target 'es5'
+src/b.css
+  Imported via "./b.css" from file 'src/a.ts'
+src/a.ts
+  Root file specified for compilation
+exitCode:: ExitStatus.Success
+Program root files: ["/src/a.ts"]
+Program options: {"explainFiles":true,"traceResolution":true,"allowArbitraryExtensions":true}
+Program structureReused: Not
+Program files::
+/lib/lib.d.ts
+/src/b.css
+/src/a.ts
+
+
+//// [/src/a.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+


### PR DESCRIPTION
From thinking about #52983


 // May be always try arbitraryextension and report error depending on options ?
// TODO:: try other flags for errpor reporting, watchMode, incremental, program reuse, host.getDeclarationForArbitraryExtensionFile on all hosts and their test
// editor scenarios, module specifier
// How does LS plugin handl this as a test