### PR TITLE
Set package.json minimum to Node 12.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
                 "which": "^2.0.2"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=12.20"
             }
         },
         "node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "tsserver": "./bin/tsserver"
     },
     "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12"
     },
     "files": [
         "bin",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "tsserver": "./bin/tsserver"
     },
     "engines": {
-        "node": ">=12"
+        "node": ">=12.20"
     },
     "files": [
         "bin",


### PR DESCRIPTION
Previously we said 5.0 was going to be Node 10, and that's what's currently documented (though with a note that we may change it to something else https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes#typescript-50), but it seems like 12 is probably a better idea.

This might be something we want to backport so it's in 5.0 as a "breaking" change.

And maybe, it should be `12.20` to give us the ability to use ESM? But, that could be on main later.