### PR TITLE
Retry string completions from the inferred type by default

### DIFF
--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -439,7 +439,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
             const literals = contextualTypes.types.filter(literal => !tracker.hasValue(literal.value));
             return { kind: StringLiteralCompletionKind.Types, types: literals, isNewIdentifier: false };
         default:
-            return fromContextualType();
+            return fromContextualType() || fromContextualType(ContextFlags.None);
     }
 
     function fromContextualType(contextFlags: ContextFlags = ContextFlags.Completions): StringLiteralCompletionsFromTypes | undefined {

--- a/tests/cases/fourslash/completionsLiteralFromInferenceWithinInferredType3.ts
+++ b/tests/cases/fourslash/completionsLiteralFromInferenceWithinInferredType3.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+//// declare function test<T>(a: {
+////   [K in keyof T]: {
+////     b?: (keyof T)[];
+////   };
+//// }): void;
+////
+//// test({
+////   foo: {},
+////   bar: {
+////     b: ["/*ts*/"],
+////   },
+//// });
+
+verify.completions({ marker: ["ts"], exact: ["foo", "bar"] });


### PR DESCRIPTION
fixes #53475

I'm using the same strategy to retry those requests as the one used in https://github.com/microsoft/TypeScript/pull/52875/files

cc @andrewbranch 
