### PR TITLE
Add a test for an error on required JSX children when an empty JSX expression is used

### DIFF
--- a/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.errors.txt
+++ b/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.errors.txt
@@ -1,0 +1,43 @@
+tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx(28,2): error TS2322: Type '{ __children__: never[]; }' is not assignable to type '{ bar?: number | undefined; } & { __children__: () => number; }'.
+  Type '{ __children__: never[]; }' is not assignable to type '{ __children__: () => number; }'.
+    Types of property '__children__' are incompatible.
+      Type 'never[]' is not assignable to type '() => number'.
+        Type 'never[]' provides no match for the signature '(): number'.
+
+
+==== tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx (1 errors) ====
+    // repro from #38108
+    
+    export {}
+    
+    declare global {
+        namespace JSX {
+            type Element = any;
+            interface ElementAttributesProperty {
+                __properties__: {};
+            }
+            interface IntrinsicElements {
+                [key: string]: string;
+            }
+            interface ElementChildrenAttribute {
+                __children__: {};
+            }
+        }
+    }
+    
+    interface MockComponentInterface {
+    	new (): {
+            __properties__: { bar?: number } & { __children__: () => number };
+    	};
+    }
+    
+    declare const MockComponent: MockComponentInterface;
+    
+    <MockComponent>{}</MockComponent>; // error
+     ~~~~~~~~~~~~~
+!!! error TS2322: Type '{ __children__: never[]; }' is not assignable to type '{ bar?: number | undefined; } & { __children__: () => number; }'.
+!!! error TS2322:   Type '{ __children__: never[]; }' is not assignable to type '{ __children__: () => number; }'.
+!!! error TS2322:     Types of property '__children__' are incompatible.
+!!! error TS2322:       Type 'never[]' is not assignable to type '() => number'.
+!!! error TS2322:         Type 'never[]' provides no match for the signature '(): number'.
+    

--- a/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.symbols
+++ b/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.symbols
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx ===
+// repro from #38108
+
+export {}
+
+declare global {
+>global : Symbol(global, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 2, 9))
+
+    namespace JSX {
+>JSX : Symbol(JSX, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 4, 16))
+
+        type Element = any;
+>Element : Symbol(Element, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 5, 19))
+
+        interface ElementAttributesProperty {
+>ElementAttributesProperty : Symbol(ElementAttributesProperty, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 6, 27))
+
+            __properties__: {};
+>__properties__ : Symbol(ElementAttributesProperty.__properties__, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 7, 45))
+        }
+        interface IntrinsicElements {
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 9, 9))
+
+            [key: string]: string;
+>key : Symbol(key, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 11, 13))
+        }
+        interface ElementChildrenAttribute {
+>ElementChildrenAttribute : Symbol(ElementChildrenAttribute, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 12, 9))
+
+            __children__: {};
+>__children__ : Symbol(ElementChildrenAttribute.__children__, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 13, 44))
+        }
+    }
+}
+
+interface MockComponentInterface {
+>MockComponentInterface : Symbol(MockComponentInterface, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 17, 1))
+
+	new (): {
+        __properties__: { bar?: number } & { __children__: () => number };
+>__properties__ : Symbol(__properties__, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 20, 10))
+>bar : Symbol(bar, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 21, 25))
+>__children__ : Symbol(__children__, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 21, 44))
+
+	};
+}
+
+declare const MockComponent: MockComponentInterface;
+>MockComponent : Symbol(MockComponent, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 25, 13))
+>MockComponentInterface : Symbol(MockComponentInterface, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 17, 1))
+
+<MockComponent>{}</MockComponent>; // error
+>MockComponent : Symbol(MockComponent, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 25, 13))
+>MockComponent : Symbol(MockComponent, Decl(jsxEmptyExpressionNotCountedAsChild2.tsx, 25, 13))
+

--- a/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.types
+++ b/tests/baselines/reference/jsxEmptyExpressionNotCountedAsChild2.types
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx ===
+// repro from #38108
+
+export {}
+
+declare global {
+>global : any
+
+    namespace JSX {
+        type Element = any;
+>Element : any
+
+        interface ElementAttributesProperty {
+            __properties__: {};
+>__properties__ : {}
+        }
+        interface IntrinsicElements {
+            [key: string]: string;
+>key : string
+        }
+        interface ElementChildrenAttribute {
+            __children__: {};
+>__children__ : {}
+        }
+    }
+}
+
+interface MockComponentInterface {
+	new (): {
+        __properties__: { bar?: number } & { __children__: () => number };
+>__properties__ : { bar?: number | undefined; } & { __children__: () => number; }
+>bar : number | undefined
+>__children__ : () => number
+
+	};
+}
+
+declare const MockComponent: MockComponentInterface;
+>MockComponent : MockComponentInterface
+
+<MockComponent>{}</MockComponent>; // error
+><MockComponent>{}</MockComponent> : any
+>MockComponent : MockComponentInterface
+>MockComponent : MockComponentInterface
+

--- a/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx
+++ b/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx
@@ -1,0 +1,32 @@
+// @strict: true
+// @noEmit: true
+// @jsx: preserve
+
+// repro from #38108
+
+export {}
+
+declare global {
+    namespace JSX {
+        type Element = any;
+        interface ElementAttributesProperty {
+            __properties__: {};
+        }
+        interface IntrinsicElements {
+            [key: string]: string;
+        }
+        interface ElementChildrenAttribute {
+            __children__: {};
+        }
+    }
+}
+
+interface MockComponentInterface {
+	new (): {
+        __properties__: { bar?: number } & { __children__: () => number };
+	};
+}
+
+declare const MockComponent: MockComponentInterface;
+
+<MockComponent>{}</MockComponent>; // error


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/38108
it was fixed by https://github.com/microsoft/TypeScript/pull/41166 (it didn't come with a test that would exercise the error like this)