### PR TITLE
fix(ArrayBuffer): the ArrayBuffer constructor does not require an argument

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -1691,7 +1691,7 @@ type ArrayBufferLike = ArrayBufferTypes[keyof ArrayBufferTypes];
 
 interface ArrayBufferConstructor {
     readonly prototype: ArrayBuffer;
-    new(byteLength: number): ArrayBuffer;
+    new(byteLength?: number): ArrayBuffer;
     isView(arg: any): arg is ArrayBufferView;
 }
 declare var ArrayBuffer: ArrayBufferConstructor;


### PR DESCRIPTION
`new ArrayBuffer()` works fine and is the same as `new ArrayBuffer(0)`.