### PR TITLE
fix(53257): Illegal .d.ts class property definition for "constructor" generated from JavaScript

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9510,7 +9510,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // need to be merged namespace members
                         return [];
                     }
-                    if (p.flags & SymbolFlags.Prototype ||
+                    if (p.flags & SymbolFlags.Prototype || p.escapedName === "constructor" ||
                         (baseType && getPropertyOfType(baseType, p.escapedName)
                          && isReadonlySymbol(getPropertyOfType(baseType, p.escapedName)!) === isReadonlySymbol(p)
                          && (p.flags & SymbolFlags.Optional) === (getPropertyOfType(baseType, p.escapedName)!.flags & SymbolFlags.Optional)

--- a/tests/baselines/reference/constructorPropertyJs.js
+++ b/tests/baselines/reference/constructorPropertyJs.js
@@ -1,0 +1,20 @@
+//// [a.js]
+class C {
+    /**
+     * @param {any} a
+     */
+    foo(a) {
+        this.constructor = a;
+    }
+}
+
+
+
+
+//// [a.d.ts]
+declare class C {
+    /**
+     * @param {any} a
+     */
+    foo(a: any): void;
+}

--- a/tests/baselines/reference/constructorPropertyJs.symbols
+++ b/tests/baselines/reference/constructorPropertyJs.symbols
@@ -1,0 +1,19 @@
+=== /a.js ===
+class C {
+>C : Symbol(C, Decl(a.js, 0, 0))
+
+    /**
+     * @param {any} a
+     */
+    foo(a) {
+>foo : Symbol(C.foo, Decl(a.js, 0, 9))
+>a : Symbol(a, Decl(a.js, 4, 8))
+
+        this.constructor = a;
+>this.constructor : Symbol(C.constructor, Decl(a.js, 4, 12))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>constructor : Symbol(C.constructor, Decl(a.js, 4, 12))
+>a : Symbol(a, Decl(a.js, 4, 8))
+    }
+}
+

--- a/tests/baselines/reference/constructorPropertyJs.types
+++ b/tests/baselines/reference/constructorPropertyJs.types
@@ -1,0 +1,20 @@
+=== /a.js ===
+class C {
+>C : C
+
+    /**
+     * @param {any} a
+     */
+    foo(a) {
+>foo : (a: any) => void
+>a : any
+
+        this.constructor = a;
+>this.constructor = a : any
+>this.constructor : any
+>this : this
+>constructor : any
+>a : any
+    }
+}
+

--- a/tests/cases/compiler/constructorPropertyJs.ts
+++ b/tests/cases/compiler/constructorPropertyJs.ts
@@ -1,0 +1,13 @@
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @filename: /a.js
+class C {
+    /**
+     * @param {any} a
+     */
+    foo(a) {
+        this.constructor = a;
+    }
+}


### PR DESCRIPTION
Fixes #53257