### PR TITLE
Fix 'var' hoisting in 'if' in SystemJS emit

### DIFF
--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -45,6 +45,7 @@ import {
     hasSyntacticModifier,
     Identifier,
     idText,
+    IfStatement,
     ImportCall,
     ImportDeclaration,
     ImportEqualsDeclaration,
@@ -1210,6 +1211,9 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
             case SyntaxKind.WithStatement:
                 return visitWithStatement(node as WithStatement);
 
+            case SyntaxKind.IfStatement:
+                return visitIfStatement(node as IfStatement);
+
             case SyntaxKind.SwitchStatement:
                 return visitSwitchStatement(node as SwitchStatement);
 
@@ -1380,6 +1384,20 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
             node,
             visitNode(node.expression, visitor, isExpression),
             Debug.checkDefined(visitNode(node.statement, topLevelNestedVisitor, isStatement, factory.liftToBlock))
+        );
+    }
+
+    /**
+     * Visits the body of a IfStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitIfStatement(node: IfStatement): VisitResult<Statement> {
+        return factory.updateIfStatement(
+            node,
+            visitNode(node.expression, visitor, isExpression),
+            Debug.checkDefined(visitNode(node.thenStatement, topLevelNestedVisitor, isStatement, factory.liftToBlock)),
+            visitNode(node.elseStatement, topLevelNestedVisitor, isStatement, factory.liftToBlock)
         );
     }
 

--- a/tests/baselines/reference/topLevelVarHoistingSystem.js
+++ b/tests/baselines/reference/topLevelVarHoistingSystem.js
@@ -1,0 +1,29 @@
+//// [topLevelVarHoistingSystem.ts]
+if (false) {
+    var y = 1;
+}
+
+function f() {
+    console.log(y);
+}
+
+export { y };
+
+//// [topLevelVarHoistingSystem.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var y;
+    var __moduleName = context_1 && context_1.id;
+    function f() {
+        console.log(y);
+    }
+    return {
+        setters: [],
+        execute: function () {
+            if (false) {
+                y = 1;
+                exports_1("y", y);
+            }
+        }
+    };
+});

--- a/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingSystem.ts
+++ b/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingSystem.ts
@@ -1,0 +1,12 @@
+// @target: esnext
+// @module: system
+// @noTypesAndSymbols: true
+if (false) {
+    var y = 1;
+}
+
+function f() {
+    console.log(y);
+}
+
+export { y };


### PR DESCRIPTION
Fixes a failure to descend into top-level `if` statements to properly hoist `var` declarations.

Fixes #54015
