### PR TITLE
Avoid calculating union in spread if types are identical

### DIFF
--- a/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).js
+++ b/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).js
@@ -1,0 +1,50 @@
+//// [spreadObjectPermutations.ts]
+declare const a: { x: string | number };
+declare const b: { x?: string | number };
+declare const c: { x?: string | number | undefined };
+
+const v_a = { ...a };
+const v_b = { ...b };
+const v_c = { ...c };
+const v_ab = { ...a, ...b };
+const v_ac = { ...a, ...c };
+const v_ba = { ...b, ...a };
+const v_bc = { ...b, ...c };
+const v_ca = { ...c, ...a };
+const v_cb = { ...c, ...b };
+const v_abc = { ...a, ...b, ...c };
+const v_acb = { ...a, ...c, ...b };
+const v_bac = { ...b, ...a, ...c };
+const v_bca = { ...b, ...c, ...a };
+const v_cab = { ...c, ...a, ...b };
+const v_cba = { ...c, ...b, ...a };
+
+
+//// [spreadObjectPermutations.js]
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var v_a = __assign({}, a);
+var v_b = __assign({}, b);
+var v_c = __assign({}, c);
+var v_ab = __assign(__assign({}, a), b);
+var v_ac = __assign(__assign({}, a), c);
+var v_ba = __assign(__assign({}, b), a);
+var v_bc = __assign(__assign({}, b), c);
+var v_ca = __assign(__assign({}, c), a);
+var v_cb = __assign(__assign({}, c), b);
+var v_abc = __assign(__assign(__assign({}, a), b), c);
+var v_acb = __assign(__assign(__assign({}, a), c), b);
+var v_bac = __assign(__assign(__assign({}, b), a), c);
+var v_bca = __assign(__assign(__assign({}, b), c), a);
+var v_cab = __assign(__assign(__assign({}, c), a), b);
+var v_cba = __assign(__assign(__assign({}, c), b), a);

--- a/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,91 @@
+=== tests/cases/compiler/spreadObjectPermutations.ts ===
+declare const a: { x: string | number };
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>x : Symbol(x, Decl(spreadObjectPermutations.ts, 0, 18))
+
+declare const b: { x?: string | number };
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>x : Symbol(x, Decl(spreadObjectPermutations.ts, 1, 18))
+
+declare const c: { x?: string | number | undefined };
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>x : Symbol(x, Decl(spreadObjectPermutations.ts, 2, 18))
+
+const v_a = { ...a };
+>v_a : Symbol(v_a, Decl(spreadObjectPermutations.ts, 4, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_b = { ...b };
+>v_b : Symbol(v_b, Decl(spreadObjectPermutations.ts, 5, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_c = { ...c };
+>v_c : Symbol(v_c, Decl(spreadObjectPermutations.ts, 6, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_ab = { ...a, ...b };
+>v_ab : Symbol(v_ab, Decl(spreadObjectPermutations.ts, 7, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_ac = { ...a, ...c };
+>v_ac : Symbol(v_ac, Decl(spreadObjectPermutations.ts, 8, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_ba = { ...b, ...a };
+>v_ba : Symbol(v_ba, Decl(spreadObjectPermutations.ts, 9, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_bc = { ...b, ...c };
+>v_bc : Symbol(v_bc, Decl(spreadObjectPermutations.ts, 10, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_ca = { ...c, ...a };
+>v_ca : Symbol(v_ca, Decl(spreadObjectPermutations.ts, 11, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_cb = { ...c, ...b };
+>v_cb : Symbol(v_cb, Decl(spreadObjectPermutations.ts, 12, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_abc = { ...a, ...b, ...c };
+>v_abc : Symbol(v_abc, Decl(spreadObjectPermutations.ts, 13, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_acb = { ...a, ...c, ...b };
+>v_acb : Symbol(v_acb, Decl(spreadObjectPermutations.ts, 14, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_bac = { ...b, ...a, ...c };
+>v_bac : Symbol(v_bac, Decl(spreadObjectPermutations.ts, 15, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_bca = { ...b, ...c, ...a };
+>v_bca : Symbol(v_bca, Decl(spreadObjectPermutations.ts, 16, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_cab = { ...c, ...a, ...b };
+>v_cab : Symbol(v_cab, Decl(spreadObjectPermutations.ts, 17, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_cba = { ...c, ...b, ...a };
+>v_cba : Symbol(v_cba, Decl(spreadObjectPermutations.ts, 18, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+

--- a/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=false).types
@@ -1,0 +1,106 @@
+=== tests/cases/compiler/spreadObjectPermutations.ts ===
+declare const a: { x: string | number };
+>a : { x: string | number; }
+>x : string | number
+
+declare const b: { x?: string | number };
+>b : { x?: string | number | undefined; }
+>x : string | number | undefined
+
+declare const c: { x?: string | number | undefined };
+>c : { x?: string | number | undefined; }
+>x : string | number | undefined
+
+const v_a = { ...a };
+>v_a : { x: string | number; }
+>{ ...a } : { x: string | number; }
+>a : { x: string | number; }
+
+const v_b = { ...b };
+>v_b : { x?: string | number | undefined; }
+>{ ...b } : { x?: string | number | undefined; }
+>b : { x?: string | number | undefined; }
+
+const v_c = { ...c };
+>v_c : { x?: string | number | undefined; }
+>{ ...c } : { x?: string | number | undefined; }
+>c : { x?: string | number | undefined; }
+
+const v_ab = { ...a, ...b };
+>v_ab : { x: string | number; }
+>{ ...a, ...b } : { x: string | number; }
+>a : { x: string | number; }
+>b : { x?: string | number | undefined; }
+
+const v_ac = { ...a, ...c };
+>v_ac : { x: string | number; }
+>{ ...a, ...c } : { x: string | number; }
+>a : { x: string | number; }
+>c : { x?: string | number | undefined; }
+
+const v_ba = { ...b, ...a };
+>v_ba : { x: string | number; }
+>{ ...b, ...a } : { x: string | number; }
+>b : { x?: string | number | undefined; }
+>a : { x: string | number; }
+
+const v_bc = { ...b, ...c };
+>v_bc : { x?: string | number | undefined; }
+>{ ...b, ...c } : { x?: string | number | undefined; }
+>b : { x?: string | number | undefined; }
+>c : { x?: string | number | undefined; }
+
+const v_ca = { ...c, ...a };
+>v_ca : { x: string | number; }
+>{ ...c, ...a } : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>a : { x: string | number; }
+
+const v_cb = { ...c, ...b };
+>v_cb : { x?: string | number | undefined; }
+>{ ...c, ...b } : { x?: string | number | undefined; }
+>c : { x?: string | number | undefined; }
+>b : { x?: string | number | undefined; }
+
+const v_abc = { ...a, ...b, ...c };
+>v_abc : { x: string | number; }
+>{ ...a, ...b, ...c } : { x: string | number; }
+>a : { x: string | number; }
+>b : { x?: string | number | undefined; }
+>c : { x?: string | number | undefined; }
+
+const v_acb = { ...a, ...c, ...b };
+>v_acb : { x: string | number; }
+>{ ...a, ...c, ...b } : { x: string | number; }
+>a : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>b : { x?: string | number | undefined; }
+
+const v_bac = { ...b, ...a, ...c };
+>v_bac : { x: string | number; }
+>{ ...b, ...a, ...c } : { x: string | number; }
+>b : { x?: string | number | undefined; }
+>a : { x: string | number; }
+>c : { x?: string | number | undefined; }
+
+const v_bca = { ...b, ...c, ...a };
+>v_bca : { x: string | number; }
+>{ ...b, ...c, ...a } : { x: string | number; }
+>b : { x?: string | number | undefined; }
+>c : { x?: string | number | undefined; }
+>a : { x: string | number; }
+
+const v_cab = { ...c, ...a, ...b };
+>v_cab : { x: string | number; }
+>{ ...c, ...a, ...b } : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>a : { x: string | number; }
+>b : { x?: string | number | undefined; }
+
+const v_cba = { ...c, ...b, ...a };
+>v_cba : { x: string | number; }
+>{ ...c, ...b, ...a } : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>b : { x?: string | number | undefined; }
+>a : { x: string | number; }
+

--- a/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=true).js
+++ b/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=true).js
@@ -1,0 +1,50 @@
+//// [spreadObjectPermutations.ts]
+declare const a: { x: string | number };
+declare const b: { x?: string | number };
+declare const c: { x?: string | number | undefined };
+
+const v_a = { ...a };
+const v_b = { ...b };
+const v_c = { ...c };
+const v_ab = { ...a, ...b };
+const v_ac = { ...a, ...c };
+const v_ba = { ...b, ...a };
+const v_bc = { ...b, ...c };
+const v_ca = { ...c, ...a };
+const v_cb = { ...c, ...b };
+const v_abc = { ...a, ...b, ...c };
+const v_acb = { ...a, ...c, ...b };
+const v_bac = { ...b, ...a, ...c };
+const v_bca = { ...b, ...c, ...a };
+const v_cab = { ...c, ...a, ...b };
+const v_cba = { ...c, ...b, ...a };
+
+
+//// [spreadObjectPermutations.js]
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var v_a = __assign({}, a);
+var v_b = __assign({}, b);
+var v_c = __assign({}, c);
+var v_ab = __assign(__assign({}, a), b);
+var v_ac = __assign(__assign({}, a), c);
+var v_ba = __assign(__assign({}, b), a);
+var v_bc = __assign(__assign({}, b), c);
+var v_ca = __assign(__assign({}, c), a);
+var v_cb = __assign(__assign({}, c), b);
+var v_abc = __assign(__assign(__assign({}, a), b), c);
+var v_acb = __assign(__assign(__assign({}, a), c), b);
+var v_bac = __assign(__assign(__assign({}, b), a), c);
+var v_bca = __assign(__assign(__assign({}, b), c), a);
+var v_cab = __assign(__assign(__assign({}, c), a), b);
+var v_cba = __assign(__assign(__assign({}, c), b), a);

--- a/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,91 @@
+=== tests/cases/compiler/spreadObjectPermutations.ts ===
+declare const a: { x: string | number };
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>x : Symbol(x, Decl(spreadObjectPermutations.ts, 0, 18))
+
+declare const b: { x?: string | number };
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>x : Symbol(x, Decl(spreadObjectPermutations.ts, 1, 18))
+
+declare const c: { x?: string | number | undefined };
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>x : Symbol(x, Decl(spreadObjectPermutations.ts, 2, 18))
+
+const v_a = { ...a };
+>v_a : Symbol(v_a, Decl(spreadObjectPermutations.ts, 4, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_b = { ...b };
+>v_b : Symbol(v_b, Decl(spreadObjectPermutations.ts, 5, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_c = { ...c };
+>v_c : Symbol(v_c, Decl(spreadObjectPermutations.ts, 6, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_ab = { ...a, ...b };
+>v_ab : Symbol(v_ab, Decl(spreadObjectPermutations.ts, 7, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_ac = { ...a, ...c };
+>v_ac : Symbol(v_ac, Decl(spreadObjectPermutations.ts, 8, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_ba = { ...b, ...a };
+>v_ba : Symbol(v_ba, Decl(spreadObjectPermutations.ts, 9, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_bc = { ...b, ...c };
+>v_bc : Symbol(v_bc, Decl(spreadObjectPermutations.ts, 10, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_ca = { ...c, ...a };
+>v_ca : Symbol(v_ca, Decl(spreadObjectPermutations.ts, 11, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_cb = { ...c, ...b };
+>v_cb : Symbol(v_cb, Decl(spreadObjectPermutations.ts, 12, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_abc = { ...a, ...b, ...c };
+>v_abc : Symbol(v_abc, Decl(spreadObjectPermutations.ts, 13, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_acb = { ...a, ...c, ...b };
+>v_acb : Symbol(v_acb, Decl(spreadObjectPermutations.ts, 14, 5))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_bac = { ...b, ...a, ...c };
+>v_bac : Symbol(v_bac, Decl(spreadObjectPermutations.ts, 15, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+
+const v_bca = { ...b, ...c, ...a };
+>v_bca : Symbol(v_bca, Decl(spreadObjectPermutations.ts, 16, 5))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+
+const v_cab = { ...c, ...a, ...b };
+>v_cab : Symbol(v_cab, Decl(spreadObjectPermutations.ts, 17, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+
+const v_cba = { ...c, ...b, ...a };
+>v_cba : Symbol(v_cba, Decl(spreadObjectPermutations.ts, 18, 5))
+>c : Symbol(c, Decl(spreadObjectPermutations.ts, 2, 13))
+>b : Symbol(b, Decl(spreadObjectPermutations.ts, 1, 13))
+>a : Symbol(a, Decl(spreadObjectPermutations.ts, 0, 13))
+

--- a/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/spreadObjectPermutations(exactoptionalpropertytypes=true).types
@@ -1,0 +1,106 @@
+=== tests/cases/compiler/spreadObjectPermutations.ts ===
+declare const a: { x: string | number };
+>a : { x: string | number; }
+>x : string | number
+
+declare const b: { x?: string | number };
+>b : { x?: string | number; }
+>x : string | number | undefined
+
+declare const c: { x?: string | number | undefined };
+>c : { x?: string | number | undefined; }
+>x : string | number | undefined
+
+const v_a = { ...a };
+>v_a : { x: string | number; }
+>{ ...a } : { x: string | number; }
+>a : { x: string | number; }
+
+const v_b = { ...b };
+>v_b : { x?: string | number; }
+>{ ...b } : { x?: string | number; }
+>b : { x?: string | number; }
+
+const v_c = { ...c };
+>v_c : { x?: string | number | undefined; }
+>{ ...c } : { x?: string | number | undefined; }
+>c : { x?: string | number | undefined; }
+
+const v_ab = { ...a, ...b };
+>v_ab : { x: string | number; }
+>{ ...a, ...b } : { x: string | number; }
+>a : { x: string | number; }
+>b : { x?: string | number; }
+
+const v_ac = { ...a, ...c };
+>v_ac : { x: string | number | undefined; }
+>{ ...a, ...c } : { x: string | number | undefined; }
+>a : { x: string | number; }
+>c : { x?: string | number | undefined; }
+
+const v_ba = { ...b, ...a };
+>v_ba : { x: string | number; }
+>{ ...b, ...a } : { x: string | number; }
+>b : { x?: string | number; }
+>a : { x: string | number; }
+
+const v_bc = { ...b, ...c };
+>v_bc : { x?: string | number | undefined; }
+>{ ...b, ...c } : { x?: string | number | undefined; }
+>b : { x?: string | number; }
+>c : { x?: string | number | undefined; }
+
+const v_ca = { ...c, ...a };
+>v_ca : { x: string | number; }
+>{ ...c, ...a } : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>a : { x: string | number; }
+
+const v_cb = { ...c, ...b };
+>v_cb : { x?: string | number | undefined; }
+>{ ...c, ...b } : { x?: string | number | undefined; }
+>c : { x?: string | number | undefined; }
+>b : { x?: string | number; }
+
+const v_abc = { ...a, ...b, ...c };
+>v_abc : { x: string | number | undefined; }
+>{ ...a, ...b, ...c } : { x: string | number | undefined; }
+>a : { x: string | number; }
+>b : { x?: string | number; }
+>c : { x?: string | number | undefined; }
+
+const v_acb = { ...a, ...c, ...b };
+>v_acb : { x: string | number | undefined; }
+>{ ...a, ...c, ...b } : { x: string | number | undefined; }
+>a : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>b : { x?: string | number; }
+
+const v_bac = { ...b, ...a, ...c };
+>v_bac : { x: string | number | undefined; }
+>{ ...b, ...a, ...c } : { x: string | number | undefined; }
+>b : { x?: string | number; }
+>a : { x: string | number; }
+>c : { x?: string | number | undefined; }
+
+const v_bca = { ...b, ...c, ...a };
+>v_bca : { x: string | number; }
+>{ ...b, ...c, ...a } : { x: string | number; }
+>b : { x?: string | number; }
+>c : { x?: string | number | undefined; }
+>a : { x: string | number; }
+
+const v_cab = { ...c, ...a, ...b };
+>v_cab : { x: string | number; }
+>{ ...c, ...a, ...b } : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>a : { x: string | number; }
+>b : { x?: string | number; }
+
+const v_cba = { ...c, ...b, ...a };
+>v_cba : { x: string | number; }
+>{ ...c, ...b, ...a } : { x: string | number; }
+>c : { x?: string | number | undefined; }
+>b : { x?: string | number; }
+>a : { x: string | number; }
+

--- a/tests/cases/compiler/spreadObjectPermutations.ts
+++ b/tests/cases/compiler/spreadObjectPermutations.ts
@@ -1,0 +1,23 @@
+// @strict: true
+// @exactOptionalPropertyTypes: false, true
+
+
+declare const a: { x: string | number };
+declare const b: { x?: string | number };
+declare const c: { x?: string | number | undefined };
+
+const v_a = { ...a };
+const v_b = { ...b };
+const v_c = { ...c };
+const v_ab = { ...a, ...b };
+const v_ac = { ...a, ...c };
+const v_ba = { ...b, ...a };
+const v_bc = { ...b, ...c };
+const v_ca = { ...c, ...a };
+const v_cb = { ...c, ...b };
+const v_abc = { ...a, ...b, ...c };
+const v_acb = { ...a, ...c, ...b };
+const v_bac = { ...b, ...a, ...c };
+const v_bca = { ...b, ...c, ...a };
+const v_cab = { ...c, ...a, ...b };
+const v_cba = { ...c, ...b, ...a };


### PR DESCRIPTION
Fixes #52345

When spreading, we remove `undefined` from the right type and union it with the left. If the two types are huge but overlap, we'll add all of the union's members together into one big list, then run subtype reduction over it, which for this test takes a long time. But, we can skip that work if we can recognize that left/right are the same. With #53406, this eliminates all of the bottlenecks in #52345.

Since this spread stuff is tricky, I generated a test which tests all combos of spreading + optional + missing to verify that I don't screw it up.


Likely, there's something more general that could be done to `getUnionType` here; it always recurses into every union and _then_ does subtype reduction. I wonder if we can deduplicate the list first (ignoring undefined-ness), and trivially bail out early where possible, but that seemed a little tricky.
