### PR TITLE
Add extra tests for contextual typing of unannotated parameters with default initializers

### DIFF
--- a/tests/baselines/reference/typeSatisfaction_contextualTyping3.symbols
+++ b/tests/baselines/reference/typeSatisfaction_contextualTyping3.symbols
@@ -1,0 +1,49 @@
+=== tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts ===
+// see https://github.com/microsoft/TypeScript/issues/53920#issuecomment-1516616255
+
+const obj = {
+>obj : Symbol(obj, Decl(typeSatisfaction_contextualTyping3.ts, 2, 5))
+
+   foo: (param = "default") => param,
+>foo : Symbol(foo, Decl(typeSatisfaction_contextualTyping3.ts, 2, 13))
+>param : Symbol(param, Decl(typeSatisfaction_contextualTyping3.ts, 3, 9))
+>param : Symbol(param, Decl(typeSatisfaction_contextualTyping3.ts, 3, 9))
+
+} satisfies {
+   [key: string]: (...params: any) => any;
+>key : Symbol(key, Decl(typeSatisfaction_contextualTyping3.ts, 5, 4))
+>params : Symbol(params, Decl(typeSatisfaction_contextualTyping3.ts, 5, 19))
+
+};
+
+const obj2 = {
+>obj2 : Symbol(obj2, Decl(typeSatisfaction_contextualTyping3.ts, 8, 5))
+
+   foo: (param = "default") => param,
+>foo : Symbol(foo, Decl(typeSatisfaction_contextualTyping3.ts, 8, 14))
+>param : Symbol(param, Decl(typeSatisfaction_contextualTyping3.ts, 9, 9))
+>param : Symbol(param, Decl(typeSatisfaction_contextualTyping3.ts, 9, 9))
+
+} satisfies {
+   [key: string]: Function;
+>key : Symbol(key, Decl(typeSatisfaction_contextualTyping3.ts, 11, 4))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+};
+
+type StringOrNumberFunc = (x: string | number) => any;
+>StringOrNumberFunc : Symbol(StringOrNumberFunc, Decl(typeSatisfaction_contextualTyping3.ts, 12, 2))
+>x : Symbol(x, Decl(typeSatisfaction_contextualTyping3.ts, 14, 27))
+
+const fn = ((x = "ok") => null) satisfies StringOrNumberFunc;
+>fn : Symbol(fn, Decl(typeSatisfaction_contextualTyping3.ts, 16, 5))
+>x : Symbol(x, Decl(typeSatisfaction_contextualTyping3.ts, 16, 13))
+>StringOrNumberFunc : Symbol(StringOrNumberFunc, Decl(typeSatisfaction_contextualTyping3.ts, 12, 2))
+
+fn();
+>fn : Symbol(fn, Decl(typeSatisfaction_contextualTyping3.ts, 16, 5))
+
+fn(32);
+>fn : Symbol(fn, Decl(typeSatisfaction_contextualTyping3.ts, 16, 5))
+
+

--- a/tests/baselines/reference/typeSatisfaction_contextualTyping3.types
+++ b/tests/baselines/reference/typeSatisfaction_contextualTyping3.types
@@ -1,0 +1,62 @@
+=== tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts ===
+// see https://github.com/microsoft/TypeScript/issues/53920#issuecomment-1516616255
+
+const obj = {
+>obj : { foo: (param?: any) => any; }
+>{   foo: (param = "default") => param,} satisfies {   [key: string]: (...params: any) => any;} : { foo: (param?: any) => any; }
+>{   foo: (param = "default") => param,} : { foo: (param?: any) => any; }
+
+   foo: (param = "default") => param,
+>foo : (param?: any) => any
+>(param = "default") => param : (param?: any) => any
+>param : any
+>"default" : "default"
+>param : any
+
+} satisfies {
+   [key: string]: (...params: any) => any;
+>key : string
+>params : any
+
+};
+
+const obj2 = {
+>obj2 : { foo: (param?: string) => string; }
+>{   foo: (param = "default") => param,} satisfies {   [key: string]: Function;} : { foo: (param?: string) => string; }
+>{   foo: (param = "default") => param,} : { foo: (param?: string) => string; }
+
+   foo: (param = "default") => param,
+>foo : (param?: string) => string
+>(param = "default") => param : (param?: string) => string
+>param : string
+>"default" : "default"
+>param : string
+
+} satisfies {
+   [key: string]: Function;
+>key : string
+
+};
+
+type StringOrNumberFunc = (x: string | number) => any;
+>StringOrNumberFunc : (x: string | number) => any
+>x : string | number
+
+const fn = ((x = "ok") => null) satisfies StringOrNumberFunc;
+>fn : (x?: string | number) => null
+>((x = "ok") => null) satisfies StringOrNumberFunc : (x?: string | number) => null
+>((x = "ok") => null) : (x?: string | number) => null
+>(x = "ok") => null : (x?: string | number) => null
+>x : string | number
+>"ok" : "ok"
+
+fn();
+>fn() : null
+>fn : (x?: string | number) => null
+
+fn(32);
+>fn(32) : null
+>fn : (x?: string | number) => null
+>32 : 32
+
+

--- a/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
+++ b/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
@@ -1,0 +1,23 @@
+// @strict: true
+// @noEmit: true
+
+// see https://github.com/microsoft/TypeScript/issues/53920#issuecomment-1516616255
+
+const obj = {
+   foo: (param = "default") => param,
+} satisfies {
+   [key: string]: (...params: any) => any;
+};
+
+const obj2 = {
+   foo: (param = "default") => param,
+} satisfies {
+   [key: string]: Function;
+};
+
+type StringOrNumberFunc = (x: string | number) => any;
+
+const fn = ((x = "ok") => null) satisfies StringOrNumberFunc;
+fn();
+fn(32);
+


### PR DESCRIPTION
just codifying the outcome of the discussion [here](https://github.com/microsoft/TypeScript/issues/53920#issuecomment-1516616255) in the test suite :)