### PR TITLE
fix(53576): Don't remove indentations from JSDoc tag documentation

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8860,19 +8860,21 @@ namespace Parser {
             }
 
             function parseTrailingTagComments(pos: number, end: number, margin: number, indentText: string) {
+                const newLinesMargin = margin;
                 // some tags, like typedef and callback, have already parsed their comments earlier
                 if (!indentText) {
                     margin += end - pos;
                 }
-                return parseTagComments(margin, indentText.slice(margin));
+                return parseTagComments(margin, newLinesMargin, indentText.slice(margin));
             }
 
-            function parseTagComments(indent: number, initialMargin?: string): string | NodeArray<JSDocComment> | undefined {
+            function parseTagComments(indent: number, newLinesMargin?: number, initialMargin?: string): string | NodeArray<JSDocComment> | undefined {
                 const commentsPos = getNodePos();
                 let comments: string[] = [];
                 const parts: JSDocComment[] = [];
                 let linkEnd;
                 let state = JSDocState.BeginningOfLine;
+                let hasParsedFirstLine = false;
                 let margin: number | undefined;
                 function pushComment(text: string) {
                     if (!margin) {
@@ -8895,6 +8897,10 @@ namespace Parser {
                             state = JSDocState.BeginningOfLine;
                             // don't use pushComment here because we want to keep the margin unchanged
                             comments.push(scanner.getTokenText());
+                            if (newLinesMargin !== undefined && !hasParsedFirstLine) {
+                                hasParsedFirstLine = true;
+                                margin = newLinesMargin;
+                            }
                             indent = 0;
                             break;
                         case SyntaxKind.AtToken:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53576
