### PR TITLE
Declare typingsInstaller as optional for ProjectService

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -579,7 +579,7 @@ export interface ProjectServiceOptions {
     cancellationToken: HostCancellationToken;
     useSingleInferredProject: boolean;
     useInferredProjectPerProjectRoot: boolean;
-    typingsInstaller: ITypingsInstaller;
+    typingsInstaller?: ITypingsInstaller;
     eventHandler?: ProjectServiceEventHandler;
     suppressDiagnosticEvents?: boolean;
     throttleWaitMilliseconds?: number;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -161,6 +161,7 @@ import {
     LogLevel,
     Msg,
     NormalizedPath,
+    nullTypingsInstaller,
     Project,
     ProjectInfoTelemetryEvent,
     ProjectKind,
@@ -926,7 +927,7 @@ export interface SessionOptions {
     cancellationToken: ServerCancellationToken;
     useSingleInferredProject: boolean;
     useInferredProjectPerProjectRoot: boolean;
-    typingsInstaller: ITypingsInstaller;
+    typingsInstaller?: ITypingsInstaller;
     byteLength: (buf: string, encoding?: BufferEncoding) => number;
     hrtime: (start?: [number, number]) => [number, number];
     logger: Logger;
@@ -972,7 +973,7 @@ export class Session<TMessage = string> implements EventSender {
     constructor(opts: SessionOptions) {
         this.host = opts.host;
         this.cancellationToken = opts.cancellationToken;
-        this.typingsInstaller = opts.typingsInstaller;
+        this.typingsInstaller = opts.typingsInstaller || nullTypingsInstaller;
         this.byteLength = opts.byteLength;
         this.hrtime = opts.hrtime;
         this.logger = opts.logger;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3554,7 +3554,7 @@ declare namespace ts {
             cancellationToken: HostCancellationToken;
             useSingleInferredProject: boolean;
             useInferredProjectPerProjectRoot: boolean;
-            typingsInstaller: ITypingsInstaller;
+            typingsInstaller?: ITypingsInstaller;
             eventHandler?: ProjectServiceEventHandler;
             suppressDiagnosticEvents?: boolean;
             throttleWaitMilliseconds?: number;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3826,7 +3826,7 @@ declare namespace ts {
             cancellationToken: ServerCancellationToken;
             useSingleInferredProject: boolean;
             useInferredProjectPerProjectRoot: boolean;
-            typingsInstaller: ITypingsInstaller;
+            typingsInstaller?: ITypingsInstaller;
             byteLength: (buf: string, encoding?: BufferEncoding) => number;
             hrtime: (start?: [
                 number,


### PR DESCRIPTION
Fixes #53803, see https://github.com/typescript-eslint/typescript-eslint/pull/6754/files#r1161949194

The code already handled `undefined`.