### PR TITLE
Close TypingInstaller watches on project close

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1012,6 +1012,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     }
 
     close() {
+        this.projectService.typingsCache.onProjectClosed(this);
         if (this.program) {
             // if we have a program - release all files that are enlisted in program but arent root
             // The releasing of the roots happens later

--- a/src/testRunner/unittests/helpers/tsserver.ts
+++ b/src/testRunner/unittests/helpers/tsserver.ts
@@ -324,7 +324,9 @@ export class TestTypingsInstaller<T extends TestTypingsInstallerWorker = TestTyp
         this.projectService = projectService;
     }
 
-    onProjectClosed = ts.noop;
+    onProjectClosed(p: ts.server.Project) {
+        this.installer?.closeProject({ projectName: p.getProjectName(), kind: "closeProject" });
+    }
 
     enqueueInstallTypingsRequest(project: ts.server.Project, typeAcquisition: ts.TypeAcquisition, unresolvedImports: ts.SortedReadonlyArray<string>) {
         if (!this.installer) {

--- a/tests/baselines/reference/tsserver/inferredProjects/inferred-projects-per-project-root-with-case-insensitive-system.js
+++ b/tests/baselines/reference/tsserver/inferredProjects/inferred-projects-per-project-root-with-case-insensitive-system.js
@@ -657,6 +657,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject3*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject3*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject3* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
@@ -668,6 +676,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject2*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject2*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject2* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /A/file2.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /b/file2.ts 500 undefined WatchType: Closed Script info
@@ -692,6 +708,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+
+PolledWatches *deleted*::
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -699,10 +719,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-
-PolledWatches *deleted*::
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches *deleted*::
@@ -844,15 +860,11 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
-  {"pollingInterval":500}
 /a/lib/lib.esnext.full.d.ts: *new*
+  {"pollingInterval":500}
+/b/bower_components: *new*
+  {"pollingInterval":500}
+/b/node_modules: *new*
   {"pollingInterval":500}
 
 Before request
@@ -926,6 +938,24 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/lib/lib.es6.d.ts:
+  {"pollingInterval":500}
+/a/bower_components:
+  {"pollingInterval":500}
+/a/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/b/bower_components:
+  {"pollingInterval":500}
+/b/node_modules:
+  {"pollingInterval":500}
+/bower_components: *new*
+  {"pollingInterval":500}
+/node_modules: *new*
+  {"pollingInterval":500}
+
 Before request
 
 Info seq  [hh:mm:ss:mss] request:
@@ -970,6 +1000,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -977,8 +1009,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1027,6 +1057,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1034,8 +1066,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1084,6 +1114,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1091,8 +1123,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1141,6 +1171,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1148,8 +1180,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1236,6 +1266,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject5*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject5*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject5* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject4*' (Inferred)
@@ -1247,6 +1285,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject4*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject4*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject4* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /A/file2.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /b/file2.ts 500 undefined WatchType: Closed Script info
@@ -1269,14 +1315,6 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
-  {"pollingInterval":500}
 /a/lib/lib.es2017.full.d.ts: *new*
   {"pollingInterval":500}
 
@@ -1284,6 +1322,14 @@ PolledWatches *deleted*::
 /a/lib/lib.es6.d.ts:
   {"pollingInterval":500}
 /a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/b/bower_components:
+  {"pollingInterval":500}
+/b/node_modules:
+  {"pollingInterval":500}
+/bower_components:
+  {"pollingInterval":500}
+/node_modules:
   {"pollingInterval":500}
 
 FsWatches *deleted*::
@@ -1423,17 +1469,13 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
-  {"pollingInterval":500}
 /a/lib/lib.es2017.full.d.ts:
   {"pollingInterval":500}
 /a/lib/lib.esnext.full.d.ts: *new*
+  {"pollingInterval":500}
+/b/bower_components: *new*
+  {"pollingInterval":500}
+/b/node_modules: *new*
   {"pollingInterval":500}
 
 Before request
@@ -1507,6 +1549,24 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/bower_components:
+  {"pollingInterval":500}
+/a/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/b/bower_components:
+  {"pollingInterval":500}
+/b/node_modules:
+  {"pollingInterval":500}
+/bower_components: *new*
+  {"pollingInterval":500}
+/node_modules: *new*
+  {"pollingInterval":500}
+
 Before request
 
 Info seq  [hh:mm:ss:mss] request:
@@ -1549,6 +1609,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1556,10 +1620,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1606,6 +1666,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1613,10 +1677,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1663,6 +1723,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1670,10 +1734,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1720,6 +1780,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1727,10 +1791,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1792,6 +1852,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject7*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject7*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject7* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject6*' (Inferred)
@@ -1803,6 +1871,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject6*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject6*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject6* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /A/file2.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /b/file2.ts 500 undefined WatchType: Closed Script info
@@ -1825,6 +1901,12 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+
+PolledWatches *deleted*::
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1832,12 +1914,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-
-PolledWatches *deleted*::
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches *deleted*::
@@ -1977,17 +2053,13 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
-  {"pollingInterval":500}
 /a/lib/lib.es2017.full.d.ts:
   {"pollingInterval":500}
 /a/lib/lib.esnext.full.d.ts: *new*
+  {"pollingInterval":500}
+/b/bower_components: *new*
+  {"pollingInterval":500}
+/b/node_modules: *new*
   {"pollingInterval":500}
 
 Before request
@@ -2061,6 +2133,24 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/bower_components:
+  {"pollingInterval":500}
+/a/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/b/bower_components:
+  {"pollingInterval":500}
+/b/node_modules:
+  {"pollingInterval":500}
+/bower_components: *new*
+  {"pollingInterval":500}
+/node_modules: *new*
+  {"pollingInterval":500}
+
 Before request
 
 Info seq  [hh:mm:ss:mss] request:
@@ -2103,6 +2193,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2110,10 +2204,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -2160,6 +2250,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2167,10 +2261,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -2217,6 +2307,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2224,10 +2318,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -2274,6 +2364,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2281,10 +2375,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::

--- a/tests/baselines/reference/tsserver/inferredProjects/inferred-projects-per-project-root-with-case-sensitive-system.js
+++ b/tests/baselines/reference/tsserver/inferredProjects/inferred-projects-per-project-root-with-case-sensitive-system.js
@@ -657,6 +657,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject3*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject3* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject3*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject3* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
@@ -668,6 +676,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject2*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject2* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject2*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject2* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /A/file2.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /b/file2.ts 500 undefined WatchType: Closed Script info
@@ -692,6 +708,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+
+PolledWatches *deleted*::
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -699,10 +719,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-
-PolledWatches *deleted*::
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches *deleted*::
@@ -786,14 +802,6 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
-  {"pollingInterval":500}
 /a/lib/lib.esnext.full.d.ts: *new*
   {"pollingInterval":500}
 /A/bower_components: *new*
@@ -871,6 +879,24 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/lib/lib.es6.d.ts:
+  {"pollingInterval":500}
+/a/bower_components:
+  {"pollingInterval":500}
+/a/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
+/b/bower_components: *new*
+  {"pollingInterval":500}
+/b/node_modules: *new*
+  {"pollingInterval":500}
+
 Before request
 
 Info seq  [hh:mm:ss:mss] request:
@@ -946,6 +972,28 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/lib/lib.es6.d.ts:
+  {"pollingInterval":500}
+/a/bower_components:
+  {"pollingInterval":500}
+/a/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
+/b/bower_components:
+  {"pollingInterval":500}
+/b/node_modules:
+  {"pollingInterval":500}
+/bower_components: *new*
+  {"pollingInterval":500}
+/node_modules: *new*
+  {"pollingInterval":500}
+
 Before request
 
 Info seq  [hh:mm:ss:mss] request:
@@ -994,6 +1042,12 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1001,12 +1055,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1059,6 +1107,12 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1066,12 +1120,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1124,6 +1172,12 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1131,12 +1185,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1189,6 +1237,12 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1196,12 +1250,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1278,6 +1326,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject6*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject6* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject6*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject6* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject4*' (Inferred)
@@ -1289,6 +1345,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject4*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /A/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /A/bower_components 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /A/bower_components 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /A/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /A/node_modules 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /A/node_modules 1 undefined Project: /dev/null/inferredProject4* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject4*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject4* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject5*' (Inferred)
@@ -1300,6 +1364,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject5*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject5* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject5*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject5* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /A/file2.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /b/file2.ts 500 undefined WatchType: Closed Script info
@@ -1324,6 +1396,14 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+
+PolledWatches *deleted*::
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1331,14 +1411,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-
-PolledWatches *deleted*::
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches *deleted*::
@@ -1480,19 +1552,11 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
 /a/lib/lib.esnext.full.d.ts: *new*
+  {"pollingInterval":500}
+/b/bower_components: *new*
+  {"pollingInterval":500}
+/b/node_modules: *new*
   {"pollingInterval":500}
 
 Before request
@@ -1566,6 +1630,24 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/lib/lib.es6.d.ts:
+  {"pollingInterval":500}
+/a/bower_components:
+  {"pollingInterval":500}
+/a/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/b/bower_components:
+  {"pollingInterval":500}
+/b/node_modules:
+  {"pollingInterval":500}
+/bower_components: *new*
+  {"pollingInterval":500}
+/node_modules: *new*
+  {"pollingInterval":500}
+
 Before request
 
 Info seq  [hh:mm:ss:mss] request:
@@ -1610,6 +1692,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1617,12 +1701,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1671,6 +1749,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1678,12 +1758,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1732,6 +1806,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1739,12 +1815,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1793,6 +1863,8 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1800,12 +1872,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -1867,6 +1933,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject8*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject8* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /bower_components 1 undefined Project: /dev/null/inferredProject8* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject8* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /node_modules 1 undefined Project: /dev/null/inferredProject8* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject8*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject8* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject7*' (Inferred)
@@ -1878,6 +1952,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject7*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/bower_components 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /b/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /b/node_modules 1 undefined Project: /dev/null/inferredProject7* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject7*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.esnext.full.d.ts 500 undefined Project: /dev/null/inferredProject7* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /A/file2.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /b/file2.ts 500 undefined WatchType: Closed Script info
@@ -1902,6 +1984,10 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+
+PolledWatches *deleted*::
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -1909,14 +1995,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-
-PolledWatches *deleted*::
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches *deleted*::
@@ -2000,19 +2078,11 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
 /a/lib/lib.es2017.full.d.ts: *new*
+  {"pollingInterval":500}
+/A/bower_components: *new*
+  {"pollingInterval":500}
+/A/node_modules: *new*
   {"pollingInterval":500}
 
 Before request
@@ -2092,21 +2162,17 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
-/b/bower_components:
-  {"pollingInterval":500}
-/b/node_modules:
-  {"pollingInterval":500}
-/bower_components:
-  {"pollingInterval":500}
-/node_modules:
+/a/lib/lib.es2017.full.d.ts:
   {"pollingInterval":500}
 /A/bower_components:
   {"pollingInterval":500}
 /A/node_modules:
   {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
 /a/lib/lib.esnext.full.d.ts: *new*
+  {"pollingInterval":500}
+/b/bower_components: *new*
+  {"pollingInterval":500}
+/b/node_modules: *new*
   {"pollingInterval":500}
 
 Before request
@@ -2184,6 +2250,30 @@ Info seq  [hh:mm:ss:mss] response:
     }
 After request
 
+PolledWatches::
+/a/lib/lib.es6.d.ts:
+  {"pollingInterval":500}
+/a/bower_components:
+  {"pollingInterval":500}
+/a/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
+/b/bower_components:
+  {"pollingInterval":500}
+/b/node_modules:
+  {"pollingInterval":500}
+/bower_components: *new*
+  {"pollingInterval":500}
+/node_modules: *new*
+  {"pollingInterval":500}
+
 Before request
 
 Info seq  [hh:mm:ss:mss] request:
@@ -2232,6 +2322,14 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2239,14 +2337,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -2299,6 +2389,14 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2306,14 +2404,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -2366,6 +2456,14 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2373,14 +2471,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::
@@ -2433,6 +2523,14 @@ PolledWatches::
   {"pollingInterval":500}
 /a/node_modules:
   {"pollingInterval":500}
+/a/lib/lib.es2017.full.d.ts:
+  {"pollingInterval":500}
+/A/bower_components:
+  {"pollingInterval":500}
+/A/node_modules:
+  {"pollingInterval":500}
+/a/lib/lib.esnext.full.d.ts:
+  {"pollingInterval":500}
 /b/bower_components:
   {"pollingInterval":500}
 /b/node_modules:
@@ -2440,14 +2538,6 @@ PolledWatches::
 /bower_components:
   {"pollingInterval":500}
 /node_modules:
-  {"pollingInterval":500}
-/A/bower_components:
-  {"pollingInterval":500}
-/A/node_modules:
-  {"pollingInterval":500}
-/a/lib/lib.es2017.full.d.ts:
-  {"pollingInterval":500}
-/a/lib/lib.esnext.full.d.ts:
   {"pollingInterval":500}
 
 FsWatches::

--- a/tests/baselines/reference/tsserver/inferredProjects/should-still-retain-configured-project-created-while-opening-the-file.js
+++ b/tests/baselines/reference/tsserver/inferredProjects/should-still-retain-configured-project-created-while-opening-the-file.js
@@ -430,6 +430,8 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject 1 undefined Config: /user/username/projects/myproject/tsconfig.json WatchType: Wild card directory
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/user/username/projects/myproject/tsconfig.json'
+TI:: [hh:mm:ss:mss] No watchers are registered for project '/user/username/projects/myproject/tsconfig.json'
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/myproject/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/myproject/tsconfig.json WatchType: Type roots

--- a/tests/baselines/reference/tsserver/skipLibCheck/jsonly-inferred-project.js
+++ b/tests/baselines/reference/tsserver/skipLibCheck/jsonly-inferred-project.js
@@ -352,6 +352,14 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 	  Root file specified for compilation
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject1*'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /a/b/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /a/b/bower_components 1 undefined Project: /dev/null/inferredProject1* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b/bower_components 1 undefined Project: /dev/null/inferredProject1* watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /a/b/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /a/b/node_modules 1 undefined Project: /dev/null/inferredProject1* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a/b/node_modules 1 undefined Project: /dev/null/inferredProject1* watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/dev/null/inferredProject1*' - done.
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
 Info seq  [hh:mm:ss:mss] 	Files (2)

--- a/tests/baselines/reference/tsserver/typingsInstaller/multiple-projects.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/multiple-projects.js
@@ -397,6 +397,16 @@ Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project 1 undefined Config: /user/username/projects/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project 1 undefined Config: /user/username/projects/project/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/projects/project/tsconfig.json 2000 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Config file
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/user/username/projects/project/tsconfig.json'
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /user/username/projects/project/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/bower_components 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/bower_components 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] FileWatcher:: Closed:: WatchInfo: /user/username/projects/project/package.json
+TI:: [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/projects/project/package.json 2000 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Closed:: WatchInfo: /user/username/projects/project/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/node_modules 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/node_modules 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Closing file watchers for project '/user/username/projects/project/tsconfig.json' - done.
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
@@ -418,10 +428,6 @@ After request
 PolledWatches::
 /user/username/projects/node_modules/@types:
   {"pollingInterval":500}
-/user/username/projects/project/bower_components:
-  {"pollingInterval":500}
-/user/username/projects/project/node_modules:
-  {"pollingInterval":500}
 /user/username/projects/project2/node_modules/@types: *new*
   {"pollingInterval":500}
 /user/username/projects/project2/bower_components: *new*
@@ -431,6 +437,10 @@ PolledWatches::
 
 PolledWatches *deleted*::
 /user/username/projects/project/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/project/bower_components:
+  {"pollingInterval":500}
+/user/username/projects/project/node_modules:
   {"pollingInterval":500}
 
 FsWatches::

--- a/tests/baselines/reference/tsserver/typingsInstaller/multiple-projects.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/multiple-projects.js
@@ -1,0 +1,458 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/a/lib/typesMap.json" doesn't exist
+Before request
+//// [/user/username/projects/project/app.js]
+
+
+//// [/user/username/projects/project/tsconfig.json]
+{"compilerOptions":{"allowJs":true},"typeAcquisition":{"enable":true}}
+
+//// [/user/username/projects/project/package.json]
+{"name":"test","dependencies":{"jquery":"^3.1.0"}}
+
+//// [/user/username/projects/project2/app.js]
+
+
+//// [/user/username/projects/project2/tsconfig.json]
+{"compilerOptions":{"allowJs":true},"typeAcquisition":{"enable":true}}
+
+//// [/user/username/projects/project2/package.json]
+{"name":"test","dependencies":{"commander":"^3.1.0"}}
+
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/user/username/projects/project/app.js"
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Search path: /user/username/projects/project
+Info seq  [hh:mm:ss:mss] For info: /user/username/projects/project/app.js :: Config file name: /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project/tsconfig.json 2000 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] Config: /user/username/projects/project/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/project/app.js"
+ ],
+ "options": {
+  "allowJs": true,
+  "configFilePath": "/user/username/projects/project/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project 1 undefined Config: /user/username/projects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project 1 undefined Config: /user/username/projects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/project/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
+	/user/username/projects/project/app.js SVC-1-0 ""
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	app.js
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: Creating typing installer
+
+PolledWatches::
+/user/username/projects/project/node_modules/@types: *new*
+  {"pollingInterval":500}
+/user/username/projects/node_modules/@types: *new*
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/project/tsconfig.json: *new*
+  {}
+/a/lib/lib.d.ts: *new*
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/project: *new*
+  {}
+
+TI:: [hh:mm:ss:mss] Global cache location '/a/data', safe file path '/safeList.json', types map path /typesMap.json
+TI:: [hh:mm:ss:mss] Processing cache location '/a/data'
+TI:: [hh:mm:ss:mss] Trying to find '/a/data/package.json'...
+TI:: [hh:mm:ss:mss] Finished processing cache location '/a/data'
+TI:: [hh:mm:ss:mss] Npm config file: /a/data/package.json
+TI:: [hh:mm:ss:mss] Npm config file: '/a/data/package.json' is missing, creating new one...
+TI:: [hh:mm:ss:mss] Updating types-registry npm package...
+TI:: [hh:mm:ss:mss] npm install --ignore-scripts types-registry@latest
+TI:: [hh:mm:ss:mss] TI:: Updated types-registry npm package
+TI:: typing installer creation complete
+//// [/a/data/package.json]
+{ "private": true }
+
+//// [/a/data/node_modules/types-registry/index.json]
+{
+ "entries": {
+  "jquery": {
+   "latest": "1.3.0",
+   "ts2.0": "1.0.0",
+   "ts2.1": "1.0.0",
+   "ts2.2": "1.2.0",
+   "ts2.3": "1.3.0",
+   "ts2.4": "1.3.0",
+   "ts2.5": "1.3.0",
+   "ts2.6": "1.3.0",
+   "ts2.7": "1.3.0"
+  },
+  "commander": {
+   "latest": "1.3.0",
+   "ts2.0": "1.0.0",
+   "ts2.1": "1.0.0",
+   "ts2.2": "1.2.0",
+   "ts2.3": "1.3.0",
+   "ts2.4": "1.3.0",
+   "ts2.5": "1.3.0",
+   "ts2.6": "1.3.0",
+   "ts2.7": "1.3.0"
+  }
+ }
+}
+
+
+TI:: [hh:mm:ss:mss] Got install request {"projectName":"/user/username/projects/project/tsconfig.json","fileNames":["/a/lib/lib.d.ts","/user/username/projects/project/app.js"],"compilerOptions":{"allowJs":true,"configFilePath":"/user/username/projects/project/tsconfig.json","allowNonTsExtensions":true},"typeAcquisition":{"enable":true,"include":[],"exclude":[]},"unresolvedImports":[],"projectRootPath":"/user/username/projects/project","cachePath":"/a/data","kind":"discover"}
+TI:: [hh:mm:ss:mss] Request specifies cache path '/a/data', loading cached information...
+TI:: [hh:mm:ss:mss] Processing cache location '/a/data'
+TI:: [hh:mm:ss:mss] Cache location was already processed...
+TI:: [hh:mm:ss:mss] Failed to load safelist from types map file '/typesMap.json'
+TI:: [hh:mm:ss:mss] Explicitly included types: []
+TI:: [hh:mm:ss:mss] Typing names in '/user/username/projects/project/package.json' dependencies: ["jquery"]
+TI:: [hh:mm:ss:mss] Inferred typings from unresolved imports: []
+TI:: [hh:mm:ss:mss] Result: {"cachedTypingPaths":[],"newTypingNames":["jquery"],"filesToWatch":["/user/username/projects/project/bower_components","/user/username/projects/project/package.json","/user/username/projects/project/node_modules"]}
+TI:: [hh:mm:ss:mss] Finished typings discovery: {"cachedTypingPaths":[],"newTypingNames":["jquery"],"filesToWatch":["/user/username/projects/project/bower_components","/user/username/projects/project/package.json","/user/username/projects/project/node_modules"]}
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/bower_components 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/bower_components 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project/package.json
+TI:: [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project/package.json 2000 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project/node_modules 1 undefined Project: /user/username/projects/project/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Installing typings ["jquery"]
+TI:: [hh:mm:ss:mss] Npm config file: /a/data/package.json
+TI:: [hh:mm:ss:mss] Sending response:
+    {"kind":"event::beginInstallTypes","eventId":1,"typingsInstallerVersion":"FakeVersion","projectName":"/user/username/projects/project/tsconfig.json"}
+TI:: [hh:mm:ss:mss] #1 with arguments'["@types/jquery@tsFakeMajor.Minor"]'.
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project/package.json 250 undefined WatchType: package.json file
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/project/app.js ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+PolledWatches::
+/user/username/projects/project/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/project/bower_components: *new*
+  {"pollingInterval":500}
+/user/username/projects/project/node_modules: *new*
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/project/tsconfig.json:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/project/package.json: *new*
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/project:
+  {}
+
+TI:: [hh:mm:ss:mss] #1 with arguments'["@types/jquery@tsFakeMajor.Minor"]':: true
+TI:: Before installWorker
+
+TI:: After installWorker
+//// [/a/data/node_modules/@types/jquery/index.d.ts]
+declare const $: { x: number }
+
+
+TI:: [hh:mm:ss:mss] Installed typings ["@types/jquery@tsFakeMajor.Minor"]
+TI:: [hh:mm:ss:mss] Installed typing files ["/a/data/node_modules/@types/jquery/index.d.ts"]
+TI:: [hh:mm:ss:mss] Sending response:
+    {"projectName":"/user/username/projects/project/tsconfig.json","typeAcquisition":{"enable":true,"include":[],"exclude":[]},"compilerOptions":{"allowJs":true,"configFilePath":"/user/username/projects/project/tsconfig.json","allowNonTsExtensions":true},"typings":["/a/data/node_modules/@types/jquery/index.d.ts"],"unresolvedImports":[],"kind":"action::set"}
+Info seq  [hh:mm:ss:mss] Scheduled: /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
+TI:: [hh:mm:ss:mss] Sending response:
+    {"kind":"event::endInstallTypes","eventId":1,"projectName":"/user/username/projects/project/tsconfig.json","packagesToInstall":["@types/jquery@tsFakeMajor.Minor"],"installSuccess":true,"typingsInstallerVersion":"FakeVersion"}
+Before running Timeout callback:: count: 2
+1: /user/username/projects/project/tsconfig.json
+2: *ensureProjectForOpenFiles*
+
+Info seq  [hh:mm:ss:mss] Running: /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/project/tsconfig.json Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
+	/user/username/projects/project/app.js SVC-1-0 ""
+	/a/data/node_modules/@types/jquery/index.d.ts Text-1 "declare const $: { x: number }"
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	app.js
+	  Matched by default include pattern '**/*'
+	../../../../a/data/node_modules/@types/jquery/index.d.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Got install request {"projectName":"/user/username/projects/project/tsconfig.json","fileNames":["/a/lib/lib.d.ts","/user/username/projects/project/app.js","/a/data/node_modules/@types/jquery/index.d.ts"],"compilerOptions":{"allowJs":true,"configFilePath":"/user/username/projects/project/tsconfig.json","allowNonTsExtensions":true},"typeAcquisition":{"enable":true,"include":[],"exclude":[]},"unresolvedImports":[],"projectRootPath":"/user/username/projects/project","cachePath":"/a/data","kind":"discover"}
+TI:: [hh:mm:ss:mss] Request specifies cache path '/a/data', loading cached information...
+TI:: [hh:mm:ss:mss] Processing cache location '/a/data'
+TI:: [hh:mm:ss:mss] Cache location was already processed...
+TI:: [hh:mm:ss:mss] Explicitly included types: []
+TI:: [hh:mm:ss:mss] Typing names in '/user/username/projects/project/package.json' dependencies: ["jquery"]
+TI:: [hh:mm:ss:mss] Inferred typings from unresolved imports: []
+TI:: [hh:mm:ss:mss] Result: {"cachedTypingPaths":["/a/data/node_modules/@types/jquery/index.d.ts"],"newTypingNames":[],"filesToWatch":["/user/username/projects/project/bower_components","/user/username/projects/project/package.json","/user/username/projects/project/node_modules"]}
+TI:: [hh:mm:ss:mss] Finished typings discovery: {"cachedTypingPaths":["/a/data/node_modules/@types/jquery/index.d.ts"],"newTypingNames":[],"filesToWatch":["/user/username/projects/project/bower_components","/user/username/projects/project/package.json","/user/username/projects/project/node_modules"]}
+TI:: [hh:mm:ss:mss] Sending response:
+    {"projectName":"/user/username/projects/project/tsconfig.json","typeAcquisition":{"enable":true,"include":[],"exclude":[]},"compilerOptions":{"allowJs":true,"configFilePath":"/user/username/projects/project/tsconfig.json","allowNonTsExtensions":true},"typings":["/a/data/node_modules/@types/jquery/index.d.ts"],"unresolvedImports":[],"kind":"action::set"}
+TI:: [hh:mm:ss:mss] No new typings were requested as a result of typings discovery
+Info seq  [hh:mm:ss:mss] Running: *ensureProjectForOpenFiles*
+Info seq  [hh:mm:ss:mss] Before ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/project/app.js ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/project/tsconfig.json
+Info seq  [hh:mm:ss:mss] After ensureProjectForOpenFiles:
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/project/app.js ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/project/tsconfig.json
+After running Timeout callback:: count: 0
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "close",
+      "arguments": {
+        "file": "/user/username/projects/project/app.js"
+      },
+      "seq": 2,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project/app.js 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+PolledWatches::
+/user/username/projects/project/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/project/bower_components:
+  {"pollingInterval":500}
+/user/username/projects/project/node_modules:
+  {"pollingInterval":500}
+
+FsWatches::
+/user/username/projects/project/tsconfig.json:
+  {}
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/project/package.json:
+  {}
+/user/username/projects/project/app.js: *new*
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/project:
+  {}
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/user/username/projects/project2/app.js"
+      },
+      "seq": 3,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Search path: /user/username/projects/project2
+Info seq  [hh:mm:ss:mss] For info: /user/username/projects/project2/app.js :: Config file name: /user/username/projects/project2/tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /user/username/projects/project2/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project2/tsconfig.json 2000 undefined Project: /user/username/projects/project2/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] Config: /user/username/projects/project2/tsconfig.json : {
+ "rootNames": [
+  "/user/username/projects/project2/app.js"
+ ],
+ "options": {
+  "allowJs": true,
+  "configFilePath": "/user/username/projects/project2/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2 1 undefined Config: /user/username/projects/project2/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2 1 undefined Config: /user/username/projects/project2/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/project2/tsconfig.json
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/project2/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/node_modules/@types 1 undefined Project: /user/username/projects/project2/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project2/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project2/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/project2/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project2/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }"
+	/user/username/projects/project2/app.js SVC-1-0 ""
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	app.js
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+TI:: [hh:mm:ss:mss] Got install request {"projectName":"/user/username/projects/project2/tsconfig.json","fileNames":["/a/lib/lib.d.ts","/user/username/projects/project2/app.js"],"compilerOptions":{"allowJs":true,"configFilePath":"/user/username/projects/project2/tsconfig.json","allowNonTsExtensions":true},"typeAcquisition":{"enable":true,"include":[],"exclude":[]},"unresolvedImports":[],"projectRootPath":"/user/username/projects/project2","cachePath":"/a/data","kind":"discover"}
+TI:: [hh:mm:ss:mss] Request specifies cache path '/a/data', loading cached information...
+TI:: [hh:mm:ss:mss] Processing cache location '/a/data'
+TI:: [hh:mm:ss:mss] Cache location was already processed...
+TI:: [hh:mm:ss:mss] Explicitly included types: []
+TI:: [hh:mm:ss:mss] Typing names in '/user/username/projects/project2/package.json' dependencies: ["commander"]
+TI:: [hh:mm:ss:mss] Inferred typings from unresolved imports: []
+TI:: [hh:mm:ss:mss] Result: {"cachedTypingPaths":[],"newTypingNames":["commander"],"filesToWatch":["/user/username/projects/project2/bower_components","/user/username/projects/project2/package.json","/user/username/projects/project2/node_modules"]}
+TI:: [hh:mm:ss:mss] Finished typings discovery: {"cachedTypingPaths":[],"newTypingNames":["commander"],"filesToWatch":["/user/username/projects/project2/bower_components","/user/username/projects/project2/package.json","/user/username/projects/project2/node_modules"]}
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/bower_components
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/bower_components 1 undefined Project: /user/username/projects/project2/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/bower_components 1 undefined Project: /user/username/projects/project2/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project2/package.json
+TI:: [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project2/package.json 2000 undefined Project: /user/username/projects/project2/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/node_modules
+TI:: [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/node_modules 1 undefined Project: /user/username/projects/project2/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /user/username/projects/project2/node_modules 1 undefined Project: /user/username/projects/project2/tsconfig.json watcher already invoked: false
+TI:: [hh:mm:ss:mss] Installing typings ["commander"]
+TI:: [hh:mm:ss:mss] Npm config file: /a/data/package.json
+TI:: [hh:mm:ss:mss] Sending response:
+    {"kind":"event::beginInstallTypes","eventId":2,"typingsInstallerVersion":"FakeVersion","projectName":"/user/username/projects/project2/tsconfig.json"}
+TI:: [hh:mm:ss:mss] #2 with arguments'["@types/commander@tsFakeMajor.Minor"]'.
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /user/username/projects/project2/package.json 250 undefined WatchType: package.json file
+Info seq  [hh:mm:ss:mss] `remove Project::
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.d.ts
+	/user/username/projects/project/app.js
+	/a/data/node_modules/@types/jquery/index.d.ts
+
+
+	../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	app.js
+	  Matched by default include pattern '**/*'
+	../../../../a/data/node_modules/@types/jquery/index.d.ts
+	  Matched by default include pattern '**/*'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project 1 undefined Config: /user/username/projects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project 1 undefined Config: /user/username/projects/project/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/projects/project/tsconfig.json 2000 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/projects/project/app.js 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project2/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/project2/app.js ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/project2/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+PolledWatches::
+/user/username/projects/node_modules/@types:
+  {"pollingInterval":500}
+/user/username/projects/project/bower_components:
+  {"pollingInterval":500}
+/user/username/projects/project/node_modules:
+  {"pollingInterval":500}
+/user/username/projects/project2/node_modules/@types: *new*
+  {"pollingInterval":500}
+/user/username/projects/project2/bower_components: *new*
+  {"pollingInterval":500}
+/user/username/projects/project2/node_modules: *new*
+  {"pollingInterval":500}
+
+PolledWatches *deleted*::
+/user/username/projects/project/node_modules/@types:
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.d.ts:
+  {}
+/user/username/projects/project/package.json:
+  {}
+/user/username/projects/project2/tsconfig.json: *new*
+  {}
+/user/username/projects/project2/package.json: *new*
+  {}
+
+FsWatches *deleted*::
+/user/username/projects/project/tsconfig.json:
+  {}
+/user/username/projects/project/app.js:
+  {}
+
+FsWatchesRecursive::
+/user/username/projects/project2: *new*
+  {}
+
+FsWatchesRecursive *deleted*::
+/user/username/projects/project:
+  {}


### PR DESCRIPTION
There was missing `onProjectClosed` call when we close the project resulting in not closing the watches for typing installer.