### PR TITLE
Change ParamaterDecorator to allow an undefined propertyKey

### DIFF
--- a/src/lib/decorators.legacy.d.ts
+++ b/src/lib/decorators.legacy.d.ts
@@ -1,4 +1,4 @@
 declare type ClassDecorator = <TFunction extends Function>(target: TFunction) => TFunction | void;
 declare type PropertyDecorator = (target: Object, propertyKey: string | symbol) => void;
 declare type MethodDecorator = <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void;
-declare type ParameterDecorator = (target: Object, propertyKey: string | symbol, parameterIndex: number) => void;
+declare type ParameterDecorator = (target: Object, propertyKey: string | symbol | undefined, parameterIndex: number) => void;


### PR DESCRIPTION
`propertyKey` argument can be undefined for constructor parameter decorators.

I believe changes between 4.9 and 5.0 tightened up decorator type checking in some areas (#52435), while a newly introduced declaration file for legacy decorators doesn't reflect this change.

After upgrading to 5.0, I noticed that in my code, a dependency's usage of `ParameterDecorator` resulted in a type checking warning: 

```
Unable to resolve signature of parameter decorator when called as an expression.
  Argument of type 'undefined' is not assignable to parameter of type 'string | symbol'
```

Changing the `propertyKey` in `decorators.legacy.d.ts` to allow `undefined` fixed the type-checking error.

I did not touch the other Decorator types as I don't know if the `propertyKey` issue affects them in the same way.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53312
