### PR TITLE
Preserve generic substitutions through instantiation more often

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19053,7 +19053,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (newConstraint.flags & TypeFlags.AnyOrUnknown || isTypeAssignableTo(getRestrictiveInstantiation(newBaseType), getRestrictiveInstantiation(newConstraint))) {
                 return newBaseType;
             }
-            return newBaseType.flags & TypeFlags.TypeVariable ? getSubstitutionType(newBaseType, newConstraint) : getIntersectionType([newConstraint, newBaseType]);
+            return (newBaseType.flags & TypeFlags.TypeVariable || newConstraint.flags & TypeFlags.TypeVariable) ? getSubstitutionType(newBaseType, newConstraint) : getIntersectionType([newConstraint, newBaseType]);
         }
         return type;
     }

--- a/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
+++ b/tests/baselines/reference/callOfConditionalTypeWithConcreteBranches.types
@@ -64,11 +64,11 @@ function fn2<T>(arg: Q2<T>) {
   arg(arg => useT(arg));
 >arg(arg => useT(arg)) : void
 >arg : Q2<T>
->arg => useT(arg) : (arg: T & number) => void
->arg : T & number
+>arg => useT(arg) : (arg: number) => void
+>arg : number
 >useT(arg) : void
 >useT : (_arg: T) => void
->arg : T & number
+>arg : number
 }
 // Legal invocations are not problematic
 fn2<string | number>(m => m(42));

--- a/tests/baselines/reference/conditionalSubstitutionInferencesLowerPriority.js
+++ b/tests/baselines/reference/conditionalSubstitutionInferencesLowerPriority.js
@@ -1,0 +1,23 @@
+//// [conditionalSubstitutionInferencesLowerPriority.ts]
+type TestType<Keys extends string> = string extends Keys ? Record<Keys, string> : Record<Keys, string>
+
+function inferHelper<Keys extends string>(data: TestType<Keys>) {
+    return data;
+}
+
+export const a = inferHelper({
+    // key1 is inferred to be value1 here
+    key1: "value1"
+})
+
+//// [conditionalSubstitutionInferencesLowerPriority.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.a = void 0;
+function inferHelper(data) {
+    return data;
+}
+exports.a = inferHelper({
+    // key1 is inferred to be value1 here
+    key1: "value1"
+});

--- a/tests/baselines/reference/conditionalSubstitutionInferencesLowerPriority.symbols
+++ b/tests/baselines/reference/conditionalSubstitutionInferencesLowerPriority.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/conditionalSubstitutionInferencesLowerPriority.ts ===
+type TestType<Keys extends string> = string extends Keys ? Record<Keys, string> : Record<Keys, string>
+>TestType : Symbol(TestType, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 0))
+>Keys : Symbol(Keys, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 14))
+>Keys : Symbol(Keys, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 14))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>Keys : Symbol(Keys, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 14))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>Keys : Symbol(Keys, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 14))
+
+function inferHelper<Keys extends string>(data: TestType<Keys>) {
+>inferHelper : Symbol(inferHelper, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 102))
+>Keys : Symbol(Keys, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 2, 21))
+>data : Symbol(data, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 2, 42))
+>TestType : Symbol(TestType, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 0))
+>Keys : Symbol(Keys, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 2, 21))
+
+    return data;
+>data : Symbol(data, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 2, 42))
+}
+
+export const a = inferHelper({
+>a : Symbol(a, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 6, 12))
+>inferHelper : Symbol(inferHelper, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 0, 102))
+
+    // key1 is inferred to be value1 here
+    key1: "value1"
+>key1 : Symbol(key1, Decl(conditionalSubstitutionInferencesLowerPriority.ts, 6, 30))
+
+})

--- a/tests/baselines/reference/conditionalSubstitutionInferencesLowerPriority.types
+++ b/tests/baselines/reference/conditionalSubstitutionInferencesLowerPriority.types
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/conditionalSubstitutionInferencesLowerPriority.ts ===
+type TestType<Keys extends string> = string extends Keys ? Record<Keys, string> : Record<Keys, string>
+>TestType : TestType<Keys>
+
+function inferHelper<Keys extends string>(data: TestType<Keys>) {
+>inferHelper : <Keys extends string>(data: TestType<Keys>) => TestType<Keys>
+>data : TestType<Keys>
+
+    return data;
+>data : TestType<Keys>
+}
+
+export const a = inferHelper({
+>a : Record<"key1", string>
+>inferHelper({    // key1 is inferred to be value1 here    key1: "value1"}) : Record<"key1", string>
+>inferHelper : <Keys extends string>(data: TestType<Keys>) => TestType<Keys>
+>{    // key1 is inferred to be value1 here    key1: "value1"} : { key1: string; }
+
+    // key1 is inferred to be value1 here
+    key1: "value1"
+>key1 : string
+>"value1" : "value1"
+
+})

--- a/tests/cases/compiler/conditionalSubstitutionInferencesLowerPriority.ts
+++ b/tests/cases/compiler/conditionalSubstitutionInferencesLowerPriority.ts
@@ -1,0 +1,10 @@
+type TestType<Keys extends string> = string extends Keys ? Record<Keys, string> : Record<Keys, string>
+
+function inferHelper<Keys extends string>(data: TestType<Keys>) {
+    return data;
+}
+
+export const a = inferHelper({
+    // key1 is inferred to be value1 here
+    key1: "value1"
+})


### PR DESCRIPTION
Fixes #53343

This fix ended up being relatively simple, but the issue is anything but. A conditional like `string extends T` produces substitutions on `string` within the true branch of the conditional, so we know all `string` instances can be used as `T`s (something sometimes needed to satisfy constraint checks). When we go to instantiate a substitute like this, we would see that `string` (the base of the substitute) isn't a generic, and go "oh, well, this can just be an intersection then, we don't really need any substitution behaviors anymore", and would instantiate it down to a plain `string & T`. Unfortunately, this discards the information that that `T` came in from a substitution constraint, which, in turn, allows inferring to that `T`. That isn't _necessarily_ bad - it is here, because the inference result doesn't satisfy the condition that produced the substitution, but inferences like this _could_ be producing useful results (especially for conditionals which are usually true). In any case, by preserving the substitution type in instantiation when the constraint is still a type variable, we preserve the substitution-ness of the position into inference, and then skip performing the inferences to the substitution constraint (because we always walk substitution types on the target side back to their base type).

I would say that if it turns out these substitution constraint position inferences (which this PR is effectively removing) are actually used usefully in the wild, we could totally keep them (by _explicitly_ inferring to the substitution constraint), but we need to make them at a much lower priority than we do now (so they don't override other, non-conditional inferences), or, better yet, conditionalize them on the result of their associated conditional passing with the given inference candidate. (which we could do by tracking conditions as we descend through inference and instantiating and testing them all as we produce inference results.)