### PR TITLE
Don't linearly search for fresh param in getConditionalType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17790,11 +17790,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const context = createInferenceContext(freshParams, /*signature*/ undefined, InferenceFlags.None);
                 if (freshMapper) {
                     const freshCombinedMapper = combineTypeMappers(mapper, freshMapper);
-                    forEach(freshParams, (p, i) => {
-                        if (p !== root.inferTypeParameters![i]) {
-                            p.mapper = freshCombinedMapper;
+                    for (let i = 0; i < freshParams.length; i++) {
+                        if (freshParams[i] !== root.inferTypeParameters[i]) {
+                            freshParams[i].mapper = freshCombinedMapper;
                         }
-                    });
+                    }
                 }
                 if (!checkTypeDeferred) {
                     // We don't want inferences from constraints as they may cause us to eagerly resolve the

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17790,11 +17790,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const context = createInferenceContext(freshParams, /*signature*/ undefined, InferenceFlags.None);
                 if (freshMapper) {
                     const freshCombinedMapper = combineTypeMappers(mapper, freshMapper);
-                    for (const p of freshParams) {
-                        if (root.inferTypeParameters.indexOf(p) === -1) {
+                    forEach(freshParams, (p, i) => {
+                        if (p !== root.inferTypeParameters![i]) {
                             p.mapper = freshCombinedMapper;
                         }
-                    }
+                    });
                 }
                 if (!checkTypeDeferred) {
                     // We don't want inferences from constraints as they may cause us to eagerly resolve the


### PR DESCRIPTION
Noticed this while working on #53087.

This loop is effectively just looking for which type parameters are "new" and were introduced by `sameMap` above. There's no need to do the N^2 behavior, they'll always have the same index.

Not sure this will really affect perf, though.