### PR TITLE
Force add lib in workflows which commit LKG

### DIFF
--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -28,7 +28,7 @@ jobs:
         git add src/compiler/corePublic.ts
         git add tests/baselines/reference/api/typescript.d.ts
         git add tests/baselines/reference/api/tsserverlibrary.d.ts
-        git add ./lib
+        git add --force ./lib
         git config user.email "typescriptbot@microsoft.com"
         git config user.name "TypeScript Bot"
         git commit -m 'Bump version to ${{ github.event.client_payload.package_version }} and LKG'

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -26,15 +26,15 @@ jobs:
         sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' tests/baselines/reference/api/typescript.d.ts
         sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' tests/baselines/reference/api/tsserverlibrary.d.ts
         sed -i -e 's/const version\(: string\)\{0,1\} = .*;/const version = "${{ github.event.client_payload.package_version }}" as string;/g' src/compiler/corePublic.ts
-        npm ci
+        npm install
         npx hereby LKG
         npm test
         git diff
-        git add package.json
+        git add package.json package-lock.json
         git add src/compiler/corePublic.ts
         git add tests/baselines/reference/api/typescript.d.ts
         git add tests/baselines/reference/api/tsserverlibrary.d.ts
-        git add ./lib
+        git add --force ./lib
         git config user.email "typescriptbot@microsoft.com"
         git config user.name "TypeScript Bot"
         git commit -m 'Bump version to ${{ github.event.client_payload.package_version }} and LKG'

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -26,11 +26,11 @@ jobs:
         sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' tests/baselines/reference/api/typescript.d.ts
         sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' tests/baselines/reference/api/tsserverlibrary.d.ts
         sed -i -e 's/const version\(: string\)\{0,1\} = .*;/const version = "${{ github.event.client_payload.package_version }}" as string;/g' src/compiler/corePublic.ts
-        npm install
+        npm ci
         npx hereby LKG
         npm test
         git diff
-        git add package.json package-lock.json
+        git add package.json
         git add src/compiler/corePublic.ts
         git add tests/baselines/reference/api/typescript.d.ts
         git add tests/baselines/reference/api/tsserverlibrary.d.ts

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -19,6 +19,6 @@ jobs:
         npx hereby LKG
         npm test
         git diff
-        git add ./lib
+        git add --firce ./lib
         git commit -m "Update LKG"
         git push

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -19,6 +19,6 @@ jobs:
         npx hereby LKG
         npm test
         git diff
-        git add --firce ./lib
+        git add --force ./lib
         git commit -m "Update LKG"
         git push


### PR DESCRIPTION
Follow-up to #52226; these need to be force added now that `lib` is gitignored.