### PR TITLE
Add tests for importing types from `.d.ts` with explicit extension

### DIFF
--- a/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
+++ b/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
@@ -1,0 +1,19 @@
+// @allowImportingTsExtensions: true,false
+// @noEmit: true
+// @moduleResolution: classic,node10,node16,nodenext
+// @noTypesAndSymbols: true
+
+// @Filename: /types.d.ts
+export declare type User = {
+    name: string;
+}
+
+// @Filename: /a.ts
+import type { User } from "./types.d.ts";
+export type { User } from "./types.d.ts";
+
+export const user: User = { name: "John" };
+
+export function getUser(): import("./types.d.ts").User {
+    return user;
+}


### PR DESCRIPTION
As far as I can tell this works since https://github.com/microsoft/TypeScript/pull/52595 and it's expected to work. I very much intend to rely on this behavior for all available module resolution types so it would be great to have an extra test case for this.

cc @andrewbranch 