### PR TITLE
Fix crash when importsNotUsedAsValues is set alongside verbatimModuleSyntax

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1472,7 +1472,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var argumentsSymbol = createSymbol(SymbolFlags.Property, "arguments" as __String);
     var requireSymbol = createSymbol(SymbolFlags.Property, "require" as __String);
     var isolatedModulesLikeFlagName = compilerOptions.verbatimModuleSyntax ? "verbatimModuleSyntax" : "isolatedModules";
-    // It is an error ro use `importsNotUsedAsValues` alongside `verbatimModuleSyntax`, but we still need to not crash.
+    // It is an error to use `importsNotUsedAsValues` alongside `verbatimModuleSyntax`, but we still need to not crash.
     // Given that, in such a scenario, `verbatimModuleSyntax` is basically disabled, as least as far as alias visibility tracking goes.
     var canCollectSymbolAliasAccessabilityData = !compilerOptions.verbatimModuleSyntax || !!compilerOptions.importsNotUsedAsValues;
 

--- a/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.errors.txt
+++ b/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.errors.txt
@@ -1,0 +1,19 @@
+error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
+tests/cases/compiler/file.ts(1,1): error TS1287: A top-level 'export' modifier cannot be used on value declarations in a CommonJS module when 'verbatimModuleSyntax' is enabled.
+tests/cases/compiler/index.ts(1,1): error TS1371: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.
+tests/cases/compiler/index.ts(1,9): error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
+
+
+!!! error TS5104: Option 'importsNotUsedAsValues' is redundant and cannot be specified with option 'verbatimModuleSyntax'.
+==== tests/cases/compiler/file.ts (1 errors) ====
+    export class A {}
+    ~~~~~~
+!!! error TS1287: A top-level 'export' modifier cannot be used on value declarations in a CommonJS module when 'verbatimModuleSyntax' is enabled.
+==== tests/cases/compiler/index.ts (2 errors) ====
+    import {A} from "./file";
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1371: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.
+            ~
+!!! error TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.
+    
+    const a: A = null as any;

--- a/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.js
+++ b/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.js
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.ts] ////
+
+//// [file.ts]
+export class A {}
+//// [index.ts]
+import {A} from "./file";
+
+const a: A = null as any;
+
+//// [file.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.A = void 0;
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+exports.A = A;
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var file_1 = require("./file");
+var a = null;

--- a/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.symbols
+++ b/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/file.ts ===
+export class A {}
+>A : Symbol(A, Decl(file.ts, 0, 0))
+
+=== tests/cases/compiler/index.ts ===
+import {A} from "./file";
+>A : Symbol(A, Decl(index.ts, 0, 8))
+
+const a: A = null as any;
+>a : Symbol(a, Decl(index.ts, 2, 5))
+>A : Symbol(A, Decl(index.ts, 0, 8))
+

--- a/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.types
+++ b/tests/baselines/reference/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/file.ts ===
+export class A {}
+>A : A
+
+=== tests/cases/compiler/index.ts ===
+import {A} from "./file";
+>A : typeof A
+
+const a: A = null as any;
+>a : A
+>null as any : any
+

--- a/tests/cases/compiler/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.ts
+++ b/tests/cases/compiler/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.ts
@@ -1,0 +1,9 @@
+// @verbatimModuleSyntax: true
+// @importsNotUsedAsValues: error
+// @ignoreDeprecations: 5.0
+// @filename: file.ts
+export class A {}
+// @filename: index.ts
+import {A} from "./file";
+
+const a: A = null as any;


### PR DESCRIPTION
Fixes #53302
