### PR TITLE
fix(53372): TypeScript cannot auto-complete keyword extends

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -165,6 +165,7 @@ import {
     isInJSFile,
     isInRightSideOfInternalImportEqualsDeclaration,
     isInString,
+    isInterfaceDeclaration,
     isIntersectionTypeNode,
     isJSDoc,
     isJSDocAugmentsTag,
@@ -4263,9 +4264,9 @@ function getCompletionData(
         return isDeclarationName(contextToken)
             && !isShorthandPropertyAssignment(contextToken.parent)
             && !isJsxAttribute(contextToken.parent)
-            // Don't block completions if we're in `class C /**/`, because we're *past* the end of the identifier and might want to complete `extends`.
-            // If `contextToken !== previousToken`, this is `class C ex/**/`.
-            && !(isClassLike(contextToken.parent) && (contextToken !== previousToken || position > previousToken.end));
+            // Don't block completions if we're in `class C /**/` or `interface I /**/`, because we're *past* the end of the identifier and might want to complete `extends`.
+            // If `contextToken !== previousToken`, this is `class C ex/**/ or `interface I ex/**/``.
+            && !((isClassLike(contextToken.parent) || isInterfaceDeclaration(contextToken.parent)) && (contextToken !== previousToken || position > previousToken.end));
     }
 
     function isPreviousPropertyDeclarationTerminated(contextToken: Node, position: number) {

--- a/tests/cases/fourslash/extendsKeywordCompletion.ts
+++ b/tests/cases/fourslash/extendsKeywordCompletion.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+////export interface B ex/**/
+
+verify.completions({
+    marker: "",
+    includes: [{ name: "extends", sortText: completion.SortText.GlobalsOrKeywords }]
+});


### PR DESCRIPTION
Fixes #53372