### PR TITLE
fix(53919): Cannot read properties of undefined (reading 'flags') in returnValueCorrect

### DIFF
--- a/src/services/codefixes/returnValueCorrect.ts
+++ b/src/services/codefixes/returnValueCorrect.ts
@@ -219,6 +219,7 @@ function getInfo(checker: TypeChecker, sourceFile: SourceFile, position: number,
         case Diagnostics.Argument_of_type_0_is_not_assignable_to_parameter_of_type_1.code:
             if (!declaration || !isCallExpression(declaration.parent) || !declaration.body) return undefined;
             const pos = declaration.parent.arguments.indexOf(declaration as Expression);
+            if (pos === -1) return undefined;
             const type = checker.getContextualTypeForArgumentAtIndex(declaration.parent, pos);
             if (!type) return undefined;
             return getFixInfo(checker, declaration, type, /*isFunctionType*/ true);

--- a/tests/cases/fourslash/codeFixCorrectReturnValue28.ts
+++ b/tests/cases/fourslash/codeFixCorrectReturnValue28.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+
+// @strict: true
+
+// @Filename: test.ts
+//// (function() {
+////   const config = {
+////     values: [],
+////     value: {},
+////   };
+////
+////   config.values.push(config.value);
+//// }());
+
+goTo.file('test.ts');
+
+verify.getSemanticDiagnostics([{
+    code: 2345,
+    message: "Argument of type '{}' is not assignable to parameter of type 'never'.",
+    range: { pos: 91, end: 103,fileName: "test.ts" }
+}]);
+
+verify.not.codeFixAvailable();


### PR DESCRIPTION
Fixes `Cannot read properties of undefined (reading 'flags')` happening because of missing validation of `declaration.parent.arguments` `pos` in `getInfo` function of `returnValueCorrect` codefix.

Fixes #53919
