### PR TITLE
Set minimal workflow permissions

### DIFF
--- a/.github/workflows/accept-baselines-fix-lints.yaml
+++ b/.github/workflows/accept-baselines-fix-lints.yaml
@@ -3,9 +3,15 @@ name: Accept Baselines and Fix Lints
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - main
       - release-*
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,9 @@ on:
     #        *  * * * *
     - cron: '30 1 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest

--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -11,6 +11,9 @@ on:
         - cron: '0 0 1 * *'
     workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/error-deltas-watchdog.yaml
+++ b/.github/workflows/error-deltas-watchdog.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'microsoft/TypeScript'
     permissions:
+      contents: read # Apparently required to create issues
       issues: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/error-deltas-watchdog.yaml
+++ b/.github/workflows/error-deltas-watchdog.yaml
@@ -5,12 +5,14 @@ on:
   schedule:
     - cron: '0 0 * * 3' # Every Wednesday
 
+permissions:
+  contents: read
+
 jobs:
   check-for-recent:
     runs-on: ubuntu-latest
     if: github.repository == 'microsoft/TypeScript'
     permissions:
-      contents: read # Apparently required to create issues
       issues: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -4,9 +4,15 @@ on:
   repository_dispatch:
     types: new-release-branch
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/setup-node@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,6 +8,9 @@ on:
   repository_dispatch:
     types: publish-nightly
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - release-*
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -10,6 +10,9 @@ on:
       - main
       - release-*
 
+permissions:
+  contents: read
+
 jobs:
   richnav:
     runs-on: windows-latest

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -4,9 +4,15 @@ on:
   repository_dispatch:
     types: set-version
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/setup-node@v3

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -9,9 +9,15 @@ on:
         description: 'Target Branch Name'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/setup-node@v3

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -2,6 +2,9 @@ name: Sync Two Wiki Repos
 
 on: [gollum]
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -19,6 +19,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   run:
     if: ${{ github.repository == 'microsoft/TypeScript' }}

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -3,9 +3,15 @@ name: Update LKG
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -7,10 +7,16 @@ on:
         - cron: '0 6 * * *'
     workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     if: github.repository == 'microsoft/TypeScript'
+
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #53296

As per the linked issue, this PR sets top-level read-only permissions on all workflows. This reduces risks in case any workflow dependencies are compromised in a supply-chain attack.

Some of the workflows seem to require `contents: write` permissions to push directly to the repository. These have been given read-only top-level permissions and then write permissions at the job level. This is for future proofing, in case additional jobs that do not require write access are added to the workflow.

