### PR TITLE
Investigation: using a mapped form of Omit in rest destructuring

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15724,7 +15724,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getGlobalOmitSymbol(): Symbol | undefined {
         // We always report an error, so cache a result in the event we could not resolve the symbol to prevent reporting it multiple times
-        deferredGlobalOmitSymbol ||= getGlobalTypeAliasSymbol("Omit" as __String, /*arity*/ 2, /*reportErrors*/ true) || unknownSymbol;
+        deferredGlobalOmitSymbol ||= getGlobalTypeAliasSymbol("MappedOmit" as __String, /*arity*/ 2, /*reportErrors*/ true) || unknownSymbol;
         return deferredGlobalOmitSymbol === unknownSymbol ? undefined : deferredGlobalOmitSymbol;
     }
 
@@ -40810,7 +40810,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkExpressionStatement(node: ExpressionStatement) {
         // Grammar checking
         checkGrammarStatementInAmbientContext(node);
-
         checkExpression(node.expression);
     }
 

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1204,6 +1204,7 @@ export namespace Completion {
         typeEntry("Record"),
         typeEntry("Exclude"),
         typeEntry("Extract"),
+        typeEntry("MappedOmit"),
         typeEntry("Omit"),
         typeEntry("NonNullable"),
         typeEntry("Parameters"),

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1585,6 +1585,12 @@ type Extract<T, U> = T extends U ? T : never;
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 
 /**
+ * Construct a type with the properties of T except for those in type K,
+ * in a mapped format
+ */
+type MappedOmit<T, K extends keyof any> = { [P in keyof T as Exclude<P, K>]: T[P]; }
+
+/**
  * Exclude null and undefined from T
  */
 type NonNullable<T> = T & {};

--- a/tests/baselines/reference/destructuringUnspreadableIntoRest.errors.txt
+++ b/tests/baselines/reference/destructuringUnspreadableIntoRest.errors.txt
@@ -1,46 +1,46 @@
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(22,15): error TS2339: Property 'publicProp' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(22,15): error TS2339: Property 'publicProp' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(23,15): error TS2339: Property 'publicProp' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(25,15): error TS2339: Property 'privateProp' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(25,15): error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(26,15): error TS2339: Property 'privateProp' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(27,15): error TS2339: Property 'privateProp' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(27,15): error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(28,15): error TS2339: Property 'privateProp' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(30,15): error TS2339: Property 'protectedProp' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(30,15): error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(31,15): error TS2339: Property 'protectedProp' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(32,15): error TS2339: Property 'protectedProp' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(32,15): error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(33,15): error TS2339: Property 'protectedProp' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(35,15): error TS2339: Property 'getter' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(35,15): error TS2339: Property 'getter' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(36,15): error TS2339: Property 'getter' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(37,15): error TS2339: Property 'getter' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(37,15): error TS2339: Property 'getter' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(38,15): error TS2339: Property 'getter' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(40,15): error TS2339: Property 'setter' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(40,15): error TS2339: Property 'setter' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(41,15): error TS2339: Property 'setter' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(42,15): error TS2339: Property 'setter' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(42,15): error TS2339: Property 'setter' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(43,15): error TS2339: Property 'setter' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(45,15): error TS2339: Property 'method' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(45,15): error TS2339: Property 'method' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(46,15): error TS2339: Property 'method' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(47,15): error TS2339: Property 'method' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(47,15): error TS2339: Property 'method' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(48,15): error TS2339: Property 'method' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(60,11): error TS2339: Property 'publicProp' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(60,11): error TS2339: Property 'publicProp' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(61,11): error TS2339: Property 'publicProp' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(63,11): error TS2339: Property 'privateProp' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(63,11): error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(64,11): error TS2339: Property 'privateProp' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(65,11): error TS2339: Property 'privateProp' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(65,11): error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(66,11): error TS2339: Property 'privateProp' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(68,11): error TS2339: Property 'protectedProp' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(68,11): error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(69,11): error TS2339: Property 'protectedProp' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(70,11): error TS2339: Property 'protectedProp' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(70,11): error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(71,11): error TS2339: Property 'protectedProp' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(73,11): error TS2339: Property 'getter' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(73,11): error TS2339: Property 'getter' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(74,11): error TS2339: Property 'getter' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(75,11): error TS2339: Property 'getter' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(75,11): error TS2339: Property 'getter' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(76,11): error TS2339: Property 'getter' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(78,11): error TS2339: Property 'setter' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(78,11): error TS2339: Property 'setter' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(79,11): error TS2339: Property 'setter' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(80,11): error TS2339: Property 'setter' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(80,11): error TS2339: Property 'setter' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(81,11): error TS2339: Property 'setter' does not exist on type '{}'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(83,11): error TS2339: Property 'method' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(83,11): error TS2339: Property 'method' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(84,11): error TS2339: Property 'method' does not exist on type '{ publicProp: string; }'.
-tests/cases/compiler/destructuringUnspreadableIntoRest.ts(85,11): error TS2339: Property 'method' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+tests/cases/compiler/destructuringUnspreadableIntoRest.ts(85,11): error TS2339: Property 'method' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
 tests/cases/compiler/destructuringUnspreadableIntoRest.ts(86,11): error TS2339: Property 'method' does not exist on type '{}'.
 
 
@@ -68,72 +68,72 @@ tests/cases/compiler/destructuringUnspreadableIntoRest.ts(86,11): error TS2339: 
             rest2.publicProp;
             rest3.publicProp;
                   ~~~~~~~~~~
-!!! error TS2339: Property 'publicProp' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'publicProp' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
             rest4.publicProp;
                   ~~~~~~~~~~
 !!! error TS2339: Property 'publicProp' does not exist on type '{}'.
     
             rest1.privateProp;
                   ~~~~~~~~~~~
-!!! error TS2339: Property 'privateProp' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
             rest2.privateProp;
                   ~~~~~~~~~~~
 !!! error TS2339: Property 'privateProp' does not exist on type '{ publicProp: string; }'.
             rest3.privateProp;
                   ~~~~~~~~~~~
-!!! error TS2339: Property 'privateProp' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
             rest4.privateProp;
                   ~~~~~~~~~~~
 !!! error TS2339: Property 'privateProp' does not exist on type '{}'.
     
             rest1.protectedProp;
                   ~~~~~~~~~~~~~
-!!! error TS2339: Property 'protectedProp' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
             rest2.protectedProp;
                   ~~~~~~~~~~~~~
 !!! error TS2339: Property 'protectedProp' does not exist on type '{ publicProp: string; }'.
             rest3.protectedProp;
                   ~~~~~~~~~~~~~
-!!! error TS2339: Property 'protectedProp' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
             rest4.protectedProp;
                   ~~~~~~~~~~~~~
 !!! error TS2339: Property 'protectedProp' does not exist on type '{}'.
     
             rest1.getter;
                   ~~~~~~
-!!! error TS2339: Property 'getter' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'getter' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
             rest2.getter;
                   ~~~~~~
 !!! error TS2339: Property 'getter' does not exist on type '{ publicProp: string; }'.
             rest3.getter;
                   ~~~~~~
-!!! error TS2339: Property 'getter' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'getter' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
             rest4.getter;
                   ~~~~~~
 !!! error TS2339: Property 'getter' does not exist on type '{}'.
     
             rest1.setter;
                   ~~~~~~
-!!! error TS2339: Property 'setter' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'setter' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
             rest2.setter;
                   ~~~~~~
 !!! error TS2339: Property 'setter' does not exist on type '{ publicProp: string; }'.
             rest3.setter;
                   ~~~~~~
-!!! error TS2339: Property 'setter' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'setter' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
             rest4.setter;
                   ~~~~~~
 !!! error TS2339: Property 'setter' does not exist on type '{}'.
     
             rest1.method;
                   ~~~~~~
-!!! error TS2339: Property 'method' does not exist on type 'Omit<this, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'method' does not exist on type 'MappedOmit<this, "getter" | "setter" | "method">'.
             rest2.method;
                   ~~~~~~
 !!! error TS2339: Property 'method' does not exist on type '{ publicProp: string; }'.
             rest3.method;
                   ~~~~~~
-!!! error TS2339: Property 'method' does not exist on type 'Omit<this, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'method' does not exist on type 'MappedOmit<this, "publicProp" | "getter" | "setter" | "method">'.
             rest4.method;
                   ~~~~~~
 !!! error TS2339: Property 'method' does not exist on type '{}'.
@@ -150,72 +150,72 @@ tests/cases/compiler/destructuringUnspreadableIntoRest.ts(86,11): error TS2339: 
         rest2.publicProp;
         rest3.publicProp;
               ~~~~~~~~~~
-!!! error TS2339: Property 'publicProp' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'publicProp' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
         rest4.publicProp;
               ~~~~~~~~~~
 !!! error TS2339: Property 'publicProp' does not exist on type '{}'.
     
         rest1.privateProp;
               ~~~~~~~~~~~
-!!! error TS2339: Property 'privateProp' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
         rest2.privateProp;
               ~~~~~~~~~~~
 !!! error TS2339: Property 'privateProp' does not exist on type '{ publicProp: string; }'.
         rest3.privateProp;
               ~~~~~~~~~~~
-!!! error TS2339: Property 'privateProp' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'privateProp' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
         rest4.privateProp;
               ~~~~~~~~~~~
 !!! error TS2339: Property 'privateProp' does not exist on type '{}'.
     
         rest1.protectedProp;
               ~~~~~~~~~~~~~
-!!! error TS2339: Property 'protectedProp' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
         rest2.protectedProp;
               ~~~~~~~~~~~~~
 !!! error TS2339: Property 'protectedProp' does not exist on type '{ publicProp: string; }'.
         rest3.protectedProp;
               ~~~~~~~~~~~~~
-!!! error TS2339: Property 'protectedProp' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'protectedProp' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
         rest4.protectedProp;
               ~~~~~~~~~~~~~
 !!! error TS2339: Property 'protectedProp' does not exist on type '{}'.
     
         rest1.getter;
               ~~~~~~
-!!! error TS2339: Property 'getter' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'getter' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
         rest2.getter;
               ~~~~~~
 !!! error TS2339: Property 'getter' does not exist on type '{ publicProp: string; }'.
         rest3.getter;
               ~~~~~~
-!!! error TS2339: Property 'getter' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'getter' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
         rest4.getter;
               ~~~~~~
 !!! error TS2339: Property 'getter' does not exist on type '{}'.
     
         rest1.setter;
               ~~~~~~
-!!! error TS2339: Property 'setter' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'setter' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
         rest2.setter;
               ~~~~~~
 !!! error TS2339: Property 'setter' does not exist on type '{ publicProp: string; }'.
         rest3.setter;
               ~~~~~~
-!!! error TS2339: Property 'setter' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'setter' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
         rest4.setter;
               ~~~~~~
 !!! error TS2339: Property 'setter' does not exist on type '{}'.
     
         rest1.method;
               ~~~~~~
-!!! error TS2339: Property 'method' does not exist on type 'Omit<T, "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'method' does not exist on type 'MappedOmit<T, "getter" | "setter" | "method">'.
         rest2.method;
               ~~~~~~
 !!! error TS2339: Property 'method' does not exist on type '{ publicProp: string; }'.
         rest3.method;
               ~~~~~~
-!!! error TS2339: Property 'method' does not exist on type 'Omit<T, "publicProp" | "getter" | "setter" | "method">'.
+!!! error TS2339: Property 'method' does not exist on type 'MappedOmit<T, "publicProp" | "getter" | "setter" | "method">'.
         rest4.method;
               ~~~~~~
 !!! error TS2339: Property 'method' does not exist on type '{}'.

--- a/tests/baselines/reference/destructuringUnspreadableIntoRest.symbols
+++ b/tests/baselines/reference/destructuringUnspreadableIntoRest.symbols
@@ -50,9 +50,9 @@ class A {
 >A : Symbol(A, Decl(destructuringUnspreadableIntoRest.ts, 0, 0))
 
         rest1.publicProp;
->rest1.publicProp : Symbol(publicProp, Decl(destructuringUnspreadableIntoRest.ts, 1, 16))
+>rest1.publicProp : Symbol(publicProp)
 >rest1 : Symbol(rest1, Decl(destructuringUnspreadableIntoRest.ts, 14, 15))
->publicProp : Symbol(publicProp, Decl(destructuringUnspreadableIntoRest.ts, 1, 16))
+>publicProp : Symbol(publicProp)
 
         rest2.publicProp;
 >rest2.publicProp : Symbol(A.publicProp, Decl(destructuringUnspreadableIntoRest.ts, 1, 16))
@@ -157,9 +157,9 @@ function destructure<T extends A>(x: T) {
 >A : Symbol(A, Decl(destructuringUnspreadableIntoRest.ts, 0, 0))
 
     rest1.publicProp;
->rest1.publicProp : Symbol(publicProp, Decl(destructuringUnspreadableIntoRest.ts, 1, 16))
+>rest1.publicProp : Symbol(publicProp)
 >rest1 : Symbol(rest1, Decl(destructuringUnspreadableIntoRest.ts, 52, 11))
->publicProp : Symbol(publicProp, Decl(destructuringUnspreadableIntoRest.ts, 1, 16))
+>publicProp : Symbol(publicProp)
 
     rest2.publicProp;
 >rest2.publicProp : Symbol(A.publicProp, Decl(destructuringUnspreadableIntoRest.ts, 1, 16))

--- a/tests/baselines/reference/destructuringUnspreadableIntoRest.types
+++ b/tests/baselines/reference/destructuringUnspreadableIntoRest.types
@@ -29,7 +29,7 @@ class A {
 >method : () => void
 
         const {                 ...rest1 } = this;
->rest1 : Omit<this, "getter" | "setter" | "method">
+>rest1 : MappedOmit<this, "getter" | "setter" | "method">
 >this : this
 
         const {                 ...rest2 } = this as A;
@@ -40,7 +40,7 @@ class A {
         const { publicProp: _1, ...rest3 } = this;
 >publicProp : any
 >_1 : string
->rest3 : Omit<this, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<this, "publicProp" | "getter" | "setter" | "method">
 >this : this
 
         const { publicProp: _2, ...rest4 } = this as A;
@@ -52,7 +52,7 @@ class A {
 
         rest1.publicProp;
 >rest1.publicProp : this["publicProp"]
->rest1 : Omit<this, "getter" | "setter" | "method">
+>rest1 : MappedOmit<this, "getter" | "setter" | "method">
 >publicProp : this["publicProp"]
 
         rest2.publicProp;
@@ -62,7 +62,7 @@ class A {
 
         rest3.publicProp;
 >rest3.publicProp : any
->rest3 : Omit<this, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<this, "publicProp" | "getter" | "setter" | "method">
 >publicProp : any
 
         rest4.publicProp;
@@ -72,7 +72,7 @@ class A {
 
         rest1.privateProp;
 >rest1.privateProp : any
->rest1 : Omit<this, "getter" | "setter" | "method">
+>rest1 : MappedOmit<this, "getter" | "setter" | "method">
 >privateProp : any
 
         rest2.privateProp;
@@ -82,7 +82,7 @@ class A {
 
         rest3.privateProp;
 >rest3.privateProp : any
->rest3 : Omit<this, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<this, "publicProp" | "getter" | "setter" | "method">
 >privateProp : any
 
         rest4.privateProp;
@@ -92,7 +92,7 @@ class A {
 
         rest1.protectedProp;
 >rest1.protectedProp : any
->rest1 : Omit<this, "getter" | "setter" | "method">
+>rest1 : MappedOmit<this, "getter" | "setter" | "method">
 >protectedProp : any
 
         rest2.protectedProp;
@@ -102,7 +102,7 @@ class A {
 
         rest3.protectedProp;
 >rest3.protectedProp : any
->rest3 : Omit<this, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<this, "publicProp" | "getter" | "setter" | "method">
 >protectedProp : any
 
         rest4.protectedProp;
@@ -112,7 +112,7 @@ class A {
 
         rest1.getter;
 >rest1.getter : any
->rest1 : Omit<this, "getter" | "setter" | "method">
+>rest1 : MappedOmit<this, "getter" | "setter" | "method">
 >getter : any
 
         rest2.getter;
@@ -122,7 +122,7 @@ class A {
 
         rest3.getter;
 >rest3.getter : any
->rest3 : Omit<this, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<this, "publicProp" | "getter" | "setter" | "method">
 >getter : any
 
         rest4.getter;
@@ -132,7 +132,7 @@ class A {
 
         rest1.setter;
 >rest1.setter : any
->rest1 : Omit<this, "getter" | "setter" | "method">
+>rest1 : MappedOmit<this, "getter" | "setter" | "method">
 >setter : any
 
         rest2.setter;
@@ -142,7 +142,7 @@ class A {
 
         rest3.setter;
 >rest3.setter : any
->rest3 : Omit<this, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<this, "publicProp" | "getter" | "setter" | "method">
 >setter : any
 
         rest4.setter;
@@ -152,7 +152,7 @@ class A {
 
         rest1.method;
 >rest1.method : any
->rest1 : Omit<this, "getter" | "setter" | "method">
+>rest1 : MappedOmit<this, "getter" | "setter" | "method">
 >method : any
 
         rest2.method;
@@ -162,7 +162,7 @@ class A {
 
         rest3.method;
 >rest3.method : any
->rest3 : Omit<this, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<this, "publicProp" | "getter" | "setter" | "method">
 >method : any
 
         rest4.method;
@@ -177,7 +177,7 @@ function destructure<T extends A>(x: T) {
 >x : T
 
     const {                 ...rest1 } = x;
->rest1 : Omit<T, "getter" | "setter" | "method">
+>rest1 : MappedOmit<T, "getter" | "setter" | "method">
 >x : T
 
     const {                 ...rest2 } = x as A;
@@ -188,7 +188,7 @@ function destructure<T extends A>(x: T) {
     const { publicProp: _1, ...rest3 } = x;
 >publicProp : any
 >_1 : string
->rest3 : Omit<T, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<T, "publicProp" | "getter" | "setter" | "method">
 >x : T
 
     const { publicProp: _2, ...rest4 } = x as A;
@@ -200,7 +200,7 @@ function destructure<T extends A>(x: T) {
 
     rest1.publicProp;
 >rest1.publicProp : T["publicProp"]
->rest1 : Omit<T, "getter" | "setter" | "method">
+>rest1 : MappedOmit<T, "getter" | "setter" | "method">
 >publicProp : T["publicProp"]
 
     rest2.publicProp;
@@ -210,7 +210,7 @@ function destructure<T extends A>(x: T) {
 
     rest3.publicProp;
 >rest3.publicProp : any
->rest3 : Omit<T, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<T, "publicProp" | "getter" | "setter" | "method">
 >publicProp : any
 
     rest4.publicProp;
@@ -220,7 +220,7 @@ function destructure<T extends A>(x: T) {
 
     rest1.privateProp;
 >rest1.privateProp : any
->rest1 : Omit<T, "getter" | "setter" | "method">
+>rest1 : MappedOmit<T, "getter" | "setter" | "method">
 >privateProp : any
 
     rest2.privateProp;
@@ -230,7 +230,7 @@ function destructure<T extends A>(x: T) {
 
     rest3.privateProp;
 >rest3.privateProp : any
->rest3 : Omit<T, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<T, "publicProp" | "getter" | "setter" | "method">
 >privateProp : any
 
     rest4.privateProp;
@@ -240,7 +240,7 @@ function destructure<T extends A>(x: T) {
 
     rest1.protectedProp;
 >rest1.protectedProp : any
->rest1 : Omit<T, "getter" | "setter" | "method">
+>rest1 : MappedOmit<T, "getter" | "setter" | "method">
 >protectedProp : any
 
     rest2.protectedProp;
@@ -250,7 +250,7 @@ function destructure<T extends A>(x: T) {
 
     rest3.protectedProp;
 >rest3.protectedProp : any
->rest3 : Omit<T, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<T, "publicProp" | "getter" | "setter" | "method">
 >protectedProp : any
 
     rest4.protectedProp;
@@ -260,7 +260,7 @@ function destructure<T extends A>(x: T) {
 
     rest1.getter;
 >rest1.getter : any
->rest1 : Omit<T, "getter" | "setter" | "method">
+>rest1 : MappedOmit<T, "getter" | "setter" | "method">
 >getter : any
 
     rest2.getter;
@@ -270,7 +270,7 @@ function destructure<T extends A>(x: T) {
 
     rest3.getter;
 >rest3.getter : any
->rest3 : Omit<T, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<T, "publicProp" | "getter" | "setter" | "method">
 >getter : any
 
     rest4.getter;
@@ -280,7 +280,7 @@ function destructure<T extends A>(x: T) {
 
     rest1.setter;
 >rest1.setter : any
->rest1 : Omit<T, "getter" | "setter" | "method">
+>rest1 : MappedOmit<T, "getter" | "setter" | "method">
 >setter : any
 
     rest2.setter;
@@ -290,7 +290,7 @@ function destructure<T extends A>(x: T) {
 
     rest3.setter;
 >rest3.setter : any
->rest3 : Omit<T, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<T, "publicProp" | "getter" | "setter" | "method">
 >setter : any
 
     rest4.setter;
@@ -300,7 +300,7 @@ function destructure<T extends A>(x: T) {
 
     rest1.method;
 >rest1.method : any
->rest1 : Omit<T, "getter" | "setter" | "method">
+>rest1 : MappedOmit<T, "getter" | "setter" | "method">
 >method : any
 
     rest2.method;
@@ -310,7 +310,7 @@ function destructure<T extends A>(x: T) {
 
     rest3.method;
 >rest3.method : any
->rest3 : Omit<T, "publicProp" | "getter" | "setter" | "method">
+>rest3 : MappedOmit<T, "publicProp" | "getter" | "setter" | "method">
 >method : any
 
     rest4.method;

--- a/tests/baselines/reference/genericIsNeverEmptyObject.types
+++ b/tests/baselines/reference/genericIsNeverEmptyObject.types
@@ -2,18 +2,18 @@
 // Repro from #29067
 
 function test<T extends { a: string }>(obj: T) {
->test : <T extends { a: string; }>(obj: T) => Omit<T, "a"> & { b: string; }
+>test : <T extends { a: string; }>(obj: T) => MappedOmit<T, "a"> & { b: string; }
 >a : string
 >obj : T
 
     let { a, ...rest } = obj;
 >a : string
->rest : Omit<T, "a">
+>rest : MappedOmit<T, "a">
 >obj : T
 
     return { ...rest, b: a };
->{ ...rest, b: a } : Omit<T, "a"> & { b: string; }
->rest : Omit<T, "a">
+>{ ...rest, b: a } : MappedOmit<T, "a"> & { b: string; }
+>rest : MappedOmit<T, "a">
 >b : string
 >a : string
 }
@@ -30,7 +30,7 @@ let o2: { b: string, x: number } = test(o1);
 >o2 : { b: string; x: number; }
 >b : string
 >x : number
->test(o1) : Omit<{ a: string; x: number; }, "a"> & { b: string; }
->test : <T extends { a: string; }>(obj: T) => Omit<T, "a"> & { b: string; }
+>test(o1) : MappedOmit<{ a: string; x: number; }, "a"> & { b: string; }
+>test : <T extends { a: string; }>(obj: T) => MappedOmit<T, "a"> & { b: string; }
 >o1 : { a: string; x: number; }
 

--- a/tests/baselines/reference/genericObjectRest.types
+++ b/tests/baselines/reference/genericObjectRest.types
@@ -16,7 +16,7 @@ function f1<T extends { a: string, b: number }>(obj: T) {
     let { a: a1, ...r1 } = obj;
 >a : any
 >a1 : string
->r1 : Omit<T, "a">
+>r1 : MappedOmit<T, "a">
 >obj : T
 
     let { a: a2, b: b2, ...r2 } = obj;
@@ -24,24 +24,24 @@ function f1<T extends { a: string, b: number }>(obj: T) {
 >a2 : string
 >b : any
 >b2 : number
->r2 : Omit<T, "a" | "b">
+>r2 : MappedOmit<T, "a" | "b">
 >obj : T
 
     let { 'a': a3, ...r3 } = obj;
 >a3 : string
->r3 : Omit<T, "a">
+>r3 : MappedOmit<T, "a">
 >obj : T
 
     let { ['a']: a4, ...r4 } = obj;
 >'a' : "a"
 >a4 : string
->r4 : Omit<T, "a">
+>r4 : MappedOmit<T, "a">
 >obj : T
 
     let { [a]: a5, ...r5 } = obj;
 >a : "a"
 >a5 : string
->r5 : Omit<T, "a">
+>r5 : MappedOmit<T, "a">
 >obj : T
 }
 
@@ -68,7 +68,7 @@ function f2<T extends { [sa]: string, [sb]: number }>(obj: T) {
 >a1 : string
 >sb : unique symbol
 >b1 : number
->r1 : Omit<T, unique symbol | unique symbol>
+>r1 : MappedOmit<T, unique symbol | unique symbol>
 >obj : T
 }
 
@@ -83,7 +83,7 @@ function f3<T, K1 extends keyof T, K2 extends keyof T>(obj: T, k1: K1, k2: K2) {
 >a1 : T[K1]
 >k2 : K2
 >a2 : T[K2]
->r1 : Omit<T, K1 | K2>
+>r1 : MappedOmit<T, K1 | K2>
 >obj : T
 }
 
@@ -104,7 +104,7 @@ function f4<K1 extends keyof Item, K2 extends keyof Item>(obj: Item, k1: K1, k2:
 >a1 : Item[K1]
 >k2 : K2
 >a2 : Item[K2]
->r1 : Omit<Item, K1 | K2>
+>r1 : MappedOmit<Item, K1 | K2>
 >obj : Item
 }
 

--- a/tests/baselines/reference/genericObjectSpreadResultInSwitch.symbols
+++ b/tests/baselines/reference/genericObjectSpreadResultInSwitch.symbols
@@ -48,10 +48,10 @@ switch (params.tag) {
         // TS 4.3: string | number
         const result = getType(params).type;
 >result : Symbol(result, Decl(genericObjectSpreadResultInSwitch.ts, 21, 13))
->getType(params).type : Symbol(type, Decl(genericObjectSpreadResultInSwitch.ts, 2, 16))
+>getType(params).type : Symbol(type)
 >getType : Symbol(getType, Decl(genericObjectSpreadResultInSwitch.ts, 4, 5))
 >params : Symbol(params, Decl(genericObjectSpreadResultInSwitch.ts, 15, 13))
->type : Symbol(type, Decl(genericObjectSpreadResultInSwitch.ts, 2, 16))
+>type : Symbol(type)
 
         break;
     }
@@ -60,10 +60,10 @@ switch (params.tag) {
         // TS 4.3: string | number
         const result = getType(params).type;
 >result : Symbol(result, Decl(genericObjectSpreadResultInSwitch.ts, 28, 13))
->getType(params).type : Symbol(type, Decl(genericObjectSpreadResultInSwitch.ts, 2, 45))
+>getType(params).type : Symbol(type)
 >getType : Symbol(getType, Decl(genericObjectSpreadResultInSwitch.ts, 4, 5))
 >params : Symbol(params, Decl(genericObjectSpreadResultInSwitch.ts, 15, 13))
->type : Symbol(type, Decl(genericObjectSpreadResultInSwitch.ts, 2, 45))
+>type : Symbol(type)
 
         break;
     }

--- a/tests/baselines/reference/genericObjectSpreadResultInSwitch.types
+++ b/tests/baselines/reference/genericObjectSpreadResultInSwitch.types
@@ -12,8 +12,8 @@ type Params = {
 >type : string
 
 const getType = <P extends Params>(params: P) => {
->getType : <P extends Params>(params: P) => Omit<P, "foo">
-><P extends Params>(params: P) => {    const {        // Omit        foo,        ...rest    } = params;    return rest;} : <P extends Params>(params: P) => Omit<P, "foo">
+>getType : <P extends Params>(params: P) => MappedOmit<P, "foo">
+><P extends Params>(params: P) => {    const {        // Omit        foo,        ...rest    } = params;    return rest;} : <P extends Params>(params: P) => MappedOmit<P, "foo">
 >params : P
 
     const {
@@ -22,13 +22,13 @@ const getType = <P extends Params>(params: P) => {
 >foo : string
 
         ...rest
->rest : Omit<P, "foo">
+>rest : MappedOmit<P, "foo">
 
     } = params;
 >params : Params
 
     return rest;
->rest : Omit<P, "foo">
+>rest : MappedOmit<P, "foo">
 
 };
 
@@ -48,8 +48,8 @@ switch (params.tag) {
         const result = getType(params).type;
 >result : number
 >getType(params).type : number
->getType(params) : Omit<{ foo: string; } & { tag: "a"; type: number; }, "foo">
->getType : <P extends Params>(params: P) => Omit<P, "foo">
+>getType(params) : MappedOmit<{ foo: string; } & { tag: "a"; type: number; }, "foo">
+>getType : <P extends Params>(params: P) => MappedOmit<P, "foo">
 >params : { foo: string; } & { tag: "a"; type: number; }
 >type : number
 
@@ -63,8 +63,8 @@ switch (params.tag) {
         const result = getType(params).type;
 >result : string
 >getType(params).type : string
->getType(params) : Omit<{ foo: string; } & { tag: "b"; type: string; }, "foo">
->getType : <P extends Params>(params: P) => Omit<P, "foo">
+>getType(params) : MappedOmit<{ foo: string; } & { tag: "b"; type: string; }, "foo">
+>getType : <P extends Params>(params: P) => MappedOmit<P, "foo">
 >params : { foo: string; } & { tag: "b"; type: string; }
 >type : string
 

--- a/tests/baselines/reference/literalTypeWidening.types
+++ b/tests/baselines/reference/literalTypeWidening.types
@@ -443,15 +443,15 @@ function test<T extends { a: string, b: string }>(obj: T): T {
 
     let { a, ...rest } = obj;
 >a : string
->rest : Omit<T, "a">
+>rest : MappedOmit<T, "a">
 >obj : T
 
     return { a: 'hello', ...rest } as T;
 >{ a: 'hello', ...rest } as T : T
->{ a: 'hello', ...rest } : { a: string; } & Omit<T, "a">
+>{ a: 'hello', ...rest } : { a: string; } & MappedOmit<T, "a">
 >a : string
 >'hello' : "hello"
->rest : Omit<T, "a">
+>rest : MappedOmit<T, "a">
 }
 
 // Repro from #32169

--- a/tests/baselines/reference/mappedTypeConstraints.symbols
+++ b/tests/baselines/reference/mappedTypeConstraints.symbols
@@ -132,9 +132,9 @@ const modifier = <T extends TargetProps>(targetProps: T) => {
 >targetProps : Symbol(targetProps, Decl(mappedTypeConstraints.ts, 30, 41))
 
     rest.foo;
->rest.foo : Symbol(foo, Decl(mappedTypeConstraints.ts, 25, 20))
+>rest.foo : Symbol(foo)
 >rest : Symbol(rest, Decl(mappedTypeConstraints.ts, 31, 13))
->foo : Symbol(foo, Decl(mappedTypeConstraints.ts, 25, 20))
+>foo : Symbol(foo)
 
 };
 

--- a/tests/baselines/reference/mappedTypeConstraints.types
+++ b/tests/baselines/reference/mappedTypeConstraints.types
@@ -98,12 +98,12 @@ const modifier = <T extends TargetProps>(targetProps: T) => {
 
     let {bar, ...rest} = targetProps;
 >bar : string
->rest : Omit<T, "bar">
+>rest : MappedOmit<T, "bar">
 >targetProps : T
 
     rest.foo;
 >rest.foo : T["foo"]
->rest : Omit<T, "bar">
+>rest : MappedOmit<T, "bar">
 >foo : T["foo"]
 
 };

--- a/tests/baselines/reference/narrowingDestructuring.types
+++ b/tests/baselines/reference/narrowingDestructuring.types
@@ -111,7 +111,7 @@ function func3<T extends { kind: "a", a: string } | { kind: "b", b: number }>(t:
 
         const { kind, ...r1 } = t;
 >kind : "a"
->r1 : Omit<T, "kind">
+>r1 : MappedOmit<T, "kind">
 >t : { kind: "a"; a: string; }
 
         const r2 = (({ kind, ...rest }) => rest)(t);

--- a/tests/baselines/reference/objectRestNegative.types
+++ b/tests/baselines/reference/objectRestNegative.types
@@ -36,18 +36,18 @@ function stillMustBeLast({ ...mustBeLast, a }: { a: number, b: string }): void {
 >b : string
 }
 function generic<T extends { x, y }>(t: T) {
->generic : <T extends { x: any; y: any; }>(t: T) => Omit<T, "x">
+>generic : <T extends { x: any; y: any; }>(t: T) => MappedOmit<T, "x">
 >x : any
 >y : any
 >t : T
 
     let { x, ...rest } = t;
 >x : any
->rest : Omit<T, "x">
+>rest : MappedOmit<T, "x">
 >t : T
 
     return rest;
->rest : Omit<T, "x">
+>rest : MappedOmit<T, "x">
 }
 
 let rest: { b: string }


### PR DESCRIPTION
Another iteration of #53110, #42524. We can't modify the global `Omit` type without breaking the world, but we can certainly introduce a new one 😶. This will cause declaration emit to start producing `MappedOmit` from rest destructurings and improves completeness in cases like this:
```ts
// Signature was Omit<T, "b">
// Is now MappedOmit<T, "b">
export function notB<T extends { b: string }>(x: T) {
  const { b, ...rest } = x;
  return rest;
}

type ABC = { a: string, b: string, c: string };
type BCD = { b: string, c: string, d: string };
declare const j:  ABC | BCD;
// k: Omit<ABC | BCD, "b"> or MappedOmit<ABC | BCD, "b">
export const k = notB(j);
if ("a" in k) {
  // was unknown (bad)
  // now is string (good)
  k.a;
}
```