### PR TITLE
Simplify LKG

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -11,7 +11,6 @@ import { task } from "hereby";
 import path from "path";
 import util from "util";
 
-import { localizationDirectories } from "./scripts/build/localization.mjs";
 import cmdLineOptions from "./scripts/build/options.mjs";
 import { buildProject, cleanProject, watchProject } from "./scripts/build/projects.mjs";
 import { localBaseline, localRwcBaseline, refBaseline, refRwcBaseline, runConsoleTests } from "./scripts/build/tests.mjs";
@@ -94,17 +93,6 @@ const cleanDiagnostics = task({
  * The file is always generated in 'enu/diagnosticMessages.generated.json.lcg'
  */
 const generatedLCGFile = "built/local/enu/diagnosticMessages.generated.json.lcg";
-
-/**
- * The localization target produces the two following transformations:
- *    1. 'src\loc\lcl\<locale>\diagnosticMessages.generated.json.lcl' => 'built\local\<locale>\diagnosticMessages.generated.json'
- *       convert localized resources into a .json file the compiler can understand
- *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'
- *       generate the lcg file (source of messages to localize) from the diagnosticMessages.generated.json
- */
-const localizationTargets = localizationDirectories
-    .map(f => `built/local/${f}/diagnosticMessages.generated.json`)
-    .concat(generatedLCGFile);
 
 const localize = task({
     name: "localize",

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -814,25 +814,6 @@ export const produceLKG = task({
         if (!cmdLineOptions.bundle) {
             throw new Error("LKG cannot be created when --bundle=false");
         }
-
-        const expectedFiles = [
-            "built/local/cancellationToken.js",
-            "built/local/tsc.js",
-            "built/local/tsserver.js",
-            "built/local/tsserverlibrary.js",
-            "built/local/tsserverlibrary.d.ts",
-            "built/local/typescript.js",
-            "built/local/typescript.d.ts",
-            "built/local/typingsInstaller.js",
-            "built/local/watchGuard.js",
-        ].concat(libs().map(lib => lib.target));
-        const missingFiles = expectedFiles
-            .concat(localizationTargets)
-            .filter(f => !fs.existsSync(f));
-        if (missingFiles.length > 0) {
-            throw new Error("Cannot replace the LKG unless all built targets are present in directory 'built/local/'. The following files are missing:\n" + missingFiles.join("\n"));
-        }
-
         await exec(process.execPath, ["scripts/produceLKG.mjs"]);
     }
 });

--- a/scripts/build/localization.mjs
+++ b/scripts/build/localization.mjs
@@ -1,1 +1,0 @@
-export const localizationDirectories = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"].map(f => f.toLowerCase());

--- a/scripts/produceLKG.mjs
+++ b/scripts/produceLKG.mjs
@@ -31,9 +31,7 @@ async function copyLibFiles() {
 async function copyLocalizedDiagnostics() {
     for (const d of localizationDirectories) {
         const fileName = path.join(source, d);
-        if (fs.statSync(fileName).isDirectory()) {
-            await fs.copy(fileName, path.join(dest, d));
-        }
+        await fs.copy(fileName, path.join(dest, d));
     }
 }
 

--- a/scripts/produceLKG.mjs
+++ b/scripts/produceLKG.mjs
@@ -3,8 +3,6 @@ import glob from "glob";
 import path from "path";
 import url from "url";
 
-import { localizationDirectories } from "./build/localization.mjs";
-
 const __filename = url.fileURLToPath(new URL(import.meta.url));
 const __dirname = path.dirname(__filename);
 
@@ -27,6 +25,8 @@ async function produceLKG() {
 async function copyLibFiles() {
     await copyFilesWithGlob("lib?(.*).d.ts");
 }
+
+const localizationDirectories = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"].map(f => f.toLowerCase());
 
 async function copyLocalizedDiagnostics() {
     for (const d of localizationDirectories) {


### PR DESCRIPTION
Now that the build is via hereby, which uses an explicit dependency tree, we can drop these file checks and just let the LKG script throw if we accidentally break its assumptions.

TODO: explicitly copy lib like we do localization?