### PR TITLE
Fix smoke test failure due to bad git restore post-LKG-deletion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
           npx hereby lkg
           mkdir /tmp/lkg
           mv lib /tmp/lkg/
-          git restore lib
-          git clean -fdx lib
+          git restore lib || true
+          git clean -fdx lib || true
           git checkout ${{ github.sha }}
           rm -rf lib
           mv /tmp/lkg/lib .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,21 @@ jobs:
 
   smoke:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./pr
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        path: pr
+
+    - uses: actions/checkout@v3
+      with:
+        path: base
+        ref: ${{ github.base_ref }}
+      if: github.event_name == 'pull_request'
+
     - uses: actions/setup-node@v3
       with:
         node-version: "*"
@@ -100,21 +112,14 @@ jobs:
     # Pre-build the base branch so we can check lib folder size changes.
     # Note that github.sha points to a merge commit, meaning we're testing
     # the base branch versus the base branch with the PR applied.
-    - if: github.event_name == 'pull_request'
+    - name: Build base LKG
+      if: github.event_name == 'pull_request'
       run: |
-        if [ ! -d lib ]; then
-          git fetch origin ${{ github.base_ref }}
-          git checkout ${{ github.base_ref }}
-          npm ci
-          npx hereby lkg
-          mkdir /tmp/lkg
-          mv lib /tmp/lkg/
-          git restore lib || true
-          git clean -fdx lib || true
-          git checkout ${{ github.sha }}
-          rm -rf lib
-          mv /tmp/lkg/lib .
-        fi
+        npm ci
+        npx hereby lkg
+        rm -rf $GITHUB_WORKSPACE/pr/lib
+        mv ./lib $GITHUB_WORKSPACE/pr/
+      working-directory: ./base
 
     - run:  npm ci
 


### PR DESCRIPTION
I broke the CI again; this time, the code I added for the LKG removal for the smoke test no longer works now that main no longer has `lib` too.