### PR TITLE
Bump TS devDep to ^5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
                 "node-fetch": "^3.2.10",
                 "source-map-support": "^0.5.21",
                 "tslib": "^2.5.0",
-                "typescript": "5.0.1-rc",
+                "typescript": "^5.0.2",
                 "which": "^2.0.2"
             },
             "engines": {
@@ -4334,16 +4334,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.0.1-rc",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.1-rc.tgz",
-            "integrity": "sha512-zh75jY8gPo/y7fpmlTVN2bb2MigoLx4hGk+Cla9pY6lgSTvzJrmQQrRt5S80VTsEt6biWPZJgLK2nm6f0Ya+mA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=12.20"
             }
         },
         "node_modules/typical": {
@@ -7591,9 +7591,9 @@
             }
         },
         "typescript": {
-            "version": "5.0.1-rc",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.1-rc.tgz",
-            "integrity": "sha512-zh75jY8gPo/y7fpmlTVN2bb2MigoLx4hGk+Cla9pY6lgSTvzJrmQQrRt5S80VTsEt6biWPZJgLK2nm6f0Ya+mA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
             "dev": true
         },
         "typical": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "node-fetch": "^3.2.10",
         "source-map-support": "^0.5.21",
         "tslib": "^2.5.0",
-        "typescript": "5.0.1-rc",
+        "typescript": "^5.0.2",
         "which": "^2.0.2"
     },
     "overrides": {


### PR DESCRIPTION
TS 5.0 is out, so we can now move back to a stable build.