### PR TITLE
Include type parameters in tagged template literals in `isPartOfTypeNode`

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2450,10 +2450,8 @@ export function isPartOfTypeNode(node: Node): boolean {
                     return node === (parent as TypeAssertion).type;
                 case SyntaxKind.CallExpression:
                 case SyntaxKind.NewExpression:
-                    return contains((parent as CallExpression).typeArguments, node);
                 case SyntaxKind.TaggedTemplateExpression:
-                    // TODO (drosen): TaggedTemplateExpressions may eventually support type arguments.
-                    return false;
+                    return contains((parent as CallExpression | TaggedTemplateExpression).typeArguments, node);
             }
         }
     }


### PR DESCRIPTION
Removes a TODO. Kind of hard to test this since removing any of the other branches doesn't necessarily make anything else fail. I think this is purely used for optimizations at the moment, so a code coverage test would be the best thing here.