### PR TITLE
Remove top-level GHA perm settings now that repo is reconfigured

### DIFF
--- a/.github/workflows/accept-baselines-fix-lints.yaml
+++ b/.github/workflows/accept-baselines-fix-lints.yaml
@@ -3,9 +3,6 @@ name: Accept Baselines and Fix Lints
 on:
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ on:
       - main
       - release-*
 
-permissions:
-  contents: read
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,6 @@ on:
     #        *  * * * *
     - cron: '30 1 * * 0'
 
-permissions:
-  contents: read
-
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest

--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -11,9 +11,6 @@ on:
         - cron: '0 0 1 * *'
     workflow_dispatch: {}
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/error-deltas-watchdog.yaml
+++ b/.github/workflows/error-deltas-watchdog.yaml
@@ -5,9 +5,6 @@ on:
   schedule:
     - cron: '0 0 * * 3' # Every Wednesday
 
-permissions:
-  contents: read
-
 jobs:
   check-for-recent:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -4,9 +4,6 @@ on:
   repository_dispatch:
     types: new-release-branch
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,9 +8,6 @@ on:
   repository_dispatch:
     types: publish-nightly
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - release-*
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -10,9 +10,6 @@ on:
       - main
       - release-*
 
-permissions:
-  contents: read
-
 jobs:
   richnav:
     runs-on: windows-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,9 +14,6 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -4,9 +4,6 @@ on:
   repository_dispatch:
     types: set-version
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -9,9 +9,6 @@ on:
         description: 'Target Branch Name'
         required: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -2,9 +2,6 @@ name: Sync Two Wiki Repos
 
 on: [gollum]
 
-permissions:
-  contents: read
-
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -19,9 +19,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-
 jobs:
   run:
     if: ${{ github.repository == 'microsoft/TypeScript' }}

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -3,9 +3,6 @@ name: Update LKG
 on:
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -7,9 +7,6 @@ on:
         - cron: '0 6 * * *'
     workflow_dispatch: {}
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #53297; the repo is now configured to be read only, so these are no longer required.