### PR TITLE
Mark binder as pure to tree shake in typingsInstaller

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -488,7 +488,7 @@ function initFlowNode<T extends FlowNode>(node: T) {
     return node;
 }
 
-const binder = createBinder();
+const binder = /* @__PURE__ */ createBinder();
 
 /** @internal */
 export function bindSourceFile(file: SourceFile, options: CompilerOptions) {


### PR DESCRIPTION
Noticed this while playing around with something else.

Marking this as pure removes the binder and other bits from the typings installer.