### PR TITLE
Prefer parameter types inferred from initializers over their contextual types within `satisfies` expressions

### DIFF
--- a/tests/baselines/reference/typeSatisfaction_contextualTyping3.symbols
+++ b/tests/baselines/reference/typeSatisfaction_contextualTyping3.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/53780
+
+const obj = {
+>obj : Symbol(obj, Decl(typeSatisfaction_contextualTyping3.ts, 2, 5))
+
+   foo: (param = "default") => param,
+>foo : Symbol(foo, Decl(typeSatisfaction_contextualTyping3.ts, 2, 13))
+>param : Symbol(param, Decl(typeSatisfaction_contextualTyping3.ts, 3, 9))
+>param : Symbol(param, Decl(typeSatisfaction_contextualTyping3.ts, 3, 9))
+
+} satisfies {
+   [key: string]: (...params: any) => any;
+>key : Symbol(key, Decl(typeSatisfaction_contextualTyping3.ts, 5, 4))
+>params : Symbol(params, Decl(typeSatisfaction_contextualTyping3.ts, 5, 19))
+
+};

--- a/tests/baselines/reference/typeSatisfaction_contextualTyping3.types
+++ b/tests/baselines/reference/typeSatisfaction_contextualTyping3.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/53780
+
+const obj = {
+>obj : { foo: (param?: string) => string; }
+>{   foo: (param = "default") => param,} satisfies {   [key: string]: (...params: any) => any;} : { foo: (param?: string) => string; }
+>{   foo: (param = "default") => param,} : { foo: (param?: string) => string; }
+
+   foo: (param = "default") => param,
+>foo : (param?: string) => string
+>(param = "default") => param : (param?: string) => string
+>param : string
+>"default" : "default"
+>param : string
+
+} satisfies {
+   [key: string]: (...params: any) => any;
+>key : string
+>params : any
+
+};

--- a/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
+++ b/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
@@ -1,0 +1,10 @@
+// @strict: true
+// @noEmit: true
+
+// repro from https://github.com/microsoft/TypeScript/issues/53780
+
+const obj = {
+   foo: (param = "default") => param,
+} satisfies {
+   [key: string]: (...params: any) => any;
+};


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/53780