### PR TITLE
Fix double-emit in constructor

### DIFF
--- a/src/compiler/transformers/esDecorators.ts
+++ b/src/compiler/transformers/esDecorators.ts
@@ -1074,10 +1074,15 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
                 const statements: Statement[] = [];
                 const nonPrologueStart = factory.copyPrologue(node.body.statements, statements, /*ensureUseStrict*/ false, visitor);
                 const superStatementIndex = findSuperStatementIndex(node.body.statements, nonPrologueStart);
-                const indexOfFirstStatementAfterSuper = superStatementIndex >= 0 ? superStatementIndex + 1 : undefined;
-                addRange(statements, visitNodes(node.body.statements, visitor, isStatement, nonPrologueStart, indexOfFirstStatementAfterSuper ? indexOfFirstStatementAfterSuper - nonPrologueStart : undefined));
-                addRange(statements, initializerStatements);
-                addRange(statements, visitNodes(node.body.statements, visitor, isStatement, indexOfFirstStatementAfterSuper));
+                if (superStatementIndex >= 0) {
+                    addRange(statements, visitNodes(node.body.statements, visitor, isStatement, nonPrologueStart, superStatementIndex + 1 - nonPrologueStart));
+                    addRange(statements, initializerStatements);
+                    addRange(statements, visitNodes(node.body.statements, visitor, isStatement, superStatementIndex + 1));
+                }
+                else {
+                    addRange(statements, initializerStatements);
+                    addRange(statements, visitNodes(node.body.statements, visitor, isStatement));
+                }
                 body = factory.createBlock(statements, /*multiLine*/ true);
                 setOriginalNode(body, node.body);
                 setTextRange(body, node.body);

--- a/tests/baselines/reference/esDecorators-classDeclaration-classSuper.7.js
+++ b/tests/baselines/reference/esDecorators-classDeclaration-classSuper.7.js
@@ -1,4 +1,4 @@
-//// [esDecorators-classExpression-classSuper.7.ts]
+//// [esDecorators-classDeclaration-classSuper.7.ts]
 class A {}
 class B extends A {
 	public constructor() {
@@ -20,8 +20,18 @@ function foo(method: any, _context: any): any {
 
 new B();
 
+// https://github.com/microsoft/TypeScript/issues/53448
+class C {
+	public constructor() {
+		this.val;
+	}
 
-//// [esDecorators-classExpression-classSuper.7.js]
+	@foo
+	public get val(): number { return 3; }
+}
+
+
+//// [esDecorators-classDeclaration-classSuper.7.js]
 class A {
 }
 let B = (() => {
@@ -48,3 +58,19 @@ function foo(method, _context) {
     };
 }
 new B();
+// https://github.com/microsoft/TypeScript/issues/53448
+let C = (() => {
+    let _instanceExtraInitializers_1 = [];
+    let _get_val_decorators;
+    return class C {
+        static {
+            _get_val_decorators = [foo];
+            __esDecorate(this, null, _get_val_decorators, { kind: "getter", name: "val", static: false, private: false, access: { has: obj => "val" in obj, get: obj => obj.val } }, null, _instanceExtraInitializers_1);
+        }
+        constructor() {
+            __runInitializers(this, _instanceExtraInitializers_1);
+            this.val;
+        }
+        get val() { return 3; }
+    };
+})();

--- a/tests/baselines/reference/esDecorators-classDeclaration-classSuper.7.js
+++ b/tests/baselines/reference/esDecorators-classDeclaration-classSuper.7.js
@@ -29,6 +29,15 @@ class C {
 	@foo
 	public get val(): number { return 3; }
 }
+class D extends A {
+	public constructor() {
+		super();
+		this.val;
+	}
+
+	@foo
+	public get val(): number { return 3; }
+}
 
 
 //// [esDecorators-classDeclaration-classSuper.7.js]
@@ -69,6 +78,22 @@ let C = (() => {
         }
         constructor() {
             __runInitializers(this, _instanceExtraInitializers_1);
+            this.val;
+        }
+        get val() { return 3; }
+    };
+})();
+let D = (() => {
+    let _instanceExtraInitializers_2 = [];
+    let _get_val_decorators;
+    return class D extends A {
+        static {
+            _get_val_decorators = [foo];
+            __esDecorate(this, null, _get_val_decorators, { kind: "getter", name: "val", static: false, private: false, access: { has: obj => "val" in obj, get: obj => obj.val } }, null, _instanceExtraInitializers_2);
+        }
+        constructor() {
+            super();
+            __runInitializers(this, _instanceExtraInitializers_2);
             this.val;
         }
         get val() { return 3; }

--- a/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.7.ts
+++ b/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.7.ts
@@ -22,3 +22,13 @@ function foo(method: any, _context: any): any {
 }
 
 new B();
+
+// https://github.com/microsoft/TypeScript/issues/53448
+class C {
+	public constructor() {
+		this.val;
+	}
+
+	@foo
+	public get val(): number { return 3; }
+}

--- a/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.7.ts
+++ b/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.7.ts
@@ -32,3 +32,12 @@ class C {
 	@foo
 	public get val(): number { return 3; }
 }
+class D extends A {
+	public constructor() {
+		super();
+		this.val;
+	}
+
+	@foo
+	public get val(): number { return 3; }
+}


### PR DESCRIPTION
Fixes the emit change in #53268 to avoid duplicate emit when `super()` is not found.

Fixes #53448