### PR TITLE
Add missing ambient check to `verbatimModuleSyntax` `export =` error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -44313,7 +44313,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (getAllSymbolFlags(sym) & SymbolFlags.Value) {
                     // However if it is a value, we need to check it's being used correctly
                     checkExpressionCached(id);
-                    if (!isIllegalExportDefaultInCJS && compilerOptions.verbatimModuleSyntax && getTypeOnlyAliasDeclaration(sym, SymbolFlags.Value)) {
+                    if (!isIllegalExportDefaultInCJS && !(node.flags & NodeFlags.Ambient) && compilerOptions.verbatimModuleSyntax && getTypeOnlyAliasDeclaration(sym, SymbolFlags.Value)) {
                         error(id,
                             node.isExportEquals
                                 ? Diagnostics.An_export_declaration_must_reference_a_real_value_when_verbatimModuleSyntax_is_enabled_but_0_resolves_to_a_type_only_declaration
@@ -44321,7 +44321,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             idText(id));
                     }
                 }
-                else if (!isIllegalExportDefaultInCJS && compilerOptions.verbatimModuleSyntax) {
+                else if (!isIllegalExportDefaultInCJS && !(node.flags & NodeFlags.Ambient) && compilerOptions.verbatimModuleSyntax) {
                     error(id,
                         node.isExportEquals
                             ? Diagnostics.An_export_declaration_must_reference_a_value_when_verbatimModuleSyntax_is_enabled_but_0_only_refers_to_a_type

--- a/tests/baselines/reference/verbatimModuleSyntaxDeclarationFile.symbols
+++ b/tests/baselines/reference/verbatimModuleSyntaxDeclarationFile.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/externalModules/type1.d.ts ===
+declare namespace NS {
+>NS : Symbol(NS, Decl(type1.d.ts, 0, 0))
+
+    type A = object;
+>A : Symbol(A, Decl(type1.d.ts, 0, 22))
+}
+
+export = NS;
+>NS : Symbol(NS, Decl(type1.d.ts, 0, 0))
+
+export as namespace MyTypes;
+>MyTypes : Symbol(MyTypes, Decl(type1.d.ts, 4, 12))
+
+=== tests/cases/conformance/externalModules/type2.d.ts ===
+import type * as NS from './type1';
+>NS : Symbol(NS, Decl(type2.d.ts, 0, 11))
+
+export = NS;
+>NS : Symbol(NS, Decl(type2.d.ts, 0, 11))
+
+export as namespace ModuleATypes;
+>ModuleATypes : Symbol(ModuleATypes, Decl(type2.d.ts, 2, 12))
+

--- a/tests/baselines/reference/verbatimModuleSyntaxDeclarationFile.types
+++ b/tests/baselines/reference/verbatimModuleSyntaxDeclarationFile.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/externalModules/type1.d.ts ===
+declare namespace NS {
+    type A = object;
+>A : object
+}
+
+export = NS;
+>NS : any
+
+export as namespace MyTypes;
+>MyTypes : error
+
+=== tests/cases/conformance/externalModules/type2.d.ts ===
+import type * as NS from './type1';
+>NS : error
+
+export = NS;
+>NS : any
+
+export as namespace ModuleATypes;
+>ModuleATypes : error
+

--- a/tests/baselines/reference/verbatimModuleSyntaxNoElisionCJS.errors.txt
+++ b/tests/baselines/reference/verbatimModuleSyntaxNoElisionCJS.errors.txt
@@ -1,7 +1,6 @@
 /a.ts(2,10): error TS1282: An 'export =' declaration must reference a value when 'verbatimModuleSyntax' is enabled, but 'I' only refers to a type.
 /b.ts(1,1): error TS1484: 'I' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
 /d.ts(3,10): error TS1283: An 'export =' declaration must reference a real value when 'verbatimModuleSyntax' is enabled, but 'J' resolves to a type-only declaration.
-/e.d.ts(2,10): error TS1282: An 'export =' declaration must reference a value when 'verbatimModuleSyntax' is enabled, but 'I' only refers to a type.
 
 
 ==== /a.ts (1 errors) ====
@@ -29,11 +28,9 @@
              ~
 !!! error TS1283: An 'export =' declaration must reference a real value when 'verbatimModuleSyntax' is enabled, but 'J' resolves to a type-only declaration.
     
-==== /e.d.ts (1 errors) ====
+==== /e.d.ts (0 errors) ====
     interface I {}
     export = I;
-             ~
-!!! error TS1282: An 'export =' declaration must reference a value when 'verbatimModuleSyntax' is enabled, but 'I' only refers to a type.
     
 ==== /f.ts (0 errors) ====
     import type I = require("./e");

--- a/tests/cases/conformance/externalModules/verbatimModuleSyntaxDeclarationFile.ts
+++ b/tests/cases/conformance/externalModules/verbatimModuleSyntaxDeclarationFile.ts
@@ -1,0 +1,15 @@
+// @verbatimModuleSyntax: true
+
+// @Filename: type1.d.ts
+declare namespace NS {
+    type A = object;
+}
+
+export = NS;
+export as namespace MyTypes;
+
+// @Filename: type2.d.ts
+import type * as NS from './type1';
+
+export = NS;
+export as namespace ModuleATypes;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53227
