### PR TITLE
Don't recommend installing typescript package globally in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Find others who are using TypeScript at [our community page](https://www.typescr
 For the latest stable version:
 
 ```bash
-npm install -g typescript
+npm install -D typescript
 ```
 
 For our nightly builds:
 
 ```bash
-npm install -g typescript@next
+npm install -D typescript@next
 ```
 
 ## Contribute


### PR DESCRIPTION
Saw this pop up in Discord today; I don't think installing the typescript package globally is a good idea at all these days (maybe no days).

Instead recommend installing it into the current package and as a dev dep.