### PR TITLE
Refactor plugin related code

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -28,6 +28,7 @@ import {
     matchesExclude,
     matchFiles,
     memoize,
+    ModuleImportResult,
     noop,
     normalizePath,
     normalizeSlashes,
@@ -35,7 +36,6 @@ import {
     Path,
     perfLogger,
     PollingWatchKind,
-    RequireResult,
     resolveJSModule,
     some,
     startsWith,
@@ -1428,7 +1428,7 @@ export interface System {
     base64decode?(input: string): string;
     base64encode?(input: string): string;
     /** @internal */ bufferFrom?(input: string, encoding?: string): Buffer;
-    /** @internal */ require?(baseDir: string, moduleName: string): RequireResult;
+    /** @internal */ require?(baseDir: string, moduleName: string): ModuleImportResult;
 
     // For testing
     /** @internal */ now?(): Date;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7371,7 +7371,7 @@ export interface ConfigFileSpecs {
 }
 
 /** @internal */
-export type RequireResult<T = {}> =
+export type ModuleImportResult<T = {}> =
     | { module: T, modulePath?: string, error: undefined }
     | { module: undefined, modulePath?: undefined, error: { stack?: string, message?: string } };
 

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -885,7 +885,7 @@ class SessionServerHost implements ts.server.ServerHost, ts.server.Logger {
         return mockHash(s);
     }
 
-    require(_initialDir: string, _moduleName: string): ts.RequireResult {
+    require(_initialDir: string, _moduleName: string): ts.ModuleImportResult {
         switch (_moduleName) {
             // Adds to the Quick Info a fixed string and a string from the config file
             // and replaces the first display part

--- a/src/testRunner/unittests/helpers/virtualFileSystemWithWatch.ts
+++ b/src/testRunner/unittests/helpers/virtualFileSystemWithWatch.ts
@@ -31,13 +31,13 @@ import {
     isString,
     mapDefined,
     matchFiles,
+    ModuleImportResult,
     ModuleResolutionHost,
     MultiMap,
     noop,
     patchWriteFileEnsuringDirectory,
     Path,
     PollingInterval,
-    RequireResult,
     server,
     SortedArray,
     sys,
@@ -292,7 +292,7 @@ export class TestServerHost implements server.ServerHost, FormatDiagnosticsHost,
     private readonly environmentVariables?: Map<string, string>;
     private readonly executingFilePath: string;
     private readonly currentDirectory: string;
-    public require: ((initialPath: string, moduleName: string) => RequireResult) | undefined;
+    public require: ((initialPath: string, moduleName: string) => ModuleImportResult) | undefined;
     public storeFilesChangingSignatureDuringEmit = true;
     watchFile: HostWatchFile;
     private inodeWatching: boolean | undefined;

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -20,7 +20,6 @@ import {
     normalizePath,
     normalizeSlashes,
     perfLogger,
-    resolveJSModule,
     SortedReadonlyArray,
     startTracing,
     stripQuotes,
@@ -57,7 +56,6 @@ import {
     ITypingsInstaller,
     Logger,
     LogLevel,
-    ModuleImportResult,
     Msg,
     nowString,
     nullCancellationToken,
@@ -380,15 +378,6 @@ export function initializeNodeSystem(): StartInput {
     if (typeof global !== "undefined" && global.gc) {
         sys.gc = () => global.gc?.();
     }
-
-    sys.require = (initialDir: string, moduleName: string): ModuleImportResult => {
-        try {
-            return { module: require(resolveJSModule(moduleName, initialDir, sys)), error: undefined };
-        }
-        catch (error) {
-            return { module: undefined, error };
-        }
-    };
 
     let cancellationToken: ServerCancellationToken;
     try {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3254,7 +3254,7 @@ declare namespace ts {
             private readonly cancellationToken;
             isNonTsProject(): boolean;
             isJsOnlyProject(): boolean;
-            static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void, logErrors?: (message: string) => void): {} | undefined;
+            static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void): {} | undefined;
             isKnownTypesPackageName(name: string): boolean;
             installPackage(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult>;
             private get typingsCache();
@@ -3343,7 +3343,6 @@ declare namespace ts {
             protected removeRoot(info: ScriptInfo): void;
             protected enableGlobalPlugins(options: CompilerOptions): void;
             protected enablePlugin(pluginConfigEntry: PluginImport, searchPaths: string[]): void;
-            private enableProxy;
             /** Starts a new check for diagnostics. Call this if some file has updated that would cause diagnostics to be changed. */
             refreshDiagnostics(): void;
         }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3341,8 +3341,8 @@ declare namespace ts {
             setTypeAcquisition(newTypeAcquisition: TypeAcquisition | undefined): void;
             getTypeAcquisition(): ts.TypeAcquisition;
             protected removeRoot(info: ScriptInfo): void;
-            protected enableGlobalPlugins(options: CompilerOptions, pluginConfigOverrides: Map<string, any> | undefined): void;
-            protected enablePlugin(pluginConfigEntry: PluginImport, searchPaths: string[], pluginConfigOverrides: Map<string, any> | undefined): void;
+            protected enableGlobalPlugins(options: CompilerOptions): void;
+            protected enablePlugin(pluginConfigEntry: PluginImport, searchPaths: string[]): void;
             private enableProxy;
             /** Starts a new check for diagnostics. Call this if some file has updated that would cause diagnostics to be changed. */
             refreshDiagnostics(): void;
@@ -3644,7 +3644,6 @@ declare namespace ts {
             readonly globalPlugins: readonly string[];
             readonly pluginProbeLocations: readonly string[];
             readonly allowLocalPluginLoads: boolean;
-            private currentPluginConfigOverrides;
             readonly typesMapLocation: string | undefined;
             readonly serverMode: LanguageServiceMode;
             /** Tracks projects that we have already sent telemetry for. */


### PR DESCRIPTION
- Simplifies code for plugin by moving it to project service for doing sync or async module load, avoids having to pass around parameters that are already available in `this`
- Project does the actual factory invocations
- Renamed internal interface to match server interface