### PR TITLE
Fix esDecorators evaluation test on Node 16+

### DIFF
--- a/src/testRunner/unittests/evaluation/esDecorators.ts
+++ b/src/testRunner/unittests/evaluation/esDecorators.ts
@@ -1863,8 +1863,8 @@ describe("unittests:: evaluation:: esDecorators", () => {
         });
     });
 
-    const nodeVersion = ts.Version.tryParse(process.version);
-    const supportsClassStaticBlock = nodeVersion && nodeVersion.major >= 16;
+    const nodeVersion = new ts.Version(process.versions.node);
+    const supportsClassStaticBlock = nodeVersion.major >= 16;
 
     const targets = [
         // NOTE: Class static blocks weren't supported in Node v14


### PR DESCRIPTION
Our `Version` type rejects the `v` prefix, which was masked by `tryParse` returning undefined, making this check never actually run. Fix this by using `process.versions.node` which does not have the `v` prefix.

Thankfully, the test passes!