### PR TITLE
Improve inference for context sensitive functions within reverse mapped types

### DIFF
--- a/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.errors.txt
+++ b/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.errors.txt
@@ -1,0 +1,148 @@
+tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts(67,21): error TS18046: 'x' is of type 'unknown'.
+tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts(71,21): error TS18046: 'x' is of type 'unknown'.
+tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts(80,21): error TS18046: 'x' is of type 'unknown'.
+tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts(86,21): error TS18046: 'x' is of type 'unknown'.
+tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts(95,21): error TS18046: 'x' is of type 'unknown'.
+tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts(101,21): error TS18046: 'x' is of type 'unknown'.
+
+
+==== tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts (6 errors) ====
+    // repro cases based on https://github.com/microsoft/TypeScript/issues/53018
+    
+    declare function f<T>(
+      arg: {
+        [K in keyof T]: {
+          produce: (n: string) => T[K];
+          consume: (x: T[K]) => void;
+        };
+      }
+    ): T;
+    
+    const res1 = f({
+      a: {
+        produce: (n) => n,
+        consume: (x) => x.toLowerCase(),
+      },
+      b: {
+        produce: (n) => ({ v: n }),
+        consume: (x) => x.v.toLowerCase(),
+      },
+    });
+    
+    const res2 = f({
+      a: {
+        produce: function () {
+          return "hello";
+        },
+        consume: (x) => x.toLowerCase(),
+      },
+      b: {
+        produce: function () {
+          return { v: "hello" };
+        },
+        consume: (x) => x.v.toLowerCase(),
+      },
+    });
+    
+    const res3 = f({
+      a: {
+        produce() {
+          return "hello";
+        },
+        consume: (x) => x.toLowerCase(),
+      },
+      b: {
+        produce() {
+          return { v: "hello" };
+        },
+        consume: (x) => x.v.toLowerCase(),
+      },
+    });
+    
+    declare function f2<T extends unknown[]>(
+      arg: [
+        ...{
+          [K in keyof T]: {
+            produce: (n: string) => T[K];
+            consume: (x: T[K]) => void;
+          };
+        }
+      ]
+    ): T;
+    
+    const res4 = f2([
+      {
+        produce: (n) => n,
+        consume: (x) => x.toLowerCase(),
+                        ~
+!!! error TS18046: 'x' is of type 'unknown'.
+      },
+      {
+        produce: (n) => ({ v: n }),
+        consume: (x) => x.v.toLowerCase(),
+                        ~
+!!! error TS18046: 'x' is of type 'unknown'.
+      },
+    ]);
+    
+    const res5 = f2([
+      {
+        produce: function () {
+          return "hello";
+        },
+        consume: (x) => x.toLowerCase(),
+                        ~
+!!! error TS18046: 'x' is of type 'unknown'.
+      },
+      {
+        produce: function () {
+          return { v: "hello" };
+        },
+        consume: (x) => x.v.toLowerCase(),
+                        ~
+!!! error TS18046: 'x' is of type 'unknown'.
+      },
+    ]);
+    
+    const res6 = f2([
+      {
+        produce() {
+          return "hello";
+        },
+        consume: (x) => x.toLowerCase(),
+                        ~
+!!! error TS18046: 'x' is of type 'unknown'.
+      },
+      {
+        produce() {
+          return { v: "hello" };
+        },
+        consume: (x) => x.v.toLowerCase(),
+                        ~
+!!! error TS18046: 'x' is of type 'unknown'.
+      },
+    ]);
+    
+    declare function f3<T>(
+      arg: {
+        [K in keyof T]: {
+          other: number,
+          produce: (n: string) => T[K];
+          consume: (x: T[K]) => void;
+        };
+      }
+    ): T;
+    
+    const res7 = f3({
+      a: {
+        other: 42,
+        produce: (n) => n,
+        consume: (x) => x.toLowerCase(),
+      },
+      b: {
+        other: 100,
+        produce: (n) => ({ v: n }),
+        consume: (x) => x.v.toLowerCase(),
+      },
+    });
+    

--- a/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.js
+++ b/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.js
@@ -1,0 +1,277 @@
+//// [intraExpressionInferencesReverseMappedTypes.ts]
+// repro cases based on https://github.com/microsoft/TypeScript/issues/53018
+
+declare function f<T>(
+  arg: {
+    [K in keyof T]: {
+      produce: (n: string) => T[K];
+      consume: (x: T[K]) => void;
+    };
+  }
+): T;
+
+const res1 = f({
+  a: {
+    produce: (n) => n,
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    produce: (n) => ({ v: n }),
+    consume: (x) => x.v.toLowerCase(),
+  },
+});
+
+const res2 = f({
+  a: {
+    produce: function () {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    produce: function () {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+});
+
+const res3 = f({
+  a: {
+    produce() {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    produce() {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+});
+
+declare function f2<T extends unknown[]>(
+  arg: [
+    ...{
+      [K in keyof T]: {
+        produce: (n: string) => T[K];
+        consume: (x: T[K]) => void;
+      };
+    }
+  ]
+): T;
+
+const res4 = f2([
+  {
+    produce: (n) => n,
+    consume: (x) => x.toLowerCase(),
+  },
+  {
+    produce: (n) => ({ v: n }),
+    consume: (x) => x.v.toLowerCase(),
+  },
+]);
+
+const res5 = f2([
+  {
+    produce: function () {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  {
+    produce: function () {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+]);
+
+const res6 = f2([
+  {
+    produce() {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  {
+    produce() {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+]);
+
+declare function f3<T>(
+  arg: {
+    [K in keyof T]: {
+      other: number,
+      produce: (n: string) => T[K];
+      consume: (x: T[K]) => void;
+    };
+  }
+): T;
+
+const res7 = f3({
+  a: {
+    other: 42,
+    produce: (n) => n,
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    other: 100,
+    produce: (n) => ({ v: n }),
+    consume: (x) => x.v.toLowerCase(),
+  },
+});
+
+
+//// [intraExpressionInferencesReverseMappedTypes.js]
+"use strict";
+// repro cases based on https://github.com/microsoft/TypeScript/issues/53018
+var res1 = f({
+    a: {
+        produce: function (n) { return n; },
+        consume: function (x) { return x.toLowerCase(); },
+    },
+    b: {
+        produce: function (n) { return ({ v: n }); },
+        consume: function (x) { return x.v.toLowerCase(); },
+    },
+});
+var res2 = f({
+    a: {
+        produce: function () {
+            return "hello";
+        },
+        consume: function (x) { return x.toLowerCase(); },
+    },
+    b: {
+        produce: function () {
+            return { v: "hello" };
+        },
+        consume: function (x) { return x.v.toLowerCase(); },
+    },
+});
+var res3 = f({
+    a: {
+        produce: function () {
+            return "hello";
+        },
+        consume: function (x) { return x.toLowerCase(); },
+    },
+    b: {
+        produce: function () {
+            return { v: "hello" };
+        },
+        consume: function (x) { return x.v.toLowerCase(); },
+    },
+});
+var res4 = f2([
+    {
+        produce: function (n) { return n; },
+        consume: function (x) { return x.toLowerCase(); },
+    },
+    {
+        produce: function (n) { return ({ v: n }); },
+        consume: function (x) { return x.v.toLowerCase(); },
+    },
+]);
+var res5 = f2([
+    {
+        produce: function () {
+            return "hello";
+        },
+        consume: function (x) { return x.toLowerCase(); },
+    },
+    {
+        produce: function () {
+            return { v: "hello" };
+        },
+        consume: function (x) { return x.v.toLowerCase(); },
+    },
+]);
+var res6 = f2([
+    {
+        produce: function () {
+            return "hello";
+        },
+        consume: function (x) { return x.toLowerCase(); },
+    },
+    {
+        produce: function () {
+            return { v: "hello" };
+        },
+        consume: function (x) { return x.v.toLowerCase(); },
+    },
+]);
+var res7 = f3({
+    a: {
+        other: 42,
+        produce: function (n) { return n; },
+        consume: function (x) { return x.toLowerCase(); },
+    },
+    b: {
+        other: 100,
+        produce: function (n) { return ({ v: n }); },
+        consume: function (x) { return x.v.toLowerCase(); },
+    },
+});
+
+
+//// [intraExpressionInferencesReverseMappedTypes.d.ts]
+declare function f<T>(arg: {
+    [K in keyof T]: {
+        produce: (n: string) => T[K];
+        consume: (x: T[K]) => void;
+    };
+}): T;
+declare const res1: {
+    a: string;
+    b: {
+        v: string;
+    };
+};
+declare const res2: {
+    a: string;
+    b: {
+        v: string;
+    };
+};
+declare const res3: {
+    a: string;
+    b: {
+        v: string;
+    };
+};
+declare function f2<T extends unknown[]>(arg: [
+    ...{
+        [K in keyof T]: {
+            produce: (n: string) => T[K];
+            consume: (x: T[K]) => void;
+        };
+    }
+]): T;
+declare const res4: [string, {
+    v: string;
+}];
+declare const res5: [string, {
+    v: string;
+}];
+declare const res6: [string, {
+    v: string;
+}];
+declare function f3<T>(arg: {
+    [K in keyof T]: {
+        other: number;
+        produce: (n: string) => T[K];
+        consume: (x: T[K]) => void;
+    };
+}): T;
+declare const res7: {
+    a: string;
+    b: {
+        v: string;
+    };
+};

--- a/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.symbols
+++ b/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.symbols
@@ -1,0 +1,356 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts ===
+// repro cases based on https://github.com/microsoft/TypeScript/issues/53018
+
+declare function f<T>(
+>f : Symbol(f, Decl(intraExpressionInferencesReverseMappedTypes.ts, 0, 0))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 2, 19))
+
+  arg: {
+>arg : Symbol(arg, Decl(intraExpressionInferencesReverseMappedTypes.ts, 2, 22))
+
+    [K in keyof T]: {
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 4, 5))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 2, 19))
+
+      produce: (n: string) => T[K];
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 4, 21))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 5, 16))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 2, 19))
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 4, 5))
+
+      consume: (x: T[K]) => void;
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 5, 35))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 6, 16))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 2, 19))
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 4, 5))
+
+    };
+  }
+): T;
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 2, 19))
+
+const res1 = f({
+>res1 : Symbol(res1, Decl(intraExpressionInferencesReverseMappedTypes.ts, 11, 5))
+>f : Symbol(f, Decl(intraExpressionInferencesReverseMappedTypes.ts, 0, 0))
+
+  a: {
+>a : Symbol(a, Decl(intraExpressionInferencesReverseMappedTypes.ts, 11, 16))
+
+    produce: (n) => n,
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 12, 6))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 13, 14))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 13, 14))
+
+    consume: (x) => x.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 13, 22))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 14, 14))
+>x.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 14, 14))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+  b: {
+>b : Symbol(b, Decl(intraExpressionInferencesReverseMappedTypes.ts, 15, 4))
+
+    produce: (n) => ({ v: n }),
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 16, 6))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 17, 14))
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 17, 22))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 17, 14))
+
+    consume: (x) => x.v.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 17, 31))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 18, 14))
+>x.v.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x.v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 17, 22))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 18, 14))
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 17, 22))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+});
+
+const res2 = f({
+>res2 : Symbol(res2, Decl(intraExpressionInferencesReverseMappedTypes.ts, 22, 5))
+>f : Symbol(f, Decl(intraExpressionInferencesReverseMappedTypes.ts, 0, 0))
+
+  a: {
+>a : Symbol(a, Decl(intraExpressionInferencesReverseMappedTypes.ts, 22, 16))
+
+    produce: function () {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 23, 6))
+
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 26, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 27, 14))
+>x.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 27, 14))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+  b: {
+>b : Symbol(b, Decl(intraExpressionInferencesReverseMappedTypes.ts, 28, 4))
+
+    produce: function () {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 29, 6))
+
+      return { v: "hello" };
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 31, 14))
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 32, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 33, 14))
+>x.v.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x.v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 31, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 33, 14))
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 31, 14))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+});
+
+const res3 = f({
+>res3 : Symbol(res3, Decl(intraExpressionInferencesReverseMappedTypes.ts, 37, 5))
+>f : Symbol(f, Decl(intraExpressionInferencesReverseMappedTypes.ts, 0, 0))
+
+  a: {
+>a : Symbol(a, Decl(intraExpressionInferencesReverseMappedTypes.ts, 37, 16))
+
+    produce() {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 38, 6))
+
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 41, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 42, 14))
+>x.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 42, 14))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+  b: {
+>b : Symbol(b, Decl(intraExpressionInferencesReverseMappedTypes.ts, 43, 4))
+
+    produce() {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 44, 6))
+
+      return { v: "hello" };
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 46, 14))
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 47, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 48, 14))
+>x.v.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x.v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 46, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 48, 14))
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 46, 14))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+});
+
+declare function f2<T extends unknown[]>(
+>f2 : Symbol(f2, Decl(intraExpressionInferencesReverseMappedTypes.ts, 50, 3))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 52, 20))
+
+  arg: [
+>arg : Symbol(arg, Decl(intraExpressionInferencesReverseMappedTypes.ts, 52, 41))
+
+    ...{
+      [K in keyof T]: {
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 55, 7))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 52, 20))
+
+        produce: (n: string) => T[K];
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 55, 23))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 56, 18))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 52, 20))
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 55, 7))
+
+        consume: (x: T[K]) => void;
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 56, 37))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 57, 18))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 52, 20))
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 55, 7))
+
+      };
+    }
+  ]
+): T;
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 52, 20))
+
+const res4 = f2([
+>res4 : Symbol(res4, Decl(intraExpressionInferencesReverseMappedTypes.ts, 63, 5))
+>f2 : Symbol(f2, Decl(intraExpressionInferencesReverseMappedTypes.ts, 50, 3))
+  {
+    produce: (n) => n,
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 64, 3))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 65, 14))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 65, 14))
+
+    consume: (x) => x.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 65, 22))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 66, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 66, 14))
+
+  },
+  {
+    produce: (n) => ({ v: n }),
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 68, 3))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 69, 14))
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 69, 22))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 69, 14))
+
+    consume: (x) => x.v.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 69, 31))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 70, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 70, 14))
+
+  },
+]);
+
+const res5 = f2([
+>res5 : Symbol(res5, Decl(intraExpressionInferencesReverseMappedTypes.ts, 74, 5))
+>f2 : Symbol(f2, Decl(intraExpressionInferencesReverseMappedTypes.ts, 50, 3))
+  {
+    produce: function () {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 75, 3))
+
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 78, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 79, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 79, 14))
+
+  },
+  {
+    produce: function () {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 81, 3))
+
+      return { v: "hello" };
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 83, 14))
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 84, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 85, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 85, 14))
+
+  },
+]);
+
+const res6 = f2([
+>res6 : Symbol(res6, Decl(intraExpressionInferencesReverseMappedTypes.ts, 89, 5))
+>f2 : Symbol(f2, Decl(intraExpressionInferencesReverseMappedTypes.ts, 50, 3))
+  {
+    produce() {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 90, 3))
+
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 93, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 94, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 94, 14))
+
+  },
+  {
+    produce() {
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 96, 3))
+
+      return { v: "hello" };
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 98, 14))
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 99, 6))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 100, 14))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 100, 14))
+
+  },
+]);
+
+declare function f3<T>(
+>f3 : Symbol(f3, Decl(intraExpressionInferencesReverseMappedTypes.ts, 102, 3))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 104, 20))
+
+  arg: {
+>arg : Symbol(arg, Decl(intraExpressionInferencesReverseMappedTypes.ts, 104, 23))
+
+    [K in keyof T]: {
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 106, 5))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 104, 20))
+
+      other: number,
+>other : Symbol(other, Decl(intraExpressionInferencesReverseMappedTypes.ts, 106, 21))
+
+      produce: (n: string) => T[K];
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 107, 20))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 108, 16))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 104, 20))
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 106, 5))
+
+      consume: (x: T[K]) => void;
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 108, 35))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 109, 16))
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 104, 20))
+>K : Symbol(K, Decl(intraExpressionInferencesReverseMappedTypes.ts, 106, 5))
+
+    };
+  }
+): T;
+>T : Symbol(T, Decl(intraExpressionInferencesReverseMappedTypes.ts, 104, 20))
+
+const res7 = f3({
+>res7 : Symbol(res7, Decl(intraExpressionInferencesReverseMappedTypes.ts, 114, 5))
+>f3 : Symbol(f3, Decl(intraExpressionInferencesReverseMappedTypes.ts, 102, 3))
+
+  a: {
+>a : Symbol(a, Decl(intraExpressionInferencesReverseMappedTypes.ts, 114, 17))
+
+    other: 42,
+>other : Symbol(other, Decl(intraExpressionInferencesReverseMappedTypes.ts, 115, 6))
+
+    produce: (n) => n,
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 116, 14))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 117, 14))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 117, 14))
+
+    consume: (x) => x.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 117, 22))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 118, 14))
+>x.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 118, 14))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+  b: {
+>b : Symbol(b, Decl(intraExpressionInferencesReverseMappedTypes.ts, 119, 4))
+
+    other: 100,
+>other : Symbol(other, Decl(intraExpressionInferencesReverseMappedTypes.ts, 120, 6))
+
+    produce: (n) => ({ v: n }),
+>produce : Symbol(produce, Decl(intraExpressionInferencesReverseMappedTypes.ts, 121, 15))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 122, 14))
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 122, 22))
+>n : Symbol(n, Decl(intraExpressionInferencesReverseMappedTypes.ts, 122, 14))
+
+    consume: (x) => x.v.toLowerCase(),
+>consume : Symbol(consume, Decl(intraExpressionInferencesReverseMappedTypes.ts, 122, 31))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 123, 14))
+>x.v.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+>x.v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 122, 22))
+>x : Symbol(x, Decl(intraExpressionInferencesReverseMappedTypes.ts, 123, 14))
+>v : Symbol(v, Decl(intraExpressionInferencesReverseMappedTypes.ts, 122, 22))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
+
+  },
+});
+

--- a/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.types
+++ b/tests/baselines/reference/intraExpressionInferencesReverseMappedTypes.types
@@ -1,0 +1,443 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts ===
+// repro cases based on https://github.com/microsoft/TypeScript/issues/53018
+
+declare function f<T>(
+>f : <T>(arg: { [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }) => T
+
+  arg: {
+>arg : { [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }
+
+    [K in keyof T]: {
+      produce: (n: string) => T[K];
+>produce : (n: string) => T[K]
+>n : string
+
+      consume: (x: T[K]) => void;
+>consume : (x: T[K]) => void
+>x : T[K]
+
+    };
+  }
+): T;
+
+const res1 = f({
+>res1 : { a: string; b: { v: string; }; }
+>f({  a: {    produce: (n) => n,    consume: (x) => x.toLowerCase(),  },  b: {    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  },}) : { a: string; b: { v: string; }; }
+>f : <T>(arg: { [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }) => T
+>{  a: {    produce: (n) => n,    consume: (x) => x.toLowerCase(),  },  b: {    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  },} : { a: { produce: (n: string) => string; consume: (x: string) => string; }; b: { produce: (n: string) => { v: string; }; consume: (x: { v: string; }) => string; }; }
+
+  a: {
+>a : { produce: (n: string) => string; consume: (x: string) => string; }
+>{    produce: (n) => n,    consume: (x) => x.toLowerCase(),  } : { produce: (n: string) => string; consume: (x: string) => string; }
+
+    produce: (n) => n,
+>produce : (n: string) => string
+>(n) => n : (n: string) => string
+>n : string
+>n : string
+
+    consume: (x) => x.toLowerCase(),
+>consume : (x: string) => string
+>(x) => x.toLowerCase() : (x: string) => string
+>x : string
+>x.toLowerCase() : string
+>x.toLowerCase : () => string
+>x : string
+>toLowerCase : () => string
+
+  },
+  b: {
+>b : { produce: (n: string) => { v: string; }; consume: (x: { v: string; }) => string; }
+>{    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  } : { produce: (n: string) => { v: string; }; consume: (x: { v: string; }) => string; }
+
+    produce: (n) => ({ v: n }),
+>produce : (n: string) => { v: string; }
+>(n) => ({ v: n }) : (n: string) => { v: string; }
+>n : string
+>({ v: n }) : { v: string; }
+>{ v: n } : { v: string; }
+>v : string
+>n : string
+
+    consume: (x) => x.v.toLowerCase(),
+>consume : (x: { v: string; }) => string
+>(x) => x.v.toLowerCase() : (x: { v: string; }) => string
+>x : { v: string; }
+>x.v.toLowerCase() : string
+>x.v.toLowerCase : () => string
+>x.v : string
+>x : { v: string; }
+>v : string
+>toLowerCase : () => string
+
+  },
+});
+
+const res2 = f({
+>res2 : { a: string; b: { v: string; }; }
+>f({  a: {    produce: function () {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  b: {    produce: function () {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },}) : { a: string; b: { v: string; }; }
+>f : <T>(arg: { [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }) => T
+>{  a: {    produce: function () {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  b: {    produce: function () {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },} : { a: { produce: () => string; consume: (x: string) => string; }; b: { produce: () => { v: string; }; consume: (x: { v: string; }) => string; }; }
+
+  a: {
+>a : { produce: () => string; consume: (x: string) => string; }
+>{    produce: function () {      return "hello";    },    consume: (x) => x.toLowerCase(),  } : { produce: () => string; consume: (x: string) => string; }
+
+    produce: function () {
+>produce : () => string
+>function () {      return "hello";    } : () => string
+
+      return "hello";
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : (x: string) => string
+>(x) => x.toLowerCase() : (x: string) => string
+>x : string
+>x.toLowerCase() : string
+>x.toLowerCase : () => string
+>x : string
+>toLowerCase : () => string
+
+  },
+  b: {
+>b : { produce: () => { v: string; }; consume: (x: { v: string; }) => string; }
+>{    produce: function () {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  } : { produce: () => { v: string; }; consume: (x: { v: string; }) => string; }
+
+    produce: function () {
+>produce : () => { v: string; }
+>function () {      return { v: "hello" };    } : () => { v: string; }
+
+      return { v: "hello" };
+>{ v: "hello" } : { v: string; }
+>v : string
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : (x: { v: string; }) => string
+>(x) => x.v.toLowerCase() : (x: { v: string; }) => string
+>x : { v: string; }
+>x.v.toLowerCase() : string
+>x.v.toLowerCase : () => string
+>x.v : string
+>x : { v: string; }
+>v : string
+>toLowerCase : () => string
+
+  },
+});
+
+const res3 = f({
+>res3 : { a: string; b: { v: string; }; }
+>f({  a: {    produce() {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  b: {    produce() {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },}) : { a: string; b: { v: string; }; }
+>f : <T>(arg: { [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }) => T
+>{  a: {    produce() {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  b: {    produce() {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },} : { a: { produce(): string; consume: (x: string) => string; }; b: { produce(): { v: string; }; consume: (x: { v: string; }) => string; }; }
+
+  a: {
+>a : { produce(): string; consume: (x: string) => string; }
+>{    produce() {      return "hello";    },    consume: (x) => x.toLowerCase(),  } : { produce(): string; consume: (x: string) => string; }
+
+    produce() {
+>produce : () => string
+
+      return "hello";
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : (x: string) => string
+>(x) => x.toLowerCase() : (x: string) => string
+>x : string
+>x.toLowerCase() : string
+>x.toLowerCase : () => string
+>x : string
+>toLowerCase : () => string
+
+  },
+  b: {
+>b : { produce(): { v: string; }; consume: (x: { v: string; }) => string; }
+>{    produce() {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  } : { produce(): { v: string; }; consume: (x: { v: string; }) => string; }
+
+    produce() {
+>produce : () => { v: string; }
+
+      return { v: "hello" };
+>{ v: "hello" } : { v: string; }
+>v : string
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : (x: { v: string; }) => string
+>(x) => x.v.toLowerCase() : (x: { v: string; }) => string
+>x : { v: string; }
+>x.v.toLowerCase() : string
+>x.v.toLowerCase : () => string
+>x.v : string
+>x : { v: string; }
+>v : string
+>toLowerCase : () => string
+
+  },
+});
+
+declare function f2<T extends unknown[]>(
+>f2 : <T extends unknown[]>(arg: [...{ [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }]) => T
+
+  arg: [
+>arg : [...{ [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }]
+
+    ...{
+      [K in keyof T]: {
+        produce: (n: string) => T[K];
+>produce : (n: string) => T[K]
+>n : string
+
+        consume: (x: T[K]) => void;
+>consume : (x: T[K]) => void
+>x : T[K]
+
+      };
+    }
+  ]
+): T;
+
+const res4 = f2([
+>res4 : [string, { v: string; }]
+>f2([  {    produce: (n) => n,    consume: (x) => x.toLowerCase(),  },  {    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  },]) : [string, { v: string; }]
+>f2 : <T extends unknown[]>(arg: [...{ [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }]) => T
+>[  {    produce: (n) => n,    consume: (x) => x.toLowerCase(),  },  {    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  },] : [{ produce: (n: string) => string; consume: (x: unknown) => any; }, { produce: (n: string) => { v: string; }; consume: (x: unknown) => any; }]
+  {
+>{    produce: (n) => n,    consume: (x) => x.toLowerCase(),  } : { produce: (n: string) => string; consume: (x: unknown) => any; }
+
+    produce: (n) => n,
+>produce : (n: string) => string
+>(n) => n : (n: string) => string
+>n : string
+>n : string
+
+    consume: (x) => x.toLowerCase(),
+>consume : (x: unknown) => any
+>(x) => x.toLowerCase() : (x: unknown) => any
+>x : unknown
+>x.toLowerCase() : any
+>x.toLowerCase : any
+>x : unknown
+>toLowerCase : any
+
+  },
+  {
+>{    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  } : { produce: (n: string) => { v: string; }; consume: (x: unknown) => any; }
+
+    produce: (n) => ({ v: n }),
+>produce : (n: string) => { v: string; }
+>(n) => ({ v: n }) : (n: string) => { v: string; }
+>n : string
+>({ v: n }) : { v: string; }
+>{ v: n } : { v: string; }
+>v : string
+>n : string
+
+    consume: (x) => x.v.toLowerCase(),
+>consume : (x: unknown) => any
+>(x) => x.v.toLowerCase() : (x: unknown) => any
+>x : unknown
+>x.v.toLowerCase() : any
+>x.v.toLowerCase : any
+>x.v : any
+>x : unknown
+>v : any
+>toLowerCase : any
+
+  },
+]);
+
+const res5 = f2([
+>res5 : [string, { v: string; }]
+>f2([  {    produce: function () {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  {    produce: function () {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },]) : [string, { v: string; }]
+>f2 : <T extends unknown[]>(arg: [...{ [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }]) => T
+>[  {    produce: function () {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  {    produce: function () {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },] : [{ produce: () => string; consume: (x: unknown) => any; }, { produce: () => { v: string; }; consume: (x: unknown) => any; }]
+  {
+>{    produce: function () {      return "hello";    },    consume: (x) => x.toLowerCase(),  } : { produce: () => string; consume: (x: unknown) => any; }
+
+    produce: function () {
+>produce : () => string
+>function () {      return "hello";    } : () => string
+
+      return "hello";
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : (x: unknown) => any
+>(x) => x.toLowerCase() : (x: unknown) => any
+>x : unknown
+>x.toLowerCase() : any
+>x.toLowerCase : any
+>x : unknown
+>toLowerCase : any
+
+  },
+  {
+>{    produce: function () {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  } : { produce: () => { v: string; }; consume: (x: unknown) => any; }
+
+    produce: function () {
+>produce : () => { v: string; }
+>function () {      return { v: "hello" };    } : () => { v: string; }
+
+      return { v: "hello" };
+>{ v: "hello" } : { v: string; }
+>v : string
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : (x: unknown) => any
+>(x) => x.v.toLowerCase() : (x: unknown) => any
+>x : unknown
+>x.v.toLowerCase() : any
+>x.v.toLowerCase : any
+>x.v : any
+>x : unknown
+>v : any
+>toLowerCase : any
+
+  },
+]);
+
+const res6 = f2([
+>res6 : [string, { v: string; }]
+>f2([  {    produce() {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  {    produce() {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },]) : [string, { v: string; }]
+>f2 : <T extends unknown[]>(arg: [...{ [K in keyof T]: { produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }]) => T
+>[  {    produce() {      return "hello";    },    consume: (x) => x.toLowerCase(),  },  {    produce() {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  },] : [{ produce(): string; consume: (x: unknown) => any; }, { produce(): { v: string; }; consume: (x: unknown) => any; }]
+  {
+>{    produce() {      return "hello";    },    consume: (x) => x.toLowerCase(),  } : { produce(): string; consume: (x: unknown) => any; }
+
+    produce() {
+>produce : () => string
+
+      return "hello";
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.toLowerCase(),
+>consume : (x: unknown) => any
+>(x) => x.toLowerCase() : (x: unknown) => any
+>x : unknown
+>x.toLowerCase() : any
+>x.toLowerCase : any
+>x : unknown
+>toLowerCase : any
+
+  },
+  {
+>{    produce() {      return { v: "hello" };    },    consume: (x) => x.v.toLowerCase(),  } : { produce(): { v: string; }; consume: (x: unknown) => any; }
+
+    produce() {
+>produce : () => { v: string; }
+
+      return { v: "hello" };
+>{ v: "hello" } : { v: string; }
+>v : string
+>"hello" : "hello"
+
+    },
+    consume: (x) => x.v.toLowerCase(),
+>consume : (x: unknown) => any
+>(x) => x.v.toLowerCase() : (x: unknown) => any
+>x : unknown
+>x.v.toLowerCase() : any
+>x.v.toLowerCase : any
+>x.v : any
+>x : unknown
+>v : any
+>toLowerCase : any
+
+  },
+]);
+
+declare function f3<T>(
+>f3 : <T>(arg: { [K in keyof T]: { other: number; produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }) => T
+
+  arg: {
+>arg : { [K in keyof T]: { other: number; produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }
+
+    [K in keyof T]: {
+      other: number,
+>other : number
+
+      produce: (n: string) => T[K];
+>produce : (n: string) => T[K]
+>n : string
+
+      consume: (x: T[K]) => void;
+>consume : (x: T[K]) => void
+>x : T[K]
+
+    };
+  }
+): T;
+
+const res7 = f3({
+>res7 : { a: string; b: { v: string; }; }
+>f3({  a: {    other: 42,    produce: (n) => n,    consume: (x) => x.toLowerCase(),  },  b: {    other: 100,    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  },}) : { a: string; b: { v: string; }; }
+>f3 : <T>(arg: { [K in keyof T]: { other: number; produce: (n: string) => T[K]; consume: (x: T[K]) => void; }; }) => T
+>{  a: {    other: 42,    produce: (n) => n,    consume: (x) => x.toLowerCase(),  },  b: {    other: 100,    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  },} : { a: { other: number; produce: (n: string) => string; consume: (x: string) => string; }; b: { other: number; produce: (n: string) => { v: string; }; consume: (x: { v: string; }) => string; }; }
+
+  a: {
+>a : { other: number; produce: (n: string) => string; consume: (x: string) => string; }
+>{    other: 42,    produce: (n) => n,    consume: (x) => x.toLowerCase(),  } : { other: number; produce: (n: string) => string; consume: (x: string) => string; }
+
+    other: 42,
+>other : number
+>42 : 42
+
+    produce: (n) => n,
+>produce : (n: string) => string
+>(n) => n : (n: string) => string
+>n : string
+>n : string
+
+    consume: (x) => x.toLowerCase(),
+>consume : (x: string) => string
+>(x) => x.toLowerCase() : (x: string) => string
+>x : string
+>x.toLowerCase() : string
+>x.toLowerCase : () => string
+>x : string
+>toLowerCase : () => string
+
+  },
+  b: {
+>b : { other: number; produce: (n: string) => { v: string; }; consume: (x: { v: string; }) => string; }
+>{    other: 100,    produce: (n) => ({ v: n }),    consume: (x) => x.v.toLowerCase(),  } : { other: number; produce: (n: string) => { v: string; }; consume: (x: { v: string; }) => string; }
+
+    other: 100,
+>other : number
+>100 : 100
+
+    produce: (n) => ({ v: n }),
+>produce : (n: string) => { v: string; }
+>(n) => ({ v: n }) : (n: string) => { v: string; }
+>n : string
+>({ v: n }) : { v: string; }
+>{ v: n } : { v: string; }
+>v : string
+>n : string
+
+    consume: (x) => x.v.toLowerCase(),
+>consume : (x: { v: string; }) => string
+>(x) => x.v.toLowerCase() : (x: { v: string; }) => string
+>x : { v: string; }
+>x.v.toLowerCase() : string
+>x.v.toLowerCase : () => string
+>x.v : string
+>x : { v: string; }
+>v : string
+>toLowerCase : () => string
+
+  },
+});
+

--- a/tests/baselines/reference/mappedTypeContextualTypesApplied.errors.txt
+++ b/tests/baselines/reference/mappedTypeContextualTypesApplied.errors.txt
@@ -1,0 +1,38 @@
+tests/cases/compiler/mappedTypeContextualTypesApplied.ts(18,10): error TS7023: 'foo' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+tests/cases/compiler/mappedTypeContextualTypesApplied.ts(18,15): error TS7006: Parameter 's' implicitly has an 'any' type.
+tests/cases/compiler/mappedTypeContextualTypesApplied.ts(19,10): error TS7023: 'foo' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+tests/cases/compiler/mappedTypeContextualTypesApplied.ts(19,15): error TS7006: Parameter 's' implicitly has an 'any' type.
+
+
+==== tests/cases/compiler/mappedTypeContextualTypesApplied.ts (4 errors) ====
+    type TakeString = (s: string) => any;
+    
+    // Various functions accepting an object whose properties are TakeString functions.
+    // Note these all use mapped types.
+    declare function mapped1<T extends {[P in string]: TakeString}>(obj: T): void;
+    declare function mapped2<T extends {[P in keyof T]: TakeString}>(obj: T): void;
+    declare function mapped3<T extends {[P in keyof any]: TakeString}>(obj: T): void;
+    declare function mapped4<T>(obj: T & {[P in keyof T]: TakeString}): void;
+    declare function mapped5<T, K extends keyof T>(obj: T & {[P in K]: TakeString}): void;
+    declare function mapped6<K extends string>(obj: {[P in K]: TakeString}): void;
+    declare function mapped7<K extends keyof any>(obj: {[P in K]: TakeString}): void;
+    declare function mapped8<K extends 'foo'>(obj: {[P in K]: TakeString}): void;
+    declare function mapped9<K extends 'foo'|'bar'>(obj: {[P in K]: TakeString}): void;
+    
+    mapped1({foo: s => 42});
+    mapped2({foo: s => 42});
+    mapped3({foo: s => 42});
+    mapped4({foo: s => 42});
+             ~~~
+!!! error TS7023: 'foo' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+                  ~
+!!! error TS7006: Parameter 's' implicitly has an 'any' type.
+    mapped5({foo: s => 42});
+             ~~~
+!!! error TS7023: 'foo' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+                  ~
+!!! error TS7006: Parameter 's' implicitly has an 'any' type.
+    mapped6({foo: s => 42});
+    mapped7({foo: s => 42});
+    mapped8({foo: s => 42});
+    mapped9({foo: s => 42});

--- a/tests/baselines/reference/mappedTypeContextualTypesApplied.types
+++ b/tests/baselines/reference/mappedTypeContextualTypesApplied.types
@@ -71,19 +71,19 @@ mapped3({foo: s => 42});
 mapped4({foo: s => 42});
 >mapped4({foo: s => 42}) : void
 >mapped4 : <T>(obj: T & { [P in keyof T]: TakeString; }) => void
->{foo: s => 42} : { foo: (s: string) => number; }
->foo : (s: string) => number
->s => 42 : (s: string) => number
->s : string
+>{foo: s => 42} : { foo: (s: any) => any; }
+>foo : (s: any) => any
+>s => 42 : (s: any) => any
+>s : any
 >42 : 42
 
 mapped5({foo: s => 42});
 >mapped5({foo: s => 42}) : void
 >mapped5 : <T, K extends keyof T>(obj: T & { [P in K]: TakeString; }) => void
->{foo: s => 42} : { foo: (s: string) => number; }
->foo : (s: string) => number
->s => 42 : (s: string) => number
->s : string
+>{foo: s => 42} : { foo: (s: any) => any; }
+>foo : (s: any) => any
+>s => 42 : (s: any) => any
+>s : any
 >42 : 42
 
 mapped6({foo: s => 42});

--- a/tests/baselines/reference/reverseMappedInferenceWithCircularConstraint.errors.txt
+++ b/tests/baselines/reference/reverseMappedInferenceWithCircularConstraint.errors.txt
@@ -1,0 +1,65 @@
+tests/cases/compiler/reverseMappedInferenceWithCircularConstraint.ts(47,3): error TS2322: Type '"unknown"' is not assignable to type '"pending"'.
+
+
+==== tests/cases/compiler/reverseMappedInferenceWithCircularConstraint.ts (1 errors) ====
+    // repro from https://github.com/microsoft/TypeScript/issues/48798
+    
+    type AnyFunction = (...args: any[]) => any;
+    
+    type InferNarrowest<T> = T extends any
+      ? T extends AnyFunction
+        ? T
+        : T extends object
+        ? InferNarrowestObject<T>
+        : T
+      : never;
+    
+    type InferNarrowestObject<T> = {
+      readonly [K in keyof T]: InferNarrowest<T[K]>;
+    };
+    
+    type Config<TGlobal, TState = Prop<TGlobal, "states">> = {
+      states: {
+        [StateKey in keyof TState]: {
+          on?: {};
+        };
+      };
+    } & {
+      initial: keyof TState;
+    };
+    
+    type Prop<T, K> = K extends keyof T ? T[K] : never;
+    
+    const createMachine = <TConfig extends Config<TConfig>>(
+      _config: InferNarrowestObject<TConfig>
+    ): void => {};
+    
+    createMachine({
+      initial: "pending",
+      states: {
+        pending: {
+          on: {
+            done() {
+              return "noData";
+            },
+          },
+        },
+      },
+    });
+    
+    createMachine({
+      initial: "unknown", // error
+      ~~~~~~~
+!!! error TS2322: Type '"unknown"' is not assignable to type '"pending"'.
+!!! related TS6500 tests/cases/compiler/reverseMappedInferenceWithCircularConstraint.ts:24:3: The expected type comes from property 'initial' which is declared here on type 'InferNarrowestObject<Config<{ initial: "unknown"; states: { pending: { on: { done: unknown; }; }; }; }, { pending: { on: { done: unknown; }; }; }>>'
+      states: {
+        pending: {
+          on: {
+            done() {
+              return "noData";
+            },
+          },
+        },
+      },
+    });
+    

--- a/tests/baselines/reference/reverseMappedInferenceWithCircularConstraint.symbols
+++ b/tests/baselines/reference/reverseMappedInferenceWithCircularConstraint.symbols
@@ -1,0 +1,142 @@
+=== tests/cases/compiler/reverseMappedInferenceWithCircularConstraint.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/48798
+
+type AnyFunction = (...args: any[]) => any;
+>AnyFunction : Symbol(AnyFunction, Decl(reverseMappedInferenceWithCircularConstraint.ts, 0, 0))
+>args : Symbol(args, Decl(reverseMappedInferenceWithCircularConstraint.ts, 2, 20))
+
+type InferNarrowest<T> = T extends any
+>InferNarrowest : Symbol(InferNarrowest, Decl(reverseMappedInferenceWithCircularConstraint.ts, 2, 43))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 4, 20))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 4, 20))
+
+  ? T extends AnyFunction
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 4, 20))
+>AnyFunction : Symbol(AnyFunction, Decl(reverseMappedInferenceWithCircularConstraint.ts, 0, 0))
+
+    ? T
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 4, 20))
+
+    : T extends object
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 4, 20))
+
+    ? InferNarrowestObject<T>
+>InferNarrowestObject : Symbol(InferNarrowestObject, Decl(reverseMappedInferenceWithCircularConstraint.ts, 10, 10))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 4, 20))
+
+    : T
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 4, 20))
+
+  : never;
+
+type InferNarrowestObject<T> = {
+>InferNarrowestObject : Symbol(InferNarrowestObject, Decl(reverseMappedInferenceWithCircularConstraint.ts, 10, 10))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 12, 26))
+
+  readonly [K in keyof T]: InferNarrowest<T[K]>;
+>K : Symbol(K, Decl(reverseMappedInferenceWithCircularConstraint.ts, 13, 12))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 12, 26))
+>InferNarrowest : Symbol(InferNarrowest, Decl(reverseMappedInferenceWithCircularConstraint.ts, 2, 43))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 12, 26))
+>K : Symbol(K, Decl(reverseMappedInferenceWithCircularConstraint.ts, 13, 12))
+
+};
+
+type Config<TGlobal, TState = Prop<TGlobal, "states">> = {
+>Config : Symbol(Config, Decl(reverseMappedInferenceWithCircularConstraint.ts, 14, 2))
+>TGlobal : Symbol(TGlobal, Decl(reverseMappedInferenceWithCircularConstraint.ts, 16, 12))
+>TState : Symbol(TState, Decl(reverseMappedInferenceWithCircularConstraint.ts, 16, 20))
+>Prop : Symbol(Prop, Decl(reverseMappedInferenceWithCircularConstraint.ts, 24, 2))
+>TGlobal : Symbol(TGlobal, Decl(reverseMappedInferenceWithCircularConstraint.ts, 16, 12))
+
+  states: {
+>states : Symbol(states, Decl(reverseMappedInferenceWithCircularConstraint.ts, 16, 58))
+
+    [StateKey in keyof TState]: {
+>StateKey : Symbol(StateKey, Decl(reverseMappedInferenceWithCircularConstraint.ts, 18, 5))
+>TState : Symbol(TState, Decl(reverseMappedInferenceWithCircularConstraint.ts, 16, 20))
+
+      on?: {};
+>on : Symbol(on, Decl(reverseMappedInferenceWithCircularConstraint.ts, 18, 33))
+
+    };
+  };
+} & {
+  initial: keyof TState;
+>initial : Symbol(initial, Decl(reverseMappedInferenceWithCircularConstraint.ts, 22, 5))
+>TState : Symbol(TState, Decl(reverseMappedInferenceWithCircularConstraint.ts, 16, 20))
+
+};
+
+type Prop<T, K> = K extends keyof T ? T[K] : never;
+>Prop : Symbol(Prop, Decl(reverseMappedInferenceWithCircularConstraint.ts, 24, 2))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 26, 10))
+>K : Symbol(K, Decl(reverseMappedInferenceWithCircularConstraint.ts, 26, 12))
+>K : Symbol(K, Decl(reverseMappedInferenceWithCircularConstraint.ts, 26, 12))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 26, 10))
+>T : Symbol(T, Decl(reverseMappedInferenceWithCircularConstraint.ts, 26, 10))
+>K : Symbol(K, Decl(reverseMappedInferenceWithCircularConstraint.ts, 26, 12))
+
+const createMachine = <TConfig extends Config<TConfig>>(
+>createMachine : Symbol(createMachine, Decl(reverseMappedInferenceWithCircularConstraint.ts, 28, 5))
+>TConfig : Symbol(TConfig, Decl(reverseMappedInferenceWithCircularConstraint.ts, 28, 23))
+>Config : Symbol(Config, Decl(reverseMappedInferenceWithCircularConstraint.ts, 14, 2))
+>TConfig : Symbol(TConfig, Decl(reverseMappedInferenceWithCircularConstraint.ts, 28, 23))
+
+  _config: InferNarrowestObject<TConfig>
+>_config : Symbol(_config, Decl(reverseMappedInferenceWithCircularConstraint.ts, 28, 56))
+>InferNarrowestObject : Symbol(InferNarrowestObject, Decl(reverseMappedInferenceWithCircularConstraint.ts, 10, 10))
+>TConfig : Symbol(TConfig, Decl(reverseMappedInferenceWithCircularConstraint.ts, 28, 23))
+
+): void => {};
+
+createMachine({
+>createMachine : Symbol(createMachine, Decl(reverseMappedInferenceWithCircularConstraint.ts, 28, 5))
+
+  initial: "pending",
+>initial : Symbol(initial, Decl(reverseMappedInferenceWithCircularConstraint.ts, 32, 15))
+
+  states: {
+>states : Symbol(states, Decl(reverseMappedInferenceWithCircularConstraint.ts, 33, 21))
+
+    pending: {
+>pending : Symbol(pending, Decl(reverseMappedInferenceWithCircularConstraint.ts, 34, 11))
+
+      on: {
+>on : Symbol(on, Decl(reverseMappedInferenceWithCircularConstraint.ts, 35, 14))
+
+        done() {
+>done : Symbol(done, Decl(reverseMappedInferenceWithCircularConstraint.ts, 36, 11))
+
+          return "noData";
+        },
+      },
+    },
+  },
+});
+
+createMachine({
+>createMachine : Symbol(createMachine, Decl(reverseMappedInferenceWithCircularConstraint.ts, 28, 5))
+
+  initial: "unknown", // error
+>initial : Symbol(initial, Decl(reverseMappedInferenceWithCircularConstraint.ts, 45, 15))
+
+  states: {
+>states : Symbol(states, Decl(reverseMappedInferenceWithCircularConstraint.ts, 46, 21))
+
+    pending: {
+>pending : Symbol(pending, Decl(reverseMappedInferenceWithCircularConstraint.ts, 47, 11))
+
+      on: {
+>on : Symbol(on, Decl(reverseMappedInferenceWithCircularConstraint.ts, 48, 14))
+
+        done() {
+>done : Symbol(done, Decl(reverseMappedInferenceWithCircularConstraint.ts, 49, 11))
+
+          return "noData";
+        },
+      },
+    },
+  },
+});
+

--- a/tests/baselines/reference/reverseMappedInferenceWithCircularConstraint.types
+++ b/tests/baselines/reference/reverseMappedInferenceWithCircularConstraint.types
@@ -1,0 +1,119 @@
+=== tests/cases/compiler/reverseMappedInferenceWithCircularConstraint.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/48798
+
+type AnyFunction = (...args: any[]) => any;
+>AnyFunction : (...args: any[]) => any
+>args : any[]
+
+type InferNarrowest<T> = T extends any
+>InferNarrowest : InferNarrowest<T>
+
+  ? T extends AnyFunction
+    ? T
+    : T extends object
+    ? InferNarrowestObject<T>
+    : T
+  : never;
+
+type InferNarrowestObject<T> = {
+>InferNarrowestObject : InferNarrowestObject<T>
+
+  readonly [K in keyof T]: InferNarrowest<T[K]>;
+};
+
+type Config<TGlobal, TState = Prop<TGlobal, "states">> = {
+>Config : Config<TGlobal, TState>
+
+  states: {
+>states : { [StateKey in keyof TState]: { on?: {} | undefined; }; }
+
+    [StateKey in keyof TState]: {
+      on?: {};
+>on : {} | undefined
+
+    };
+  };
+} & {
+  initial: keyof TState;
+>initial : keyof TState
+
+};
+
+type Prop<T, K> = K extends keyof T ? T[K] : never;
+>Prop : Prop<T, K>
+
+const createMachine = <TConfig extends Config<TConfig>>(
+>createMachine : <TConfig extends Config<TConfig, Prop<TConfig, "states">>>(_config: InferNarrowestObject<TConfig>) => void
+><TConfig extends Config<TConfig>>(  _config: InferNarrowestObject<TConfig>): void => {} : <TConfig extends Config<TConfig, Prop<TConfig, "states">>>(_config: InferNarrowestObject<TConfig>) => void
+
+  _config: InferNarrowestObject<TConfig>
+>_config : InferNarrowestObject<TConfig>
+
+): void => {};
+
+createMachine({
+>createMachine({  initial: "pending",  states: {    pending: {      on: {        done() {          return "noData";        },      },    },  },}) : void
+>createMachine : <TConfig extends Config<TConfig, Prop<TConfig, "states">>>(_config: InferNarrowestObject<TConfig>) => void
+>{  initial: "pending",  states: {    pending: {      on: {        done() {          return "noData";        },      },    },  },} : { initial: "pending"; states: { pending: { on: { done(): "noData"; }; }; }; }
+
+  initial: "pending",
+>initial : "pending"
+>"pending" : "pending"
+
+  states: {
+>states : { pending: { on: { done(): "noData"; }; }; }
+>{    pending: {      on: {        done() {          return "noData";        },      },    },  } : { pending: { on: { done(): "noData"; }; }; }
+
+    pending: {
+>pending : { on: { done(): "noData"; }; }
+>{      on: {        done() {          return "noData";        },      },    } : { on: { done(): "noData"; }; }
+
+      on: {
+>on : { done(): "noData"; }
+>{        done() {          return "noData";        },      } : { done(): "noData"; }
+
+        done() {
+>done : () => "noData"
+
+          return "noData";
+>"noData" : "noData"
+
+        },
+      },
+    },
+  },
+});
+
+createMachine({
+>createMachine({  initial: "unknown", // error  states: {    pending: {      on: {        done() {          return "noData";        },      },    },  },}) : void
+>createMachine : <TConfig extends Config<TConfig, Prop<TConfig, "states">>>(_config: InferNarrowestObject<TConfig>) => void
+>{  initial: "unknown", // error  states: {    pending: {      on: {        done() {          return "noData";        },      },    },  },} : { initial: "unknown"; states: { pending: { on: { done(): string; }; }; }; }
+
+  initial: "unknown", // error
+>initial : "unknown"
+>"unknown" : "unknown"
+
+  states: {
+>states : { pending: { on: { done(): string; }; }; }
+>{    pending: {      on: {        done() {          return "noData";        },      },    },  } : { pending: { on: { done(): string; }; }; }
+
+    pending: {
+>pending : { on: { done(): string; }; }
+>{      on: {        done() {          return "noData";        },      },    } : { on: { done(): string; }; }
+
+      on: {
+>on : { done(): string; }
+>{        done() {          return "noData";        },      } : { done(): string; }
+
+        done() {
+>done : () => string
+
+          return "noData";
+>"noData" : "noData"
+
+        },
+      },
+    },
+  },
+});
+

--- a/tests/baselines/reference/reverseMappedPartiallyInferableTypes.types
+++ b/tests/baselines/reference/reverseMappedPartiallyInferableTypes.types
@@ -206,8 +206,8 @@ const obj2 = id({
 // No properties have inferable types
 
 const obj3 = id({
->obj3 : Mapped<unknown>
->id({    foo: {        contains(k) {            return k.length > 0;        }    }}) : Mapped<unknown>
+>obj3 : Mapped<{ foo: unknown; }>
+>id({    foo: {        contains(k) {            return k.length > 0;        }    }}) : Mapped<{ foo: unknown; }>
 >id : <T>(arg: Mapped<T>) => Mapped<T>
 >{    foo: {        contains(k) {            return k.length > 0;        }    }} : { foo: { contains(k: unknown): boolean; }; }
 

--- a/tests/cases/compiler/reverseMappedInferenceWithCircularConstraint.ts
+++ b/tests/cases/compiler/reverseMappedInferenceWithCircularConstraint.ts
@@ -1,0 +1,60 @@
+// @strict: true
+// @noEmit: true
+
+// repro from https://github.com/microsoft/TypeScript/issues/48798
+
+type AnyFunction = (...args: any[]) => any;
+
+type InferNarrowest<T> = T extends any
+  ? T extends AnyFunction
+    ? T
+    : T extends object
+    ? InferNarrowestObject<T>
+    : T
+  : never;
+
+type InferNarrowestObject<T> = {
+  readonly [K in keyof T]: InferNarrowest<T[K]>;
+};
+
+type Config<TGlobal, TState = Prop<TGlobal, "states">> = {
+  states: {
+    [StateKey in keyof TState]: {
+      on?: {};
+    };
+  };
+} & {
+  initial: keyof TState;
+};
+
+type Prop<T, K> = K extends keyof T ? T[K] : never;
+
+const createMachine = <TConfig extends Config<TConfig>>(
+  _config: InferNarrowestObject<TConfig>
+): void => {};
+
+createMachine({
+  initial: "pending",
+  states: {
+    pending: {
+      on: {
+        done() {
+          return "noData";
+        },
+      },
+    },
+  },
+});
+
+createMachine({
+  initial: "unknown", // error
+  states: {
+    pending: {
+      on: {
+        done() {
+          return "noData";
+        },
+      },
+    },
+  },
+});

--- a/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesReverseMappedTypes.ts
@@ -1,0 +1,129 @@
+// @strict: true
+// @declaration: true
+
+// repro cases based on https://github.com/microsoft/TypeScript/issues/53018
+
+declare function f<T>(
+  arg: {
+    [K in keyof T]: {
+      produce: (n: string) => T[K];
+      consume: (x: T[K]) => void;
+    };
+  }
+): T;
+
+const res1 = f({
+  a: {
+    produce: (n) => n,
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    produce: (n) => ({ v: n }),
+    consume: (x) => x.v.toLowerCase(),
+  },
+});
+
+const res2 = f({
+  a: {
+    produce: function () {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    produce: function () {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+});
+
+const res3 = f({
+  a: {
+    produce() {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    produce() {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+});
+
+declare function f2<T extends unknown[]>(
+  arg: [
+    ...{
+      [K in keyof T]: {
+        produce: (n: string) => T[K];
+        consume: (x: T[K]) => void;
+      };
+    }
+  ]
+): T;
+
+const res4 = f2([
+  {
+    produce: (n) => n,
+    consume: (x) => x.toLowerCase(),
+  },
+  {
+    produce: (n) => ({ v: n }),
+    consume: (x) => x.v.toLowerCase(),
+  },
+]);
+
+const res5 = f2([
+  {
+    produce: function () {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  {
+    produce: function () {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+]);
+
+const res6 = f2([
+  {
+    produce() {
+      return "hello";
+    },
+    consume: (x) => x.toLowerCase(),
+  },
+  {
+    produce() {
+      return { v: "hello" };
+    },
+    consume: (x) => x.v.toLowerCase(),
+  },
+]);
+
+declare function f3<T>(
+  arg: {
+    [K in keyof T]: {
+      other: number,
+      produce: (n: string) => T[K];
+      consume: (x: T[K]) => void;
+    };
+  }
+): T;
+
+const res7 = f3({
+  a: {
+    other: 42,
+    produce: (n) => n,
+    consume: (x) => x.toLowerCase(),
+  },
+  b: {
+    other: 100,
+    produce: (n) => ({ v: n }),
+    consume: (x) => x.v.toLowerCase(),
+  },
+});


### PR DESCRIPTION
it's an extension of the algorithm introduced in https://github.com/microsoft/TypeScript/pull/48538
closes https://github.com/microsoft/TypeScript/issues/53018
fixes https://github.com/microsoft/TypeScript/issues/48798