### PR TITLE
Use Set to push symbol.declarations in const time

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3,7 +3,6 @@ import {
     AccessExpression,
     addRelatedInfo,
     append,
-    appendIfUnique,
     ArrayBindingElement,
     ArrayLiteralExpression,
     ArrowFunction,
@@ -624,7 +623,16 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         symbol.flags |= symbolFlags;
 
         node.symbol = symbol;
-        symbol.declarations = appendIfUnique(symbol.declarations, node);
+        if (symbol.declarations) {
+          if (!symbol.declarationSet!.has(node)) {
+            symbol.declarations.push(node);
+            symbol.declarationSet!.add(node);
+          }
+        }
+        else {
+          symbol.declarations = [node];
+          symbol.declarationSet = new Set([node]);
+        }
 
         if (symbolFlags & (SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.Module | SymbolFlags.Variable) && !symbol.exports) {
             symbol.exports = createSymbolTable();

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -45,6 +45,21 @@ export function forEach<T, U>(array: readonly T[] | undefined, callback: (elemen
     return undefined;
 }
 
+/** @internal */
+export function forEachIterator<T, U>(iterator: Iterable<T> | undefined, callback: (element: T, index: number) => U | undefined): U | undefined {
+    if (iterator) {
+        let pos = 0;
+        for (const value of iterator) {
+            const result = callback(value, pos);
+            if (result) {
+                return result;
+            }
+            pos++;
+        }
+    }
+    return undefined;
+}
+
 /**
  * Like `forEach`, but iterates in reverse order.
  *

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5813,6 +5813,7 @@ export interface Symbol {
     /** @internal */ isReplaceableByMethod?: boolean; // Can this Javascript class property be replaced by a method symbol?
     /** @internal */ isAssigned?: boolean;  // True if the symbol is a parameter with assignments
     /** @internal */ assignmentDeclarationMembers?: Map<number, Declaration>; // detected late-bound assignment declarations associated with the symbol
+    /** @internal */ declarationSet?: Set<Declaration>; // Same as `declarations`. Used for constant time 'contains/has' checks.
 }
 
 /** @internal */


### PR DESCRIPTION
Using `appendIfUnique` to add a new declaration to `symbol.declarations` is expensive if the symbol has many declarations.

Add `/** @internal */ Symbol.prototype.declarationSet` and use that instead for constant time 'contains/has' check.

This trades of CPU time with additional memory used for the Set.

<details>
<summary><code>--diagnostics</code> output comparing main to this PR with the project in <a href="https://github.com/frigus02/test-ts-add-declaration-to-symbol-set">frigus02/test-ts-add-declaration-to-symbol-set</a></summary>

```
# main
$ npm run build_stable

> test-ts-add-declaration-to-symbol-set@1.0.0 build_stable
> node node_modules/typescript/lib/tsc.js -p tsconfig.json --diagnostics

Files:               22
Lines:            71557
Identifiers:     102148
Symbols:          86095
Types:               93
Instantiations:       1
Memory used:    118376K
I/O read:         0.01s
I/O write:        0.00s
Parse time:       0.63s
Bind time:        4.86s
Check time:       0.04s
Emit time:        0.00s
Total time:       5.53s

# this PR
$ npm run build_patched

> test-ts-add-declaration-to-symbol-set@1.0.0 build_patched
> node node_modules/typescript/lib/tsc_patched.js -p tsconfig.json --diagnostics

Files:               22
Lines:            71557
Identifiers:     102148
Symbols:          86095
Types:               93
Instantiations:       1
Memory used:    141528K
I/O read:         0.01s
I/O write:        0.00s
Parse time:       0.60s
Bind time:        0.45s
Check time:       0.03s
Emit time:        0.00s
Total time:       1.08s
```

</details>

That is quite a big memory increase. Not sure if that's worth it. We could change the type of `symbol.declarations` to a `Set`. Or we could only use a `Set` once `symbol.declarations` has more than X entries.

Fixes #53565
