### PR TITLE
feat(7411) - Replace helper to get namespaced name

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -89,7 +89,7 @@ import {
     getEnclosingBlockScopeContainer,
     getErrorSpanForNode,
     getEscapedTextOfIdentifierOrLiteral,
-    getEscapedTextOfJsxAttributeName,
+    getEscapedTextOfJsxNamespacedName,
     getExpandoInitializer,
     getHostSignatureFromJSDoc,
     getImmediatelyInvokedFunctionExpression,
@@ -682,7 +682,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 return getSymbolNameForPrivateIdentifier(containingClassSymbol, name.escapedText);
             }
             if (isJsxNamespacedName(name)) {
-                return getEscapedTextOfJsxAttributeName(name);
+                return getEscapedTextOfJsxNamespacedName(name);
             }
             return isPropertyNameLiteral(name) ? getEscapedTextOfIdentifierOrLiteral(name) : undefined;
         }


### PR DESCRIPTION
The implementation has been updated to retrieve only the namespaced name, eliminating the use of the helper function that previously resolved both Identifier and namespaced name which is useless.