### PR TITLE
Bump TS devDep to 5.0 RC to fix eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "ms": "^2.1.3",
                 "node-fetch": "^3.2.10",
                 "source-map-support": "^0.5.21",
-                "typescript": "5.0.0-dev.20230112",
+                "typescript": "5.0.1-rc",
                 "which": "^2.0.2"
             },
             "engines": {
@@ -4333,9 +4333,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.0.0-dev.20230112",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.0-dev.20230112.tgz",
-            "integrity": "sha512-cO+lTlZiNKqZIkjDOZWjh4WtFz8Jba/Ut4nvjcguXGgHoEnHD3+LSmgJjotPcWxALJZyvpd4EuAd5D3H9XF8Ig==",
+            "version": "5.0.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.1-rc.tgz",
+            "integrity": "sha512-zh75jY8gPo/y7fpmlTVN2bb2MigoLx4hGk+Cla9pY6lgSTvzJrmQQrRt5S80VTsEt6biWPZJgLK2nm6f0Ya+mA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -7590,9 +7590,9 @@
             }
         },
         "typescript": {
-            "version": "5.0.0-dev.20230112",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.0-dev.20230112.tgz",
-            "integrity": "sha512-cO+lTlZiNKqZIkjDOZWjh4WtFz8Jba/Ut4nvjcguXGgHoEnHD3+LSmgJjotPcWxALJZyvpd4EuAd5D3H9XF8Ig==",
+            "version": "5.0.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.1-rc.tgz",
+            "integrity": "sha512-zh75jY8gPo/y7fpmlTVN2bb2MigoLx4hGk+Cla9pY6lgSTvzJrmQQrRt5S80VTsEt6biWPZJgLK2nm6f0Ya+mA==",
             "dev": true
         },
         "typical": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "ms": "^2.1.3",
         "node-fetch": "^3.2.10",
         "source-map-support": "^0.5.21",
-        "typescript": "5.0.0-dev.20230112",
+        "typescript": "5.0.1-rc",
         "which": "^2.0.2"
     },
     "overrides": {


### PR DESCRIPTION
The version of TypeScript that we had in our package.json was an old build that predated some API changes (specifically the monomorphization changes). However, ts-eslint has now updated to support 5.0 and assumes the new APIs are present, so we broke on the dependency bump last night.

#53151 would have caught this, but it's not merged.