### PR TITLE
Remove old references to Node v4, small cleanup of node version stuff

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1449,21 +1449,6 @@ declare const global: any;
 declare const __filename: string;
 declare const __dirname: string;
 
-export function getNodeMajorVersion(): number | undefined {
-    if (typeof process === "undefined") {
-        return undefined;
-    }
-    const version: string = process.version;
-    if (!version) {
-        return undefined;
-    }
-    const dot = version.indexOf(".");
-    if (dot === -1) {
-        return undefined;
-    }
-    return parseInt(version.substring(1, dot));
-}
-
 // TODO: GH#18217 this is used as if it's certainly defined in many places.
 export let sys: System = (() => {
     // NodeJS detects "\uFEFF" at the start of the string and *replaces* it with the actual

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1492,8 +1492,6 @@ export let sys: System = (() => {
             from?(input: string, encoding?: string): any;
         } = require("buffer").Buffer;
 
-        const nodeVersion = getNodeMajorVersion();
-        const isNode4OrLater = nodeVersion! >= 4;
         const isLinuxOrMacOs = process.platform === "linux" || process.platform === "darwin";
 
         const platform: string = _os.platform();
@@ -1507,7 +1505,7 @@ export let sys: System = (() => {
         // Note that if we ever emit as files like cjs/mjs, this check will be wrong.
         const executingFilePath = __filename.endsWith("sys.js") ? _path.join(_path.dirname(__dirname), "__fake__.js") : __filename;
 
-        const fsSupportsRecursiveFsWatch = isNode4OrLater && (process.platform === "win32" || process.platform === "darwin");
+        const fsSupportsRecursiveFsWatch = process.platform === "win32" || process.platform === "darwin";
         const getCurrentDirectory = memoize(() => process.cwd());
         const { watchFile, watchDirectory } = createSystemWatchFunctions({
             pollingWatchFileWorker: fsWatchFileWorker,

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -11,7 +11,6 @@ import {
     DirectoryWatcherCallback,
     FileWatcher,
     getDirectoryPath,
-    getNodeMajorVersion,
     getRootLength,
     JsTyping,
     LanguageServiceMode,
@@ -299,9 +298,7 @@ export function initializeNodeSystem(): StartInput {
 
     const libDirectory = getDirectoryPath(normalizePath(sys.getExecutingFilePath()));
 
-    const nodeVersion = getNodeMajorVersion();
-    // use watchGuard process on Windows when node version is 4 or later
-    const useWatchGuard = process.platform === "win32" && nodeVersion! >= 4;
+    const useWatchGuard = process.platform === "win32";
     const originalWatchDirectory: ServerHost["watchDirectory"] = sys.watchDirectory.bind(sys);
     const logger = createLogger();
 

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -1,6 +1,5 @@
 import {
     Debug,
-    getNodeMajorVersion,
     setStackTraceLimit,
     sys,
     version,
@@ -30,7 +29,7 @@ function start({ args, logger, cancellationToken, serverMode, unknownServerMode,
     logger.info(`Starting TS Server`);
     logger.info(`Version: ${version}`);
     logger.info(`Arguments: ${args.join(" ")}`);
-    logger.info(`Platform: ${platform} NodeVersion: ${getNodeMajorVersion()} CaseSensitive: ${sys.useCaseSensitiveFileNames}`);
+    logger.info(`Platform: ${platform} NodeVersion: ${process.version} CaseSensitive: ${sys.useCaseSensitiveFileNames}`);
     logger.info(`ServerMode: ${serverMode} hasUnknownServerMode: ${unknownServerMode}`);
 
     setStackTraceLimit();

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8285,7 +8285,6 @@ declare namespace ts {
         negative: boolean;
         base10Value: string;
     }
-    function getNodeMajorVersion(): number | undefined;
     enum FileWatcherEventKind {
         Created = 0,
         Changed = 1,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4342,7 +4342,6 @@ declare namespace ts {
         negative: boolean;
         base10Value: string;
     }
-    function getNodeMajorVersion(): number | undefined;
     enum FileWatcherEventKind {
         Created = 0,
         Changed = 1,


### PR DESCRIPTION
This removes the places where we check if we're in Node 4 as we at a minimum realistically only support Node 10.

Also, remove a helper for parsing out the node version; it's only used for a debug log.