### PR TITLE
Cache normalized tuple types as made during relationship checking

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20183,9 +20183,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getNormalizedTupleType(type: TupleTypeReference, writing: boolean): Type {
+        const cache = writing ? "normalizedForWriting" : "normalizedForReading";
+        if (type[cache]) {
+            return type[cache]!;
+        }
         const elements = getTypeArguments(type);
         const normalizedElements = sameMap(elements, t => t.flags & TypeFlags.Simplifiable ? getSimplifiedType(t, writing) : t);
-        return elements !== normalizedElements ? createNormalizedTupleType(type.target, normalizedElements) : type;
+        return type[cache] = (elements !== normalizedElements ? createNormalizedTupleType(type.target, normalizedElements) : type);
     }
 
     /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6407,6 +6407,10 @@ export interface TupleType extends GenericType {
 
 export interface TupleTypeReference extends TypeReference {
     target: TupleType;
+    /** @internal */
+    normalizedForReading?: Type;
+    /** @internal */
+    normalizedForWriting?: Type;
 }
 
 export interface UnionOrIntersectionType extends Type {


### PR DESCRIPTION
Since tuple normalization can involve a bit of work, and relationship checking is often called on the same type more than once, caching this work could be beneficial.