### PR TITLE
Fix package-lock update task

### DIFF
--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -33,7 +33,6 @@ jobs:
       run: |
         rm package-lock.json
         npm install
-        git add -f package-lock.json
 
         if git diff --exit-code --name-only package-lock.json; then
           echo "No change."
@@ -42,6 +41,7 @@ jobs:
           npx hereby lkg
           git config user.email "typescriptbot@microsoft.com"
           git config user.name "TypeScript Bot"
+          git add -f package-lock.json
           git commit -m "Update package-lock.json"
           git push
         fi


### PR DESCRIPTION
When I fixed this task to run tests, I unintentionally broke it by putting the `git add` before the `git diff`. This resulted in it not seeing the change and doing nothing.