### PR TITLE
Fix 'var' hoisting in 'if' in CJS/AMD emit

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -8,14 +8,20 @@ import {
     ArrowFunction,
     BinaryExpression,
     BindingElement,
+    Block,
     Bundle,
     CallExpression,
+    CaseBlock,
+    CaseClause,
+    CatchClause,
     chainBundle,
     ClassDeclaration,
     collectExternalModuleInfo,
     Debug,
     Declaration,
+    DefaultClause,
     DestructuringAssignment,
+    DoStatement,
     EmitFlags,
     EmitHelper,
     EmitHint,
@@ -28,6 +34,8 @@ import {
     firstOrUndefined,
     flattenDestructuringAssignment,
     FlattenLevel,
+    ForInStatement,
+    ForOfStatement,
     ForStatement,
     FunctionDeclaration,
     FunctionExpression,
@@ -52,6 +60,7 @@ import {
     hasSyntacticModifier,
     Identifier,
     idText,
+    IfStatement,
     ImportCall,
     ImportDeclaration,
     ImportEqualsDeclaration,
@@ -62,6 +71,9 @@ import {
     isArrowFunction,
     isAssignmentOperator,
     isBindingPattern,
+    isBlock,
+    isCaseBlock,
+    isCaseOrDefaultClause,
     isClassElement,
     isClassExpression,
     isDeclarationNameOfEnumOrNamespace,
@@ -100,6 +112,8 @@ import {
     isStatement,
     isStringLiteral,
     isVariableDeclaration,
+    isVariableDeclarationList,
+    LabeledStatement,
     length,
     mapDefined,
     Modifier,
@@ -123,22 +137,28 @@ import {
     setTextRange,
     ShorthandPropertyAssignment,
     singleOrMany,
+    some,
     SourceFile,
     startOnNewLine,
     Statement,
+    SwitchStatement,
     SyntaxKind,
     TaggedTemplateExpression,
     TextRange,
     TransformationContext,
     TransformFlags,
     tryGetModuleNameFromFile,
+    TryStatement,
     VariableDeclaration,
+    VariableDeclarationList,
     VariableStatement,
     visitEachChild,
     visitIterationBody,
     visitNode,
     visitNodes,
     VisitResult,
+    WhileStatement,
+    WithStatement,
 } from "../../_namespaces/ts";
 
 /** @internal */
@@ -669,6 +689,72 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
                 return visitClassDeclaration(node as ClassDeclaration);
 
             default:
+                return topLevelNestedVisitor(node);
+        }
+    }
+
+    /**
+     * Visit nested elements at the top-level of a module.
+     *
+     * @param node The node to visit.
+     */
+    function topLevelNestedVisitor(node: Node): VisitResult<Node | undefined> {
+        switch (node.kind) {
+            case SyntaxKind.VariableStatement:
+                return visitVariableStatement(node as VariableStatement);
+
+            case SyntaxKind.FunctionDeclaration:
+                return visitFunctionDeclaration(node as FunctionDeclaration);
+
+            case SyntaxKind.ClassDeclaration:
+                return visitClassDeclaration(node as ClassDeclaration);
+
+            case SyntaxKind.ForStatement:
+                return visitForStatement(node as ForStatement, /*isTopLevel*/ true);
+
+            case SyntaxKind.ForInStatement:
+                return visitForInStatement(node as ForInStatement);
+
+            case SyntaxKind.ForOfStatement:
+                return visitForOfStatement(node as ForOfStatement);
+
+            case SyntaxKind.DoStatement:
+                return visitDoStatement(node as DoStatement);
+
+            case SyntaxKind.WhileStatement:
+                return visitWhileStatement(node as WhileStatement);
+
+            case SyntaxKind.LabeledStatement:
+                return visitLabeledStatement(node as LabeledStatement);
+
+            case SyntaxKind.WithStatement:
+                return visitWithStatement(node as WithStatement);
+
+            case SyntaxKind.IfStatement:
+                return visitIfStatement(node as IfStatement);
+
+            case SyntaxKind.SwitchStatement:
+                return visitSwitchStatement(node as SwitchStatement);
+
+            case SyntaxKind.CaseBlock:
+                return visitCaseBlock(node as CaseBlock);
+
+            case SyntaxKind.CaseClause:
+                return visitCaseClause(node as CaseClause);
+
+            case SyntaxKind.DefaultClause:
+                return visitDefaultClause(node as DefaultClause);
+
+            case SyntaxKind.TryStatement:
+                return visitTryStatement(node as TryStatement);
+
+            case SyntaxKind.CatchClause:
+                return visitCatchClause(node as CatchClause);
+
+            case SyntaxKind.Block:
+                return visitBlock(node as Block);
+
+            default:
                 return visitor(node);
         }
     }
@@ -682,7 +768,7 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
 
         switch (node.kind) {
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement);
+                return visitForStatement(node as ForStatement, /*isTopLevel*/ false);
             case SyntaxKind.ExpressionStatement:
                 return visitExpressionStatement(node as ExpressionStatement);
             case SyntaxKind.ParenthesizedExpression:
@@ -767,14 +853,230 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
         return visitEachChild(node, visitor, context);
     }
 
-    function visitForStatement(node: ForStatement) {
+    function visitForStatement(node: ForStatement, isTopLevel: boolean) {
+        if (isTopLevel && node.initializer &&
+            isVariableDeclarationList(node.initializer) &&
+            !(node.initializer.flags & NodeFlags.BlockScoped)) {
+            const exportStatements = appendExportsOfVariableDeclarationList(/*statements*/ undefined, node.initializer, /*isForInOrOfInitializer*/ false);
+            if (exportStatements) {
+                const statements: Statement[] = [];
+                const varDeclList = visitNode(node.initializer, discardedValueVisitor, isVariableDeclarationList);
+                const varStatement = factory.createVariableStatement(/*modifiers*/ undefined, varDeclList);
+                statements.push(varStatement);
+                addRange(statements, exportStatements);
+
+                const condition = visitNode(node.condition, visitor, isExpression);
+                const incrementor = visitNode(node.incrementor, discardedValueVisitor, isExpression);
+                const body = visitIterationBody(node.statement, isTopLevel ? topLevelNestedVisitor : visitor, context);
+                statements.push(factory.updateForStatement(node, /*initializer*/ undefined, condition, incrementor, body));
+                return statements;
+            }
+        }
         return factory.updateForStatement(
             node,
             visitNode(node.initializer, discardedValueVisitor, isForInitializer),
             visitNode(node.condition, visitor, isExpression),
             visitNode(node.incrementor, discardedValueVisitor, isExpression),
-            visitIterationBody(node.statement, visitor, context)
+            visitIterationBody(node.statement, isTopLevel ? topLevelNestedVisitor : visitor, context)
         );
+    }
+
+    /**
+     * Visits the body of a ForInStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitForInStatement(node: ForInStatement): VisitResult<Statement> {
+        if (isVariableDeclarationList(node.initializer) && !(node.initializer.flags & NodeFlags.BlockScoped)) {
+            const exportStatements = appendExportsOfVariableDeclarationList(/*statements*/ undefined, node.initializer, /*isForInOrOfInitializer*/ true);
+            if (some(exportStatements)) {
+                const initializer = visitNode(node.initializer, discardedValueVisitor, isForInitializer);
+                const expression = visitNode(node.expression, visitor, isExpression);
+                const body = visitIterationBody(node.statement, topLevelNestedVisitor, context);
+                const mergedBody = isBlock(body) ?
+                    factory.updateBlock(body, [...exportStatements, ...body.statements]) :
+                    factory.createBlock([...exportStatements, body], /*multiLine*/ true);
+                return factory.updateForInStatement(node, initializer, expression, mergedBody);
+            }
+        }
+        return factory.updateForInStatement(
+            node,
+            visitNode(node.initializer, discardedValueVisitor, isForInitializer),
+            visitNode(node.expression, visitor, isExpression),
+            visitIterationBody(node.statement, topLevelNestedVisitor, context)
+        );
+    }
+
+    /**
+     * Visits the body of a ForOfStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitForOfStatement(node: ForOfStatement): VisitResult<Statement> {
+        if (isVariableDeclarationList(node.initializer) && !(node.initializer.flags & NodeFlags.BlockScoped)) {
+            const exportStatements = appendExportsOfVariableDeclarationList(/*statements*/ undefined, node.initializer, /*isForInOrOfInitializer*/ true);
+            const initializer = visitNode(node.initializer, discardedValueVisitor, isForInitializer);
+            const expression = visitNode(node.expression, visitor, isExpression);
+            let body = visitIterationBody(node.statement, topLevelNestedVisitor, context);
+            if (some(exportStatements)) {
+                body = isBlock(body) ?
+                    factory.updateBlock(body, [...exportStatements, ...body.statements]) :
+                    factory.createBlock([...exportStatements, body], /*multiLine*/ true);
+            }
+            return factory.updateForOfStatement(node, node.awaitModifier, initializer, expression, body);
+        }
+        return factory.updateForOfStatement(
+            node,
+            node.awaitModifier,
+            visitNode(node.initializer, discardedValueVisitor, isForInitializer),
+            visitNode(node.expression, visitor, isExpression),
+            visitIterationBody(node.statement, topLevelNestedVisitor, context)
+        );
+    }
+
+    /**
+     * Visits the body of a DoStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitDoStatement(node: DoStatement): DoStatement {
+        return factory.updateDoStatement(
+            node,
+            visitIterationBody(node.statement, topLevelNestedVisitor, context),
+            visitNode(node.expression, visitor, isExpression)
+        );
+    }
+
+    /**
+     * Visits the body of a WhileStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitWhileStatement(node: WhileStatement): WhileStatement {
+        return factory.updateWhileStatement(
+            node,
+            visitNode(node.expression, visitor, isExpression),
+            visitIterationBody(node.statement, topLevelNestedVisitor, context)
+        );
+    }
+
+    /**
+     * Visits the body of a LabeledStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitLabeledStatement(node: LabeledStatement): LabeledStatement {
+        return factory.updateLabeledStatement(
+            node,
+            node.label,
+            Debug.checkDefined(visitNode(node.statement, topLevelNestedVisitor, isStatement, factory.liftToBlock))
+        );
+    }
+
+    /**
+     * Visits the body of a WithStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitWithStatement(node: WithStatement): WithStatement {
+        return factory.updateWithStatement(
+            node,
+            visitNode(node.expression, visitor, isExpression),
+            Debug.checkDefined(visitNode(node.statement, topLevelNestedVisitor, isStatement, factory.liftToBlock))
+        );
+    }
+
+    /**
+     * Visits the body of a IfStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitIfStatement(node: IfStatement): IfStatement {
+        return factory.updateIfStatement(
+            node,
+            visitNode(node.expression, visitor, isExpression),
+            Debug.checkDefined(visitNode(node.thenStatement, topLevelNestedVisitor, isStatement, factory.liftToBlock)),
+            visitNode(node.elseStatement, topLevelNestedVisitor, isStatement, factory.liftToBlock)
+        );
+    }
+
+    /**
+     * Visits the body of a SwitchStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitSwitchStatement(node: SwitchStatement): SwitchStatement {
+        return factory.updateSwitchStatement(
+            node,
+            visitNode(node.expression, visitor, isExpression),
+            Debug.checkDefined(visitNode(node.caseBlock, topLevelNestedVisitor, isCaseBlock))
+        );
+    }
+
+    /**
+     * Visits the body of a CaseBlock to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitCaseBlock(node: CaseBlock): CaseBlock {
+        return factory.updateCaseBlock(
+            node,
+            visitNodes(node.clauses, topLevelNestedVisitor, isCaseOrDefaultClause)
+        );
+    }
+
+    /**
+     * Visits the body of a CaseClause to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitCaseClause(node: CaseClause): CaseClause {
+        return factory.updateCaseClause(
+            node,
+            visitNode(node.expression, visitor, isExpression),
+            visitNodes(node.statements, topLevelNestedVisitor, isStatement)
+        );
+    }
+
+    /**
+     * Visits the body of a DefaultClause to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitDefaultClause(node: DefaultClause): DefaultClause {
+        return visitEachChild(node, topLevelNestedVisitor, context);
+    }
+
+    /**
+     * Visits the body of a TryStatement to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitTryStatement(node: TryStatement): TryStatement {
+        return visitEachChild(node, topLevelNestedVisitor, context);
+    }
+
+    /**
+     * Visits the body of a CatchClause to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitCatchClause(node: CatchClause): CatchClause {
+        return factory.updateCatchClause(
+            node,
+            node.variableDeclaration,
+            Debug.checkDefined(visitNode(node.block, topLevelNestedVisitor, isBlock))
+        );
+    }
+
+    /**
+     * Visits the body of a Block to hoist declarations.
+     *
+     * @param node The node to visit.
+     */
+    function visitBlock(node: Block): Block {
+        node = visitEachChild(node, topLevelNestedVisitor, context);
+        return node;
     }
 
     function visitExpressionStatement(node: ExpressionStatement) {
@@ -1629,12 +1931,25 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
      * @param node The VariableStatement whose exports are to be recorded.
      */
     function appendExportsOfVariableStatement(statements: Statement[] | undefined, node: VariableStatement): Statement[] | undefined {
+        return appendExportsOfVariableDeclarationList(statements, node.declarationList, /*isForInOrOfInitializer*/ false);
+    }
+
+    /**
+     * Appends the exports of a VariableDeclarationList to a statement list, returning the statement
+     * list.
+     *
+     * @param statements A statement list to which the down-level export statements are to be
+     * appended. If `statements` is `undefined`, a new array is allocated if statements are
+     * appended.
+     * @param node The VariableDeclarationList whose exports are to be recorded.
+     */
+    function appendExportsOfVariableDeclarationList(statements: Statement[] | undefined, node: VariableDeclarationList, isForInOrOfInitializer: boolean): Statement[] | undefined {
         if (currentModuleInfo.exportEquals) {
             return statements;
         }
 
-        for (const decl of node.declarationList.declarations) {
-            statements = appendExportsOfBindingElement(statements, decl);
+        for (const decl of node.declarations) {
+            statements = appendExportsOfBindingElement(statements, decl, isForInOrOfInitializer);
         }
 
         return statements;
@@ -1649,7 +1964,7 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
      * appended.
      * @param decl The declaration whose exports are to be recorded.
      */
-    function appendExportsOfBindingElement(statements: Statement[] | undefined, decl: VariableDeclaration | BindingElement): Statement[] | undefined {
+    function appendExportsOfBindingElement(statements: Statement[] | undefined, decl: VariableDeclaration | BindingElement, isForInOrOfInitializer: boolean): Statement[] | undefined {
         if (currentModuleInfo.exportEquals) {
             return statements;
         }
@@ -1657,11 +1972,11 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
         if (isBindingPattern(decl.name)) {
             for (const element of decl.name.elements) {
                 if (!isOmittedExpression(element)) {
-                    statements = appendExportsOfBindingElement(statements, element);
+                    statements = appendExportsOfBindingElement(statements, element, isForInOrOfInitializer);
                 }
             }
         }
-        else if (!isGeneratedIdentifier(decl.name) && (!isVariableDeclaration(decl) || decl.initializer)) {
+        else if (!isGeneratedIdentifier(decl.name) && (!isVariableDeclaration(decl) || decl.initializer || isForInOrOfInitializer)) {
             statements = appendExportsOfDeclaration(statements, decl);
         }
 

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -679,9 +679,6 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
             case SyntaxKind.ExportAssignment:
                 return visitExportAssignment(node as ExportAssignment);
 
-            case SyntaxKind.VariableStatement:
-                return visitVariableStatement(node as VariableStatement);
-
             case SyntaxKind.FunctionDeclaration:
                 return visitFunctionDeclaration(node as FunctionDeclaration);
 

--- a/tests/baselines/reference/declarationEmitInvalidExport.js
+++ b/tests/baselines/reference/declarationEmitInvalidExport.js
@@ -10,5 +10,5 @@ export type MyClass = typeof myClass;
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 if (false) {
-    export var myClass = 0;
+    exports.myClass = 0;
 }

--- a/tests/baselines/reference/topLevelVarHoistingCommonJS.js
+++ b/tests/baselines/reference/topLevelVarHoistingCommonJS.js
@@ -1,0 +1,150 @@
+//// [topLevelVarHoistingCommonJS.ts]
+declare var _: any;
+
+{
+    var a = _;
+}
+
+if (_) {
+    var b = _;
+}
+else {
+    var c = _;
+}
+
+switch (_) {
+    case _:
+        var d = _;
+    default:
+        var e = _;
+}
+
+while (_) {
+    var f = _;
+}
+
+do {
+    var g = _;
+}
+while (_);
+
+for (var h = _; ;) {
+    break;
+}
+
+for (; ;) {
+    var m = _;
+    break;
+}
+
+for (var n in _) break;
+
+for (_ in _) {
+    var o = _;
+}
+
+for (var p of _) break;
+
+for (_ of _) {
+    var u = _;
+}
+
+try {
+    var v = _;
+}
+catch {
+    var w = _;
+}
+
+label: {
+    var x = _;
+    break label;
+}
+
+// @ts-ignore
+with (_) {
+    var y = _;
+}
+
+var z = _;
+
+export { a, b, c, d, e, f, g, h, m, n, o, p, u, v, w, x, y, z };
+
+//// [topLevelVarHoistingCommonJS.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.z = exports.y = exports.x = exports.w = exports.v = exports.u = exports.p = exports.o = exports.n = exports.m = exports.h = exports.g = exports.f = exports.e = exports.d = exports.c = exports.b = exports.a = void 0;
+{
+    var a = _;
+    exports.a = a;
+}
+if (_) {
+    var b = _;
+    exports.b = b;
+}
+else {
+    var c = _;
+    exports.c = c;
+}
+switch (_) {
+    case _:
+        var d = _;
+        exports.d = d;
+    default:
+        var e = _;
+        exports.e = e;
+}
+while (_) {
+    var f = _;
+    exports.f = f;
+}
+do {
+    var g = _;
+    exports.g = g;
+} while (_);
+var h = _;
+exports.h = h;
+for (;;) {
+    break;
+}
+for (;;) {
+    var m = _;
+    exports.m = m;
+    break;
+}
+for (var n in _) {
+    exports.n = n;
+    break;
+}
+for (_ in _) {
+    var o = _;
+    exports.o = o;
+}
+for (var p of _) {
+    exports.p = p;
+    break;
+}
+for (_ of _) {
+    var u = _;
+    exports.u = u;
+}
+try {
+    var v = _;
+    exports.v = v;
+}
+catch {
+    var w = _;
+    exports.w = w;
+}
+label: {
+    var x = _;
+    exports.x = x;
+    break label;
+}
+// @ts-ignore
+with (_) {
+    var y = _;
+    exports.y = y;
+}
+var z = _;
+exports.z = z;

--- a/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingCommonJS.ts
+++ b/tests/cases/conformance/es6/moduleExportsSystem/topLevelVarHoistingCommonJS.ts
@@ -1,0 +1,74 @@
+// @target: esnext
+// @module: commonjs
+// @noTypesAndSymbols: true
+
+declare var _: any;
+
+{
+    var a = _;
+}
+
+if (_) {
+    var b = _;
+}
+else {
+    var c = _;
+}
+
+switch (_) {
+    case _:
+        var d = _;
+    default:
+        var e = _;
+}
+
+while (_) {
+    var f = _;
+}
+
+do {
+    var g = _;
+}
+while (_);
+
+for (var h = _; ;) {
+    break;
+}
+
+for (; ;) {
+    var m = _;
+    break;
+}
+
+for (var n in _) break;
+
+for (_ in _) {
+    var o = _;
+}
+
+for (var p of _) break;
+
+for (_ of _) {
+    var u = _;
+}
+
+try {
+    var v = _;
+}
+catch {
+    var w = _;
+}
+
+label: {
+    var x = _;
+    break label;
+}
+
+// @ts-ignore
+with (_) {
+    var y = _;
+}
+
+var z = _;
+
+export { a, b, c, d, e, f, g, h, m, n, o, p, u, v, w, x, y, z };


### PR DESCRIPTION
Fixes a failure to descend into top-level, block-containing statements to properly hoist `var` declarations.

Fixes #54017
