### PR TITLE
Ignore template literal types which contain intersections in removeStringLiteralsMatchedByTemplateLiterals

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16339,7 +16339,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function removeStringLiteralsMatchedByTemplateLiterals(types: Type[]) {
-        const templates = filter(types, t => !!(t.flags & TypeFlags.TemplateLiteral) && isPatternLiteralType(t)) as TemplateLiteralType[];
+        // Skip TemplateLiteralTypes which contain intersections; plain string literals can never match these.
+        const templates = filter(types, t => !!(t.flags & TypeFlags.TemplateLiteral) && isPatternLiteralType(t) && !some((t as TemplateLiteralType).types, t2 => !!(t2.flags & TypeFlags.Intersection))) as TemplateLiteralType[];
         if (templates.length) {
             let i = types.length;
             while (i > 0) {


### PR DESCRIPTION
For #52345

There's no reason to waste time checking template literal types which contain intersections in `removeStringLiteralsMatchedByTemplateLiterals`; the only thing that these can match are other template literals with intersections too.

e.g., `"foo"` will not match `` `fo${"o" & { _brand: any}}` ``.

Before:

![image](https://user-images.githubusercontent.com/5341706/226524002-708a3286-d40e-4611-bffd-38fae871ac7f.png)

After:

![image](https://user-images.githubusercontent.com/5341706/226524058-b50c93e1-34e6-48dd-b932-5d6a61507aba.png)

Maybe there's still something to do to speed up `removeSubtypes` for this case; will have to look harder. But, I want feedback on this PR first.