### PR TITLE
fix: escape module specifier for snippet after quoted

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1990,7 +1990,7 @@ function completionEntryDataToSymbolOriginInfo(data: CompletionEntryData, comple
 
 function getInsertTextAndReplacementSpanForImportCompletion(name: string, importStatementCompletion: ImportStatementCompletionInfo, origin: SymbolOriginInfoResolvedExport, useSemicolons: boolean, sourceFile: SourceFile, options: CompilerOptions, preferences: UserPreferences) {
     const replacementSpan = importStatementCompletion.replacementSpan;
-    const quotedModuleSpecifier = quote(sourceFile, preferences, escapeSnippetText(origin.moduleSpecifier));
+    const quotedModuleSpecifier = escapeSnippetText(quote(sourceFile, preferences, origin.moduleSpecifier));
     const exportKind =
         origin.isDefaultExport ? ExportKind.Default :
         origin.exportName === InternalSymbolName.ExportEquals ? ExportKind.ExportEquals :

--- a/tests/baselines/reference/importStatementCompletions3.baseline
+++ b/tests/baselines/reference/importStatementCompletions3.baseline
@@ -34,7 +34,7 @@
               "kind": "text"
             }
           ],
-          "insertText": "import { foo$1 } from \"./\\\\$foo\";",
+          "insertText": "import { foo$1 } from \"./\\$foo\";",
           "replacementSpan": {
             "start": 0,
             "length": 8


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53290. I think The original fix for #52543 isn't in the correct order. In TypeScript 5.0 it became `import { foo } from "\/foo";` instead of `import { foo } from "$lib/foo"`;
