### PR TITLE
Fix build watch task in tasks.json post-LKG removal

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,7 +25,7 @@
             "label": "tsc: watch ./src",
             "type": "shell",
             "command": "node",
-            "args": ["${workspaceFolder}/node_modules/tsc.js", "--build", "${workspaceFolder}/src", "--watch"],
+            "args": ["${workspaceFolder}/node_modules/typescript/lib/tsc.js", "--build", "${workspaceFolder}/src", "--watch"],
             "group": "build",
             "isBackground": true,
             "problemMatcher": [


### PR DESCRIPTION
I accidentally screwed up this path. Just noticed as I was trying to use it to make a refactor.