### PR TITLE
fix(53722): Overloaded constructors: 'TValue' not assignable to 'string'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14541,8 +14541,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
 
-            const constructorDeclaration = tryGetConstructorDeclaration(declaration);
-            const classType = constructorDeclaration ? getDeclaredTypeOfClassOrInterface(getMergedSymbol((constructorDeclaration.parent as ClassDeclaration).symbol)) : undefined;
+            const hostDeclaration = isJSDocSignature(declaration) ? getEffectiveJSDocHost(declaration) : declaration;
+            const classType = hostDeclaration && isConstructorDeclaration(hostDeclaration) ?
+                getDeclaredTypeOfClassOrInterface(getMergedSymbol((hostDeclaration.parent as ClassDeclaration).symbol))
+                : undefined;
             const typeParameters = classType ? classType.localTypeParameters : getTypeParametersFromDeclaration(declaration);
             if (hasRestParameter(declaration) || isInJSFile(declaration) && maybeAddJsSyntheticRestParameter(declaration, parameters)) {
                 flags |= SignatureFlags.HasRestParameter;
@@ -14556,11 +14558,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 minArgumentCount, flags);
         }
         return links.resolvedSignature;
-    }
-
-    function tryGetConstructorDeclaration(declaration: SignatureDeclaration | JSDocSignature) {
-        const node = isJSDocSignature(declaration) ? getEffectiveJSDocHost(declaration) : declaration;
-        return node && isConstructorDeclaration(node) ? node : undefined;
     }
 
     /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14541,9 +14541,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
 
-            const classType = declaration.kind === SyntaxKind.Constructor ?
-                getDeclaredTypeOfClassOrInterface(getMergedSymbol((declaration.parent as ClassDeclaration).symbol))
-                : undefined;
+            const constructorDeclaration = tryGetConstructorDeclaration(declaration);
+            const classType = constructorDeclaration ? getDeclaredTypeOfClassOrInterface(getMergedSymbol((constructorDeclaration.parent as ClassDeclaration).symbol)) : undefined;
             const typeParameters = classType ? classType.localTypeParameters : getTypeParametersFromDeclaration(declaration);
             if (hasRestParameter(declaration) || isInJSFile(declaration) && maybeAddJsSyntheticRestParameter(declaration, parameters)) {
                 flags |= SignatureFlags.HasRestParameter;
@@ -14557,6 +14556,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 minArgumentCount, flags);
         }
         return links.resolvedSignature;
+    }
+
+    function tryGetConstructorDeclaration(declaration: SignatureDeclaration | JSDocSignature) {
+        const node = isJSDocSignature(declaration) ? getEffectiveJSDocHost(declaration) : declaration;
+        return node && isConstructorDeclaration(node) ? node : undefined;
     }
 
     /**

--- a/tests/baselines/reference/overloadTag3.symbols
+++ b/tests/baselines/reference/overloadTag3.symbols
@@ -1,0 +1,29 @@
+=== /a.js ===
+/**
+ * @template T
+ */
+export class Foo {
+>Foo : Symbol(Foo, Decl(a.js, 0, 0))
+
+    /**
+     * @constructor
+     * @overload
+     */
+    constructor() { }
+
+    /**
+     * @param {T} value
+     */
+    bar(value) { }
+>bar : Symbol(Foo.bar, Decl(a.js, 8, 21))
+>value : Symbol(value, Decl(a.js, 13, 8))
+}
+
+/** @type {Foo<number>} */
+let foo;
+>foo : Symbol(foo, Decl(a.js, 17, 3))
+
+foo = new Foo();
+>foo : Symbol(foo, Decl(a.js, 17, 3))
+>Foo : Symbol(Foo, Decl(a.js, 0, 0))
+

--- a/tests/baselines/reference/overloadTag3.types
+++ b/tests/baselines/reference/overloadTag3.types
@@ -1,0 +1,31 @@
+=== /a.js ===
+/**
+ * @template T
+ */
+export class Foo {
+>Foo : Foo<T>
+
+    /**
+     * @constructor
+     * @overload
+     */
+    constructor() { }
+
+    /**
+     * @param {T} value
+     */
+    bar(value) { }
+>bar : (value: T) => void
+>value : T
+}
+
+/** @type {Foo<number>} */
+let foo;
+>foo : Foo<number>
+
+foo = new Foo();
+>foo = new Foo() : Foo<number>
+>foo : Foo<number>
+>new Foo() : Foo<number>
+>Foo : typeof Foo
+

--- a/tests/cases/conformance/jsdoc/overloadTag3.ts
+++ b/tests/cases/conformance/jsdoc/overloadTag3.ts
@@ -1,0 +1,24 @@
+// @checkJs: true
+// @allowJs: true
+// @strict: true
+// @noEmit: true
+// @filename: /a.js
+/**
+ * @template T
+ */
+export class Foo {
+    /**
+     * @constructor
+     * @overload
+     */
+    constructor() { }
+
+    /**
+     * @param {T} value
+     */
+    bar(value) { }
+}
+
+/** @type {Foo<number>} */
+let foo;
+foo = new Foo();


### PR DESCRIPTION
Fixes #53722