### PR TITLE
Remove non-ascii characters from internal code comments

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2802,7 +2802,7 @@ const codePointAt: (s: string, i: number) => number = (String.prototype as any).
     }
     // Get the first code unit
     const first = str.charCodeAt(i);
-    // check if it’s the start of a surrogate pair
+    // check if it's the start of a surrogate pair
     if (first >= 0xD800 && first <= 0xDBFF && size > i + 1) { // high surrogate and there is a next code unit
         const second = str.charCodeAt(i + 1);
         if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate

--- a/src/services/codefixes/addMissingAwait.ts
+++ b/src/services/codefixes/addMissingAwait.ts
@@ -129,7 +129,7 @@ function getDeclarationSiteFix(context: CodeFixContext | CodeFixAllContext, expr
             }
         });
         // No fix-all because it will already be included once with the use site fix,
-        // and for simplicity the fix-all doesn‘t let the user choose between use-site and declaration-site fixes.
+        // and for simplicity the fix-all doesn't let the user choose between use-site and declaration-site fixes.
         return createCodeFixActionWithoutFixAll(
             "addMissingAwaitToInitializer",
             initializerChanges,
@@ -257,7 +257,7 @@ function symbolReferenceIsAlsoMissingAwait(reference: Identifier, diagnostics: r
         (diagnostic.start + diagnostic.length!) === errorNode.getEnd());
 
     return diagnostic && contains(errorCodes, diagnostic.code) ||
-        // A Promise is usually not correct in a binary expression (it’s not valid
+        // A Promise is usually not correct in a binary expression (it's not valid
         // in an arithmetic expression and an equality comparison seems unusual),
         // but if the other side of the binary expression has an error, the side
         // is typed `any` which will squash the error that would identify this

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -255,7 +255,7 @@ export function createCacheableExportInfoMap(host: CacheableExportInfoMapHost): 
                 typeAcquisitionEnabled && consumesNodeCoreModules(oldSourceFile) !== consumesNodeCoreModules(newSourceFile) ||
                 // Module agumentation and ambient module changes can add or remove exports available to be auto-imported.
                 // Changes elsewhere in the file can change the *type* of an export in a module augmentation,
-                // but type info is gathered in getCompletionEntryDetails, which doesn’t use the cache.
+                // but type info is gathered in getCompletionEntryDetails, which doesn't use the cache.
                 !arrayIsEqualTo(oldSourceFile.moduleAugmentations, newSourceFile.moduleAugmentations) ||
                 !ambientModuleDeclarationsAreEqual(oldSourceFile, newSourceFile)
             ) {

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1203,7 +1203,7 @@ export namespace Core {
                 return undefined;
             }
             // Likewise, when we *are* looking for a special keyword, make sure we
-            // *don’t* include readonly member modifiers.
+            // *don't* include readonly member modifiers.
             return getAllReferencesForKeyword(
                 sourceFiles,
                 node.kind,
@@ -1444,7 +1444,7 @@ export namespace Core {
             });
         }
 
-        // Source file ID → symbol ID → Whether the symbol has been searched for in the source file.
+        // Source file ID -> symbol ID -> Whether the symbol has been searched for in the source file.
         private readonly sourceFileToSeenSymbols: Set<number>[] = [];
         /** Returns `true` the first time we search for a symbol in a file and `false` afterwards. */
         markSearchedSymbols(sourceFile: SourceFile, symbols: readonly Symbol[]): boolean {

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -904,7 +904,7 @@ function isSemicolonDeletionContext(context: FormattingContext): boolean {
     if (context.contextNode.kind === SyntaxKind.InterfaceDeclaration ||
         context.contextNode.kind === SyntaxKind.TypeAliasDeclaration
     ) {
-        // Can’t remove semicolon after `foo`; it would parse as a method declaration:
+        // Can't remove semicolon after `foo`; it would parse as a method declaration:
         //
         // interface I {
         //   foo;

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -263,9 +263,9 @@ function removeUnusedImports(oldImports: readonly ImportDeclaration[], sourceFil
         if (name || namedBindings) {
             usedImports.push(updateImportDeclarationAndClause(importDecl, name, namedBindings));
         }
-        // If a module is imported to be augmented, it’s used
+        // If a module is imported to be augmented, it's used
         else if (hasModuleDeclarationMatchingSpecifier(sourceFile, moduleSpecifier)) {
-            // If we’re in a declaration file, it’s safe to remove the import clause from it
+            // If we're in a declaration file, it's safe to remove the import clause from it
             if (sourceFile.isDeclarationFile) {
                 usedImports.push(factory.createImportDeclaration(
                     importDecl.modifiers,
@@ -273,7 +273,7 @@ function removeUnusedImports(oldImports: readonly ImportDeclaration[], sourceFil
                     moduleSpecifier,
                     /*assertClause*/ undefined));
             }
-            // If we’re not in a declaration file, we can’t remove the import clause even though
+            // If we're not in a declaration file, we can't remove the import clause even though
             // the imported symbols are unused, because removing them makes it look like the import
             // declaration has side effects, which will cause it to be preserved in the JS emit.
             else {

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -227,7 +227,7 @@ function createJSSignatureHelpItems(argumentInfo: ArgumentListInfo, program: Pro
 
 function containsPrecedingToken(startingToken: Node, sourceFile: SourceFile, container: Node) {
     const pos = startingToken.getFullStart();
-    // There’s a possibility that `startingToken.parent` contains only `startingToken` and
+    // There's a possibility that `startingToken.parent` contains only `startingToken` and
     // missing nodes, none of which are valid to be returned by `findPrecedingToken`. In that
     // case, the preceding token we want is actually higher up the tree—almost definitely the
     // next parent, but theoretically the situation with missing nodes might be happening on

--- a/src/services/smartSelection.ts
+++ b/src/services/smartSelection.ts
@@ -81,7 +81,7 @@ export function getSmartSelectionRange(pos: number, sourceFile: SourceFile): Sel
                 // 1. Blocks are effectively redundant with SyntaxLists.
                 // 2. TemplateSpans, along with the SyntaxLists containing them, are a somewhat unintuitive grouping
                 //    of things that should be considered independently.
-                // 3. A VariableStatement’s children are just a VaraiableDeclarationList and a semicolon.
+                // 3. A VariableStatement's children are just a VaraiableDeclarationList and a semicolon.
                 // 4. A lone VariableDeclaration in a VaraibleDeclaration feels redundant with the VariableStatement.
                 // Dive in without pushing a selection range.
                 if (isBlock(node)
@@ -135,8 +135,8 @@ export function getSmartSelectionRange(pos: number, sourceFile: SourceFile): Sel
                 break;
             }
 
-            // If we made it to the end of the for loop, we’re done.
-            // In practice, I’ve only seen this happen at the very end
+            // If we made it to the end of the for loop, we're done.
+            // In practice, I've only seen this happen at the very end
             // of a SourceFile.
             if (i === children.length - 1) {
                 break outer;
@@ -153,7 +153,7 @@ export function getSmartSelectionRange(pos: number, sourceFile: SourceFile): Sel
             if (!selectionRange || (
                 // Skip ranges that are identical to the parent
                 !textSpansEqual(textSpan, selectionRange.textSpan) &&
-                // Skip ranges that don’t contain the original position
+                // Skip ranges that don't contain the original position
                 textSpanIntersectsWithPosition(textSpan, pos)
             )) {
                 selectionRange = { textSpan, ...selectionRange && { parent: selectionRange } };
@@ -182,8 +182,8 @@ export function getSmartSelectionRange(pos: number, sourceFile: SourceFile): Sel
  * @param node The candidate node to snap to.
  */
 function positionShouldSnapToNode(sourceFile: SourceFile, pos: number, node: Node) {
-    // Can’t use 'ts.positionBelongsToNode()' here because it cleverly accounts
-    // for missing nodes, which can’t really be considered when deciding what
+    // Can't use 'ts.positionBelongsToNode()' here because it cleverly accounts
+    // for missing nodes, which can't really be considered when deciding what
     // to select.
     Debug.assert(node.pos <= pos);
     if (pos < node.end) {
@@ -203,7 +203,7 @@ const isImport = or(isImportDeclaration, isImportEqualsDeclaration);
  * transforming them into an artificial tree according to their intuitive
  * grouping where no grouping actually exists in the parse tree. For example,
  * top-level imports are grouped into their own SyntaxList so they can be
- * selected all together, even though in the AST they’re just siblings of each
+ * selected all together, even though in the AST they're just siblings of each
  * other as well as of other top-level statements and declarations.
  */
 function getSelectionChildren(node: Node): readonly Node[] {
@@ -213,13 +213,13 @@ function getSelectionChildren(node: Node): readonly Node[] {
     }
 
     // Mapped types _look_ like ObjectTypes with a single member,
-    // but in fact don’t contain a SyntaxList or a node containing
-    // the “key/value” pair like ObjectTypes do, but it seems intuitive
+    // but in fact don't contain a SyntaxList or a node containing
+    // the "key/value" pair like ObjectTypes do, but it seems intuitive
     // that the selection would snap to those points. The philosophy
     // of choosing a selection range is not so much about what the
     // syntax currently _is_ as what the syntax might easily become
     // if the user is making a selection; e.g., we synthesize a selection
-    // around the “key/value” pair not because there’s a node there, but
+    // around the "key/value" pair not because there's a node there, but
     // because it allows the mapped type to become an object type with a
     // few keystrokes.
     if (isMappedTypeNode(node)) {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3457,7 +3457,7 @@ function nodeIsASICandidate(node: Node, sourceFile: SourceFileLike): boolean {
         return false;
     }
 
-    // See comment in parser’s `parseDoStatement`
+    // See comment in parser's `parseDoStatement`
     if (node.kind === SyntaxKind.DoStatement) {
         return true;
     }
@@ -3524,7 +3524,7 @@ export function probablyUsesSemicolons(sourceFile: SourceFile): boolean {
     });
 
     // One statement missing a semicolon isn't sufficient evidence to say the user
-    // doesn’t want semicolons, because they may not even be done writing that statement.
+    // doesn't want semicolons, because they may not even be done writing that statement.
     if (withSemicolon === 0 && withoutSemicolon <= 1) {
         return true;
     }
@@ -3677,7 +3677,7 @@ export interface PackageJsonImportFilter {
     /**
      * Use for a specific module specifier that has already been resolved.
      * Use `allowsImportingAmbientModule` or `allowsImportingSourceFile` to resolve
-     * the best module specifier for a given module _and_ determine if it’s importable.
+     * the best module specifier for a given module _and_ determine if it's importable.
      */
     allowsImportingSpecifier: (moduleSpecifier: string) => boolean;
 }
@@ -3779,7 +3779,7 @@ export function createPackageJsonImportFilter(fromFile: SourceFile, preferences:
     }
 
     function isAllowedCoreNodeModulesImport(moduleSpecifier: string) {
-        // If we’re in JavaScript, it can be difficult to tell whether the user wants to import
+        // If we're in JavaScript, it can be difficult to tell whether the user wants to import
         // from Node core modules or not. We can start by seeing if the user is actually using
         // any node core modules, as opposed to simply having @types/node accidentally as a
         // dependency of a dependency.
@@ -3809,7 +3809,7 @@ export function createPackageJsonImportFilter(fromFile: SourceFile, preferences:
         if (!specifier) {
             return undefined;
         }
-        // Paths here are not node_modules, so we don’t care about them;
+        // Paths here are not node_modules, so we don't care about them;
         // returning anything will trigger a lookup in package.json.
         if (!pathIsRelative(specifier) && !isRootedDiskPath(specifier)) {
             return getNodeModuleRootSpecifier(specifier);


### PR DESCRIPTION
In Deno we now require 7-bit ascii for our internal code. When TypeScript builds, some of these characters end up in the build output. It seems like there weren't that many instances of non-ascii characters in TypeScript's comments so is it ok to remove them? It makes my life a little easier and makes the code a bit more consistent.

I only did a search for the characters that ended up in the build output in the "src" directory and nothing else.