### PR TITLE
Fixed symbol declarations for generic filtering mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13174,8 +13174,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // and T as the template type.
         const typeParameter = getTypeParameterFromMappedType(type);
         const constraintType = getConstraintTypeFromMappedType(type);
-        const nameType = getNameTypeFromMappedType(type.target as MappedType || type);
-        const isFilteringMappedType = nameType && isTypeAssignableTo(nameType, typeParameter);
+        const mappedType = (type.target as MappedType) || type;
+        const nameType = getNameTypeFromMappedType(mappedType);
+        const shouldLinkPropDeclarations = !nameType || isFilteringMappedType(mappedType);
         const templateType = getTemplateTypeFromMappedType(type.target as MappedType || type);
         const modifiersType = getApparentType(getModifiersTypeFromMappedType(type)); // The 'T' in 'keyof T'
         const templateModifiers = getMappedTypeModifiers(type);
@@ -13222,7 +13223,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     prop.links.keyType = keyType;
                     if (modifiersProp) {
                         prop.links.syntheticOrigin = modifiersProp;
-                        prop.declarations = !nameType || isFilteringMappedType ? modifiersProp.declarations : undefined;
+                        prop.declarations = shouldLinkPropDeclarations ? modifiersProp.declarations : undefined;
                     }
                     members.set(propName, prop);
                 }
@@ -13353,6 +13354,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
         return false;
+    }
+
+    function isFilteringMappedType(type: MappedType): boolean {
+        const nameType = getNameTypeFromMappedType(type);
+        return !!nameType && isTypeAssignableTo(nameType, getTypeParameterFromMappedType(type));
     }
 
     function resolveStructuredTypeMembers(type: StructuredType): ResolvedType {
@@ -17473,8 +17479,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // K is generic and N is assignable to P, instantiate E using a mapper that substitutes the index type for P.
         // For example, for an index access { [P in K]: Box<T[P]> }[X], we construct the type Box<T[X]>.
         if (isGenericMappedType(objectType)) {
-            const nameType = getNameTypeFromMappedType(objectType);
-            if (!nameType || isTypeAssignableTo(nameType, getTypeParameterFromMappedType(objectType))) {
+            if (!getNameTypeFromMappedType(objectType) || isFilteringMappedType(objectType)) {
                 return type[cache] = mapType(substituteIndexedMappedType(objectType, type.indexType), t => getSimplifiedType(t, writing));
             }
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13177,7 +13177,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const mappedType = (type.target as MappedType) || type;
         const nameType = getNameTypeFromMappedType(mappedType);
         const shouldLinkPropDeclarations = !nameType || isFilteringMappedType(mappedType);
-        const templateType = getTemplateTypeFromMappedType(type.target as MappedType || type);
+        const templateType = getTemplateTypeFromMappedType(mappedType);
         const modifiersType = getApparentType(getModifiersTypeFromMappedType(type)); // The 'T' in 'keyof T'
         const templateModifiers = getMappedTypeModifiers(type);
         const include = keyofStringsOnly ? TypeFlags.StringLiteral : TypeFlags.StringOrNumberLiteralOrUnique;

--- a/tests/cases/fourslash/goToDefinition_filteringGenericMappedType.ts
+++ b/tests/cases/fourslash/goToDefinition_filteringGenericMappedType.ts
@@ -1,0 +1,25 @@
+///<reference path="fourslash.ts"/>
+
+//// const obj = {
+////   get /*def*/id() {
+////     return 1;
+////   },
+////   name: "test",
+//// };
+////
+//// type Omit2<T, DroppedKeys extends PropertyKey> = {
+////   [K in keyof T as Exclude<K, DroppedKeys>]: T[K];
+//// };
+////
+//// declare function omit2<O, Mask extends { [K in keyof O]?: true }>(
+////   obj: O,
+////   mask: Mask
+//// ): Omit2<O, keyof Mask>;
+////
+//// const obj2 = omit2(obj, {
+////   name: true,
+//// });
+////
+//// obj2.[|/*ref*/id|];
+
+verify.goToDefinition("ref", "def");


### PR DESCRIPTION
the issue was noticed [here](https://github.com/microsoft/TypeScript/issues/53169#issuecomment-1464363214)

this PR is basically a fix for an unnoticed bug in the feature implemented in https://github.com/microsoft/TypeScript/pull/51650 , the implementation itself is just a pulled-out refactor from https://github.com/microsoft/TypeScript/pull/52972 since it (accidentally) fixed this issue

cc @sandersn @weswigham (reviewers of my original PR)