### PR TITLE
Treat `TemplateExpression` as possibly discriminant values

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29289,6 +29289,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.NumericLiteral:
             case SyntaxKind.BigIntLiteral:
             case SyntaxKind.NoSubstitutionTemplateLiteral:
+            case SyntaxKind.TemplateExpression:
             case SyntaxKind.TrueKeyword:
             case SyntaxKind.FalseKeyword:
             case SyntaxKind.NullKeyword:

--- a/tests/baselines/reference/templateExpressionAsPossiblyDiscriminantValue.symbols
+++ b/tests/baselines/reference/templateExpressionAsPossiblyDiscriminantValue.symbols
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/templateExpressionAsPossiblyDiscriminantValue.ts ===
+// repro mentioned in https://github.com/microsoft/TypeScript/issues/53888
+
+type BiomePlainLinkProps = {
+>BiomePlainLinkProps : Symbol(BiomePlainLinkProps, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 0, 0))
+
+  href: string;
+>href : Symbol(href, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 2, 28))
+
+  onClick?: (event: string) => void;
+>onClick : Symbol(onClick, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 3, 15))
+>event : Symbol(event, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 4, 13))
+}
+
+type BiomeButtonProps = {
+>BiomeButtonProps : Symbol(BiomeButtonProps, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 5, 1))
+
+  href?: never;
+>href : Symbol(href, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 7, 25))
+
+  onClick?: (event: number) => void;
+>onClick : Symbol(onClick, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 8, 15))
+>event : Symbol(event, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 9, 13))
+}
+
+export type ClickableDiscriminatedUnion =
+>ClickableDiscriminatedUnion : Symbol(ClickableDiscriminatedUnion, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 10, 1))
+
+  | BiomePlainLinkProps
+>BiomePlainLinkProps : Symbol(BiomePlainLinkProps, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 0, 0))
+
+  | BiomeButtonProps;
+>BiomeButtonProps : Symbol(BiomeButtonProps, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 5, 1))
+
+const p3: ClickableDiscriminatedUnion = {
+>p3 : Symbol(p3, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 16, 5))
+>ClickableDiscriminatedUnion : Symbol(ClickableDiscriminatedUnion, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 10, 1))
+
+  href: `2${undefined}332132`,
+>href : Symbol(href, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 16, 41))
+>undefined : Symbol(undefined)
+
+  onClick: (ev) => console.log('@@@@', ev),
+>onClick : Symbol(onClick, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 17, 30))
+>ev : Symbol(ev, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 18, 12))
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(templateExpressionAsPossiblyDiscriminantValue.ts, 18, 12))
+}
+

--- a/tests/baselines/reference/templateExpressionAsPossiblyDiscriminantValue.types
+++ b/tests/baselines/reference/templateExpressionAsPossiblyDiscriminantValue.types
@@ -1,0 +1,52 @@
+=== tests/cases/compiler/templateExpressionAsPossiblyDiscriminantValue.ts ===
+// repro mentioned in https://github.com/microsoft/TypeScript/issues/53888
+
+type BiomePlainLinkProps = {
+>BiomePlainLinkProps : { href: string; onClick?: ((event: string) => void) | undefined; }
+
+  href: string;
+>href : string
+
+  onClick?: (event: string) => void;
+>onClick : ((event: string) => void) | undefined
+>event : string
+}
+
+type BiomeButtonProps = {
+>BiomeButtonProps : { href?: undefined; onClick?: ((event: number) => void) | undefined; }
+
+  href?: never;
+>href : undefined
+
+  onClick?: (event: number) => void;
+>onClick : ((event: number) => void) | undefined
+>event : number
+}
+
+export type ClickableDiscriminatedUnion =
+>ClickableDiscriminatedUnion : BiomePlainLinkProps | BiomeButtonProps
+
+  | BiomePlainLinkProps
+  | BiomeButtonProps;
+
+const p3: ClickableDiscriminatedUnion = {
+>p3 : ClickableDiscriminatedUnion
+>{  href: `2${undefined}332132`,  onClick: (ev) => console.log('@@@@', ev),} : { href: string; onClick: (ev: string) => void; }
+
+  href: `2${undefined}332132`,
+>href : string
+>`2${undefined}332132` : string
+>undefined : undefined
+
+  onClick: (ev) => console.log('@@@@', ev),
+>onClick : (ev: string) => void
+>(ev) => console.log('@@@@', ev) : (ev: string) => void
+>ev : string
+>console.log('@@@@', ev) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>'@@@@' : "@@@@"
+>ev : string
+}
+

--- a/tests/cases/compiler/templateExpressionAsPossiblyDiscriminantValue.ts
+++ b/tests/cases/compiler/templateExpressionAsPossiblyDiscriminantValue.ts
@@ -1,0 +1,23 @@
+// @strict: true
+// @noEmit: true
+
+// repro mentioned in https://github.com/microsoft/TypeScript/issues/53888
+
+type BiomePlainLinkProps = {
+  href: string;
+  onClick?: (event: string) => void;
+}
+
+type BiomeButtonProps = {
+  href?: never;
+  onClick?: (event: number) => void;
+}
+
+export type ClickableDiscriminatedUnion =
+  | BiomePlainLinkProps
+  | BiomeButtonProps;
+
+const p3: ClickableDiscriminatedUnion = {
+  href: `2${undefined}332132`,
+  onClick: (ev) => console.log('@@@@', ev),
+}


### PR DESCRIPTION
fixes the case based on which https://github.com/microsoft/TypeScript/issues/53888 was created but it doesn't fix the case with which it was created 😅 