### PR TITLE
Improve contextual completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2595,7 +2595,7 @@ function getContextualType(previousToken: Node, position: number, sourceFile: So
                 isEqualityOperatorKind(previousToken.kind) && isBinaryExpression(parent) && isEqualityOperatorKind(parent.operatorToken.kind) ?
                     // completion at `x ===/**/` should be for the right side
                     checker.getTypeAtLocation(parent.left) :
-                    checker.getContextualType(previousToken as Expression);
+                    checker.getContextualType(previousToken as Expression, ContextFlags.Completions) || checker.getContextualType(previousToken as Expression);
     }
 }
 

--- a/tests/cases/fourslash/completionEntryForArgumentConstrainedToString.ts
+++ b/tests/cases/fourslash/completionEntryForArgumentConstrainedToString.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+//// declare function test<P extends "a" | "b">(p: P): void;
+////
+//// test(/*ts*/)
+////
+
+verify.completions({ marker: ["ts"], includes: ['"a"', '"b"'], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionEntryForArrayElementConstrainedToString.ts
+++ b/tests/cases/fourslash/completionEntryForArrayElementConstrainedToString.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+//// declare function test<T extends 'a' | 'b'>(a: { foo: T[] }): void
+////
+//// test({ foo: [/*ts*/] })
+
+verify.completions({ marker: ["ts"], includes: ['"a"', '"b"'], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionEntryForArrayElementConstrainedToString2.ts
+++ b/tests/cases/fourslash/completionEntryForArrayElementConstrainedToString2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+//// declare function test<T extends 'a' | 'b'>(a: { foo: T[] }): void
+////
+//// test({ foo: ['a', /*ts*/] })
+
+verify.completions({ marker: ["ts"], includes: ['"a"', '"b"'], isNewIdentifierLocation: true });

--- a/tests/cases/fourslash/completionEntryForPropertyConstrainedToString.ts
+++ b/tests/cases/fourslash/completionEntryForPropertyConstrainedToString.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+//// declare function test<P extends "a" | "b">(p: { type: P }): void;
+////
+//// test({ type: /*ts*/ })
+
+verify.completions({ marker: ["ts"], includes: ['"a"', '"b"'], isNewIdentifierLocation: false });

--- a/tests/cases/fourslash/completionsLiteralFromInferenceWithinInferredType1.ts
+++ b/tests/cases/fourslash/completionsLiteralFromInferenceWithinInferredType1.ts
@@ -13,5 +13,13 @@
 ////     b: "/*ts*/",
 ////   },
 //// });
+////
+//// test({
+////   foo: {},
+////   bar: {
+////     b: /*ts2*/,
+////   },
+//// });
 
 verify.completions({ marker: ["ts"], exact: ["foo", "bar"] });
+verify.completions({ marker: ["ts2"], includes: ['"foo"', '"bar"'], isNewIdentifierLocation: false });

--- a/tests/cases/fourslash/completionsLiteralFromInferenceWithinInferredType3.ts
+++ b/tests/cases/fourslash/completionsLiteralFromInferenceWithinInferredType3.ts
@@ -12,5 +12,13 @@
 ////     b: ["/*ts*/"],
 ////   },
 //// });
+////
+//// test({
+////   foo: {},
+////   bar: {
+////     b: [/*ts2*/],
+////   },
+//// });
 
 verify.completions({ marker: ["ts"], exact: ["foo", "bar"] });
+verify.completions({ marker: ["ts2"], includes: ['"foo"', '"bar"'], isNewIdentifierLocation: true });


### PR DESCRIPTION
This PR is meant to bring "regular" completions closer to how equivalent~ string completions work. To get a better grasp of what that means you can look into the **changed** tests that have `ts` (within string/quotes) and `ts2` (at the same position but not within quotes) markers

fixes https://github.com/microsoft/TypeScript/issues/53555