### PR TITLE
Supported data URLs in core paths utilities

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -214,6 +214,12 @@ function getEncodedRootLength(path: string): number {
         return ~path.length; // URL: "file://server", "http://server"
     }
 
+    // Data: "data:application/typescript,42"
+    const match = path.match(/*regexp*/ /^(data:(?:[a-z0-9]+(?:\/[a-z0-9]+))?(?:;base64)?,)./);
+    if (match) {
+        return ~match[1].length;
+    }
+
     // relative
     return 0;
 }
@@ -697,7 +703,7 @@ export function ensureTrailingDirectorySeparator(path: Path): Path;
 export function ensureTrailingDirectorySeparator(path: string): string;
 /** @internal */
 export function ensureTrailingDirectorySeparator(path: string) {
-    if (!hasTrailingDirectorySeparator(path)) {
+    if (!hasTrailingDirectorySeparator(path) && !path.startsWith("data:")) {
         return path + directorySeparator;
     }
 


### PR DESCRIPTION
Adds a regex to `getEncodedRootLength ` that matches data URLs [[MDN data urls docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)]. That lets functions which use `getEncodedRootLength`, including `isUrl` and `pathIsAbsolute`, detect them.

Also adds an explicit check for data URLs to `ensureTrailingDirectorySeparator`, per https://github.com/microsoft/TypeScript/issues/53605#issuecomment-1492167313.

Fixes #53605