### PR TITLE
Separate interactive from non-interactive refactors in API

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -1,4 +1,6 @@
 import {
+    ApplicableInteractiveRefactorInfo,
+    ApplicableNonInteractiveRefactorInfo,
     ApplicableRefactorInfo,
     CallHierarchyIncomingCall,
     CallHierarchyItem,
@@ -52,6 +54,7 @@ import {
     Program,
     QuickInfo,
     RefactorEditInfo,
+    RefactorTriggerReason,
     ReferencedSymbol,
     ReferenceEntry,
     RenameInfo,
@@ -785,10 +788,13 @@ export class SessionClient implements LanguageService {
         return { file, line, offset, endLine, endOffset };
     }
 
-    getApplicableRefactors(fileName: string, positionOrRange: number | TextRange): ApplicableRefactorInfo[] {
+    getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string): ApplicableNonInteractiveRefactorInfo[];
+    getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason: RefactorTriggerReason | undefined, kind: string | undefined, includeInteractive: true): ApplicableInteractiveRefactorInfo[];
+    getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractive?: boolean): ApplicableRefactorInfo[];
+    getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, _preferences: UserPreferences | undefined, _triggerReason?: RefactorTriggerReason, _kind?: string, includeInteractive?: boolean): ApplicableRefactorInfo[] {
         const args = this.createFileLocationOrRangeRequestArgs(positionOrRange, fileName);
 
-        const request = this.processRequest<protocol.GetApplicableRefactorsRequest>(protocol.CommandTypes.GetApplicableRefactors, args);
+        const request = this.processRequest<protocol.GetApplicableRefactorsRequest>(protocol.CommandTypes.GetApplicableRefactors, { ...args, includeInteractive });
         const response = this.processResponse<protocol.GetApplicableRefactorsResponse>(request);
         return response.body!; // TODO: GH#18217
     }

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -613,6 +613,9 @@ class LanguageServiceShimProxy implements ts.LanguageService {
     getEditsForRefactor(): ts.RefactorEditInfo {
         throw new Error("Not supported on the shim.");
     }
+    getApplicableRefactors(): ts.ApplicableNonInteractiveRefactorInfo[];
+    getApplicableRefactors(): ts.ApplicableInteractiveRefactorInfo[];
+    getApplicableRefactors(): ts.ApplicableRefactorInfo[];
     getApplicableRefactors(): ts.ApplicableRefactorInfo[] {
         throw new Error("Not supported on the shim.");
     }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -4,11 +4,14 @@ import type {
     EndOfLineState,
     FileExtensionInfo,
     HighlightSpanKind,
+    InteractiveRefactorName,
     MapLike,
+    NonInteractiveRefactorName,
     OutliningSpanKind,
     OutputFile,
     PluginImport,
     ProjectReference,
+    RefactorName,
     RenameLocation,
     ScriptElementKind,
     ScriptKind,
@@ -586,6 +589,7 @@ export interface GetApplicableRefactorsRequest extends Request {
 export type GetApplicableRefactorsRequestArgs = FileLocationOrRangeRequestArgs & {
     triggerReason?: RefactorTriggerReason;
     kind?: string;
+    includeInteractive?: boolean;
 };
 
 export type RefactorTriggerReason = "implicit" | "invoked";
@@ -594,18 +598,18 @@ export type RefactorTriggerReason = "implicit" | "invoked";
  * Response is a list of available refactorings.
  * Each refactoring exposes one or more "Actions"; a user selects one action to invoke a refactoring
  */
-export interface GetApplicableRefactorsResponse extends Response {
-    body?: ApplicableRefactorInfo[];
+export interface GetApplicableRefactorsResponse<TRefactorInfo extends ApplicableRefactorInfo = ApplicableRefactorInfo> extends Response {
+    body?: TRefactorInfo[];
 }
 
 /**
  * A set of one or more available refactoring actions, grouped under a parent refactoring.
  */
-export interface ApplicableRefactorInfo {
+export interface BaseApplicableRefactorInfo {
     /**
      * The programmatic name of the refactoring
      */
-    name: string;
+    name: RefactorName;
     /**
      * A description of this refactoring category to show to the user.
      * If the refactoring gets inlined (see below), this text will not be visible.
@@ -622,6 +626,17 @@ export interface ApplicableRefactorInfo {
 
     actions: RefactorActionInfo[];
 }
+
+export interface ApplicableNonInteractiveRefactorInfo extends BaseApplicableRefactorInfo {
+    name: NonInteractiveRefactorName;
+}
+
+export interface ApplicableInteractiveRefactorInfo extends BaseApplicableRefactorInfo {
+    name: InteractiveRefactorName;
+}
+
+export type ApplicableRefactorInfo = ApplicableNonInteractiveRefactorInfo | ApplicableInteractiveRefactorInfo;
+
 
 /**
  * Represents a single refactoring action - for example, the "Extract Method..." refactor might

--- a/src/services/refactorProvider.ts
+++ b/src/services/refactorProvider.ts
@@ -2,35 +2,44 @@ import {
     ApplicableRefactorInfo,
     arrayFrom,
     flatMapIterator,
+    InteractiveRefactor,
+    InteractiveRefactorName,
+    NonInteractiveRefactor,
+    NonInteractiveRefactorName,
     Refactor,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
 } from "./_namespaces/ts";
 import { refactorKindBeginsWith } from "./_namespaces/ts.refactor";
 
 // A map with the refactor code as key, the refactor itself as value
 // e.g.  nonSuggestableRefactors[refactorCode] -> the refactor you want
-const refactors = new Map<string, Refactor>();
+const refactors = new Map<RefactorName, Refactor>();
 
 /**
  * @param name An unique code associated with each refactor. Does not have to be human-readable.
  *
  * @internal
  */
-export function registerRefactor(name: string, refactor: Refactor) {
+export function registerRefactor<Name extends InteractiveRefactorName>(name: Name, refactor: InteractiveRefactor<Name>): void;
+/** @internal */
+export function registerRefactor(name: NonInteractiveRefactorName, refactor: NonInteractiveRefactor): void;
+/** @internal */
+export function registerRefactor(name: RefactorName, refactor: Refactor) {
     refactors.set(name, refactor);
 }
 
 /** @internal */
-export function getApplicableRefactors(context: RefactorContext): ApplicableRefactorInfo[] {
+export function getApplicableRefactors(context: RefactorContext, includeInteractive?: boolean): ApplicableRefactorInfo[] {
     return arrayFrom(flatMapIterator(refactors.values(), refactor =>
         context.cancellationToken && context.cancellationToken.isCancellationRequested() ||
-        !refactor.kinds?.some(kind => refactorKindBeginsWith(kind, context.kind)) ? undefined :
+        (!refactor.kinds?.some(kind => refactorKindBeginsWith(kind, context.kind)) || refactor.isInteractive && !includeInteractive) ? undefined :
         refactor.getAvailableActions(context)));
 }
 
 /** @internal */
-export function getEditsForRefactor(context: RefactorContext, refactorName: string, actionName: string): RefactorEditInfo | undefined {
+export function getEditsForRefactor(context: RefactorContext, refactorName: RefactorName, actionName: string, ...args: unknown[]): RefactorEditInfo | undefined {
     const refactor = refactors.get(refactorName);
-    return refactor && refactor.getEditsForAction(context, actionName);
+    return refactor && refactor.getEditsForAction(context, actionName, ...args);
 }

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -19,10 +19,10 @@ import {
     isExpression,
     isReturnStatement,
     needsParentheses,
+    NonInteractiveRefactorName,
     rangeContainsRange,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     ReturnStatement,
     SourceFile,
     SyntaxKind,
@@ -35,7 +35,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.AddOrRemoveBracesToArrowFunction;
+const refactorName = NonInteractiveRefactorName.AddOrRemoveBracesToArrowFunction;
 const refactorDescription = Diagnostics.Add_or_remove_braces_in_an_arrow_function.message;
 
 const addBracesAction = {

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -22,6 +22,7 @@ import {
     rangeContainsRange,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     ReturnStatement,
     SourceFile,
     SyntaxKind,
@@ -34,7 +35,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Add or remove braces in an arrow function";
+const refactorName = RefactorName.AddOrRemoveBracesToArrowFunction;
 const refactorDescription = Diagnostics.Add_or_remove_braces_in_an_arrow_function.message;
 
 const addBracesAction = {

--- a/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
+++ b/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
@@ -35,12 +35,12 @@ import {
     length,
     ModifierFlags,
     Node,
+    NonInteractiveRefactorName,
     Program,
     rangeContainsRange,
     RefactorActionInfo,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     ReturnStatement,
     setTextRange,
     SourceFile,
@@ -59,7 +59,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ConvertArrowFunctionOrFunctionExpression;
+const refactorName = NonInteractiveRefactorName.ConvertArrowFunctionOrFunctionExpression;
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_arrow_function_or_function_expression);
 
 const toAnonymousFunctionAction = {

--- a/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
+++ b/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
@@ -40,6 +40,7 @@ import {
     RefactorActionInfo,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     ReturnStatement,
     setTextRange,
     SourceFile,
@@ -58,7 +59,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Convert arrow function or function expression";
+const refactorName = RefactorName.ConvertArrowFunctionOrFunctionExpression;
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_arrow_function_or_function_expression);
 
 const toAnonymousFunctionAction = {

--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -37,13 +37,13 @@ import {
     NamespaceDeclaration,
     Node,
     NodeFlags,
+    NonInteractiveRefactorName,
     Program,
     PropertyAccessExpression,
     QuotePreference,
     quotePreferenceFromString,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     SourceFile,
     Symbol,
     SyntaxKind,
@@ -58,7 +58,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ConvertExport;
+const refactorName = NonInteractiveRefactorName.ConvertExport;
 
 const defaultToNamedAction = {
     name: "Convert default export to named export",

--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -43,6 +43,7 @@ import {
     quotePreferenceFromString,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     SourceFile,
     Symbol,
     SyntaxKind,
@@ -57,7 +58,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Convert export";
+const refactorName = RefactorName.ConvertExport;
 
 const defaultToNamedAction = {
     name: "Convert default export to named export",

--- a/src/services/refactors/convertImport.ts
+++ b/src/services/refactors/convertImport.ts
@@ -35,6 +35,7 @@ import {
     QualifiedName,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     ScriptTarget,
     some,
     SourceFile,
@@ -50,7 +51,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Convert import";
+const refactorName = RefactorName.ConvertImport;
 
 const actions = {
     [ImportKind.Named]: {

--- a/src/services/refactors/convertImport.ts
+++ b/src/services/refactors/convertImport.ts
@@ -30,12 +30,12 @@ import {
     isStringLiteral,
     NamedImports,
     NamespaceImport,
+    NonInteractiveRefactorName,
     Program,
     PropertyAccessExpression,
     QualifiedName,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     ScriptTarget,
     some,
     SourceFile,
@@ -51,7 +51,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ConvertImport;
+const refactorName = NonInteractiveRefactorName.ConvertImport;
 
 const actions = {
     [ImportKind.Named]: {

--- a/src/services/refactors/convertOverloadListToSingleSignature.ts
+++ b/src/services/refactors/convertOverloadListToSingleSignature.ts
@@ -25,12 +25,12 @@ import {
     NamedTupleMember,
     Node,
     NodeArray,
+    NonInteractiveRefactorName,
     ParameterDeclaration,
     Program,
     rangeContainsPosition,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     setEmitFlags,
     setSyntheticLeadingComments,
     setTextRange,
@@ -42,7 +42,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ConvertOverloadListToSingleSignature;
+const refactorName = NonInteractiveRefactorName.ConvertOverloadListToSingleSignature;
 const refactorDescription = Diagnostics.Convert_overload_list_to_single_signature.message;
 
 const functionOverloadAction = {

--- a/src/services/refactors/convertOverloadListToSingleSignature.ts
+++ b/src/services/refactors/convertOverloadListToSingleSignature.ts
@@ -30,6 +30,7 @@ import {
     rangeContainsPosition,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     setEmitFlags,
     setSyntheticLeadingComments,
     setTextRange,
@@ -41,7 +42,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = "Convert overload list to single signature";
+const refactorName = RefactorName.ConvertOverloadListToSingleSignature;
 const refactorDescription = Diagnostics.Convert_overload_list_to_single_signature.message;
 
 const functionOverloadAction = {

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -90,6 +90,7 @@ import {
     rangeContainsRange,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     SemanticMeaning,
     ShorthandPropertyAssignment,
     sortAndDeduplicate,
@@ -106,7 +107,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = "Convert parameters to destructured object";
+const refactorName = RefactorName.ConvertParamsToDestructuredObject;
 const minimumParameterLength = 1;
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_parameters_to_destructured_object);
 

--- a/src/services/refactors/convertParamsToDestructuredObject.ts
+++ b/src/services/refactors/convertParamsToDestructuredObject.ts
@@ -80,6 +80,7 @@ import {
     NewExpression,
     Node,
     NodeArray,
+    NonInteractiveRefactorName,
     ObjectLiteralElementLike,
     ObjectLiteralExpression,
     ParameterDeclaration,
@@ -90,7 +91,6 @@ import {
     rangeContainsRange,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     SemanticMeaning,
     ShorthandPropertyAssignment,
     sortAndDeduplicate,
@@ -107,7 +107,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ConvertParamsToDestructuredObject;
+const refactorName = NonInteractiveRefactorName.ConvertParamsToDestructuredObject;
 const minimumParameterLength = 1;
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_parameters_to_destructured_object);
 

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -27,6 +27,7 @@ import {
     ParenthesizedExpression,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     SourceFile,
     SyntaxKind,
     TemplateHead,
@@ -38,7 +39,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = "Convert to template string";
+const refactorName = RefactorName.ConvertStringOrTemplateLiteral;
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_to_template_string);
 
 const convertStringAction = {

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -24,10 +24,10 @@ import {
     isTemplateMiddle,
     map,
     Node,
+    NonInteractiveRefactorName,
     ParenthesizedExpression,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     SourceFile,
     SyntaxKind,
     TemplateHead,
@@ -39,7 +39,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ConvertStringOrTemplateLiteral;
+const refactorName = NonInteractiveRefactorName.ConvertStringOrTemplateLiteral;
 const refactorDescription = getLocaleSpecificMessage(Diagnostics.Convert_to_template_string);
 
 const convertStringAction = {

--- a/src/services/refactors/convertToOptionalChainExpression.ts
+++ b/src/services/refactors/convertToOptionalChainExpression.ts
@@ -32,6 +32,7 @@ import {
     PropertyAccessExpression,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     ReturnStatement,
     skipParentheses,
     SourceFile,
@@ -47,7 +48,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Convert to optional chain expression";
+const refactorName = RefactorName.ConvertToOptionalChainExpression;
 const convertToOptionalChainExpressionMessage = getLocaleSpecificMessage(Diagnostics.Convert_to_optional_chain_expression);
 
 const toOptionalChainAction = {

--- a/src/services/refactors/convertToOptionalChainExpression.ts
+++ b/src/services/refactors/convertToOptionalChainExpression.ts
@@ -29,10 +29,10 @@ import {
     isStringOrNumericLiteralLike,
     isVariableStatement,
     Node,
+    NonInteractiveRefactorName,
     PropertyAccessExpression,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     ReturnStatement,
     skipParentheses,
     SourceFile,
@@ -48,7 +48,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ConvertToOptionalChainExpression;
+const refactorName = NonInteractiveRefactorName.ConvertToOptionalChainExpression;
 const convertToOptionalChainExpressionMessage = getLocaleSpecificMessage(Diagnostics.Convert_to_optional_chain_expression);
 
 const toOptionalChainAction = {

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -129,6 +129,7 @@ import {
     RefactorActionInfo,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     setEmitFlags,
     ShorthandPropertyAssignment,
     SignatureKind,
@@ -165,7 +166,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Extract Symbol";
+const refactorName = RefactorName.ExtractSymbol;
 
 const extractConstantAction = {
     name: "Extract Constant",

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -120,6 +120,7 @@ import {
     Node,
     NodeBuilderFlags,
     NodeFlags,
+    NonInteractiveRefactorName,
     nullTransformationContext,
     ObjectLiteralElementLike,
     ParameterDeclaration,
@@ -129,7 +130,6 @@ import {
     RefactorActionInfo,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     setEmitFlags,
     ShorthandPropertyAssignment,
     SignatureKind,
@@ -166,7 +166,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ExtractSymbol;
+const refactorName = NonInteractiveRefactorName.ExtractSymbol;
 
 const extractConstantAction = {
     name: "Extract Constant",

--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -52,6 +52,7 @@ import {
     rangeContainsStartEnd,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     setEmitFlags,
     setTextRange,
     skipTrivia,
@@ -70,7 +71,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Extract type";
+const refactorName = RefactorName.ExtractType;
 
 const extractToTypeAliasAction = {
     name: "Extract to type alias",

--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -48,11 +48,11 @@ import {
     JSDocTemplateTag,
     Node,
     nodeOverlapsWithStartEnd,
+    NonInteractiveRefactorName,
     pushIfUnique,
     rangeContainsStartEnd,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     setEmitFlags,
     setTextRange,
     skipTrivia,
@@ -71,7 +71,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.ExtractType;
+const refactorName = NonInteractiveRefactorName.ExtractType;
 
 const extractToTypeAliasAction = {
     name: "Extract to type alias",

--- a/src/services/refactors/generateGetAccessorAndSetAccessor.ts
+++ b/src/services/refactors/generateGetAccessorAndSetAccessor.ts
@@ -7,15 +7,15 @@ import {
     getRenameLocation,
     isIdentifier,
     isParameter,
+    NonInteractiveRefactorName,
     RefactorContext,
-    RefactorName,
 } from "../_namespaces/ts";
 import {
     isRefactorErrorInfo,
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const actionName = RefactorName.GenerateGetAccessorAndSetAccessor;
+const actionName = NonInteractiveRefactorName.GenerateGetAccessorAndSetAccessor;
 const actionDescription = Diagnostics.Generate_get_and_set_accessors.message;
 
 const generateGetSetAction = {

--- a/src/services/refactors/generateGetAccessorAndSetAccessor.ts
+++ b/src/services/refactors/generateGetAccessorAndSetAccessor.ts
@@ -8,13 +8,14 @@ import {
     isIdentifier,
     isParameter,
     RefactorContext,
+    RefactorName,
 } from "../_namespaces/ts";
 import {
     isRefactorErrorInfo,
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const actionName = "Generate 'get' and 'set' accessors";
+const actionName = RefactorName.GenerateGetAccessorAndSetAccessor;
 const actionDescription = Diagnostics.Generate_get_and_set_accessors.message;
 
 const generateGetSetAction = {

--- a/src/services/refactors/inferFunctionReturnType.ts
+++ b/src/services/refactors/inferFunctionReturnType.ts
@@ -18,9 +18,9 @@ import {
     MethodDeclaration,
     Node,
     NodeBuilderFlags,
+    NonInteractiveRefactorName,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     SourceFile,
     SyntaxKind,
     textChanges,
@@ -35,7 +35,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.InferFunctionReturnType;
+const refactorName = NonInteractiveRefactorName.InferFunctionReturnType;
 const refactorDescription = Diagnostics.Infer_function_return_type.message;
 
 const inferReturnTypeAction = {

--- a/src/services/refactors/inferFunctionReturnType.ts
+++ b/src/services/refactors/inferFunctionReturnType.ts
@@ -20,6 +20,7 @@ import {
     NodeBuilderFlags,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     SourceFile,
     SyntaxKind,
     textChanges,
@@ -34,7 +35,7 @@ import {
     registerRefactor,
 } from "../_namespaces/ts.refactor";
 
-const refactorName = "Infer function return type";
+const refactorName = RefactorName.InferFunctionReturnType;
 const refactorDescription = Diagnostics.Infer_function_return_type.message;
 
 const inferReturnTypeAction = {

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -104,6 +104,7 @@ import {
     rangeContainsRange,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     RequireOrImportCall,
     RequireVariableStatement,
     resolvePath,
@@ -131,7 +132,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = "Move to a new file";
+const refactorName = RefactorName.MoveToNewFile;
 const description = getLocaleSpecificMessage(Diagnostics.Move_to_a_new_file);
 
 const moveToNewFileAction = {

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -95,6 +95,7 @@ import {
     Node,
     NodeFlags,
     nodeSeenTracker,
+    NonInteractiveRefactorName,
     normalizePath,
     ObjectBindingElementWithoutPropertyName,
     Program,
@@ -104,7 +105,6 @@ import {
     rangeContainsRange,
     RefactorContext,
     RefactorEditInfo,
-    RefactorName,
     RequireOrImportCall,
     RequireVariableStatement,
     resolvePath,
@@ -132,7 +132,7 @@ import {
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
-const refactorName = RefactorName.MoveToNewFile;
+const refactorName = NonInteractiveRefactorName.MoveToNewFile;
 const description = getLocaleSpecificMessage(Diagnostics.Move_to_a_new_file);
 
 const moveToNewFileAction = {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,5 +1,6 @@
 import {
     __String,
+    ApplicableNonInteractiveRefactorInfo,
     ApplicableRefactorInfo,
     ApplyCodeActionCommandResult,
     AssignmentDeclarationKind,
@@ -243,6 +244,7 @@ import {
     refactor,
     RefactorContext,
     RefactorEditInfo,
+    RefactorName,
     RefactorTriggerReason,
     ReferencedSymbol,
     ReferenceEntry,
@@ -2967,23 +2969,26 @@ export function createLanguageService(
         return SmartSelectionRange.getSmartSelectionRange(position, syntaxTreeCache.getCurrentSourceFile(fileName));
     }
 
-    function getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences = emptyOptions, triggerReason: RefactorTriggerReason, kind: string): ApplicableRefactorInfo[] {
+    function getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string): ApplicableNonInteractiveRefactorInfo[];
+    function getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractive?: boolean): ApplicableRefactorInfo[];
+    function getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined = emptyOptions, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractive?: boolean): ApplicableRefactorInfo[] {
         synchronizeHostData();
         const file = getValidSourceFile(fileName);
-        return refactor.getApplicableRefactors(getRefactorContext(file, positionOrRange, preferences, emptyOptions, triggerReason, kind));
+        return refactor.getApplicableRefactors(getRefactorContext(file, positionOrRange, preferences, emptyOptions, triggerReason, kind), includeInteractive);
     }
 
     function getEditsForRefactor(
         fileName: string,
         formatOptions: FormatCodeSettings,
         positionOrRange: number | TextRange,
-        refactorName: string,
+        refactorName: RefactorName,
         actionName: string,
         preferences: UserPreferences = emptyOptions,
+        ...args: unknown[]
     ): RefactorEditInfo | undefined {
         synchronizeHostData();
         const file = getValidSourceFile(fileName);
-        return refactor.getEditsForRefactor(getRefactorContext(file, positionOrRange, preferences, formatOptions), refactorName, actionName);
+        return refactor.getEditsForRefactor(getRefactorContext(file, positionOrRange, preferences, formatOptions), refactorName, actionName, ...args);
     }
 
     function toLineColumnOffset(fileName: string, position: number): LineAndCharacter {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -631,6 +631,11 @@ export interface LanguageService {
     applyCodeActionCommand(fileName: string, action: CodeActionCommand | CodeActionCommand[]): Promise<ApplyCodeActionCommandResult | ApplyCodeActionCommandResult[]>;
 
     getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string): ApplicableRefactorInfo[];
+    getEditsForRefactor<Name extends RefactorName>(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: Name, actionName: string, preferences: UserPreferences | undefined, ...args: RefactorHandlerArgs<Name>): RefactorEditInfo | undefined;
+    /**
+     * @deprecated
+     * As of TypeScript 5.1, some refactors may require an additional argument.
+     */
     getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined): RefactorEditInfo | undefined;
     organizeImports(args: OrganizeImportsArgs, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): readonly FileTextChanges[];
     getEditsForFileRename(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): readonly FileTextChanges[];
@@ -911,6 +916,40 @@ export interface InstallPackageAction {
     /** @internal */ readonly packageName: string;
 }
 
+export const enum RefactorName {
+    AddOrRemoveBracesToArrowFunction = "Add or remove braces in an arrow function",
+    ConvertArrowFunctionOrFunctionExpression = "Convert arrow function or function expression",
+    ConvertExport = "Convert export",
+    ConvertImport = "Convert import",
+    ConvertOverloadListToSingleSignature = "Convert overload list to single signature",
+    ConvertParamsToDestructuredObject = "Convert parameters to destructured object",
+    ConvertStringOrTemplateLiteral = "Convert to template string",
+    ConvertToOptionalChainExpression = "Convert to optional chain expression",
+    ExtractSymbol = "Extract Symbol",
+    ExtractType = "Extract type",
+    GenerateGetAccessorAndSetAccessor = "Generate 'get' and 'set' accessors",
+    InferFunctionReturnType = "Infer function return type",
+    MoveToNewFile = "Move to a new file",
+}
+
+interface RefactorHandlerMap {
+    [RefactorName.AddOrRemoveBracesToArrowFunction]: () => void;
+    [RefactorName.ConvertArrowFunctionOrFunctionExpression]: () => void;
+    [RefactorName.ConvertExport]: () => void;
+    [RefactorName.ConvertImport]: () => void;
+    [RefactorName.ConvertOverloadListToSingleSignature]: () => void;
+    [RefactorName.ConvertParamsToDestructuredObject]: () => void;
+    [RefactorName.ConvertStringOrTemplateLiteral]: () => void;
+    [RefactorName.ConvertToOptionalChainExpression]: () => void;
+    [RefactorName.ExtractSymbol]: () => void;
+    [RefactorName.ExtractType]: () => void;
+    [RefactorName.GenerateGetAccessorAndSetAccessor]: () => void;
+    [RefactorName.InferFunctionReturnType]: () => void;
+    [RefactorName.MoveToNewFile]: () => void;
+}
+
+type RefactorHandlerArgs<T extends RefactorName> = RefactorHandlerMap[T] extends (...args: infer A) => void ? A : never;
+
 /**
  * A set of one or more available refactoring actions, grouped under a parent refactoring.
  */
@@ -918,7 +957,7 @@ export interface ApplicableRefactorInfo {
     /**
      * The programmatic name of the refactoring
      */
-    name: string;
+    name: RefactorName;
     /**
      * A description of this refactoring category to show to the user.
      * If the refactoring gets inlined (see below), this text will not be visible.

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -501,23 +501,24 @@ declare namespace ts {
             type GetApplicableRefactorsRequestArgs = FileLocationOrRangeRequestArgs & {
                 triggerReason?: RefactorTriggerReason;
                 kind?: string;
+                includeInteractive?: boolean;
             };
             type RefactorTriggerReason = "implicit" | "invoked";
             /**
              * Response is a list of available refactorings.
              * Each refactoring exposes one or more "Actions"; a user selects one action to invoke a refactoring
              */
-            interface GetApplicableRefactorsResponse extends Response {
-                body?: ApplicableRefactorInfo[];
+            interface GetApplicableRefactorsResponse<TRefactorInfo extends ApplicableRefactorInfo = ApplicableRefactorInfo> extends Response {
+                body?: TRefactorInfo[];
             }
             /**
              * A set of one or more available refactoring actions, grouped under a parent refactoring.
              */
-            interface ApplicableRefactorInfo {
+            interface BaseApplicableRefactorInfo {
                 /**
                  * The programmatic name of the refactoring
                  */
-                name: string;
+                name: RefactorName;
                 /**
                  * A description of this refactoring category to show to the user.
                  * If the refactoring gets inlined (see below), this text will not be visible.
@@ -533,6 +534,13 @@ declare namespace ts {
                 inlineable?: boolean;
                 actions: RefactorActionInfo[];
             }
+            interface ApplicableNonInteractiveRefactorInfo extends BaseApplicableRefactorInfo {
+                name: NonInteractiveRefactorName;
+            }
+            interface ApplicableInteractiveRefactorInfo extends BaseApplicableRefactorInfo {
+                name: InteractiveRefactorName;
+            }
+            type ApplicableRefactorInfo = ApplicableNonInteractiveRefactorInfo | ApplicableInteractiveRefactorInfo;
             /**
              * Represents a single refactoring action - for example, the "Extract Method..." refactor might
              * offer several actions, each corresponding to a surround class or closure to extract into.
@@ -10117,7 +10125,29 @@ declare namespace ts {
         applyCodeActionCommand(fileName: string, action: CodeActionCommand[]): Promise<ApplyCodeActionCommandResult[]>;
         /** @deprecated `fileName` will be ignored */
         applyCodeActionCommand(fileName: string, action: CodeActionCommand | CodeActionCommand[]): Promise<ApplyCodeActionCommandResult | ApplyCodeActionCommandResult[]>;
-        getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string): ApplicableRefactorInfo[];
+        getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractive?: false): ApplicableNonInteractiveRefactorInfo[];
+        getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractive?: boolean): ApplicableRefactorInfo[];
+        getEditsForRefactor<Name extends InteractiveRefactorName>(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: Name, actionName: string, preferences: UserPreferences | undefined, ...args: RefactorArgs<Name>): RefactorEditInfo | undefined;
+        getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: NonInteractiveRefactorName, actionName: string, preferences: UserPreferences | undefined): RefactorEditInfo | undefined;
+        /**
+         * @deprecated
+         * As of TypeScript 5.1, some refactors may require an additional argument.
+         * If the `isInteractive` property of the `ApplicableRefactorInfo` object is `true`,
+         * getting edits for the refactor will require a specific argument linked to its name:
+         *
+         * ```ts
+         * if (refactor.isInteractive) {
+         *   if (refactor.name === ts.InteractiveRefactorName.MoveToFile) {
+         *     const action = getAction(refactor);
+         *     const edits = ls.getEditsForRefactor(fileName, formatOptions, positionOrRange, refactor.name, action.name, preferences, {
+         *       targetFile: await askUserForTargetFileName()
+         *     });
+         *   }
+         * } else {
+         *   const edits = ls.getEditsForRefactor(...)
+         * }
+         * ```
+         */
         getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined): RefactorEditInfo | undefined;
         organizeImports(args: OrganizeImportsArgs, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): readonly FileTextChanges[];
         getEditsForFileRename(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): readonly FileTextChanges[];
@@ -10342,14 +10372,38 @@ declare namespace ts {
     type CodeActionCommand = InstallPackageAction;
     interface InstallPackageAction {
     }
+    enum NonInteractiveRefactorName {
+        AddOrRemoveBracesToArrowFunction = "Add or remove braces in an arrow function",
+        ConvertArrowFunctionOrFunctionExpression = "Convert arrow function or function expression",
+        ConvertExport = "Convert export",
+        ConvertImport = "Convert import",
+        ConvertOverloadListToSingleSignature = "Convert overload list to single signature",
+        ConvertParamsToDestructuredObject = "Convert parameters to destructured object",
+        ConvertStringOrTemplateLiteral = "Convert to template string",
+        ConvertToOptionalChainExpression = "Convert to optional chain expression",
+        ExtractSymbol = "Extract Symbol",
+        ExtractType = "Extract type",
+        GenerateGetAccessorAndSetAccessor = "Generate 'get' and 'set' accessors",
+        InferFunctionReturnType = "Infer function return type",
+        MoveToNewFile = "Move to a new file"
+    }
+    enum InteractiveRefactorName {
+        MoveToFile = "Move to file"
+    }
+    type RefactorName = NonInteractiveRefactorName | InteractiveRefactorName;
+    type RefactorArgs<T extends InteractiveRefactorName> = {
+        [InteractiveRefactorName.MoveToFile]: (args: {
+            targetFile: string;
+        }) => void;
+    }[T] extends (...args: infer A) => void ? A : never;
     /**
      * A set of one or more available refactoring actions, grouped under a parent refactoring.
      */
-    interface ApplicableRefactorInfo {
+    interface BaseApplicableRefactorInfo {
         /**
          * The programmatic name of the refactoring
          */
-        name: string;
+        name: RefactorName;
         /**
          * A description of this refactoring category to show to the user.
          * If the refactoring gets inlined (see below), this text will not be visible.
@@ -10365,6 +10419,13 @@ declare namespace ts {
         inlineable?: boolean;
         actions: RefactorActionInfo[];
     }
+    interface ApplicableNonInteractiveRefactorInfo extends BaseApplicableRefactorInfo {
+        name: NonInteractiveRefactorName;
+    }
+    interface ApplicableInteractiveRefactorInfo extends BaseApplicableRefactorInfo {
+        name: InteractiveRefactorName;
+    }
+    type ApplicableRefactorInfo = ApplicableNonInteractiveRefactorInfo | ApplicableInteractiveRefactorInfo;
     /**
      * Represents a single refactoring action - for example, the "Extract Method..." refactor might
      * offer several actions, each corresponding to a surround class or closure to extract into.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

#53542 introduces a refactor that requires an extra argument beyond what any existing refactor needs: the file name the user wants to move code to. VS Code implemented support for this via an interactive dialog with the user. Other TS Server clients and language service consumers will need to implement some way of obtaining this information too, and ensure they provide it when calling `getEditsForRefactor`.

This breaks the existing contract that clients have with refactors, which is that anything returned from `getApplicableRefactors` can be executed right away, with no additional context. If #53542 were merged as-is, any existing clients that simply call `getApplicableRefactors`, allow the user to select one, and call `getEditsForRefactor` with the one selected, will break. At minimum, we need to avoid returning any refactors that require additional arguments by default. A secondary goal is to ensure that when clients do opt into receiving refactors that require additional handling, the API ensures they send the correct arguments for the correct refactor.

This PR shows a possible method for doing both. Refactor names are migrated from opaque `string`s to literals from either `NonInteractiveRefactorName` or `InteractiveRefactorName` const enums. `ApplicableRefactorInfo` is then split into a union of interactive and non-interactive flavors, and `getApplicableRefactors` gets an additional parameter `includeInteractive` that gets used in overloads to control the return type. Existing code, lacking the `includeInteractive` parameter, will hit an overload that returns non-interactive refactors, which can then be passed to `getEditsForRefactor` as usual without any additional arguments. If the `includeInteractive` parameter is included, though, the refactors returned will prevent `getEditsForRefactor` from being called without discriminating on `refactor.isInteractive` and/or `refactor.name` to ensure the correct argument is passed. (A similar system ensures consistency between this external API and internal `registerRefactor` calls.) Finally, a deprecated catch-all overload for `getEditsForRefactor` has the old signature where refactor names are plain `string`s, so as not to break (but to warn) anyone who’s calling the API with a refactor name that didn’t come straight from the `getApplicableRefactors` return value.

This approach does come with a bit of cognitive overhead—hopefully mostly for us and less for API consumers—and would best serve a scenario where we continue to introduce more interactive refactors like Move To File in the future. Alternative approaches:

1. Make Move-To-File-specific language service methods and TS Server commands, like #53542 already does, but with a `getMoveToFileRefactorInfo` too, to replace `getApplicableRefactorInfo`
2. Slap the `includeInteractive` or `includeMoveToFile` parameter onto `getApplicableRefactors` like this PR does, but do nothing to try to add type safety between that response and `getEditsForRefactor`, and say that if you’re going to pass `includeInteractive`, you just have to make sure you call and pass the right stuff on your own.

Note that the TS Server protocol side of this PR is somewhat incomplete. I wanted to get feedback on what direction we want to go first.