### PR TITLE
Ignore `allowImportingTsExtensions` in transpileModule to suppress option validation error with `noEmit`

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1105,6 +1105,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         category: Diagnostics.Modules,
         description: Diagnostics.Allow_imports_to_include_TypeScript_file_extensions_Requires_moduleResolution_bundler_and_either_noEmit_or_emitDeclarationOnly_to_be_set,
         defaultValueDescription: false,
+        transpileOptionValue: undefined,
     },
     {
         name: "resolvePackageJsonExports",

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -606,4 +606,18 @@ export * as alias from './file';`, {
             testVerbatimModuleSyntax: "only"
         }
     );
+
+    transpilesCorrectly("Can transpile .ts extensions without error",
+        `import { foo } from "./foo.ts";`, {
+            options: { compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ESNext } },
+            testVerbatimModuleSyntax: true
+        }
+    );
+
+    transpilesCorrectly("Ignores `allowImportingTsExtensions` without `noEmit` error",
+        `import { foo } from "./foo.ts";`, {
+            options: { compilerOptions: { module: ts.ModuleKind.ESNext, allowImportingTsExtensions: true, target: ts.ScriptTarget.ESNext } },
+            testVerbatimModuleSyntax: true
+        }
+    );
 });

--- a/tests/baselines/reference/transpile/Can transpile .ts extensions without error (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Can transpile .ts extensions without error (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+import { foo } from "./foo.ts";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Can transpile .ts extensions without error (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Can transpile .ts extensions without error (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+import { foo } from "./foo.ts";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Can transpile .ts extensions without error.js
+++ b/tests/baselines/reference/transpile/Can transpile .ts extensions without error.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Can transpile .ts extensions without error.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Can transpile .ts extensions without error.oldTranspile.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error (verbatimModuleSyntax=true).js
+++ b/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error (verbatimModuleSyntax=true).js
@@ -1,0 +1,2 @@
+import { foo } from "./foo.ts";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error (verbatimModuleSyntax=true).oldTranspile.js
+++ b/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error (verbatimModuleSyntax=true).oldTranspile.js
@@ -1,0 +1,2 @@
+import { foo } from "./foo.ts";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error.js
+++ b/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Ignores allowImportingTsExtensions without noEmit error.oldTranspile.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=file.js.map


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes ~ https://github.com/TypeStrong/ts-loader/issues/1602
Fixes ~ https://github.com/TypeStrong/ts-node/issues/1981

`ts.transpileModule` erases any value of `noEmit` from the incoming compiler options, but still creates a program that does option validation. One validation is that `allowImportingTsExtensions` requires `noEmit` to be set, so including this option in `transpileModule` calls was always an error. The fix is to erase `allowImportingTsExtensions` too—since its only purpose is to silence an error in checker code that doesn‘t run in transpilation, it’s not necessary to include in the first place. It can be completely ignored in transpilation.
