### PR TITLE
Expose getJSDocCommentsAndTags

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4182,25 +4182,23 @@ export function canHaveJSDoc(node: Node): node is HasJSDoc {
 }
 
 /**
- * Gets either the {@link JSDoc} object or {@link JSDocTag} providing documentation for the provided node.
- * A {@link JSDoc} object will be returned if an entire comment is associated with this node. This is always
- * the case when requesting a comment for declarations which are not a parameter or type parameter.
- * A {@link JSDocTag} object will be returned if only part of a comment is associated with this node. This
- * may happen when requesting comments for a parameter or type parameter, but is not guaranteed since the
- * a comment may appear directly before the parameter/type parameter, in which case the entire comment is
- * associated with this node.
+ * This function checks multiple locations for JSDoc comments that apply to a host node.
+ * At each location, the whole comment may apply to the node, or only a specific tag in
+ * the comment. In the first case, location adds the entire {@link JSDoc} object. In the
+ * second case, it adds the applicable {@link JSDocTag}.
+ *
+ * For example, a JSDoc comment before a parameter adds the entire {@link JSDoc}. But a
+ * `@param` tag on the parent function only adds the {@link JSDocTag} for the `@param`.
  *
  * ```ts
  * /** JSDoc will be returned for `a` *\/
  * const a = 0
  * /**
  *  * Entire JSDoc will be returned for `b`
- *  * JSDocTag will be returned for `c`
+ *  * @param c JSDocTag will be returned for `c`
  *  *\/
  * function b(/** JSDoc will be returned for `c` *\/ c) {}
  * ```
- *
- * @param hostNode node to get the associated JSDoc comment for.
  */
 export function getJSDocCommentsAndTags(hostNode: Node): readonly (JSDoc | JSDocTag)[];
 /** @internal separate signature so that stripInternal can remove noCache from the public API */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4203,7 +4203,8 @@ export function canHaveJSDoc(node: Node): node is HasJSDoc {
  * @param hostNode node to get the associated JSDoc comment for.
  */
 export function getJSDocCommentsAndTags(hostNode: Node): readonly (JSDoc | JSDocTag)[];
-/** @internal */
+/** @internal separate signature so that stripInternal can remove noCache from the public API */
+// eslint-disable-next-line @typescript-eslint/unified-signatures
 export function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): readonly (JSDoc | JSDocTag)[];
 export function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): readonly (JSDoc | JSDocTag)[] {
     let result: (JSDoc | JSDocTag)[] | undefined;

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -2,6 +2,7 @@ import {
     __String,
     AccessExpression,
     AccessorDeclaration,
+    addRange,
     ArrayBindingElement,
     ArrayBindingOrAssignmentElement,
     ArrayBindingOrAssignmentPattern,
@@ -76,9 +77,9 @@ import {
     getEffectiveModifierFlagsAlwaysIncludeJSDoc,
     getElementOrPropertyAccessArgumentExpressionOrName,
     getEmitScriptTarget,
-    getJSDocCommentsAndTags,
     getJSDocRoot,
     getJSDocTypeParameterDeclarations,
+    getNextJSDocCommentLocation,
     hasAccessorModifier,
     HasDecorators,
     hasDecorators,
@@ -147,6 +148,7 @@ import {
     isNotEmittedStatement,
     isOmittedExpression,
     isParameter,
+    isParenthesizedExpression,
     isPartiallyEmittedExpression,
     isPrivateIdentifier,
     isPropertyAccessExpression,
@@ -160,9 +162,11 @@ import {
     isTypeReferenceNode,
     isVariableDeclaration,
     isVariableDeclarationList,
+    isVariableLike,
     isVariableStatement,
     isWhiteSpaceLike,
     IterationStatement,
+    JSDoc,
     JSDocAugmentsTag,
     JSDocClassTag,
     JSDocComment,
@@ -196,6 +200,7 @@ import {
     JsxTagNameExpression,
     KeywordSyntaxKind,
     LabeledStatement,
+    last,
     lastOrUndefined,
     LeftHandSideExpression,
     length,
@@ -954,6 +959,52 @@ export function getModifiers(node: HasModifiers): readonly Modifier[] | undefine
     if (hasSyntacticModifier(node, ModifierFlags.Modifier)) {
         return filter(node.modifiers, isModifier);
     }
+}
+
+export function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): readonly (JSDoc | JSDocTag)[] {
+    let result: (JSDoc | JSDocTag)[] | undefined;
+    // Pull parameter comments from declaring function as well
+    if (isVariableLike(hostNode) && hasInitializer(hostNode) && hasJSDocNodes(hostNode.initializer!)) {
+        result = addRange(result, filterOwnedJSDocTags(hostNode, last((hostNode.initializer as HasJSDoc).jsDoc!)));
+    }
+
+    let node: Node | undefined = hostNode;
+    while (node && node.parent) {
+        if (hasJSDocNodes(node)) {
+            result = addRange(result, filterOwnedJSDocTags(hostNode, last(node.jsDoc!)));
+        }
+
+        if (node.kind === SyntaxKind.Parameter) {
+            result = addRange(result, (noCache ? getJSDocParameterTagsNoCache : getJSDocParameterTags)(node as ParameterDeclaration));
+            break;
+        }
+        if (node.kind === SyntaxKind.TypeParameter) {
+            result = addRange(result, (noCache ? getJSDocTypeParameterTagsNoCache : getJSDocTypeParameterTags)(node as TypeParameterDeclaration));
+            break;
+        }
+        node = getNextJSDocCommentLocation(node);
+    }
+    return result || emptyArray;
+}
+
+function filterOwnedJSDocTags(hostNode: Node, jsDoc: JSDoc | JSDocTag) {
+    if (isJSDoc(jsDoc)) {
+        const ownedTags = filter(jsDoc.tags, tag => ownsJSDocTag(hostNode, tag));
+        return jsDoc.tags === ownedTags ? [jsDoc] : ownedTags;
+    }
+    return ownsJSDocTag(hostNode, jsDoc) ? [jsDoc] : undefined;
+}
+
+/**
+ * Determines whether a host node owns a jsDoc tag. A `@type`/`@satisfies` tag attached to a
+ * a ParenthesizedExpression belongs only to the ParenthesizedExpression.
+ */
+function ownsJSDocTag(hostNode: Node, tag: JSDocTag) {
+    return !(isJSDocTypeTag(tag) || isJSDocSatisfiesTag(tag))
+        || !tag.parent
+        || !isJSDoc(tag.parent)
+        || !isParenthesizedExpression(tag.parent.parent)
+        || tag.parent.parent === hostNode;
 }
 
 function getJSDocParameterTagsWorker(param: ParameterDeclaration, noCache?: boolean): readonly JSDocParameterTag[] {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8706,25 +8706,23 @@ declare namespace ts {
         name: Identifier;
     };
     /**
-     * Gets either the {@link JSDoc} object or {@link JSDocTag} providing documentation for the provided node.
-     * A {@link JSDoc} object will be returned if an entire comment is associated with this node. This is always
-     * the case when requesting a comment for declarations which are not a parameter or type parameter.
-     * A {@link JSDocTag} object will be returned if only part of a comment is associated with this node. This
-     * may happen when requesting comments for a parameter or type parameter, but is not guaranteed since the
-     * a comment may appear directly before the parameter/type parameter, in which case the entire comment is
-     * associated with this node.
+     * This function checks multiple locations for JSDoc comments that apply to a host node.
+     * At each location, the whole comment may apply to the node, or only a specific tag in
+     * the comment. In the first case, location adds the entire {@link JSDoc} object. In the
+     * second case, it adds the applicable {@link JSDocTag}.
+     *
+     * For example, a JSDoc comment before a parameter adds the entire {@link JSDoc}. But a
+     * `@param` tag on the parent function only adds the {@link JSDocTag} for the `@param`.
      *
      * ```ts
      * /** JSDoc will be returned for `a` *\/
      * const a = 0
      * /**
      *  * Entire JSDoc will be returned for `b`
-     *  * JSDocTag will be returned for `c`
+     *  * @param c JSDocTag will be returned for `c`
      *  *\/
      * function b(/** JSDoc will be returned for `c` *\/ c) {}
      * ```
-     *
-     * @param hostNode node to get the associated JSDoc comment for.
      */
     function getJSDocCommentsAndTags(hostNode: Node): readonly (JSDoc | JSDocTag)[];
     /** @deprecated */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8507,6 +8507,7 @@ declare namespace ts {
     function getNameOfDeclaration(declaration: Declaration | Expression | undefined): DeclarationName | undefined;
     function getDecorators(node: HasDecorators): readonly Decorator[] | undefined;
     function getModifiers(node: HasModifiers): readonly Modifier[] | undefined;
+    function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): readonly (JSDoc | JSDocTag)[];
     /**
      * Gets the JSDoc parameter tags for the node if present.
      *

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8507,7 +8507,6 @@ declare namespace ts {
     function getNameOfDeclaration(declaration: Declaration | Expression | undefined): DeclarationName | undefined;
     function getDecorators(node: HasDecorators): readonly Decorator[] | undefined;
     function getModifiers(node: HasModifiers): readonly Modifier[] | undefined;
-    function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): readonly (JSDoc | JSDocTag)[];
     /**
      * Gets the JSDoc parameter tags for the node if present.
      *
@@ -8706,6 +8705,28 @@ declare namespace ts {
         parent: ConstructorDeclaration;
         name: Identifier;
     };
+    /**
+     * Gets either the {@link JSDoc} object or {@link JSDocTag} providing documentation for the provided node.
+     * A {@link JSDoc} object will be returned if an entire comment is associated with this node. This is always
+     * the case when requesting a comment for declarations which are not a parameter or type parameter.
+     * A {@link JSDocTag} object will be returned if only part of a comment is associated with this node. This
+     * may happen when requesting comments for a parameter or type parameter, but is not guaranteed since the
+     * a comment may appear directly before the parameter/type parameter, in which case the entire comment is
+     * associated with this node.
+     *
+     * ```ts
+     * /** JSDoc will be returned for `a` *\/
+     * const a = 0
+     * /**
+     *  * Entire JSDoc will be returned for `b`
+     *  * JSDocTag will be returned for `c`
+     *  *\/
+     * function b(/** JSDoc will be returned for `c` *\/ c) {}
+     * ```
+     *
+     * @param hostNode node to get the associated JSDoc comment for.
+     */
+    function getJSDocCommentsAndTags(hostNode: Node): readonly (JSDoc | JSDocTag)[];
     /** @deprecated */
     function createUnparsedSourceFile(text: string): UnparsedSource;
     /** @deprecated */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4763,25 +4763,23 @@ declare namespace ts {
         name: Identifier;
     };
     /**
-     * Gets either the {@link JSDoc} object or {@link JSDocTag} providing documentation for the provided node.
-     * A {@link JSDoc} object will be returned if an entire comment is associated with this node. This is always
-     * the case when requesting a comment for declarations which are not a parameter or type parameter.
-     * A {@link JSDocTag} object will be returned if only part of a comment is associated with this node. This
-     * may happen when requesting comments for a parameter or type parameter, but is not guaranteed since the
-     * a comment may appear directly before the parameter/type parameter, in which case the entire comment is
-     * associated with this node.
+     * This function checks multiple locations for JSDoc comments that apply to a host node.
+     * At each location, the whole comment may apply to the node, or only a specific tag in
+     * the comment. In the first case, location adds the entire {@link JSDoc} object. In the
+     * second case, it adds the applicable {@link JSDocTag}.
+     *
+     * For example, a JSDoc comment before a parameter adds the entire {@link JSDoc}. But a
+     * `@param` tag on the parent function only adds the {@link JSDocTag} for the `@param`.
      *
      * ```ts
      * /** JSDoc will be returned for `a` *\/
      * const a = 0
      * /**
      *  * Entire JSDoc will be returned for `b`
-     *  * JSDocTag will be returned for `c`
+     *  * @param c JSDocTag will be returned for `c`
      *  *\/
      * function b(/** JSDoc will be returned for `c` *\/ c) {}
      * ```
-     *
-     * @param hostNode node to get the associated JSDoc comment for.
      */
     function getJSDocCommentsAndTags(hostNode: Node): readonly (JSDoc | JSDocTag)[];
     /** @deprecated */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4564,7 +4564,6 @@ declare namespace ts {
     function getNameOfDeclaration(declaration: Declaration | Expression | undefined): DeclarationName | undefined;
     function getDecorators(node: HasDecorators): readonly Decorator[] | undefined;
     function getModifiers(node: HasModifiers): readonly Modifier[] | undefined;
-    function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): readonly (JSDoc | JSDocTag)[];
     /**
      * Gets the JSDoc parameter tags for the node if present.
      *
@@ -4763,6 +4762,28 @@ declare namespace ts {
         parent: ConstructorDeclaration;
         name: Identifier;
     };
+    /**
+     * Gets either the {@link JSDoc} object or {@link JSDocTag} providing documentation for the provided node.
+     * A {@link JSDoc} object will be returned if an entire comment is associated with this node. This is always
+     * the case when requesting a comment for declarations which are not a parameter or type parameter.
+     * A {@link JSDocTag} object will be returned if only part of a comment is associated with this node. This
+     * may happen when requesting comments for a parameter or type parameter, but is not guaranteed since the
+     * a comment may appear directly before the parameter/type parameter, in which case the entire comment is
+     * associated with this node.
+     *
+     * ```ts
+     * /** JSDoc will be returned for `a` *\/
+     * const a = 0
+     * /**
+     *  * Entire JSDoc will be returned for `b`
+     *  * JSDocTag will be returned for `c`
+     *  *\/
+     * function b(/** JSDoc will be returned for `c` *\/ c) {}
+     * ```
+     *
+     * @param hostNode node to get the associated JSDoc comment for.
+     */
+    function getJSDocCommentsAndTags(hostNode: Node): readonly (JSDoc | JSDocTag)[];
     /** @deprecated */
     function createUnparsedSourceFile(text: string): UnparsedSource;
     /** @deprecated */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4564,6 +4564,7 @@ declare namespace ts {
     function getNameOfDeclaration(declaration: Declaration | Expression | undefined): DeclarationName | undefined;
     function getDecorators(node: HasDecorators): readonly Decorator[] | undefined;
     function getModifiers(node: HasModifiers): readonly Modifier[] | undefined;
+    function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): readonly (JSDoc | JSDocTag)[];
     /**
      * Gets the JSDoc parameter tags for the node if present.
      *


### PR DESCRIPTION
As discussed in the TS Discord, TypeDoc is now relying on this internal function in order parse comments more closely to TypeScript's parsing.

Fixes #45197
