### PR TITLE
Move smoke test package script into scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,8 @@ jobs:
         echo "Testing tsserver..."
         echo '{"seq": 1, "command": "status"}' | npx tsserver
 
-        node $GITHUB_WORKSPACE/pr/scripts/checkModuleFormat.mjs typescript
-        node $GITHUB_WORKSPACE/pr/scripts/checkModuleFormat.mjs typescript/lib/tsserverlibrary
+        node $GITHUB_WORKSPACE/scripts/checkModuleFormat.mjs typescript
+        node $GITHUB_WORKSPACE/scripts/checkModuleFormat.mjs typescript/lib/tsserverlibrary
 
   package-size:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,14 @@ jobs:
     - run: |
         npm pack
         mv typescript*.tgz typescript.tgz
-        echo "PACKAGE=$PWD/typescript.tgz" >> $GITHUB_ENV
+        echo "package=$PWD/typescript.tgz" >> "$GITHUB_OUTPUT"
+      id: pack
 
     - name: Smoke test
       run: |
         cd "$(mktemp -d)"
         npm init --yes
-        npm install $PACKAGE tslib
+        npm install ${{ steps.pack.outputs.package }}
 
         echo "Testing tsc..."
         npx tsc --version
@@ -141,41 +142,8 @@ jobs:
         echo "Testing tsserver..."
         echo '{"seq": 1, "command": "status"}' | npx tsserver
 
-        cat > smoke.js << 'EOF'
-        console.log(`Testing ${process.argv[2]}...`);
-        const { __importDefault, __importStar } = require("tslib");
-        const ts = require(process.argv[2]);
-
-        // See: https://github.com/microsoft/TypeScript/pull/51474#issuecomment-1310871623
-        const fns = [
-          [() => ts.version,                          true],
-          [() => ts.default.version,                  false],
-          [() => __importDefault(ts).version,         false],
-          [() => __importDefault(ts).default.version, true],
-          [() => __importStar(ts).version,            true],
-          [() => __importStar(ts).default.version,    true],
-        ];
-
-        for (const [fn, shouldSucceed] of fns) {
-          let success = false;
-          try {
-            success = !!fn();
-          }
-          catch {}
-          const status = success ? "succeeded" : "failed";
-          if (success === shouldSucceed) {
-            console.log(`${fn.toString()} ${status} as expected.`);
-          }
-          else {
-            console.log(`${fn.toString()} unexpectedly ${status}.`);
-            process.exitCode = 1;
-          }
-        }
-        console.log("ok");
-        EOF
-
-        node ./smoke.js typescript
-        node ./smoke.js typescript/lib/tsserverlibrary
+        node $GITHUB_WORKSPACE/pr/scripts/checkModuleFormat.mjs typescript
+        node $GITHUB_WORKSPACE/pr/scripts/checkModuleFormat.mjs typescript/lib/tsserverlibrary
 
   misc:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
                 "ms": "^2.1.3",
                 "node-fetch": "^3.2.10",
                 "source-map-support": "^0.5.21",
+                "tslib": "^2.5.0",
                 "typescript": "5.0.1-rc",
                 "which": "^2.0.2"
             },

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "ms": "^2.1.3",
         "node-fetch": "^3.2.10",
         "source-map-support": "^0.5.21",
+        "tslib": "^2.5.0",
         "typescript": "5.0.1-rc",
         "which": "^2.0.2"
     },

--- a/scripts/checkModuleFormat.mjs
+++ b/scripts/checkModuleFormat.mjs
@@ -1,0 +1,41 @@
+import { createRequire } from "module";
+import { __importDefault, __importStar } from "tslib";
+
+// This script tests that TypeScript's CJS API is structured
+// as expected. It calls "require" as though it were in CWD,
+// so it can be tested on a separate install of TypeScript.
+
+const require = createRequire(process.cwd());
+
+console.log(`Testing ${process.argv[2]}...`);
+const ts = require(process.argv[2]);
+
+// See: https://github.com/microsoft/TypeScript/pull/51474#issuecomment-1310871623
+/** @type {[fn: (() => any), shouldSucceed: boolean][]} */
+const fns = [
+    [() => ts.version,                          true],
+    [() => ts.default.version,                  false],
+    [() => __importDefault(ts).version,         false],
+    [() => __importDefault(ts).default.version, true],
+    [() => __importStar(ts).version,            true],
+    [() => __importStar(ts).default.version,    true],
+];
+
+for (const [fn, shouldSucceed] of fns) {
+    let success = false;
+    try {
+        success = !!fn();
+    }
+    catch {
+        // Ignore
+    }
+    const status = success ? "succeeded" : "failed";
+    if (success === shouldSucceed) {
+        console.log(`${fn.toString()} ${status} as expected.`);
+    }
+    else {
+        console.log(`${fn.toString()} unexpectedly ${status}.`);
+        process.exitCode = 1;
+    }
+}
+console.log("ok");

--- a/scripts/checkModuleFormat.mjs
+++ b/scripts/checkModuleFormat.mjs
@@ -5,7 +5,7 @@ import { __importDefault, __importStar } from "tslib";
 // as expected. It calls "require" as though it were in CWD,
 // so it can be tested on a separate install of TypeScript.
 
-const require = createRequire(process.cwd());
+const require = createRequire(process.cwd() + "/index.js");
 
 console.log(`Testing ${process.argv[2]}...`);
 const ts = require(process.argv[2]);


### PR DESCRIPTION
This is better than having a heredoc in a YAML file.

Will conflict with #53241 as that removes the package size stuff from the smoke test.