### PR TITLE
Allow 'verbatimModuleSyntax' with transpileModule

### DIFF
--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -73,9 +73,11 @@ export function transpileModule(input: string, transpileOptions: TranspileOption
 
     for (const option of transpileOptionValueCompilerOptions) {
         // Do not set redundant config options if `verbatimModuleSyntax` was supplied.
-        if (!options.verbatimModuleSyntax || !optionsRedundantWithVerbatimModuleSyntax.has(option.name)) {
-            options[option.name] = option.transpileOptionValue;
+        if (options.verbatimModuleSyntax && optionsRedundantWithVerbatimModuleSyntax.has(option.name)) {
+            continue;
         }
+
+        options[option.name] = option.transpileOptionValue;
     }
 
     // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths.

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -43,6 +43,12 @@ export interface TranspileOutput {
     sourceMapText?: string;
 }
 
+const optionsRedundantWithVerbatimModuleSyntax = new Set([
+    "isolatedModules",
+    "preserveValueImports",
+    "importsNotUsedAsValues"
+]);
+
 /*
  * This function will compile source text from 'input' argument using specified compiler options.
  * If not options are provided - it will use a set of default compiler options.
@@ -66,7 +72,10 @@ export function transpileModule(input: string, transpileOptions: TranspileOption
     }
 
     for (const option of transpileOptionValueCompilerOptions) {
-        options[option.name] = option.transpileOptionValue;
+        // Do not set redundant config options if `verbatimModuleSyntax` was supplied.
+        if (!options.verbatimModuleSyntax || !optionsRedundantWithVerbatimModuleSyntax.has(option.name)) {
+            options[option.name] = option.transpileOptionValue;
+        }
     }
 
     // transpileModule does not write anything to disk so there is no need to verify that there are no conflicts between input and output paths.

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -6,10 +6,11 @@ describe("unittests:: services:: Transpile", () => {
     interface TranspileTestSettings {
         options?: ts.TranspileOptions;
         noSetFileName?: boolean;
+        testVerbatimModuleSyntax?: true | "only";
     }
 
-    function transpilesCorrectly(name: string, input: string, testSettings: TranspileTestSettings) {
-        describe(name, () => {
+    function transpilesCorrectly(nameIn: string, input: string, testSettings: TranspileTestSettings) {
+        const runOnce = (name: string, testSettings: TranspileTestSettings) => describe(name, () => {
             let transpileResult: ts.TranspileOutput;
             let oldTranspileResult: string;
             let oldTranspileDiagnostics: ts.Diagnostic[];
@@ -39,7 +40,7 @@ describe("unittests:: services:: Transpile", () => {
 
             transpileOptions.reportDiagnostics = true;
 
-            const justName = "transpile/" + name.replace(/[^a-z0-9\-. ]/ig, "") + (transpileOptions.compilerOptions.jsx ? ts.Extension.Tsx : ts.Extension.Ts);
+            const justName = "transpile/" + name.replace(/[^a-z0-9\-. ()=]/ig, "") + (transpileOptions.compilerOptions.jsx ? ts.Extension.Tsx : ts.Extension.Ts);
             const toBeCompiled = [{
                 unitName,
                 content: input
@@ -85,27 +86,48 @@ describe("unittests:: services:: Transpile", () => {
                 });
             }
         });
+
+        if (testSettings.testVerbatimModuleSyntax !== "only") {
+            runOnce(nameIn, testSettings);
+        }
+        if (testSettings.testVerbatimModuleSyntax) {
+            runOnce(nameIn + " (verbatimModuleSyntax=true)", {
+                ...testSettings,
+                options: {
+                    ...testSettings.options,
+                    compilerOptions: {
+                        ...testSettings.options?.compilerOptions,
+                        verbatimModuleSyntax: true
+                    }
+                }
+            });
+        }
     }
 
     transpilesCorrectly("Generates no diagnostics with valid inputs", `var x = 0;`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Generates no diagnostics for missing file references", `/// <reference path="file2.ts" />
 var x = 0;`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Generates no diagnostics for missing module imports", `import {a} from "module2";`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Generates expected syntactic diagnostics", `a b`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Does not generate semantic diagnostics", `var x: string = 0;`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Generates module output", `var x = 0;`, {
@@ -113,7 +135,8 @@ var x = 0;`, {
     });
 
     transpilesCorrectly("Uses correct newLine character", `var x = 0;`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS, newLine: ts.NewLineKind.LineFeed } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS, newLine: ts.NewLineKind.LineFeed } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Sets module name", "var x = 1;", {
@@ -121,7 +144,8 @@ var x = 0;`, {
     });
 
     transpilesCorrectly("No extra errors for file without extension", `"use strict";\r\nvar x = 0;`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS }, fileName: "file" }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS }, fileName: "file" },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Rename dependencies - System",
@@ -168,7 +192,8 @@ var x = 0;`, {
                     experimentalDecorators: true,
                     target: ts.ScriptTarget.ES5,
                 }
-            }
+            },
+            testVerbatimModuleSyntax: true
         });
 
     transpilesCorrectly("Supports backslashes in file name", "var x", {
@@ -206,227 +231,287 @@ var x = 0;`, {
     });
 
     transpilesCorrectly("Support options with lib values", "const a = 10;", {
-        options: { compilerOptions: { lib: ["es6", "dom"], module: ts.ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { lib: ["es6", "dom"], module: ts.ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Support options with types values", "const a = 10;", {
-        options: { compilerOptions: { types: ["jquery", "typescript"], module: ts.ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { types: ["jquery", "typescript"], module: ts.ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'allowJs'", "x;", {
-        options: { compilerOptions: { allowJs: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { allowJs: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'allowSyntheticDefaultImports'", "x;", {
-        options: { compilerOptions: { allowSyntheticDefaultImports: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { allowSyntheticDefaultImports: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'allowUnreachableCode'", "x;", {
-        options: { compilerOptions: { allowUnreachableCode: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { allowUnreachableCode: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'allowUnusedLabels'", "x;", {
-        options: { compilerOptions: { allowUnusedLabels: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { allowUnusedLabels: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'alwaysStrict'", "x;", {
-        options: { compilerOptions: { alwaysStrict: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { alwaysStrict: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'baseUrl'", "x;", {
-        options: { compilerOptions: { baseUrl: "./folder/baseUrl" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { baseUrl: "./folder/baseUrl" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'charset'", "x;", {
-        options: { compilerOptions: { charset: "en-us" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { charset: "en-us" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'declaration'", "x;", {
-        options: { compilerOptions: { declaration: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { declaration: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'declarationDir'", "x;", {
-        options: { compilerOptions: { declarationDir: "out/declarations" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { declarationDir: "out/declarations" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'emitBOM'", "x;", {
-        options: { compilerOptions: { emitBOM: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { emitBOM: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'emitDecoratorMetadata'", "x;", {
-        options: { compilerOptions: { emitDecoratorMetadata: true, experimentalDecorators: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { emitDecoratorMetadata: true, experimentalDecorators: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'experimentalDecorators'", "x;", {
-        options: { compilerOptions: { experimentalDecorators: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { experimentalDecorators: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'forceConsistentCasingInFileNames'", "x;", {
-        options: { compilerOptions: { forceConsistentCasingInFileNames: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { forceConsistentCasingInFileNames: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'isolatedModules'", "x;", {
         options: { compilerOptions: { isolatedModules: true }, fileName: "input.js", reportDiagnostics: true }
     });
 
+    transpilesCorrectly("Does not support setting 'isolatedModules'", "x;", {
+        options: { compilerOptions: { isolatedModules: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: "only"
+    });
+
     transpilesCorrectly("Supports setting 'jsx'", "x;", {
-        options: { compilerOptions: { jsx: 1 }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { jsx: 1 }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'lib'", "x;", {
-        options: { compilerOptions: { lib: ["es2015", "dom"] }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { lib: ["es2015", "dom"] }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'locale'", "x;", {
-        options: { compilerOptions: { locale: "en-us" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { locale: "en-us" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'module'", "x;", {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'moduleResolution'", "x;", {
-        options: { compilerOptions: { moduleResolution: ts.ModuleResolutionKind.Node10 }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { moduleResolution: ts.ModuleResolutionKind.Node10 }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'newLine'", "x;", {
-        options: { compilerOptions: { newLine: ts.NewLineKind.CarriageReturnLineFeed }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { newLine: ts.NewLineKind.CarriageReturnLineFeed }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noEmit'", "x;", {
-        options: { compilerOptions: { noEmit: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noEmit: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noEmitHelpers'", "x;", {
-        options: { compilerOptions: { noEmitHelpers: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noEmitHelpers: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noEmitOnError'", "x;", {
-        options: { compilerOptions: { noEmitOnError: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noEmitOnError: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noErrorTruncation'", "x;", {
-        options: { compilerOptions: { noErrorTruncation: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noErrorTruncation: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noFallthroughCasesInSwitch'", "x;", {
-        options: { compilerOptions: { noFallthroughCasesInSwitch: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noFallthroughCasesInSwitch: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noImplicitAny'", "x;", {
-        options: { compilerOptions: { noImplicitAny: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noImplicitAny: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noImplicitReturns'", "x;", {
-        options: { compilerOptions: { noImplicitReturns: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noImplicitReturns: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noImplicitThis'", "x;", {
-        options: { compilerOptions: { noImplicitThis: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noImplicitThis: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noImplicitUseStrict'", "x;", {
-        options: { compilerOptions: { noImplicitUseStrict: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noImplicitUseStrict: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noLib'", "x;", {
-        options: { compilerOptions: { noLib: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noLib: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'noResolve'", "x;", {
-        options: { compilerOptions: { noResolve: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { noResolve: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'out'", "x;", {
-        options: { compilerOptions: { out: "./out" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { out: "./out" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'outDir'", "x;", {
-        options: { compilerOptions: { outDir: "./outDir" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { outDir: "./outDir" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'outFile'", "x;", {
-        options: { compilerOptions: { outFile: "./outFile" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { outFile: "./outFile" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'paths'", "x;", {
-        options: { compilerOptions: { paths: { "*": ["./generated*"] } }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { paths: { "*": ["./generated*"] } }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'preserveConstEnums'", "x;", {
-        options: { compilerOptions: { preserveConstEnums: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { preserveConstEnums: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'reactNamespace'", "x;", {
-        options: { compilerOptions: { reactNamespace: "react" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { reactNamespace: "react" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'jsxFactory'", "x;", {
-        options: { compilerOptions: { jsxFactory: "createElement" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { jsxFactory: "createElement" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'jsxFragmentFactory'", "x;", {
-        options: { compilerOptions: { jsxFactory: "x", jsxFragmentFactory: "frag" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { jsxFactory: "x", jsxFragmentFactory: "frag" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'removeComments'", "x;", {
-        options: { compilerOptions: { removeComments: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { removeComments: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'rootDir'", "x;", {
-        options: { compilerOptions: { rootDir: "./rootDir" }, fileName: "./rootDir/input.js", reportDiagnostics: true }
+        options: { compilerOptions: { rootDir: "./rootDir" }, fileName: "./rootDir/input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'rootDirs'", "x;", {
-        options: { compilerOptions: { rootDirs: ["./a", "./b"] }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { rootDirs: ["./a", "./b"] }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'skipLibCheck'", "x;", {
-        options: { compilerOptions: { skipLibCheck: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { skipLibCheck: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'skipDefaultLibCheck'", "x;", {
-        options: { compilerOptions: { skipDefaultLibCheck: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { skipDefaultLibCheck: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'strictNullChecks'", "x;", {
-        options: { compilerOptions: { strictNullChecks: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { strictNullChecks: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'stripInternal'", "x;", {
-        options: { compilerOptions: { stripInternal: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { stripInternal: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'suppressExcessPropertyErrors'", "x;", {
-        options: { compilerOptions: { suppressExcessPropertyErrors: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { suppressExcessPropertyErrors: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'suppressImplicitAnyIndexErrors'", "x;", {
-        options: { compilerOptions: { suppressImplicitAnyIndexErrors: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { suppressImplicitAnyIndexErrors: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'target'", "x;", {
-        options: { compilerOptions: { target: 2 }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { target: 2 }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'types'", "x;", {
-        options: { compilerOptions: { types: ["jquery", "jasmine"] }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { types: ["jquery", "jasmine"] }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'typeRoots'", "x;", {
-        options: { compilerOptions: { typeRoots: ["./folder"] }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { typeRoots: ["./folder"] }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'incremental'", "x;", {
-        options: { compilerOptions: { incremental: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { incremental: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'composite'", "x;", {
-        options: { compilerOptions: { composite: true }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { composite: true }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports setting 'tsbuildinfo'", "x;", {
-        options: { compilerOptions: { incremental: true, tsBuildInfoFile: "./folder/config.tsbuildinfo" }, fileName: "input.js", reportDiagnostics: true }
+        options: { compilerOptions: { incremental: true, tsBuildInfoFile: "./folder/config.tsbuildinfo" }, fileName: "input.js", reportDiagnostics: true },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Correctly serialize metadata when transpile with CommonJS option",
@@ -443,9 +528,9 @@ var x = 0;`, {
                     moduleResolution: ts.ModuleResolutionKind.Node10,
                     emitDecoratorMetadata: true,
                     experimentalDecorators: true,
-                    isolatedModules: true,
                 }
-            }
+            },
+            testVerbatimModuleSyntax: true
         }
     );
 
@@ -463,29 +548,33 @@ var x = 0;`, {
                     moduleResolution: ts.ModuleResolutionKind.Node10,
                     emitDecoratorMetadata: true,
                     experimentalDecorators: true,
-                    isolatedModules: true,
+                    isolatedModules: true
                 }
             }
         }
     );
 
     transpilesCorrectly("Supports readonly keyword for arrays", "let x: readonly string[];", {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Supports 'as const' arrays", `([] as const).forEach(k => console.log(k));`, {
-        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Infer correct file extension", `const fn = <T>(a: T) => a`, {
-        noSetFileName: true
+        noSetFileName: true,
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Export star as ns conflict does not crash", `
 var a;
 export { a as alias };
 export * as alias from './file';`, {
-        noSetFileName: true
+        noSetFileName: true,
+        testVerbatimModuleSyntax: true
     });
 
     transpilesCorrectly("Elides import equals referenced only by export type",
@@ -495,10 +584,26 @@ export * as alias from './file';`, {
         }
     );
 
+    transpilesCorrectly("Does not elide import equals referenced only by export type",
+        `import IFoo = Namespace.IFoo;` +
+        `export type { IFoo };`, {
+            options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+            testVerbatimModuleSyntax: "only"
+        }
+    );
+
     transpilesCorrectly("Elides import equals referenced only by type only export specifier",
         `import IFoo = Namespace.IFoo;` +
         `export { type IFoo };`, {
             options: { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+        }
+    );
+
+    transpilesCorrectly("Does not elide import equals referenced only by type only export specifier",
+        `import IFoo = Namespace.IFoo;` +
+        `export { type IFoo };`, {
+            options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
+            testVerbatimModuleSyntax: "only"
         }
     );
 });

--- a/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with CommonJS option (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with CommonJS option (verbatimModuleSyntax=true).js
@@ -1,0 +1,24 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var ng = require("angular2/core");
+var MyClass1 = /** @class */ (function () {
+    function MyClass1(_elementRef) {
+        this._elementRef = _elementRef;
+    }
+    var _a;
+    MyClass1 = __decorate([
+        fooexport,
+        __metadata("design:paramtypes", [typeof (_a = typeof ng !== "undefined" && ng.ElementRef) === "function" ? _a : Object])
+    ], MyClass1);
+    return MyClass1;
+}());
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with CommonJS option (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Correctly serialize metadata when transpile with CommonJS option (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,24 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var ng = require("angular2/core");
+var MyClass1 = /** @class */ (function () {
+    function MyClass1(_elementRef) {
+        this._elementRef = _elementRef;
+    }
+    var _a;
+    MyClass1 = __decorate([
+        fooexport,
+        __metadata("design:paramtypes", [typeof (_a = typeof ng !== "undefined" && ng.ElementRef) === "function" ? _a : Object])
+    ], MyClass1);
+    return MyClass1;
+}());
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    import IFoo = Namespace.IFoo;export type { IFoo };

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+var IFoo = Namespace.IFoo;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    import IFoo = Namespace.IFoo;export type { IFoo };

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by export type (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+var IFoo = Namespace.IFoo;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    import IFoo = Namespace.IFoo;export { type IFoo };

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+var IFoo = Namespace.IFoo;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    import IFoo = Namespace.IFoo;export { type IFoo };

--- a/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Does not elide import equals referenced only by type only export specifier (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+var IFoo = Namespace.IFoo;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    var x: string = 0;

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    var x: string = 0;

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,8 @@
+error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,8 @@
+error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Does not support setting isolatedModules (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,9 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    
+    var a;
+    export { a as alias };
+    export * as alias from './file';

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.alias = void 0;
+var a;
+exports.alias = a;
+exports.alias = require("./file");
+//# sourceMappingURL=module.js.map

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,9 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    
+    var a;
+    export { a as alias };
+    export * as alias from './file';

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.alias = void 0;
+var a;
+exports.alias = a;
+exports.alias = require("./file");
+//# sourceMappingURL=module.js.map

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,9 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+file.ts(1,1): error TS1434: Unexpected keyword or identifier.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (1 errors) ====
+    a b
+    ~
+!!! error TS1434: Unexpected keyword or identifier.

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).js
@@ -1,0 +1,3 @@
+a;
+b;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,9 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+file.ts(1,1): error TS1434: Unexpected keyword or identifier.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (1 errors) ====
+    a b
+    ~
+!!! error TS1434: Unexpected keyword or identifier.

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,3 @@
+a;
+b;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,7 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    /// <reference path="file2.ts" />
+    var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).js
@@ -1,0 +1,3 @@
+/// <reference path="file2.ts" />
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,7 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    /// <reference path="file2.ts" />
+    var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,3 @@
+/// <reference path="file2.ts" />
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    import {a} from "module2";

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+var module2_1 = require("module2");
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    import {a} from "module2";

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,4 @@
+"use strict";
+exports.__esModule = true;
+var module2_1 = require("module2");
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    var x = 0;

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    const fn = <T>(a: T) => a

--- a/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+var fn = function (a) { return a; };
+//# sourceMappingURL=module.js.map

--- a/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    const fn = <T>(a: T) => a

--- a/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Infer correct file extension (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+var fn = function (a) { return a; };
+//# sourceMappingURL=module.js.map

--- a/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,7 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file (0 errors) ====
+    "use strict";
+    var x = 0;

--- a/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).js
@@ -1,0 +1,3 @@
+"use strict";
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,7 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file (0 errors) ====
+    "use strict";
+    var x = 0;

--- a/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,3 @@
+"use strict";
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    const a = 10;

--- a/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    const a = 10;

--- a/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Support options with lib values (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    const a = 10;

--- a/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    const a = 10;

--- a/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Support options with types values (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    ([] as const).forEach(k => console.log(k));

--- a/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+[].forEach(function (k) { return console.log(k); });
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    ([] as const).forEach(k => console.log(k));

--- a/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports as const arrays (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+[].forEach(function (k) { return console.log(k); });
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    let x: readonly string[];

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+var x;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    let x: readonly string[];

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+var x;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowJs (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).js
@@ -1,0 +1,3 @@
+"use strict";
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,3 @@
+"use strict";
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting charset (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting composite (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting declaration (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting incremental (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting jsx (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting jsxFragmentFactory (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting lib (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting locale (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting module (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting newLine (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmit (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'noImplicitUseStrict' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitUseStrict (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noLib (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noResolve (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting out (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting outDir (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting outFile (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting paths (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting removeComments (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== ./rootDir/input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== ./rootDir/input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting rootDir (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'suppressExcessPropertyErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,8 @@
+error TS5101: Option 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5101: Option 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting target (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting target (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting target (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting target (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting tsbuildinfo (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== input.js (0 errors) ====
+    x;

--- a/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting types (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata (verbatimModuleSyntax=true).js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MyClass = void 0;
+var db_1 = require("./db");
+function someDecorator(target) {
+    return target;
+}
+var MyClass = /** @class */ (function () {
+    function MyClass(db) {
+        this.db = db;
+        this.db.doSomething();
+    }
+    var _a;
+    MyClass = __decorate([
+        someDecorator,
+        __metadata("design:paramtypes", [typeof (_a = typeof db_1.db !== "undefined" && db_1.db) === "function" ? _a : Object])
+    ], MyClass);
+    return MyClass;
+}());
+exports.MyClass = MyClass;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MyClass = void 0;
+var db_1 = require("./db");
+function someDecorator(target) {
+    return target;
+}
+var MyClass = /** @class */ (function () {
+    function MyClass(db) {
+        this.db = db;
+        this.db.doSomething();
+    }
+    var _a;
+    MyClass = __decorate([
+        someDecorator,
+        __metadata("design:paramtypes", [typeof (_a = typeof db_1.db !== "undefined" && db_1.db) === "function" ? _a : Object])
+    ], MyClass);
+    return MyClass;
+}());
+exports.MyClass = MyClass;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).errors.txt
+++ b/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    var x = 0;

--- a/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).oldTranspile.errors.txt
@@ -1,0 +1,6 @@
+error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+
+
+!!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
+==== file.ts (0 errors) ====
+    var x = 0;

--- a/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Uses correct newLine character (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+var x = 0;
+//# sourceMappingURL=file.js.map


### PR DESCRIPTION
Since `--verbatimModuleSyntax` implies `--isolatedModules`, it should be allowed in conjunction with `transpileModule`. However, when both options are specified an error is reported, and `transpileModule` always explicitly sets `isolatedModules` with no way to unset the option.

This changes `transpileModule` to skip any potential redudndant flags when setting defaults for `transpileModule`.

Fixes #53160
