### PR TITLE
Provide snippet completions for @param in JSDoc

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -45467,7 +45467,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         if (isDeclaration(node)) {
             // In this case, we call getSymbolOfNode instead of getSymbolAtLocation because it is a declaration
-            const symbol = getSymbolOfDeclaration(node) || getSymbolAtLocation(node);
+            const symbol = getSymbolOfDeclaration(node);
             return symbol ? getTypeOfSymbol(symbol) : errorType;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -45461,9 +45461,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return symbol ? getDeclaredTypeOfSymbol(symbol) : errorType;
         }
 
+        if (isBindingElement(node)) {
+            return getTypeForVariableLikeDeclaration(node, /*includeOptionality*/ true, CheckMode.Normal) || errorType;
+        }
+
         if (isDeclaration(node)) {
             // In this case, we call getSymbolOfNode instead of getSymbolAtLocation because it is a declaration
-            const symbol = getSymbolOfDeclaration(node);
+            const symbol = getSymbolOfDeclaration(node) || getSymbolAtLocation(node);
             return symbol ? getTypeOfSymbol(symbol) : errorType;
         }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -710,10 +710,14 @@ export function getCompletionsAtPosition(
             return response;
         case CompletionDataKind.JsDocTagName:
             // If the current position is a jsDoc tag name, only tag names should be provided for completion
-            return jsdocCompletionInfo(JsDoc.getJSDocTagNameCompletions().concat(getJSDocParameterCompletions(sourceFile, position, preferences, compilerOptions, /*tagNameOnly*/ true)));
+            return jsdocCompletionInfo([
+                ...JsDoc.getJSDocTagNameCompletions(),
+                ...getJSDocParameterCompletions(sourceFile, position, preferences, compilerOptions, /*tagNameOnly*/ true)]);
         case CompletionDataKind.JsDocTag:
             // If the current position is a jsDoc tag, only tags should be provided for completion
-            return jsdocCompletionInfo(JsDoc.getJSDocTagCompletions().concat(getJSDocParameterCompletions(sourceFile, position, preferences, compilerOptions, /*tagNameOnly*/ false)));
+            return jsdocCompletionInfo([
+                ...JsDoc.getJSDocTagCompletions(),
+                ...getJSDocParameterCompletions(sourceFile, position, preferences, compilerOptions, /*tagNameOnly*/ false)]);
         case CompletionDataKind.JsDocParameterName:
             return jsdocCompletionInfo(JsDoc.getJSDocParameterNameCompletions(completionData.tag));
         case CompletionDataKind.Keywords:
@@ -879,12 +883,8 @@ function getJSDocParameterCompletions(
                 generateJSDocParamTagsForDestructuring(paramPath, param.name, param.initializer, isJs, /*isSnippet*/ false);
             const snippetTextResult =
                 generateJSDocParamTagsForDestructuring(paramPath, param.name, param.initializer, isJs, /*isSnippet*/ true);
-            for (let i = 1; i < insertTextResult.length; i++) {
-                insertTextResult[i] = `* ${insertTextResult[i]}`;
-                snippetTextResult[i] = `* ${snippetTextResult[i]}`;
-            }
-            let insertText = insertTextResult.join(getNewLineCharacter(options));
-            let snippetText = snippetTextResult.join(getNewLineCharacter(options));
+            let insertText = insertTextResult.join(getNewLineCharacter(options) + "* ");
+            let snippetText = snippetTextResult.join(getNewLineCharacter(options) + "* ");
             if (tagNameOnly) { // Remove `@`
                 insertText = insertText.slice(1);
                 snippetText = snippetText.slice(1);
@@ -924,12 +924,12 @@ function generateJSDocParamTagsForDestructuring(
                     break;
                 }
                 else {
-                    childTags = childTags.concat(elementTags);
+                    childTags.push(...elementTags);
                 }
             }
             if (childTags) {
                 counter.tabstop = childCounter.tabstop;
-                return [rootParam].concat(childTags);
+                return [rootParam, ...childTags];
             }
         }
         return [getJSDocParamAnnotation(path, initializer, isJs, /*isObject*/ false, isSnippet, counter)];

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1099,7 +1099,7 @@ function getJSDocParamAnnotation(
         else {
             if (initializer) {
                 const inferredType = checker.getTypeAtLocation(initializer.parent);
-                if (!(inferredType.flags & TypeFlags.Any)) {
+                if (!(inferredType.flags & (TypeFlags.Any | TypeFlags.Void))) {
                     const sourceFile = initializer.getSourceFile();
                     const quotePreference = getQuotePreference(sourceFile, preferences);
                     const builderFlags = (quotePreference === QuotePreference.Single ? NodeBuilderFlags.UseSingleQuotesForStringLiteralType : NodeBuilderFlags.None);
@@ -1121,7 +1121,7 @@ function getJSDocParamAnnotation(
                     }
                 }
             }
-            if (isSnippet) {
+            if (isSnippet && type === "*") {
                 type = `\${${tabstopCounter!.tabstop++}:${type}}`;
             }
         }

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
@@ -87,7 +87,7 @@
 // | virtual
 // | yields
 // | param {Object} param0 
-// | * @param {*} [param0.a=1] 
+// | * @param {number} [param0.a=1] 
 // | param {*} b 
 // | ----------------------------------------------------------------------
 //   */
@@ -8263,13 +8263,13 @@
           "documentation": []
         },
         {
-          "name": "param {Object} param0 \r\n* @param {*} [param0.a=1] ",
+          "name": "param {Object} param0 \r\n* @param {number} [param0.a=1] ",
           "kind": "",
           "sortText": "11",
           "kindModifiers": "",
           "displayParts": [
             {
-              "text": "param {Object} param0 \r\n* @param {*} [param0.a=1] ",
+              "text": "param {Object} param0 \r\n* @param {number} [param0.a=1] ",
               "kind": "text"
             }
           ],

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
@@ -1,0 +1,15640 @@
+=== /tests/cases/fourslash/b.js ===
+// /**
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {*} [param0.a=1] 
+// | param {*} b 
+// | ----------------------------------------------------------------------
+//  */
+// function aa({ a = 1 }, b) {
+//     a;
+// }
+// /**
+//  * 
+//    ^
+// | ----------------------------------------------------------------------
+// | @abstract
+// | @access
+// | @alias
+// | @argument
+// | @async
+// | @augments
+// | @author
+// | @borrows
+// | @callback
+// | @class
+// | @classdesc
+// | @constant
+// | @constructor
+// | @constructs
+// | @copyright
+// | @default
+// | @deprecated
+// | @description
+// | @emits
+// | @enum
+// | @event
+// | @example
+// | @exports
+// | @extends
+// | @external
+// | @field
+// | @file
+// | @fileoverview
+// | @fires
+// | @function
+// | @generator
+// | @global
+// | @hideconstructor
+// | @host
+// | @ignore
+// | @implements
+// | @inheritdoc
+// | @inner
+// | @instance
+// | @interface
+// | @kind
+// | @lends
+// | @license
+// | @link
+// | @linkcode
+// | @linkplain
+// | @listens
+// | @member
+// | @memberof
+// | @method
+// | @mixes
+// | @module
+// | @name
+// | @namespace
+// | @overload
+// | @override
+// | @package
+// | @param
+// | @private
+// | @prop
+// | @property
+// | @protected
+// | @public
+// | @readonly
+// | @requires
+// | @returns
+// | @satisfies
+// | @see
+// | @since
+// | @static
+// | @summary
+// | @template
+// | @this
+// | @throws
+// | @todo
+// | @tutorial
+// | @type
+// | @typedef
+// | @var
+// | @variation
+// | @version
+// | @virtual
+// | @yields
+// | @param {*} b 
+// | ----------------------------------------------------------------------
+//  */
+// function bb(b) {}
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {Object} [param0.b={ a: 1, c: 3 }] 
+// | * @param {*} param0.b.a 
+// | * @param {*} param0.b.c 
+// | ----------------------------------------------------------------------
+//  */
+// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+// }
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {Object} param0.a 
+// | * @param {*} param0.a.b 
+// | * @param {*} param0.a.c 
+// | * @param {*} param0.d 
+// | ----------------------------------------------------------------------
+//  */
+// function dd({ a: { b, c }, d: [e, f] }) {
+// }
+// const someconst = "aa";
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {*} param0 
+// | ----------------------------------------------------------------------
+//  */
+// function ee({ [someconst]: b }) {
+// }
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {*} param0.a 
+// | ----------------------------------------------------------------------
+//  */
+// function ff({ "a": b }) {
+// }
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {*} a 
+// | ----------------------------------------------------------------------
+//  */
+// function gg(a, { b }) {
+// }
+// /**
+//  * 
+//  * @param {boolean} a a's description
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param1 
+// | * @param {*} param1.b 
+// | ----------------------------------------------------------------------
+//  */
+// function hh(a, { b }) {
+
+=== /tests/cases/fourslash/a.ts ===
+// /**
+//  * @para
+//         ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param value 
+// | param maximumFractionDigits 
+// | ----------------------------------------------------------------------
+//  */
+// function printValue(value, maximumFractionDigits) {}
+// /**
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param param0 
+// | param b 
+// | ----------------------------------------------------------------------
+//  */
+// function aa({ a = 1 }, b: string) {
+//     a;
+// }
+// /**
+//  * 
+//    ^
+// | ----------------------------------------------------------------------
+// | @abstract
+// | @access
+// | @alias
+// | @argument
+// | @async
+// | @augments
+// | @author
+// | @borrows
+// | @callback
+// | @class
+// | @classdesc
+// | @constant
+// | @constructor
+// | @constructs
+// | @copyright
+// | @default
+// | @deprecated
+// | @description
+// | @emits
+// | @enum
+// | @event
+// | @example
+// | @exports
+// | @extends
+// | @external
+// | @field
+// | @file
+// | @fileoverview
+// | @fires
+// | @function
+// | @generator
+// | @global
+// | @hideconstructor
+// | @host
+// | @ignore
+// | @implements
+// | @inheritdoc
+// | @inner
+// | @instance
+// | @interface
+// | @kind
+// | @lends
+// | @license
+// | @link
+// | @linkcode
+// | @linkplain
+// | @listens
+// | @member
+// | @memberof
+// | @method
+// | @mixes
+// | @module
+// | @name
+// | @namespace
+// | @overload
+// | @override
+// | @package
+// | @param
+// | @private
+// | @prop
+// | @property
+// | @protected
+// | @public
+// | @readonly
+// | @requires
+// | @returns
+// | @satisfies
+// | @see
+// | @since
+// | @static
+// | @summary
+// | @template
+// | @this
+// | @throws
+// | @todo
+// | @tutorial
+// | @type
+// | @typedef
+// | @var
+// | @variation
+// | @version
+// | @virtual
+// | @yields
+// | @param b 
+// | ----------------------------------------------------------------------
+//  */
+// function bb(b: string) {}
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param param0 
+// | ----------------------------------------------------------------------
+//  */
+// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+// }
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param param0 
+// | ----------------------------------------------------------------------
+//  */
+// function dd({ a: { b, c }, d: [e, f] }: { a: { b: number, c: number }, d: [string, string] }) {
+// }
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.ts",
+      "position": 12,
+      "name": "0"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param value ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param value ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param maximumFractionDigits ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param maximumFractionDigits ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.ts",
+      "position": 79,
+      "name": "a"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param param0 ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param param0 ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param b ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.ts",
+      "position": 136,
+      "name": "b"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "@abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param b ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "@param b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.ts",
+      "position": 180,
+      "name": "c"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param param0 ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param param0 ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.ts",
+      "position": 248,
+      "name": "d"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param param0 ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param param0 ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 9,
+      "name": "ja"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {*} [param0.a=1] ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {*} [param0.a=1] ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {*} b ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {*} b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 58,
+      "name": "jb"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "@abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param {*} b ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "@param {*} b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 94,
+      "name": "jc"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 162,
+      "name": "jd"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {Object} param0.a \r\n* @param {*} param0.a.b \r\n* @param {*} param0.a.c \r\n* @param {*} param0.d ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {Object} param0.a \r\n* @param {*} param0.a.b \r\n* @param {*} param0.a.c \r\n* @param {*} param0.d ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 248,
+      "name": "je"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {*} param0 ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {*} param0 ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 302,
+      "name": "jf"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {*} param0.a ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {*} param0.a ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 348,
+      "name": "jg"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {*} a ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {*} a ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 430,
+      "name": "jh"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param1 \r\n* @param {*} param1.b ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param1 \r\n* @param {*} param1.b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
@@ -94,6 +94,7 @@
 // function aa({ a = 1 }, b) {
 //     a;
 // }
+// 
 // /**
 //  * 
 //    ^
@@ -185,6 +186,7 @@
 // | ----------------------------------------------------------------------
 //  */
 // function bb(b) {}
+// 
 // /**
 //  * 
 //  * @p
@@ -280,7 +282,9 @@
 // | ----------------------------------------------------------------------
 //  */
 // function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+// 
 // }
+// 
 // /**
 //  * 
 //  * @p
@@ -377,7 +381,9 @@
 // | ----------------------------------------------------------------------
 //  */
 // function dd({ a: { b, c }, d: [e, f] }) {
+// 
 // }
+// 
 // const someconst = "aa";
 // /**
 //  * 
@@ -471,7 +477,9 @@
 // | ----------------------------------------------------------------------
 //  */
 // function ee({ [someconst]: b }) {
+// 
 // }
+// 
 // /**
 //  * 
 //  * @p
@@ -565,7 +573,9 @@
 // | ----------------------------------------------------------------------
 //  */
 // function ff({ "a": b }) {
+// 
 // }
+// 
 // /**
 //  * 
 //  * @p
@@ -658,7 +668,9 @@
 // | ----------------------------------------------------------------------
 //  */
 // function gg(a, { b }) {
+// 
 // }
+// 
 // /**
 //  * 
 //  * @param {boolean} a a's description
@@ -753,6 +765,289 @@
 // | ----------------------------------------------------------------------
 //  */
 // function hh(a, { b }) {
+//    
+// }
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {*} param0.b 
+// | * @param {...*} param0.c 
+// | param {...*} a 
+// | ----------------------------------------------------------------------
+//  */
+// function ii({ b, ...c }, ...a) {}
+// 
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {...*} param0 
+// | ----------------------------------------------------------------------
+//  */
+// function jj(...{ length }) {}
+// 
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {...*} a 
+// | ----------------------------------------------------------------------
+//  */
+// function kk(...a) {}
 
 === /tests/cases/fourslash/a.ts ===
 // /**
@@ -847,6 +1142,7 @@
 // | ----------------------------------------------------------------------
 //  */
 // function printValue(value, maximumFractionDigits) {}
+// 
 // /**
 //  * @p
 //      ^
@@ -941,6 +1237,7 @@
 // function aa({ a = 1 }, b: string) {
 //     a;
 // }
+// 
 // /**
 //  * 
 //    ^
@@ -1032,6 +1329,7 @@
 // | ----------------------------------------------------------------------
 //  */
 // function bb(b: string) {}
+// 
 // /**
 //  * 
 //  * @p
@@ -1124,7 +1422,9 @@
 // | ----------------------------------------------------------------------
 //  */
 // function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+// 
 // }
+// 
 // /**
 //  * 
 //  * @p
@@ -1217,6 +1517,7 @@
 // | ----------------------------------------------------------------------
 //  */
 // function dd({ a: { b, c }, d: [e, f] }: { a: { b: number, c: number }, d: [string, string] }) {
+// 
 // }
 
 [
@@ -2342,7 +2643,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/a.ts",
-      "position": 79,
+      "position": 80,
       "name": "a"
     },
     "item": {
@@ -3461,7 +3762,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/a.ts",
-      "position": 136,
+      "position": 138,
       "name": "b"
     },
     "item": {
@@ -4567,7 +4868,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/a.ts",
-      "position": 180,
+      "position": 183,
       "name": "c"
     },
     "item": {
@@ -5673,7 +5974,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/a.ts",
-      "position": 248,
+      "position": 253,
       "name": "d"
     },
     "item": {
@@ -7898,7 +8199,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 58,
+      "position": 59,
       "name": "jb"
     },
     "item": {
@@ -9004,7 +9305,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 94,
+      "position": 96,
       "name": "jc"
     },
     "item": {
@@ -10110,7 +10411,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 162,
+      "position": 166,
       "name": "jd"
     },
     "item": {
@@ -11216,7 +11517,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 248,
+      "position": 254,
       "name": "je"
     },
     "item": {
@@ -12322,7 +12623,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 302,
+      "position": 310,
       "name": "jf"
     },
     "item": {
@@ -13428,7 +13729,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 348,
+      "position": 358,
       "name": "jg"
     },
     "item": {
@@ -14534,7 +14835,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 430,
+      "position": 442,
       "name": "jh"
     },
     "item": {
@@ -15629,6 +15930,3337 @@
           "displayParts": [
             {
               "text": "param {Object} param1 \r\n* @param {*} param1.b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 490,
+      "name": "ji"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {*} param0.b \r\n* @param {...*} param0.c ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {*} param0.b \r\n* @param {...*} param0.c ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {...*} a ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {...*} a ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 543,
+      "name": "jj"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {...*} param0 ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {...*} param0 ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 592,
+      "name": "jk"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {...*} a ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {...*} a ",
               "kind": "text"
             }
           ],

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion1.baseline
@@ -1,7 +1,7 @@
 === /tests/cases/fourslash/b.js ===
-// /**
-//  * @p
-//      ^
+//  /**
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -90,14 +90,14 @@
 // | * @param {*} [param0.a=1] 
 // | param {*} b 
 // | ----------------------------------------------------------------------
-//  */
-// function aa({ a = 1 }, b) {
-//     a;
-// }
+//   */
+//  function aa({ a = 1 }, b) {
+//      a;
+//  }
 // 
-// /**
-//  * 
-//    ^
+//  /**
+//   * 
+//     ^
 // | ----------------------------------------------------------------------
 // | @abstract
 // | @access
@@ -184,13 +184,13 @@
 // | @yields
 // | @param {*} b 
 // | ----------------------------------------------------------------------
-//  */
-// function bb(b) {}
+//   */
+//  function bb(b) {}
 // 
-// /**
-//  * 
-//  * @p
-//      ^
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -280,15 +280,15 @@
 // | * @param {*} param0.b.a 
 // | * @param {*} param0.b.c 
 // | ----------------------------------------------------------------------
-//  */
-// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+//   */
+//  function cc({ b: { a, c } = { a: 1, c: 3 } }) {
 // 
-// }
+//  }
 // 
-// /**
-//  * 
-//  * @p
-//      ^
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -379,16 +379,16 @@
 // | * @param {*} param0.a.c 
 // | * @param {*} param0.d 
 // | ----------------------------------------------------------------------
-//  */
-// function dd({ a: { b, c }, d: [e, f] }) {
+//   */
+//  function dd({ a: { b, c }, d: [e, f] }) {
 // 
-// }
+//  }
 // 
-// const someconst = "aa";
-// /**
-//  * 
-//  * @p
-//      ^
+//  const someconst = "aa";
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -475,15 +475,15 @@
 // | yields
 // | param {*} param0 
 // | ----------------------------------------------------------------------
-//  */
-// function ee({ [someconst]: b }) {
+//   */
+//  function ee({ [someconst]: b }) {
 // 
-// }
+//  }
 // 
-// /**
-//  * 
-//  * @p
-//      ^
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -571,15 +571,15 @@
 // | param {Object} param0 
 // | * @param {*} param0.a 
 // | ----------------------------------------------------------------------
-//  */
-// function ff({ "a": b }) {
+//   */
+//  function ff({ "a": b }) {
 // 
-// }
+//  }
 // 
-// /**
-//  * 
-//  * @p
-//      ^
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -666,16 +666,16 @@
 // | yields
 // | param {*} a 
 // | ----------------------------------------------------------------------
-//  */
-// function gg(a, { b }) {
+//   */
+//  function gg(a, { b }) {
 // 
-// }
+//  }
 // 
-// /**
-//  * 
-//  * @param {boolean} a a's description
-//  * @p
-//      ^
+//  /**
+//   * 
+//   * @param {boolean} a a's description
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -763,14 +763,14 @@
 // | param {Object} param1 
 // | * @param {*} param1.b 
 // | ----------------------------------------------------------------------
-//  */
-// function hh(a, { b }) {
-//    
-// }
-// /**
-//  * 
-//  * @p
-//      ^
+//   */
+//  function hh(a, { b }) {
+//     
+//  }
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -860,13 +860,13 @@
 // | * @param {...*} param0.c 
 // | param {...*} a 
 // | ----------------------------------------------------------------------
-//  */
-// function ii({ b, ...c }, ...a) {}
+//   */
+//  function ii({ b, ...c }, ...a) {}
 // 
-// /**
-//  * 
-//  * @p
-//      ^
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -953,13 +953,13 @@
 // | yields
 // | param {...*} param0 
 // | ----------------------------------------------------------------------
-//  */
-// function jj(...{ length }) {}
+//   */
+//  function jj(...{ length }) {}
 // 
-// /**
-//  * 
-//  * @p
-//      ^
+//  /**
+//   * 
+//   * @p
+//       ^
 // | ----------------------------------------------------------------------
 // | abstract
 // | access
@@ -1046,8 +1046,103 @@
 // | yields
 // | param {...*} a 
 // | ----------------------------------------------------------------------
-//  */
-// function kk(...a) {}
+//   */
+//  function kk(...a) {}
+// 
+//  function reallylongfunctionnameabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl(a) {}
+//  /**
+//   *
+//   * @p
+//       ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {*} [a] 
+// | ----------------------------------------------------------------------
+//   */
+//  function ll(a = reallylongfunctionnameabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl("")) {}
+// }
 
 === /tests/cases/fourslash/a.ts ===
 // /**
@@ -7080,7 +7175,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 9,
+      "position": 11,
       "name": "ja"
     },
     "item": {
@@ -8199,7 +8294,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 59,
+      "position": 67,
       "name": "jb"
     },
     "item": {
@@ -9305,7 +9400,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 96,
+      "position": 109,
       "name": "jc"
     },
     "item": {
@@ -10411,7 +10506,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 166,
+      "position": 185,
       "name": "jd"
     },
     "item": {
@@ -11517,7 +11612,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 254,
+      "position": 280,
       "name": "je"
     },
     "item": {
@@ -12623,7 +12718,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 310,
+      "position": 342,
       "name": "jf"
     },
     "item": {
@@ -13729,7 +13824,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 358,
+      "position": 396,
       "name": "jg"
     },
     "item": {
@@ -14835,7 +14930,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 442,
+      "position": 487,
       "name": "jh"
     },
     "item": {
@@ -15941,7 +16036,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 490,
+      "position": 542,
       "name": "ji"
     },
     "item": {
@@ -17060,7 +17155,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 543,
+      "position": 600,
       "name": "jj"
     },
     "item": {
@@ -18166,7 +18261,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 592,
+      "position": 654,
       "name": "jk"
     },
     "item": {
@@ -19261,6 +19356,1112 @@
           "displayParts": [
             {
               "text": "param {...*} a ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 827,
+      "name": "jl"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {*} [a] ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {*} [a] ",
               "kind": "text"
             }
           ],

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion2.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion2.baseline
@@ -90,6 +90,7 @@
 // | ----------------------------------------------------------------------
 //  */
 // function bb(b) {}
+// 
 // /**
 //  * 
 //  * @p
@@ -185,7 +186,101 @@
 // | ----------------------------------------------------------------------
 //  */
 // function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+// 
 // }
+// 
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {...*} a 
+// | ----------------------------------------------------------------------
+//  */
+// function dd(...a) {}
 
 === /tests/cases/fourslash/a.ts ===
 // /**
@@ -2500,7 +2595,7 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/b.js",
-      "position": 43,
+      "position": 44,
       "name": "jc"
     },
     "item": {
@@ -3597,6 +3692,1114 @@
           "displayParts": [
             {
               "text": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 114,
+      "name": "jd"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {...*} a ",
+          "kind": "",
+          "sortText": "11",
+          "insertText": "param {...${1:*}} a ${2}",
+          "isSnippet": true,
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {...*} a ",
               "kind": "text"
             }
           ],

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion2.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion2.baseline
@@ -1,0 +1,3608 @@
+=== /tests/cases/fourslash/b.js ===
+// /**
+//  * 
+//    ^
+// | ----------------------------------------------------------------------
+// | @abstract
+// | @access
+// | @alias
+// | @argument
+// | @async
+// | @augments
+// | @author
+// | @borrows
+// | @callback
+// | @class
+// | @classdesc
+// | @constant
+// | @constructor
+// | @constructs
+// | @copyright
+// | @default
+// | @deprecated
+// | @description
+// | @emits
+// | @enum
+// | @event
+// | @example
+// | @exports
+// | @extends
+// | @external
+// | @field
+// | @file
+// | @fileoverview
+// | @fires
+// | @function
+// | @generator
+// | @global
+// | @hideconstructor
+// | @host
+// | @ignore
+// | @implements
+// | @inheritdoc
+// | @inner
+// | @instance
+// | @interface
+// | @kind
+// | @lends
+// | @license
+// | @link
+// | @linkcode
+// | @linkplain
+// | @listens
+// | @member
+// | @memberof
+// | @method
+// | @mixes
+// | @module
+// | @name
+// | @namespace
+// | @overload
+// | @override
+// | @package
+// | @param
+// | @private
+// | @prop
+// | @property
+// | @protected
+// | @public
+// | @readonly
+// | @requires
+// | @returns
+// | @satisfies
+// | @see
+// | @since
+// | @static
+// | @summary
+// | @template
+// | @this
+// | @throws
+// | @todo
+// | @tutorial
+// | @type
+// | @typedef
+// | @var
+// | @variation
+// | @version
+// | @virtual
+// | @yields
+// | @param {*} b 
+// | ----------------------------------------------------------------------
+//  */
+// function bb(b) {}
+// /**
+//  * 
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {Object} [param0.b={ a: 1, c: 3 }] 
+// | * @param {*} param0.b.a 
+// | * @param {*} param0.b.c 
+// | ----------------------------------------------------------------------
+//  */
+// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+// }
+
+=== /tests/cases/fourslash/a.ts ===
+// /**
+//  * 
+//    ^
+// | ----------------------------------------------------------------------
+// | @abstract
+// | @access
+// | @alias
+// | @argument
+// | @async
+// | @augments
+// | @author
+// | @borrows
+// | @callback
+// | @class
+// | @classdesc
+// | @constant
+// | @constructor
+// | @constructs
+// | @copyright
+// | @default
+// | @deprecated
+// | @description
+// | @emits
+// | @enum
+// | @event
+// | @example
+// | @exports
+// | @extends
+// | @external
+// | @field
+// | @file
+// | @fileoverview
+// | @fires
+// | @function
+// | @generator
+// | @global
+// | @hideconstructor
+// | @host
+// | @ignore
+// | @implements
+// | @inheritdoc
+// | @inner
+// | @instance
+// | @interface
+// | @kind
+// | @lends
+// | @license
+// | @link
+// | @linkcode
+// | @linkplain
+// | @listens
+// | @member
+// | @memberof
+// | @method
+// | @mixes
+// | @module
+// | @name
+// | @namespace
+// | @overload
+// | @override
+// | @package
+// | @param
+// | @private
+// | @prop
+// | @property
+// | @protected
+// | @public
+// | @readonly
+// | @requires
+// | @returns
+// | @satisfies
+// | @see
+// | @since
+// | @static
+// | @summary
+// | @template
+// | @this
+// | @throws
+// | @todo
+// | @tutorial
+// | @type
+// | @typedef
+// | @var
+// | @variation
+// | @version
+// | @virtual
+// | @yields
+// | @param b 
+// | ----------------------------------------------------------------------
+//  */
+// function bb(b: string) {}
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.ts",
+      "position": 7,
+      "name": "b"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "@abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param b ",
+          "kind": "",
+          "sortText": "11",
+          "insertText": "@param b ${1}",
+          "isSnippet": true,
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "@param b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 7,
+      "name": "jb"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "@abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "@yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "@param {*} b ",
+          "kind": "",
+          "sortText": "11",
+          "insertText": "@param {${1:*}} b ${2}",
+          "isSnippet": true,
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "@param {*} b ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/b.js",
+      "position": 43,
+      "name": "jc"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
+          "kind": "",
+          "sortText": "11",
+          "insertText": "param {Object} param0 ${1}\r\n* @param {Object} [param0.b={ a: 1, c: 3 }] ${2}\r\n* @param {${3:*}} param0.b.a ${4}\r\n* @param {${5:*}} param0.b.c ${6}",
+          "isSnippet": true,
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/jsdocParameterTagSnippetCompletion3.baseline
+++ b/tests/baselines/reference/jsdocParameterTagSnippetCompletion3.baseline
@@ -1,287 +1,4 @@
-=== /tests/cases/fourslash/b.js ===
-// /**
-//  * 
-//    ^
-// | ----------------------------------------------------------------------
-// | @abstract
-// | @access
-// | @alias
-// | @argument
-// | @async
-// | @augments
-// | @author
-// | @borrows
-// | @callback
-// | @class
-// | @classdesc
-// | @constant
-// | @constructor
-// | @constructs
-// | @copyright
-// | @default
-// | @deprecated
-// | @description
-// | @emits
-// | @enum
-// | @event
-// | @example
-// | @exports
-// | @extends
-// | @external
-// | @field
-// | @file
-// | @fileoverview
-// | @fires
-// | @function
-// | @generator
-// | @global
-// | @hideconstructor
-// | @host
-// | @ignore
-// | @implements
-// | @inheritdoc
-// | @inner
-// | @instance
-// | @interface
-// | @kind
-// | @lends
-// | @license
-// | @link
-// | @linkcode
-// | @linkplain
-// | @listens
-// | @member
-// | @memberof
-// | @method
-// | @mixes
-// | @module
-// | @name
-// | @namespace
-// | @overload
-// | @override
-// | @package
-// | @param
-// | @private
-// | @prop
-// | @property
-// | @protected
-// | @public
-// | @readonly
-// | @requires
-// | @returns
-// | @satisfies
-// | @see
-// | @since
-// | @static
-// | @summary
-// | @template
-// | @this
-// | @throws
-// | @todo
-// | @tutorial
-// | @type
-// | @typedef
-// | @var
-// | @variation
-// | @version
-// | @virtual
-// | @yields
-// | @param {*} b 
-// | ----------------------------------------------------------------------
-//  */
-// function bb(b) {}
-// 
-// /**
-//  * 
-//  * @p
-//      ^
-// | ----------------------------------------------------------------------
-// | abstract
-// | access
-// | alias
-// | argument
-// | async
-// | augments
-// | author
-// | borrows
-// | callback
-// | class
-// | classdesc
-// | constant
-// | constructor
-// | constructs
-// | copyright
-// | default
-// | deprecated
-// | description
-// | emits
-// | enum
-// | event
-// | example
-// | exports
-// | extends
-// | external
-// | field
-// | file
-// | fileoverview
-// | fires
-// | function
-// | generator
-// | global
-// | hideconstructor
-// | host
-// | ignore
-// | implements
-// | inheritdoc
-// | inner
-// | instance
-// | interface
-// | kind
-// | lends
-// | license
-// | link
-// | linkcode
-// | linkplain
-// | listens
-// | member
-// | memberof
-// | method
-// | mixes
-// | module
-// | name
-// | namespace
-// | overload
-// | override
-// | package
-// | param
-// | private
-// | prop
-// | property
-// | protected
-// | public
-// | readonly
-// | requires
-// | returns
-// | satisfies
-// | see
-// | since
-// | static
-// | summary
-// | template
-// | this
-// | throws
-// | todo
-// | tutorial
-// | type
-// | typedef
-// | var
-// | variation
-// | version
-// | virtual
-// | yields
-// | param {Object} param0 
-// | * @param {Object} [param0.b={ a: 1, c: 3 }] 
-// | * @param {*} param0.b.a 
-// | * @param {*} param0.b.c 
-// | ----------------------------------------------------------------------
-//  */
-// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
-// 
-// }
-// 
-// /**
-//  * 
-//  * @p
-//      ^
-// | ----------------------------------------------------------------------
-// | abstract
-// | access
-// | alias
-// | argument
-// | async
-// | augments
-// | author
-// | borrows
-// | callback
-// | class
-// | classdesc
-// | constant
-// | constructor
-// | constructs
-// | copyright
-// | default
-// | deprecated
-// | description
-// | emits
-// | enum
-// | event
-// | example
-// | exports
-// | extends
-// | external
-// | field
-// | file
-// | fileoverview
-// | fires
-// | function
-// | generator
-// | global
-// | hideconstructor
-// | host
-// | ignore
-// | implements
-// | inheritdoc
-// | inner
-// | instance
-// | interface
-// | kind
-// | lends
-// | license
-// | link
-// | linkcode
-// | linkplain
-// | listens
-// | member
-// | memberof
-// | method
-// | mixes
-// | module
-// | name
-// | namespace
-// | overload
-// | override
-// | package
-// | param
-// | private
-// | prop
-// | property
-// | protected
-// | public
-// | readonly
-// | requires
-// | returns
-// | satisfies
-// | see
-// | since
-// | static
-// | summary
-// | template
-// | this
-// | throws
-// | todo
-// | tutorial
-// | type
-// | typedef
-// | var
-// | variation
-// | version
-// | virtual
-// | yields
-// | param {...*} a 
-// | ----------------------------------------------------------------------
-//  */
-// function dd(...a) {}
-// 
+=== /tests/cases/fourslash/a.js ===
 // /**
 //  * @p
 //      ^
@@ -373,4537 +90,479 @@
 // | ----------------------------------------------------------------------
 //  */
 // function zz(a = 3) {}
-
-=== /tests/cases/fourslash/a.ts ===
 // /**
-//  * 
-//    ^
+//  * @p
+//      ^
 // | ----------------------------------------------------------------------
-// | @abstract
-// | @access
-// | @alias
-// | @argument
-// | @async
-// | @augments
-// | @author
-// | @borrows
-// | @callback
-// | @class
-// | @classdesc
-// | @constant
-// | @constructor
-// | @constructs
-// | @copyright
-// | @default
-// | @deprecated
-// | @description
-// | @emits
-// | @enum
-// | @event
-// | @example
-// | @exports
-// | @extends
-// | @external
-// | @field
-// | @file
-// | @fileoverview
-// | @fires
-// | @function
-// | @generator
-// | @global
-// | @hideconstructor
-// | @host
-// | @ignore
-// | @implements
-// | @inheritdoc
-// | @inner
-// | @instance
-// | @interface
-// | @kind
-// | @lends
-// | @license
-// | @link
-// | @linkcode
-// | @linkplain
-// | @listens
-// | @member
-// | @memberof
-// | @method
-// | @mixes
-// | @module
-// | @name
-// | @namespace
-// | @overload
-// | @override
-// | @package
-// | @param
-// | @private
-// | @prop
-// | @property
-// | @protected
-// | @public
-// | @readonly
-// | @requires
-// | @returns
-// | @satisfies
-// | @see
-// | @since
-// | @static
-// | @summary
-// | @template
-// | @this
-// | @throws
-// | @todo
-// | @tutorial
-// | @type
-// | @typedef
-// | @var
-// | @variation
-// | @version
-// | @virtual
-// | @yields
-// | @param b 
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {number} [param0.a=3] 
 // | ----------------------------------------------------------------------
 //  */
-// function bb(b: string) {}
+// function yy({ a = 3 }) {}
+// /**
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {*} param0.a 
+// | * @param {Object} param0.o 
+// | * @param {*} param0.o.b 
+// | * @param {*} param0.o.c 
+// | ----------------------------------------------------------------------
+//  */
+// function xx({ a, o: { b, c: [d, e = 1] }}) {}
+// /**
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {*} param0.a 
+// | * @param {Object} param0.o 
+// | * @param {*} param0.o.b 
+// | * @param {[number, boolean]} [param0.o.c=[1, true]] 
+// | ----------------------------------------------------------------------
+//  */
+// function ww({ a, o: { b, c: [d, e] = [1, true] }}) {}
+// /**
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {(number | boolean)[]} [param0.a=[1, true]] 
+// | ----------------------------------------------------------------------
+//  */
+// function vv({ a = [1, true] }) {}
+// function random(a) { return a }
+// /**
+//  * @p
+//      ^
+// | ----------------------------------------------------------------------
+// | abstract
+// | access
+// | alias
+// | argument
+// | async
+// | augments
+// | author
+// | borrows
+// | callback
+// | class
+// | classdesc
+// | constant
+// | constructor
+// | constructs
+// | copyright
+// | default
+// | deprecated
+// | description
+// | emits
+// | enum
+// | event
+// | example
+// | exports
+// | extends
+// | external
+// | field
+// | file
+// | fileoverview
+// | fires
+// | function
+// | generator
+// | global
+// | hideconstructor
+// | host
+// | ignore
+// | implements
+// | inheritdoc
+// | inner
+// | instance
+// | interface
+// | kind
+// | lends
+// | license
+// | link
+// | linkcode
+// | linkplain
+// | listens
+// | member
+// | memberof
+// | method
+// | mixes
+// | module
+// | name
+// | namespace
+// | overload
+// | override
+// | package
+// | param
+// | private
+// | prop
+// | property
+// | protected
+// | public
+// | readonly
+// | requires
+// | returns
+// | satisfies
+// | see
+// | since
+// | static
+// | summary
+// | template
+// | this
+// | throws
+// | todo
+// | tutorial
+// | type
+// | typedef
+// | var
+// | variation
+// | version
+// | virtual
+// | yields
+// | param {Object} param0 
+// | * @param {*} [param0.a=random()] 
+// | ----------------------------------------------------------------------
+//  */
+// function uu({ a = random() }) {}
 
 [
   {
     "marker": {
-      "fileName": "/tests/cases/fourslash/a.ts",
-      "position": 7,
-      "name": "b"
-    },
-    "item": {
-      "isGlobalCompletion": false,
-      "isMemberCompletion": false,
-      "isNewIdentifierLocation": false,
-      "entries": [
-        {
-          "name": "@abstract",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@abstract",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@access",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@access",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@alias",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@alias",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@argument",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@argument",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@async",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@async",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@augments",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@augments",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@author",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@author",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@borrows",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@borrows",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@callback",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@callback",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@class",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@class",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@classdesc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@classdesc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@constant",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@constant",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@constructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@constructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@constructs",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@constructs",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@copyright",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@copyright",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@default",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@default",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@deprecated",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@deprecated",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@description",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@description",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@emits",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@emits",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@enum",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@enum",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@event",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@event",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@example",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@example",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@exports",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@exports",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@extends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@extends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@external",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@external",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@field",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@field",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@file",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@file",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@fileoverview",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@fileoverview",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@fires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@fires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@function",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@function",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@generator",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@generator",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@global",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@global",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@hideconstructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@hideconstructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@host",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@host",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@ignore",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@ignore",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@implements",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@implements",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@inheritdoc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@inheritdoc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@inner",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@inner",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@instance",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@instance",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@interface",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@interface",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@kind",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@kind",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@lends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@lends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@license",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@license",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@link",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@link",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@linkcode",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@linkcode",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@linkplain",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@linkplain",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@listens",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@listens",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@member",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@member",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@memberof",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@memberof",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@method",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@method",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@mixes",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@mixes",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@module",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@module",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@name",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@name",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@namespace",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@namespace",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@overload",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@overload",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@override",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@override",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@package",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@package",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@param",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@param",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@private",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@private",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@prop",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@prop",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@property",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@property",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@protected",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@protected",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@public",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@public",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@readonly",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@readonly",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@requires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@requires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@returns",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@returns",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@satisfies",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@satisfies",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@see",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@see",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@since",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@since",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@static",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@static",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@summary",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@summary",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@template",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@template",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@this",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@this",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@throws",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@throws",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@todo",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@todo",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@tutorial",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@tutorial",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@type",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@type",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@typedef",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@typedef",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@var",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@var",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@variation",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@variation",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@version",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@version",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@virtual",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@virtual",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@yields",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@yields",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@param b ",
-          "kind": "",
-          "sortText": "11",
-          "insertText": "@param b ${1}",
-          "isSnippet": true,
-          "kindModifiers": "",
-          "displayParts": [
-            {
-              "text": "@param b ",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        }
-      ]
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/b.js",
-      "position": 7,
-      "name": "jb"
-    },
-    "item": {
-      "isGlobalCompletion": false,
-      "isMemberCompletion": false,
-      "isNewIdentifierLocation": false,
-      "entries": [
-        {
-          "name": "@abstract",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@abstract",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@access",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@access",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@alias",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@alias",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@argument",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@argument",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@async",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@async",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@augments",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@augments",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@author",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@author",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@borrows",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@borrows",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@callback",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@callback",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@class",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@class",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@classdesc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@classdesc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@constant",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@constant",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@constructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@constructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@constructs",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@constructs",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@copyright",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@copyright",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@default",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@default",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@deprecated",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@deprecated",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@description",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@description",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@emits",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@emits",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@enum",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@enum",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@event",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@event",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@example",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@example",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@exports",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@exports",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@extends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@extends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@external",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@external",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@field",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@field",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@file",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@file",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@fileoverview",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@fileoverview",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@fires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@fires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@function",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@function",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@generator",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@generator",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@global",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@global",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@hideconstructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@hideconstructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@host",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@host",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@ignore",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@ignore",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@implements",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@implements",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@inheritdoc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@inheritdoc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@inner",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@inner",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@instance",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@instance",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@interface",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@interface",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@kind",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@kind",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@lends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@lends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@license",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@license",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@link",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@link",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@linkcode",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@linkcode",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@linkplain",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@linkplain",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@listens",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@listens",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@member",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@member",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@memberof",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@memberof",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@method",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@method",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@mixes",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@mixes",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@module",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@module",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@name",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@name",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@namespace",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@namespace",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@overload",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@overload",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@override",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@override",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@package",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@package",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@param",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@param",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@private",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@private",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@prop",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@prop",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@property",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@property",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@protected",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@protected",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@public",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@public",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@readonly",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@readonly",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@requires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@requires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@returns",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@returns",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@satisfies",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@satisfies",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@see",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@see",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@since",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@since",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@static",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@static",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@summary",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@summary",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@template",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@template",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@this",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@this",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@throws",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@throws",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@todo",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@todo",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@tutorial",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@tutorial",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@type",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@type",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@typedef",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@typedef",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@var",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@var",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@variation",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@variation",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@version",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@version",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@virtual",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@virtual",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@yields",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "@yields",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "@param {*} b ",
-          "kind": "",
-          "sortText": "11",
-          "insertText": "@param {${1:*}} b ${2}",
-          "isSnippet": true,
-          "kindModifiers": "",
-          "displayParts": [
-            {
-              "text": "@param {*} b ",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        }
-      ]
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/b.js",
-      "position": 44,
-      "name": "jc"
-    },
-    "item": {
-      "isGlobalCompletion": false,
-      "isMemberCompletion": false,
-      "isNewIdentifierLocation": false,
-      "entries": [
-        {
-          "name": "abstract",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "abstract",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "access",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "access",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "alias",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "alias",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "argument",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "argument",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "async",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "async",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "augments",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "augments",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "author",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "author",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "borrows",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "borrows",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "callback",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "callback",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "class",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "class",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "classdesc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "classdesc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "constant",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "constant",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "constructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "constructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "constructs",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "constructs",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "copyright",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "copyright",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "default",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "default",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "deprecated",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "deprecated",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "description",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "description",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "emits",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "emits",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "enum",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "enum",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "event",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "event",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "example",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "example",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "exports",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "exports",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "extends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "extends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "external",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "external",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "field",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "field",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "file",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "file",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "fileoverview",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "fileoverview",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "fires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "fires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "function",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "function",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "generator",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "generator",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "global",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "global",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "hideconstructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "hideconstructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "host",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "host",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "ignore",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "ignore",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "implements",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "implements",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "inheritdoc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "inheritdoc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "inner",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "inner",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "instance",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "instance",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "interface",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "interface",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "kind",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "kind",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "lends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "lends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "license",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "license",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "link",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "link",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "linkcode",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "linkcode",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "linkplain",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "linkplain",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "listens",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "listens",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "member",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "member",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "memberof",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "memberof",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "method",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "method",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "mixes",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "mixes",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "module",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "module",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "name",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "name",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "namespace",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "namespace",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "overload",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "overload",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "override",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "override",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "package",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "package",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "param",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "param",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "private",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "private",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "prop",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "prop",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "property",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "property",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "protected",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "protected",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "public",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "public",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "readonly",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "readonly",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "requires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "requires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "returns",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "returns",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "satisfies",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "satisfies",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "see",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "see",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "since",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "since",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "static",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "static",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "summary",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "summary",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "template",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "template",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "this",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "this",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "throws",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "throws",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "todo",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "todo",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "tutorial",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "tutorial",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "type",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "type",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "typedef",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "typedef",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "var",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "var",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "variation",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "variation",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "version",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "version",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "virtual",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "virtual",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "yields",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "yields",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
-          "kind": "",
-          "sortText": "11",
-          "insertText": "param {Object} param0 ${1}\r\n* @param {Object} [param0.b={ a: 1, c: 3 }] ${2}\r\n* @param {${3:*}} param0.b.a ${4}\r\n* @param {${5:*}} param0.b.c ${6}",
-          "isSnippet": true,
-          "kindModifiers": "",
-          "displayParts": [
-            {
-              "text": "param {Object} param0 \r\n* @param {Object} [param0.b={ a: 1, c: 3 }] \r\n* @param {*} param0.b.a \r\n* @param {*} param0.b.c ",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        }
-      ]
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/b.js",
-      "position": 114,
-      "name": "jd"
-    },
-    "item": {
-      "isGlobalCompletion": false,
-      "isMemberCompletion": false,
-      "isNewIdentifierLocation": false,
-      "entries": [
-        {
-          "name": "abstract",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "abstract",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "access",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "access",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "alias",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "alias",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "argument",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "argument",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "async",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "async",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "augments",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "augments",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "author",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "author",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "borrows",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "borrows",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "callback",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "callback",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "class",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "class",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "classdesc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "classdesc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "constant",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "constant",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "constructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "constructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "constructs",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "constructs",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "copyright",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "copyright",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "default",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "default",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "deprecated",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "deprecated",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "description",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "description",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "emits",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "emits",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "enum",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "enum",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "event",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "event",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "example",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "example",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "exports",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "exports",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "extends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "extends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "external",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "external",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "field",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "field",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "file",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "file",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "fileoverview",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "fileoverview",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "fires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "fires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "function",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "function",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "generator",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "generator",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "global",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "global",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "hideconstructor",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "hideconstructor",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "host",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "host",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "ignore",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "ignore",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "implements",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "implements",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "inheritdoc",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "inheritdoc",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "inner",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "inner",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "instance",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "instance",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "interface",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "interface",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "kind",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "kind",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "lends",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "lends",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "license",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "license",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "link",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "link",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "linkcode",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "linkcode",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "linkplain",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "linkplain",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "listens",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "listens",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "member",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "member",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "memberof",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "memberof",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "method",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "method",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "mixes",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "mixes",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "module",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "module",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "name",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "name",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "namespace",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "namespace",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "overload",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "overload",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "override",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "override",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "package",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "package",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "param",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "param",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "private",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "private",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "prop",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "prop",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "property",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "property",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "protected",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "protected",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "public",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "public",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "readonly",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "readonly",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "requires",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "requires",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "returns",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "returns",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "satisfies",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "satisfies",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "see",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "see",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "since",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "since",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "static",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "static",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "summary",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "summary",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "template",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "template",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "this",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "this",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "throws",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "throws",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "todo",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "todo",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "tutorial",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "tutorial",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "type",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "type",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "typedef",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "typedef",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "var",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "var",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "variation",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "variation",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "version",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "version",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "virtual",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "virtual",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "yields",
-          "kind": "",
-          "kindModifiers": "",
-          "sortText": "11",
-          "displayParts": [
-            {
-              "text": "yields",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        },
-        {
-          "name": "param {...*} a ",
-          "kind": "",
-          "sortText": "11",
-          "insertText": "param {...${1:*}} a ${2}",
-          "isSnippet": true,
-          "kindModifiers": "",
-          "displayParts": [
-            {
-              "text": "param {...*} a ",
-              "kind": "text"
-            }
-          ],
-          "documentation": []
-        }
-      ]
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/b.js",
-      "position": 150,
+      "fileName": "/tests/cases/fourslash/a.js",
+      "position": 9,
       "name": "z"
     },
     "item": {
@@ -5994,12 +1653,5540 @@
           "name": "param {number} [a=3] ",
           "kind": "",
           "sortText": "11",
-          "insertText": "param {number} [a=3] ${1}",
-          "isSnippet": true,
           "kindModifiers": "",
           "displayParts": [
             {
               "text": "param {number} [a=3] ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.js",
+      "position": 45,
+      "name": "y"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {number} [param0.a=3] ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {number} [param0.a=3] ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.js",
+      "position": 85,
+      "name": "x"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {*} param0.a \r\n* @param {Object} param0.o \r\n* @param {*} param0.o.b \r\n* @param {*} param0.o.c ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {*} param0.a \r\n* @param {Object} param0.o \r\n* @param {*} param0.o.b \r\n* @param {*} param0.o.c ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.js",
+      "position": 145,
+      "name": "w"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {*} param0.a \r\n* @param {Object} param0.o \r\n* @param {*} param0.o.b \r\n* @param {[number, boolean]} [param0.o.c=[1, true]] ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {*} param0.a \r\n* @param {Object} param0.o \r\n* @param {*} param0.o.b \r\n* @param {[number, boolean]} [param0.o.c=[1, true]] ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.js",
+      "position": 213,
+      "name": "v"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {(number | boolean)[]} [param0.a=[1, true]] ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {(number | boolean)[]} [param0.a=[1, true]] ",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/a.js",
+      "position": 293,
+      "name": "u"
+    },
+    "item": {
+      "isGlobalCompletion": false,
+      "isMemberCompletion": false,
+      "isNewIdentifierLocation": false,
+      "entries": [
+        {
+          "name": "abstract",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "abstract",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "access",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "access",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "alias",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "alias",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "argument",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "argument",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "async",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "async",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "augments",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "augments",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "author",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "author",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "borrows",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "borrows",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "callback",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "callback",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "class",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "class",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "classdesc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "classdesc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constant",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constant",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "constructs",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "constructs",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "copyright",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "copyright",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "default",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "default",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "deprecated",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "deprecated",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "description",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "description",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "emits",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "emits",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "enum",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "enum",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "event",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "event",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "example",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "example",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "exports",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "exports",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "extends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "extends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "external",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "external",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "field",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "field",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "file",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "file",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fileoverview",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fileoverview",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "fires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "fires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "function",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "function",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "generator",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "generator",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "global",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "global",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "hideconstructor",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "hideconstructor",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "host",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "host",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "ignore",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "ignore",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "implements",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "implements",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inheritdoc",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inheritdoc",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "inner",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "inner",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "instance",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "instance",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "interface",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "interface",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "kind",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "kind",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "lends",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "lends",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "license",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "license",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "link",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "link",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkcode",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkcode",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "linkplain",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "linkplain",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "listens",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "listens",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "member",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "member",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "memberof",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "memberof",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "method",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "method",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "mixes",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "mixes",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "module",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "module",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "name",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "name",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "namespace",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "namespace",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "overload",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "overload",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "override",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "override",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "package",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "package",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "param",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "private",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "private",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "prop",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "prop",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "property",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "property",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "protected",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "protected",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "public",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "public",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "readonly",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "readonly",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "requires",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "requires",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "returns",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "returns",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "satisfies",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "satisfies",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "see",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "see",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "since",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "since",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "static",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "static",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "summary",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "summary",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "template",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "template",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "this",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "this",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "throws",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "throws",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "todo",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "todo",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "tutorial",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "tutorial",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "type",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "type",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "typedef",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "typedef",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "var",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "var",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "variation",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "variation",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "version",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "version",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "virtual",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "virtual",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "yields",
+          "kind": "",
+          "kindModifiers": "",
+          "sortText": "11",
+          "displayParts": [
+            {
+              "text": "yields",
+              "kind": "text"
+            }
+          ],
+          "documentation": []
+        },
+        {
+          "name": "param {Object} param0 \r\n* @param {*} [param0.a=random()] ",
+          "kind": "",
+          "sortText": "11",
+          "kindModifiers": "",
+          "displayParts": [
+            {
+              "text": "param {Object} param0 \r\n* @param {*} [param0.a=random()] ",
               "kind": "text"
             }
           ],

--- a/tests/cases/fourslash/jsdocParameterTagSnippetCompletion1.ts
+++ b/tests/cases/fourslash/jsdocParameterTagSnippetCompletion1.ts
@@ -1,0 +1,103 @@
+///<reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: a.ts
+//// /**
+////  * @para/*0*/
+////  */
+//// function printValue(value, maximumFractionDigits) {}
+
+//// /**
+////  * @p/*a*/
+////  */
+//// function aa({ a = 1 }, b: string) {
+////     a;
+//// }
+
+//// /**
+////  * /*b*/
+////  */
+//// function bb(b: string) {}
+
+//// /**
+////  * 
+////  * @p/*c*/
+////  */
+//// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+
+//// }
+
+//// /**
+////  * 
+////  * @p/*d*/
+////  */
+//// function dd({ a: { b, c }, d: [e, f] }: { a: { b: number, c: number }, d: [string, string] }) {
+
+//// }
+
+// @Filename: b.js
+//// /**
+////  * @p/*ja*/
+////  */
+//// function aa({ a = 1 }, b) {
+////     a;
+//// }
+
+//// /**
+////  * /*jb*/
+////  */
+//// function bb(b) {}
+
+
+//// /**
+////  * 
+////  * @p/*jc*/
+////  */
+//// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+
+//// }
+
+//// /**
+////  * 
+////  * @p/*jd*/
+////  */
+//// function dd({ a: { b, c }, d: [e, f] }) {
+
+//// }
+
+//// const someconst = "aa";
+//// /**
+////  * 
+////  * @p/*je*/
+////  */
+//// function ee({ [someconst]: b }) {
+
+//// }
+
+//// /**
+////  * 
+////  * @p/*jf*/
+////  */
+//// function ff({ "a": b }) {
+
+//// }
+
+//// /**
+////  * 
+////  * @p/*jg*/
+////  */
+//// function gg(a, { b }) {
+
+//// }
+
+//// /**
+////  * 
+////  * @param {boolean} a a's description
+////  * @p/*jh*/
+////  */
+//// function hh(a, { b }) {
+    
+//// }
+
+verify.baselineCompletions();

--- a/tests/cases/fourslash/jsdocParameterTagSnippetCompletion1.ts
+++ b/tests/cases/fourslash/jsdocParameterTagSnippetCompletion1.ts
@@ -7,33 +7,33 @@
 ////  * @para/*0*/
 ////  */
 //// function printValue(value, maximumFractionDigits) {}
-
+////
 //// /**
 ////  * @p/*a*/
 ////  */
 //// function aa({ a = 1 }, b: string) {
 ////     a;
 //// }
-
+////
 //// /**
 ////  * /*b*/
 ////  */
 //// function bb(b: string) {}
-
+////
 //// /**
 ////  * 
 ////  * @p/*c*/
 ////  */
 //// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
-
+////
 //// }
-
+////
 //// /**
 ////  * 
 ////  * @p/*d*/
 ////  */
 //// function dd({ a: { b, c }, d: [e, f] }: { a: { b: number, c: number }, d: [string, string] }) {
-
+////
 //// }
 
 // @Filename: b.js
@@ -43,61 +43,77 @@
 //// function aa({ a = 1 }, b) {
 ////     a;
 //// }
-
+////
 //// /**
 ////  * /*jb*/
 ////  */
 //// function bb(b) {}
-
-
+////
 //// /**
 ////  * 
 ////  * @p/*jc*/
 ////  */
 //// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
-
+////
 //// }
-
+////
 //// /**
 ////  * 
 ////  * @p/*jd*/
 ////  */
 //// function dd({ a: { b, c }, d: [e, f] }) {
-
+////
 //// }
-
+////
 //// const someconst = "aa";
 //// /**
 ////  * 
 ////  * @p/*je*/
 ////  */
 //// function ee({ [someconst]: b }) {
-
+////
 //// }
-
+////
 //// /**
 ////  * 
 ////  * @p/*jf*/
 ////  */
 //// function ff({ "a": b }) {
-
+////
 //// }
-
+////
 //// /**
 ////  * 
 ////  * @p/*jg*/
 ////  */
 //// function gg(a, { b }) {
-
+////
 //// }
-
+////
 //// /**
 ////  * 
 ////  * @param {boolean} a a's description
 ////  * @p/*jh*/
 ////  */
 //// function hh(a, { b }) {
-    
+////    
 //// }
+//// /**
+////  * 
+////  * @p/*ji*/
+////  */
+//// function ii({ b, ...c }, ...a) {}
+////
+//// /**
+////  * 
+////  * @p/*jj*/
+////  */
+//// function jj(...{ length }) {}
+////
+//// /**
+////  * 
+////  * @p/*jk*/
+////  */
+//// function kk(...a) {}
 
 verify.baselineCompletions();

--- a/tests/cases/fourslash/jsdocParameterTagSnippetCompletion1.ts
+++ b/tests/cases/fourslash/jsdocParameterTagSnippetCompletion1.ts
@@ -115,5 +115,13 @@
 ////  * @p/*jk*/
 ////  */
 //// function kk(...a) {}
+////
+//// function reallylongfunctionnameabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl(a) {}
+//// /**
+////  *
+////  * @p/*jl*/
+////  */
+//// function ll(a = reallylongfunctionnameabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl("")) {}
+////}
 
 verify.baselineCompletions();

--- a/tests/cases/fourslash/jsdocParameterTagSnippetCompletion2.ts
+++ b/tests/cases/fourslash/jsdocParameterTagSnippetCompletion2.ts
@@ -13,15 +13,21 @@
 ////  * /*jb*/
 ////  */
 //// function bb(b) {}
-
-
+////
 //// /**
 ////  * 
 ////  * @p/*jc*/
 ////  */
 //// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
-
+////
 //// }
+////
+//// /**
+////  * 
+////  * @p/*jd*/
+////  */
+//// function dd(...a) {}
+
 
 verify.baselineCompletions({
     includeCompletionsWithSnippetText: true,

--- a/tests/cases/fourslash/jsdocParameterTagSnippetCompletion2.ts
+++ b/tests/cases/fourslash/jsdocParameterTagSnippetCompletion2.ts
@@ -1,0 +1,28 @@
+///<reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: a.ts
+//// /**
+////  * /*b*/
+////  */
+//// function bb(b: string) {}
+
+// @Filename: b.js
+//// /**
+////  * /*jb*/
+////  */
+//// function bb(b) {}
+
+
+//// /**
+////  * 
+////  * @p/*jc*/
+////  */
+//// function cc({ b: { a, c } = { a: 1, c: 3 } }) {
+
+//// }
+
+verify.baselineCompletions({
+    includeCompletionsWithSnippetText: true,
+});

--- a/tests/cases/fourslash/jsdocParameterTagSnippetCompletion2.ts
+++ b/tests/cases/fourslash/jsdocParameterTagSnippetCompletion2.ts
@@ -27,6 +27,11 @@
 ////  * @p/*jd*/
 ////  */
 //// function dd(...a) {}
+////
+//// /**
+////  * @p/*z*/
+////  */
+//// function zz(a = 3) {}
 
 
 verify.baselineCompletions({

--- a/tests/cases/fourslash/jsdocParameterTagSnippetCompletion3.ts
+++ b/tests/cases/fourslash/jsdocParameterTagSnippetCompletion3.ts
@@ -1,0 +1,39 @@
+///<reference path="fourslash.ts" />
+
+// Infer types from initializer
+
+// @allowJs: true
+
+// @Filename: a.js
+//// /**
+////  * @p/*z*/
+////  */
+//// function zz(a = 3) {}
+
+//// /**
+////  * @p/*y*/
+////  */
+//// function yy({ a = 3 }) {}
+
+//// /**
+////  * @p/*x*/
+////  */
+//// function xx({ a, o: { b, c: [d, e = 1] }}) {}
+
+//// /**
+////  * @p/*w*/
+////  */
+//// function ww({ a, o: { b, c: [d, e] = [1, true] }}) {}
+
+//// /**
+////  * @p/*v*/
+////  */
+//// function vv({ a = [1, true] }) {}
+
+//// function random(a) { return a }
+//// /**
+////  * @p/*u*/
+////  */
+//// function uu({ a = random() }) {}
+
+verify.baselineCompletions();


### PR DESCRIPTION
Fixes #52370.

Possibly relevant things to pay attention to:
- Destructuring is handled one way in JS files, with the multiline syntax e.g. `@param {Object} param0 @param {*} param0.a`, but in TS files for now we just don't offer those detailed `@param` completions, because that same syntax (minus type annotations) doesn't work, as reported in #32783. When/if we merge #50951, we could use that syntax instead for TS files.

- The completion is a snippet, with a placeholder on the type annotation when one is present (and when it's not `Object` in a destructuring), and a tab stop on the place where the comment should go. Should the made-up parameter names for destructured parameters also be a placeholder?

- The implementation takes parameter initializers into consideration and includes them in the generated `@param` completion, but I currently have a rule that we don't include the initializer if its text is too long (> 80 characters), or if it spans across multiple lines.
