### PR TITLE
Remove redundant throws of Debug.assertNever

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4736,7 +4736,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
         else {
-            throw Debug.assertNever(name, "Unknown entity name kind.");
+            Debug.assertNever(name, "Unknown entity name kind.");
         }
         Debug.assert((getCheckFlags(symbol) & CheckFlags.Instantiated) === 0, "Should never get an instantiated symbol here.");
         if (!nodeIsSynthesized(name) && isEntityName(name) && (symbol.flags & SymbolFlags.Alias || name.parent.kind === SyntaxKind.ExportAssignment)) {
@@ -17030,7 +17030,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     links.resolvedType = getTypeFromTypeNode(node.type);
                     break;
                 default:
-                    throw Debug.assertNever(node.operator);
+                    Debug.assertNever(node.operator);
             }
         }
         return links.resolvedType;
@@ -33931,7 +33931,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.JsxSelfClosingElement:
                 return resolveJsxOpeningLikeElement(node, candidatesOutArray, checkMode);
         }
-        throw Debug.assertNever(node, "Branch in 'resolveSignature' should be unreachable.");
+        Debug.assertNever(node, "Branch in 'resolveSignature' should be unreachable.");
     }
 
     /**
@@ -47670,7 +47670,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     currentKind = DeclarationMeaning.SetAccessor;
                     break;
                 default:
-                    throw Debug.assertNever(prop, "Unexpected syntax kind:" + (prop as Node).kind);
+                    Debug.assertNever(prop, "Unexpected syntax kind:" + (prop as Node).kind);
             }
 
             if (!inDestructuring) {

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -467,6 +467,6 @@ function renderPackageNameValidationFailureWorker(typing: string, result: NameVa
         case NameValidationResult.Ok:
             return Debug.fail(); // Shouldn't have called this.
         default:
-            throw Debug.assertNever(result);
+            Debug.assertNever(result);
     }
 }

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -656,7 +656,7 @@ function getClassificationTypeName(type: ClassificationType): ClassificationType
         case ClassificationType.jsxAttribute: return ClassificationTypeNames.jsxAttribute;
         case ClassificationType.jsxText: return ClassificationTypeNames.jsxText;
         case ClassificationType.jsxAttributeStringLiteralValue: return ClassificationTypeNames.jsxAttributeStringLiteralValue;
-        default: return undefined!; // TODO: GH#18217 throw Debug.assertNever(type);
+        default: return undefined!; // TODO: GH#18217 Debug.assertNever(type);
     }
 }
 

--- a/src/services/codefixes/requireInTs.ts
+++ b/src/services/codefixes/requireInTs.ts
@@ -67,7 +67,7 @@ interface Info {
 function getInfo(sourceFile: SourceFile, program: Program, pos: number): Info | undefined {
     const { parent } = getTokenAtPosition(sourceFile, pos);
     if (!isRequireCall(parent, /*checkArgumentIsStringLiteralLike*/ true)) {
-        throw Debug.failBadSyntaxKind(parent);
+        Debug.failBadSyntaxKind(parent);
     }
 
     const decl = cast(parent.parent, isVariableDeclaration);

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1001,7 +1001,7 @@ function getDescriptionForFunctionLikeDeclaration(scope: FunctionLikeDeclaration
         case SyntaxKind.SetAccessor:
             return `'set ${scope.name.getText()}'`;
         default:
-            throw Debug.assertNever(scope, `Unexpected scope kind ${(scope as FunctionLikeDeclaration).kind}`);
+            Debug.assertNever(scope, `Unexpected scope kind ${(scope as FunctionLikeDeclaration).kind}`);
     }
 }
 function getDescriptionForClassLikeDeclaration(scope: ClassLikeDeclaration): string {


### PR DESCRIPTION
These functions return `never`; they already indicate that execution will stop after being called. No need to throw their result.