### PR TITLE
Ensure paths-based resolution does not generate module specifiers with `..` in the middle

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -452,7 +452,7 @@ function getLocalModuleSpecifier(moduleFileName: string, info: Info, compilerOpt
     }
 
     const baseDirectory = getNormalizedAbsolutePath(getPathsBasePath(compilerOptions, host) || baseUrl!, host.getCurrentDirectory());
-    const relativeToBaseUrl = getRelativePathIfInDirectory(moduleFileName, baseDirectory, getCanonicalFileName);
+    const relativeToBaseUrl = getRelativePathIfInSameVolume(moduleFileName, baseDirectory, getCanonicalFileName);
     if (!relativeToBaseUrl) {
         return pathsOnly ? undefined : relativePath;
     }
@@ -766,7 +766,7 @@ function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<rea
                         validateEnding({ ending, value })
                     ) {
                         const matchedStar = value.substring(prefix.length, value.length - suffix.length);
-                        return key.replace("*", matchedStar);
+                        return pathIsRelative(matchedStar) ? undefined : key.replace("*", matchedStar);
                     }
                 }
             }
@@ -1031,7 +1031,7 @@ function tryGetAnyFileFromPath(host: ModuleSpecifierResolutionHost, path: string
 
 function getPathsRelativeToRootDirs(path: string, rootDirs: readonly string[], getCanonicalFileName: GetCanonicalFileName): string[] | undefined {
     return mapDefined(rootDirs, rootDir => {
-        const relativePath = getRelativePathIfInDirectory(path, rootDir, getCanonicalFileName);
+        const relativePath = getRelativePathIfInSameVolume(path, rootDir, getCanonicalFileName);
         return relativePath !== undefined && isPathRelativeToParent(relativePath) ? undefined : relativePath;
     });
 }
@@ -1122,7 +1122,7 @@ export function tryGetJSExtensionForFile(fileName: string, options: CompilerOpti
     }
 }
 
-function getRelativePathIfInDirectory(path: string, directoryPath: string, getCanonicalFileName: GetCanonicalFileName): string | undefined {
+function getRelativePathIfInSameVolume(path: string, directoryPath: string, getCanonicalFileName: GetCanonicalFileName): string | undefined {
     const relativePath = getRelativePathToDirectoryOrUrl(directoryPath, path, directoryPath, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
     return isRootedDiskPath(relativePath) ? undefined : relativePath;
 }

--- a/tests/cases/fourslash/server/autoImportCrossPackage_pathsAndSymlink.ts
+++ b/tests/cases/fourslash/server/autoImportCrossPackage_pathsAndSymlink.ts
@@ -1,0 +1,40 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /project/packages/common/package.json
+//// {
+////   "name": "@company/common",
+////   "version": "1.0.0",
+////   "main": "./lib/index.tsx"
+//// }
+
+// @Filename: /project/packages/common/lib/index.tsx
+//// export function Tooltip {};
+
+// @Filename: /project/packages/app/package.json
+//// {
+////   "name": "@company/app",
+////   "version": "1.0.0",
+////   "dependencies": {
+////     "@company/common": "1.0.0"
+////   }
+//// }
+
+// @Filename: /project/packages/app/tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "composite": true,
+////     "module": "esnext",
+////     "moduleResolution": "bundler",
+////     "paths": {
+////       "@/*": ["./*"]
+////     }
+////   }
+//// }
+
+// @Filename: /project/packages/app/lib/index.ts
+//// Tooltip/**/
+
+// @link: /project/packages/common -> /project/node_modules/@company/common
+
+goTo.marker("");
+verify.importFixModuleSpecifiers("", ["@company/common"]);


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53369 
