### PR TITLE
fix(53933): Confusing rules around function parameter names in a type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40928,7 +40928,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             forEach(node.name.elements, checkSourceElement);
         }
         // For a parameter declaration with an initializer, error and exit if the containing function doesn't have a body
-        if (isParameter(node) && node.initializer && nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)) {
+        if (hasInitializer(node) && isParameterDeclaration(node) && nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)) {
             error(node, Diagnostics.A_parameter_initializer_is_only_allowed_in_a_function_or_constructor_implementation);
             return;
         }

--- a/tests/baselines/reference/defaultValueInFunctionTypes.errors.txt
+++ b/tests/baselines/reference/defaultValueInFunctionTypes.errors.txt
@@ -1,11 +1,17 @@
-tests/cases/compiler/defaultValueInFunctionTypes.ts(1,9): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
-tests/cases/compiler/defaultValueInFunctionTypes.ts(2,11): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/compiler/defaultValueInFunctionTypes.ts(1,15): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/compiler/defaultValueInFunctionTypes.ts(3,9): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+tests/cases/compiler/defaultValueInFunctionTypes.ts(4,11): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
 
 
-==== tests/cases/compiler/defaultValueInFunctionTypes.ts (2 errors) ====
+==== tests/cases/compiler/defaultValueInFunctionTypes.ts (3 errors) ====
+    type Foo = ({ first = 0 }: { first?: number }) => unknown;
+                  ~~~~~
+!!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+    
     var x: (a: number = 1) => number;
             ~~~~~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
     var y = <(a : string = "") => any>(undefined)
               ~~~~~~~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
+    

--- a/tests/baselines/reference/defaultValueInFunctionTypes.js
+++ b/tests/baselines/reference/defaultValueInFunctionTypes.js
@@ -1,6 +1,9 @@
 //// [defaultValueInFunctionTypes.ts]
+type Foo = ({ first = 0 }: { first?: number }) => unknown;
+
 var x: (a: number = 1) => number;
 var y = <(a : string = "") => any>(undefined)
+
 
 //// [defaultValueInFunctionTypes.js]
 var x;

--- a/tests/baselines/reference/defaultValueInFunctionTypes.symbols
+++ b/tests/baselines/reference/defaultValueInFunctionTypes.symbols
@@ -1,10 +1,15 @@
 === tests/cases/compiler/defaultValueInFunctionTypes.ts ===
+type Foo = ({ first = 0 }: { first?: number }) => unknown;
+>Foo : Symbol(Foo, Decl(defaultValueInFunctionTypes.ts, 0, 0))
+>first : Symbol(first, Decl(defaultValueInFunctionTypes.ts, 0, 13))
+>first : Symbol(first, Decl(defaultValueInFunctionTypes.ts, 0, 28))
+
 var x: (a: number = 1) => number;
->x : Symbol(x, Decl(defaultValueInFunctionTypes.ts, 0, 3))
->a : Symbol(a, Decl(defaultValueInFunctionTypes.ts, 0, 8))
+>x : Symbol(x, Decl(defaultValueInFunctionTypes.ts, 2, 3))
+>a : Symbol(a, Decl(defaultValueInFunctionTypes.ts, 2, 8))
 
 var y = <(a : string = "") => any>(undefined)
->y : Symbol(y, Decl(defaultValueInFunctionTypes.ts, 1, 3))
->a : Symbol(a, Decl(defaultValueInFunctionTypes.ts, 1, 10))
+>y : Symbol(y, Decl(defaultValueInFunctionTypes.ts, 3, 3))
+>a : Symbol(a, Decl(defaultValueInFunctionTypes.ts, 3, 10))
 >undefined : Symbol(undefined)
 

--- a/tests/baselines/reference/defaultValueInFunctionTypes.types
+++ b/tests/baselines/reference/defaultValueInFunctionTypes.types
@@ -1,4 +1,10 @@
 === tests/cases/compiler/defaultValueInFunctionTypes.ts ===
+type Foo = ({ first = 0 }: { first?: number }) => unknown;
+>Foo : ({ first }: { first?: number; }) => unknown
+>first : number
+>0 : 0
+>first : number
+
 var x: (a: number = 1) => number;
 >x : (a?: number) => number
 >a : number

--- a/tests/cases/compiler/defaultValueInFunctionTypes.ts
+++ b/tests/cases/compiler/defaultValueInFunctionTypes.ts
@@ -1,2 +1,4 @@
+type Foo = ({ first = 0 }: { first?: number }) => unknown;
+
 var x: (a: number = 1) => number;
 var y = <(a : string = "") => any>(undefined)


### PR DESCRIPTION
Fixes #53933