### PR TITLE
perf: ensure compiler options affecting semantic diagnostics get included in build info

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -1182,7 +1182,8 @@ function getBuildInfo(state: BuilderProgramState, bundle: BundleBuildInfo | unde
         const { optionsNameMap } = getOptionsNameMap();
         for (const name of getOwnKeys(options).sort(compareStringsCaseSensitive)) {
             const optionInfo = optionsNameMap.get(name.toLowerCase());
-            if (optionInfo?.affectsBuildInfo) {
+            // all semantic diagnostics affect build info
+            if (optionInfo && (optionInfo.affectsBuildInfo || optionInfo.affectsSemanticDiagnostics)) {
                 (result ||= {})[name] = convertToReusableCompilerOptionValue(
                     optionInfo,
                     options[name] as CompilerOptionsValue,

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -1182,8 +1182,7 @@ function getBuildInfo(state: BuilderProgramState, bundle: BundleBuildInfo | unde
         const { optionsNameMap } = getOptionsNameMap();
         for (const name of getOwnKeys(options).sort(compareStringsCaseSensitive)) {
             const optionInfo = optionsNameMap.get(name.toLowerCase());
-            // all semantic diagnostics affect build info
-            if (optionInfo && (optionInfo.affectsBuildInfo || optionInfo.affectsSemanticDiagnostics)) {
+            if (optionInfo?.affectsBuildInfo) {
                 (result ||= {})[name] = convertToReusableCompilerOptionValue(
                     optionInfo,
                     options[name] as CompilerOptionsValue,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1101,6 +1101,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         name: "allowImportingTsExtensions",
         type: "boolean",
         affectsSemanticDiagnostics: true,
+        affectsBuildInfo: true,
         category: Diagnostics.Modules,
         description: Diagnostics.Allow_imports_to_include_TypeScript_file_extensions_Requires_moduleResolution_bundler_and_either_noEmit_or_emitDeclarationOnly_to_be_set,
         defaultValueDescription: false,

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -245,3 +245,14 @@ describe("unittests:: config:: commandLineParsing:: parseBuildOptions", () => {
         assertParseResult("errors on invalid excludeFiles", ["--excludeFiles", "**/../*"]);
     });
 });
+
+describe("unittests:: config:: commandLineParsing:: optionDeclarations", () => {
+    it("should have affectsBuildInfo true for every option with affectsSemanticDiagnostics", () => {
+        for (const option of ts.optionDeclarations) {
+            if (option.affectsSemanticDiagnostics) {
+                // semantic diagnostics affect the build info, so ensure they're included
+                assert(option.affectsBuildInfo ?? false, option.name);
+            }
+        }
+    });
+});


### PR DESCRIPTION
With `--allowImportingTsExtensions` it was never using the build info because it wouldn't store "allowImportingTsExtensions" in the buildinfo file.

~~I'm not sure how to write a test for this as it doesn't seem easily unit testable. Some guidance would be helpful if you'd like a test.~~