### PR TITLE
Disallow instantiation expressions on the right side of instanceof

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34353,6 +34353,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkExpressionWithTypeArguments(node: ExpressionWithTypeArguments | TypeQueryNode) {
         checkGrammarExpressionWithTypeArguments(node);
         forEach(node.typeArguments, checkSourceElement);
+        if (node.kind === SyntaxKind.ExpressionWithTypeArguments) {
+            const parent = walkUpParenthesizedExpressions(node.parent);
+            if (parent.kind === SyntaxKind.BinaryExpression && (parent as BinaryExpression).operatorToken.kind === SyntaxKind.InstanceOfKeyword && isNodeDescendantOf(node, (parent as BinaryExpression).right)) {
+                error(node, Diagnostics.The_right_hand_side_of_an_instanceof_expression_must_not_be_an_instantiation_expression);
+            }
+        }
         const exprType = node.kind === SyntaxKind.ExpressionWithTypeArguments ? checkExpression(node.expression) :
             isThisIdentifier(node.exprName) ? checkThisExpression(node.exprName) :
             checkExpression(node.exprName);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3615,6 +3615,10 @@
         "category": "Error",
         "code": 2847
     },
+    "The right-hand side of an 'instanceof' expression must not be an instantiation expression.": {
+        "category": "Error",
+        "code": 2848
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/instanceofOnInstantiationExpression.errors.txt
+++ b/tests/baselines/reference/instanceofOnInstantiationExpression.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/instanceofOnInstantiationExpression.ts(10,21): error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
-tests/cases/compiler/instanceofOnInstantiationExpression.ts(11,22): error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
-tests/cases/compiler/instanceofOnInstantiationExpression.ts(12,23): error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+tests/cases/compiler/instanceofOnInstantiationExpression.ts(10,21): error TS2848: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+tests/cases/compiler/instanceofOnInstantiationExpression.ts(11,22): error TS2848: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+tests/cases/compiler/instanceofOnInstantiationExpression.ts(12,23): error TS2848: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
 
 
 ==== tests/cases/compiler/instanceofOnInstantiationExpression.ts (3 errors) ====
@@ -15,13 +15,13 @@ tests/cases/compiler/instanceofOnInstantiationExpression.ts(12,23): error TS2847
     
     maybeBox instanceof Box<number>; // error
                         ~~~~~~~~~~~
-!!! error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+!!! error TS2848: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
     maybeBox instanceof (Box<number>); // error
                          ~~~~~~~~~~~
-!!! error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+!!! error TS2848: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
     maybeBox instanceof ((Box<number>)); // error
                           ~~~~~~~~~~~
-!!! error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+!!! error TS2848: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
     
     Box<number> instanceof Object; // OK
     (Box<number>) instanceof Object; // OK

--- a/tests/baselines/reference/instanceofOnInstantiationExpression.errors.txt
+++ b/tests/baselines/reference/instanceofOnInstantiationExpression.errors.txt
@@ -1,0 +1,29 @@
+tests/cases/compiler/instanceofOnInstantiationExpression.ts(10,21): error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+tests/cases/compiler/instanceofOnInstantiationExpression.ts(11,22): error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+tests/cases/compiler/instanceofOnInstantiationExpression.ts(12,23): error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+
+
+==== tests/cases/compiler/instanceofOnInstantiationExpression.ts (3 errors) ====
+    declare class Box<T> {
+        value: T;
+    }
+    
+    
+    declare const maybeBox: unknown;
+    
+    maybeBox instanceof Box; // OK
+    
+    maybeBox instanceof Box<number>; // error
+                        ~~~~~~~~~~~
+!!! error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+    maybeBox instanceof (Box<number>); // error
+                         ~~~~~~~~~~~
+!!! error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+    maybeBox instanceof ((Box<number>)); // error
+                          ~~~~~~~~~~~
+!!! error TS2847: The right-hand side of an 'instanceof' expression must not be an instantiation expression.
+    
+    Box<number> instanceof Object; // OK
+    (Box<number>) instanceof Object; // OK
+    ((Box<number>)) instanceof Object; // OK
+    

--- a/tests/baselines/reference/instanceofOnInstantiationExpression.js
+++ b/tests/baselines/reference/instanceofOnInstantiationExpression.js
@@ -1,0 +1,27 @@
+//// [instanceofOnInstantiationExpression.ts]
+declare class Box<T> {
+    value: T;
+}
+
+
+declare const maybeBox: unknown;
+
+maybeBox instanceof Box; // OK
+
+maybeBox instanceof Box<number>; // error
+maybeBox instanceof (Box<number>); // error
+maybeBox instanceof ((Box<number>)); // error
+
+Box<number> instanceof Object; // OK
+(Box<number>) instanceof Object; // OK
+((Box<number>)) instanceof Object; // OK
+
+
+//// [instanceofOnInstantiationExpression.js]
+maybeBox instanceof Box; // OK
+maybeBox instanceof (Box); // error
+maybeBox instanceof (Box); // error
+maybeBox instanceof ((Box)); // error
+(Box) instanceof Object; // OK
+(Box) instanceof Object; // OK
+((Box)) instanceof Object; // OK

--- a/tests/baselines/reference/instanceofOnInstantiationExpression.symbols
+++ b/tests/baselines/reference/instanceofOnInstantiationExpression.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/instanceofOnInstantiationExpression.ts ===
+declare class Box<T> {
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+>T : Symbol(T, Decl(instanceofOnInstantiationExpression.ts, 0, 18))
+
+    value: T;
+>value : Symbol(Box.value, Decl(instanceofOnInstantiationExpression.ts, 0, 22))
+>T : Symbol(T, Decl(instanceofOnInstantiationExpression.ts, 0, 18))
+}
+
+
+declare const maybeBox: unknown;
+>maybeBox : Symbol(maybeBox, Decl(instanceofOnInstantiationExpression.ts, 5, 13))
+
+maybeBox instanceof Box; // OK
+>maybeBox : Symbol(maybeBox, Decl(instanceofOnInstantiationExpression.ts, 5, 13))
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+
+maybeBox instanceof Box<number>; // error
+>maybeBox : Symbol(maybeBox, Decl(instanceofOnInstantiationExpression.ts, 5, 13))
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+
+maybeBox instanceof (Box<number>); // error
+>maybeBox : Symbol(maybeBox, Decl(instanceofOnInstantiationExpression.ts, 5, 13))
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+
+maybeBox instanceof ((Box<number>)); // error
+>maybeBox : Symbol(maybeBox, Decl(instanceofOnInstantiationExpression.ts, 5, 13))
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+
+Box<number> instanceof Object; // OK
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+(Box<number>) instanceof Object; // OK
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+((Box<number>)) instanceof Object; // OK
+>Box : Symbol(Box, Decl(instanceofOnInstantiationExpression.ts, 0, 0))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/instanceofOnInstantiationExpression.types
+++ b/tests/baselines/reference/instanceofOnInstantiationExpression.types
@@ -1,0 +1,59 @@
+=== tests/cases/compiler/instanceofOnInstantiationExpression.ts ===
+declare class Box<T> {
+>Box : Box<T>
+
+    value: T;
+>value : T
+}
+
+
+declare const maybeBox: unknown;
+>maybeBox : unknown
+
+maybeBox instanceof Box; // OK
+>maybeBox instanceof Box : boolean
+>maybeBox : unknown
+>Box : typeof Box
+
+maybeBox instanceof Box<number>; // error
+>maybeBox instanceof Box<number> : boolean
+>maybeBox : unknown
+>Box<number> : { new (): Box<number>; prototype: Box<any>; }
+>Box : typeof Box
+
+maybeBox instanceof (Box<number>); // error
+>maybeBox instanceof (Box<number>) : boolean
+>maybeBox : unknown
+>(Box<number>) : { new (): Box<number>; prototype: Box<any>; }
+>Box<number> : { new (): Box<number>; prototype: Box<any>; }
+>Box : typeof Box
+
+maybeBox instanceof ((Box<number>)); // error
+>maybeBox instanceof ((Box<number>)) : boolean
+>maybeBox : unknown
+>((Box<number>)) : { new (): Box<number>; prototype: Box<any>; }
+>(Box<number>) : { new (): Box<number>; prototype: Box<any>; }
+>Box<number> : { new (): Box<number>; prototype: Box<any>; }
+>Box : typeof Box
+
+Box<number> instanceof Object; // OK
+>Box<number> instanceof Object : boolean
+>Box<number> : { new (): Box<number>; prototype: Box<any>; }
+>Box : typeof Box
+>Object : ObjectConstructor
+
+(Box<number>) instanceof Object; // OK
+>(Box<number>) instanceof Object : boolean
+>(Box<number>) : { new (): Box<number>; prototype: Box<any>; }
+>Box<number> : { new (): Box<number>; prototype: Box<any>; }
+>Box : typeof Box
+>Object : ObjectConstructor
+
+((Box<number>)) instanceof Object; // OK
+>((Box<number>)) instanceof Object : boolean
+>((Box<number>)) : { new (): Box<number>; prototype: Box<any>; }
+>(Box<number>) : { new (): Box<number>; prototype: Box<any>; }
+>Box<number> : { new (): Box<number>; prototype: Box<any>; }
+>Box : typeof Box
+>Object : ObjectConstructor
+

--- a/tests/cases/compiler/instanceofOnInstantiationExpression.ts
+++ b/tests/cases/compiler/instanceofOnInstantiationExpression.ts
@@ -1,0 +1,16 @@
+declare class Box<T> {
+    value: T;
+}
+
+
+declare const maybeBox: unknown;
+
+maybeBox instanceof Box; // OK
+
+maybeBox instanceof Box<number>; // error
+maybeBox instanceof (Box<number>); // error
+maybeBox instanceof ((Box<number>)); // error
+
+Box<number> instanceof Object; // OK
+(Box<number>) instanceof Object; // OK
+((Box<number>)) instanceof Object; // OK


### PR DESCRIPTION
In reviewing #49863, we noticed that we don't emit any sort of error when you use an instantiation expression on the right side of an instanceof check. E.g. in the below code, `<number>` does nothing; you'll still get `any`.

```ts
declare class Box<T> {
    value: T;
}

declare const maybeBox: unknown;

if (maybeBox instanceof Box<number>) {
    maybeBox;                     // Still Box<any>!
    const value = maybeBox.value; // Still any!
}
```

[Playground Link](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEkoGdnwEIHsAeAeAKgHzwDeAUPJfAG5QQCuIAXPPgNxkC+ZZoSciTADtkAF3gBbKAE8ARiCzYW9IQGshmAO5COZAJYAzeAAopchTnh6RoqELAhMRxbiH0J8mIQCUpClTN5RQ4qeAB6MMoAPQB+HlCwYTEaOkZ4AF5JGSCcADpaBhAQqgjQ+FiuMiA)

This PR disallows this syntactically.

We _could_ try and figure out how to do:

```ts
const BoxOfNumber = Box<number>;
if (maybeBox instanceof BoxOfNumber) {
    // ...
}
```

And that fix would look different.