### PR TITLE
Make perfLogger potentially undefined rather than using a noop logger

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -493,9 +493,9 @@ const binder = /* @__PURE__ */ createBinder();
 /** @internal */
 export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
     performance.mark("beforeBind");
-    perfLogger.logStartBindFile("" + file.fileName);
+    perfLogger?.logStartBindFile("" + file.fileName);
     binder(file, options);
-    perfLogger.logStopBindFile();
+    perfLogger?.logStopBindFile();
     performance.mark("afterBind");
     performance.measure("Bind", "beforeBind", "afterBind");
 }

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1328,7 +1328,7 @@ export function resolveModuleName(moduleName: string, containingFile: string, co
             }
         }
 
-        perfLogger.logStartResolveModule(moduleName /* , containingFile, ModuleResolutionKind[moduleResolution]*/);
+        perfLogger?.logStartResolveModule(moduleName /* , containingFile, ModuleResolutionKind[moduleResolution]*/);
         switch (moduleResolution) {
             case ModuleResolutionKind.Node16:
                 result = node16ModuleNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference, resolutionMode);
@@ -1348,8 +1348,8 @@ export function resolveModuleName(moduleName: string, containingFile: string, co
             default:
                 return Debug.fail(`Unexpected moduleResolution: ${moduleResolution}`);
         }
-        if (result && result.resolvedModule) perfLogger.logInfoEvent(`Module "${moduleName}" resolved to "${result.resolvedModule.resolvedFileName}"`);
-        perfLogger.logStopResolveModule((result && result.resolvedModule) ? "" + result.resolvedModule.resolvedFileName : "null");
+        if (result && result.resolvedModule) perfLogger?.logInfoEvent(`Module "${moduleName}" resolved to "${result.resolvedModule.resolvedFileName}"`);
+        perfLogger?.logStopResolveModule((result && result.resolvedModule) ? "" + result.resolvedModule.resolvedFileName : "null");
 
         cache?.getOrCreateCacheForDirectory(containingDirectory, redirectedReference).set(moduleName, resolutionMode, result);
         if (!isExternalModuleNameRelative(moduleName)) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1321,7 +1321,7 @@ export function createSourceFile(fileName: string, sourceText: string, languageV
     performance.mark("beforeParse");
     let result: SourceFile;
 
-    perfLogger.logStartParseSourceFile(fileName);
+    perfLogger?.logStartParseSourceFile(fileName);
     const {
         languageVersion,
         setExternalModuleIndicator: overrideSetExternalModuleIndicator,
@@ -1337,7 +1337,7 @@ export function createSourceFile(fileName: string, sourceText: string, languageV
         };
         result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind, setIndicator);
     }
-    perfLogger.logStopParseSourceFile();
+    perfLogger?.logStopParseSourceFile();
 
     performance.mark("afterParse");
     performance.measure("Parse", "beforeParse", "afterParse");

--- a/src/compiler/perfLogger.ts
+++ b/src/compiler/perfLogger.ts
@@ -1,5 +1,3 @@
-import { noop } from "./_namespaces/ts";
-
 /** @internal */
 export interface PerfLogger {
     logEvent(msg: string): void;
@@ -24,28 +22,6 @@ export interface PerfLogger {
     logStopScheduledOperation(): void;
 }
 
-const nullLogger: PerfLogger = {
-    logEvent: noop,
-    logErrEvent: noop,
-    logPerfEvent: noop,
-    logInfoEvent: noop,
-    logStartCommand: noop,
-    logStopCommand: noop,
-    logStartUpdateProgram: noop,
-    logStopUpdateProgram: noop,
-    logStartUpdateGraph: noop,
-    logStopUpdateGraph: noop,
-    logStartResolveModule: noop,
-    logStopResolveModule: noop,
-    logStartParseSourceFile: noop,
-    logStopParseSourceFile: noop,
-    logStartReadFile: noop,
-    logStopReadFile: noop,
-    logStartBindFile: noop,
-    logStopBindFile: noop,
-    logStartScheduledOperation: noop,
-    logStopScheduledOperation: noop,
-};
 
 // Load optional module to enable Event Tracing for Windows
 // See https://github.com/microsoft/typescript-etw for more information
@@ -66,4 +42,4 @@ catch (e) {
  *
  * @internal
  */
-export const perfLogger: PerfLogger = etwModule?.logEvent ? etwModule : nullLogger;
+export const perfLogger: PerfLogger | undefined = etwModule?.logEvent ? etwModule : undefined;

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1814,14 +1814,14 @@ export let sys: System = (() => {
         }
 
         function readFile(fileName: string, _encoding?: string): string | undefined {
-            perfLogger.logStartReadFile(fileName);
+            perfLogger?.logStartReadFile(fileName);
             const file = readFileWorker(fileName, _encoding);
-            perfLogger.logStopReadFile();
+            perfLogger?.logStopReadFile();
             return file;
         }
 
         function writeFile(fileName: string, data: string, writeByteOrderMark?: boolean): void {
-            perfLogger.logEvent("WriteFile: " + fileName);
+            perfLogger?.logEvent("WriteFile: " + fileName);
             // If a BOM is required, emit one
             if (writeByteOrderMark) {
                 data = byteOrderMarkIndicator + data;
@@ -1841,7 +1841,7 @@ export let sys: System = (() => {
         }
 
         function getAccessibleFileSystemEntries(path: string): FileSystemEntries {
-            perfLogger.logEvent("ReadDir: " + (path || "."));
+            perfLogger?.logEvent("ReadDir: " + (path || "."));
             try {
                 const entries = _fs.readdirSync(path || ".", { withFileTypes: true });
                 const files: string[] = [];

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -843,19 +843,19 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
     function updateProgram() {
         switch (reloadLevel) {
             case ConfigFileProgramReloadLevel.Partial:
-                perfLogger.logStartUpdateProgram("PartialConfigReload");
+                perfLogger?.logStartUpdateProgram("PartialConfigReload");
                 reloadFileNamesFromConfigFile();
                 break;
             case ConfigFileProgramReloadLevel.Full:
-                perfLogger.logStartUpdateProgram("FullConfigReload");
+                perfLogger?.logStartUpdateProgram("FullConfigReload");
                 reloadConfigFile();
                 break;
             default:
-                perfLogger.logStartUpdateProgram("SynchronizeProgram");
+                perfLogger?.logStartUpdateProgram("SynchronizeProgram");
                 synchronizeProgram();
                 break;
         }
-        perfLogger.logStopUpdateProgram("Done");
+        perfLogger?.logStopUpdateProgram("Done");
         return getCurrentBuilderProgram();
     }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1259,7 +1259,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
      */
     updateGraph(): boolean {
         tracing?.push(tracing.Phase.Session, "updateGraph", { name: this.projectName, kind: ProjectKind[this.projectKind] });
-        perfLogger.logStartUpdateGraph();
+        perfLogger?.logStartUpdateGraph();
         this.resolutionCache.startRecordingFilesWithChangedResolutions();
 
         const hasNewProgram = this.updateGraphWorker();
@@ -1305,7 +1305,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
             // Preload auto import provider so it's not created during completions request
             this.getPackageJsonAutoImportProvider();
         }
-        perfLogger.logStopUpdateGraph();
+        perfLogger?.logStopUpdateGraph();
         tracing?.pop();
         return !hasNewProgram;
     }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1177,7 +1177,7 @@ export class Session<TMessage = string> implements EventSender {
 
     protected writeMessage(msg: protocol.Message) {
         const msgText = formatMessage(msg, this.logger, this.byteLength, this.host.newLine);
-        perfLogger.logEvent(`Response message size: ${msgText.length}`);
+        perfLogger?.logEvent(`Response message size: ${msgText.length}`);
         this.host.write(msgText);
     }
 
@@ -3540,7 +3540,7 @@ export class Session<TMessage = string> implements EventSender {
             relevantFile = request.arguments && (request as protocol.FileRequest).arguments.file ? (request as protocol.FileRequest).arguments : undefined;
 
             tracing?.instant(tracing.Phase.Session, "request", { seq: request.seq, command: request.command });
-            perfLogger.logStartCommand("" + request.command, this.toStringMessage(message).substring(0, 100));
+            perfLogger?.logStartCommand("" + request.command, this.toStringMessage(message).substring(0, 100));
 
             tracing?.push(tracing.Phase.Session, "executeCommand", { seq: request.seq, command: request.command }, /*separateBeginAndEnd*/ true);
             const { response, responseRequired } = this.executeCommand(request);
@@ -3557,7 +3557,7 @@ export class Session<TMessage = string> implements EventSender {
             }
 
             // Note: Log before writing the response, else the editor can complete its activity before the server does
-            perfLogger.logStopCommand("" + request.command, "Success");
+            perfLogger?.logStopCommand("" + request.command, "Success");
             tracing?.instant(tracing.Phase.Session, "response", { seq: request.seq, command: request.command, success: !!response });
             if (response) {
                 this.doOutput(response, request.command, request.seq, /*success*/ true);
@@ -3572,14 +3572,14 @@ export class Session<TMessage = string> implements EventSender {
 
             if (err instanceof OperationCanceledException) {
                 // Handle cancellation exceptions
-                perfLogger.logStopCommand("" + (request && request.command), "Canceled: " + err);
+                perfLogger?.logStopCommand("" + (request && request.command), "Canceled: " + err);
                 tracing?.instant(tracing.Phase.Session, "commandCanceled", { seq: request?.seq, command: request?.command });
                 this.doOutput({ canceled: true }, request!.command, request!.seq, /*success*/ true);
                 return;
             }
 
             this.logErrorWorker(err, this.toStringMessage(message), relevantFile);
-            perfLogger.logStopCommand("" + (request && request.command), "Error: " + err);
+            perfLogger?.logStopCommand("" + (request && request.command), "Error: " + err);
             tracing?.instant(tracing.Phase.Session, "commandError", { seq: request?.seq, command: request?.command, message: (err as Error).message });
 
             this.doOutput(

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -48,13 +48,13 @@ export class ThrottledOperations {
     }
 
     private static run(self: ThrottledOperations, operationId: string, cb: () => void) {
-        perfLogger.logStartScheduledOperation(operationId);
+        perfLogger?.logStartScheduledOperation(operationId);
         self.pendingTimeouts.delete(operationId);
         if (self.logger) {
             self.logger.info(`Running: ${operationId}`);
         }
         cb();
-        perfLogger.logStopScheduledOperation();
+        perfLogger?.logStopScheduledOperation();
     }
 }
 
@@ -75,7 +75,7 @@ export class GcTimer {
     private static run(self: GcTimer) {
         self.timerId = undefined;
 
-        perfLogger.logStartScheduledOperation("GC collect");
+        perfLogger?.logStartScheduledOperation("GC collect");
         const log = self.logger.hasLevel(LogLevel.requestTime);
         const before = log && self.host.getMemoryUsage!(); // TODO: GH#18217
 
@@ -84,7 +84,7 @@ export class GcTimer {
             const after = self.host.getMemoryUsage!(); // TODO: GH#18217
             self.logger.perftrc(`GC::before ${before}, after ${after}`);
         }
-        perfLogger.logStopScheduledOperation();
+        perfLogger?.logStopScheduledOperation();
     }
 }
 

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -259,13 +259,13 @@ export function initializeNodeSystem(): StartInput {
         msg(s: string, type: Msg = Msg.Err) {
             switch (type) {
                 case Msg.Info:
-                    perfLogger.logInfoEvent(s);
+                    perfLogger?.logInfoEvent(s);
                     break;
                 case Msg.Perf:
-                    perfLogger.logPerfEvent(s);
+                    perfLogger?.logPerfEvent(s);
                     break;
                 default: // Msg.Err
-                    perfLogger.logErrEvent(s);
+                    perfLogger?.logErrEvent(s);
                     break;
             }
 


### PR DESCRIPTION
Effectively 100% of the time, ETW has not been loaded. Rather than using a noopLogger object, instead make `perfLogger` undefined when ETW isn't loaded, and reference with `?.` just like our other tracing API. This should be faster, and hopefully observable since we trace some of our most-called APIs like file reads/writes, parsing/binding, module resolution, etc.