### PR TITLE
Type-only auto-import improvements

### DIFF
--- a/tests/cases/fourslash/autoImportTypeOnlyPreferred2.ts
+++ b/tests/cases/fourslash/autoImportTypeOnlyPreferred2.ts
@@ -1,0 +1,41 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /node_modules/react/index.d.ts
+//// export interface ComponentType {}
+//// export interface ComponentProps {}
+//// export declare function useState<T>(initialState: T): [T, (newState: T) => void];
+//// export declare function useEffect(callback: () => void, deps: any[]): void;
+
+// @Filename: /main.ts
+//// import type { ComponentType } from "react";
+//// import { useState } from "react";
+////
+//// export function Component({ prop } : { prop: ComponentType }) {
+////     const codeIsUnimportant = useState(1);
+////     useEffect/*1*/(() => {}, []);
+//// }
+
+// @Filename: /main2.ts
+//// import { useState } from "react";
+//// import type { ComponentType } from "react";
+////
+//// type _ = ComponentProps/*2*/;
+
+goTo.marker("1");
+verify.importFixAtPosition([
+`import type { ComponentType } from "react";
+import { useEffect, useState } from "react";
+
+export function Component({ prop } : { prop: ComponentType }) {
+    const codeIsUnimportant = useState(1);
+    useEffect(() => {}, []);
+}`,
+]);
+
+goTo.marker("2");
+verify.importFixAtPosition([
+`import { useState } from "react";
+import type { ComponentProps, ComponentType } from "react";
+
+type _ = ComponentProps;`,
+]);

--- a/tests/cases/fourslash/importNameCodeFixConvertTypeOnly1.ts
+++ b/tests/cases/fourslash/importNameCodeFixConvertTypeOnly1.ts
@@ -9,5 +9,5 @@
 //// new B
 
 goTo.file('/b.ts');
-verify.importFixAtPosition([`import { A, B } from './a';
+verify.importFixAtPosition([`import { B, type A } from './a';
 new B`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Closes #53008

1. When more than one import declaration from the same module specifier exists, find the one that’s the best match with respect to type-onlyness instead of modifying the first one to work:
   ```ts
   import type {} from "react"; // <-- auto-imported types will go here
   import {} from "react";      // <-- auto-imported values will go here
   ```
2. When promoting a type-only import declaration to a real one due to a new value import, always add `type` modifiers to the existing specifiers, even if emit settings don’t require it. For example, if a value import of `SomeValue` is to be auto-imported here:
   ```ts
   import type { SomeType } from "mod";
   ```
   the result will now always be:
   ```ts
   import { SomeValue, type SomeType } from "mod";
   ```
   regardless of compiler options. Previously, we would only insert the `type` modifier on `SomeType` if it was necessary according to compiler options, e.g. if `verbatimModuleSyntax` is enabled.
