### PR TITLE
Allow custom switch-case indentation in formatting

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3418,6 +3418,7 @@ export interface FormatCodeSettings extends EditorSettings {
     placeOpenBraceOnNewLineForControlBlocks?: boolean;
     insertSpaceBeforeTypeAnnotation?: boolean;
     semicolons?: SemicolonPreference;
+    indentSwitchCase?: boolean;
 }
 
 export interface UserPreferences {

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -653,9 +653,6 @@ export namespace SmartIndenter {
             case SyntaxKind.TypeLiteral:
             case SyntaxKind.MappedType:
             case SyntaxKind.TupleType:
-            case SyntaxKind.CaseBlock:
-            case SyntaxKind.DefaultClause:
-            case SyntaxKind.CaseClause:
             case SyntaxKind.ParenthesizedExpression:
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.CallExpression:
@@ -684,7 +681,11 @@ export namespace SmartIndenter {
             case SyntaxKind.ExportSpecifier:
             case SyntaxKind.ImportSpecifier:
             case SyntaxKind.PropertyDeclaration:
+            case SyntaxKind.CaseClause:
+            case SyntaxKind.DefaultClause:
                 return true;
+            case SyntaxKind.CaseBlock:
+                return settings.indentSwitchCase ?? true;
             case SyntaxKind.VariableDeclaration:
             case SyntaxKind.PropertyAssignment:
             case SyntaxKind.BinaryExpression:

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1118,6 +1118,7 @@ export interface FormatCodeSettings extends EditorSettings {
     readonly insertSpaceBeforeTypeAnnotation?: boolean;
     readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
     readonly semicolons?: SemicolonPreference;
+    readonly indentSwitchCase?: boolean;
 }
 
 export function getDefaultFormatCodeSettings(newLineCharacter?: string): FormatCodeSettings {
@@ -1142,7 +1143,8 @@ export function getDefaultFormatCodeSettings(newLineCharacter?: string): FormatC
         placeOpenBraceOnNewLineForFunctions: false,
         placeOpenBraceOnNewLineForControlBlocks: false,
         semicolons: SemicolonPreference.Ignore,
-        trimTrailingWhitespace: true
+        trimTrailingWhitespace: true,
+        indentSwitchCase: true
     };
 }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2718,6 +2718,7 @@ declare namespace ts {
                 placeOpenBraceOnNewLineForControlBlocks?: boolean;
                 insertSpaceBeforeTypeAnnotation?: boolean;
                 semicolons?: SemicolonPreference;
+                indentSwitchCase?: boolean;
             }
             interface UserPreferences {
                 readonly disableSuggestions?: boolean;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -10524,6 +10524,7 @@ declare namespace ts {
         readonly insertSpaceBeforeTypeAnnotation?: boolean;
         readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
         readonly semicolons?: SemicolonPreference;
+        readonly indentSwitchCase?: boolean;
     }
     interface DefinitionInfo extends DocumentSpan {
         kind: ScriptElementKind;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6594,6 +6594,7 @@ declare namespace ts {
         readonly insertSpaceBeforeTypeAnnotation?: boolean;
         readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
         readonly semicolons?: SemicolonPreference;
+        readonly indentSwitchCase?: boolean;
     }
     interface DefinitionInfo extends DocumentSpan {
         kind: ScriptElementKind;

--- a/tests/baselines/reference/tsserver/formatSettings/works-when-extends-is-specified-with-a-case-insensitive-file-system.js
+++ b/tests/baselines/reference/tsserver/formatSettings/works-when-extends-is-specified-with-a-case-insensitive-file-system.js
@@ -76,7 +76,8 @@ Info seq  [hh:mm:ss:mss] request:
           "placeOpenBraceOnNewLineForFunctions": false,
           "placeOpenBraceOnNewLineForControlBlocks": true,
           "semicolons": "ignore",
-          "trimTrailingWhitespace": true
+          "trimTrailingWhitespace": true,
+          "indentSwitchCase": true
         }
       },
       "seq": 2,
@@ -112,7 +113,8 @@ FormatCodeOptions should be global:: /a/b/app.ts:: {
  "placeOpenBraceOnNewLineForFunctions": false,
  "placeOpenBraceOnNewLineForControlBlocks": true,
  "semicolons": "ignore",
- "trimTrailingWhitespace": true
+ "trimTrailingWhitespace": true,
+ "indentSwitchCase": true
 }
 Before request
 
@@ -141,7 +143,8 @@ Info seq  [hh:mm:ss:mss] request:
           "placeOpenBraceOnNewLineForFunctions": false,
           "placeOpenBraceOnNewLineForControlBlocks": false,
           "semicolons": "ignore",
-          "trimTrailingWhitespace": true
+          "trimTrailingWhitespace": true,
+          "indentSwitchCase": true
         },
         "file": "/a/b/app.ts"
       },
@@ -178,7 +181,8 @@ FormatCodeOptions should be per file:: /a/b/app.ts:: {
  "placeOpenBraceOnNewLineForFunctions": false,
  "placeOpenBraceOnNewLineForControlBlocks": false,
  "semicolons": "ignore",
- "trimTrailingWhitespace": true
+ "trimTrailingWhitespace": true,
+ "indentSwitchCase": true
 }
 Before request
 
@@ -207,7 +211,8 @@ Info seq  [hh:mm:ss:mss] request:
           "placeOpenBraceOnNewLineForFunctions": false,
           "placeOpenBraceOnNewLineForControlBlocks": false,
           "semicolons": "ignore",
-          "trimTrailingWhitespace": true
+          "trimTrailingWhitespace": true,
+          "indentSwitchCase": true
         }
       },
       "seq": 4,
@@ -243,5 +248,6 @@ FormatCodeOptions should be per file:: /a/b/app.ts:: {
  "placeOpenBraceOnNewLineForFunctions": false,
  "placeOpenBraceOnNewLineForControlBlocks": false,
  "semicolons": "ignore",
- "trimTrailingWhitespace": true
+ "trimTrailingWhitespace": true,
+ "indentSwitchCase": true
 }

--- a/tests/cases/fourslash/formattingIndentSwitchCase.ts
+++ b/tests/cases/fourslash/formattingIndentSwitchCase.ts
@@ -1,0 +1,31 @@
+/// <reference path='fourslash.ts'/>
+
+////let foo = 1;
+////switch (foo) {
+/////*1*/case 0:
+/////*2*/break;
+/////*3*/default:
+/////*4*/break;
+////}
+
+format.setOption('indentSwitchCase', true);
+format.document();
+goTo.marker('1');
+verify.indentationIs(4);
+goTo.marker('2');
+verify.indentationIs(8);
+goTo.marker('3');
+verify.indentationIs(4);
+goTo.marker('4');
+verify.indentationIs(8);
+
+format.setOption('indentSwitchCase', false);
+format.document();
+goTo.marker('1');
+verify.indentationIs(0);
+goTo.marker('2');
+verify.indentationIs(4);
+goTo.marker('3');
+verify.indentationIs(0);
+goTo.marker('4');
+verify.indentationIs(4);

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -196,6 +196,7 @@ declare namespace FourSlashInterface {
         readonly insertSpaceBeforeTypeAnnotation?: boolean;
         readonly indentMultiLineObjectLiteralBeginningOnBlankLine?: boolean;
         readonly semicolons?: ts.SemicolonPreference;
+        readonly indentSwitchCase?: boolean;
     }
     interface Range {
         fileName: string;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Added a new option `indentSwitchCase` in `FormatCodeSettings`.
Closes #18682
