### PR TITLE
Fix class alias reference in static initializer for legacy class decorators

### DIFF
--- a/tests/baselines/reference/staticInitializersAndLegacyClassDecorators.js
+++ b/tests/baselines/reference/staticInitializersAndLegacyClassDecorators.js
@@ -1,0 +1,43 @@
+//// [staticInitializersAndLegacyClassDecorators.ts]
+// https://github.com/microsoft/TypeScript/issues/52004
+declare var dec: any;
+
+@dec
+class C1
+{
+    static instance = new C1();
+}
+
+@dec
+class C2
+{
+    static {
+        new C2();
+    }
+}
+
+
+//// [staticInitializersAndLegacyClassDecorators.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var C1_1, C2_1;
+let C1 = class C1 {
+    static { C1_1 = this; }
+    static instance = new C1_1();
+};
+C1 = C1_1 = __decorate([
+    dec
+], C1);
+let C2 = class C2 {
+    static { C2_1 = this; }
+    static {
+        new C2_1();
+    }
+};
+C2 = C2_1 = __decorate([
+    dec
+], C2);

--- a/tests/cases/compiler/staticInitializersAndLegacyClassDecorators.ts
+++ b/tests/cases/compiler/staticInitializersAndLegacyClassDecorators.ts
@@ -1,0 +1,20 @@
+// @target: es2022
+// @experimentalDecorators: true
+// @noTypesAndSymbols: true
+
+// https://github.com/microsoft/TypeScript/issues/52004
+declare var dec: any;
+
+@dec
+class C1
+{
+    static instance = new C1();
+}
+
+@dec
+class C2
+{
+    static {
+        new C2();
+    }
+}


### PR DESCRIPTION
This fixes an issue related to the class alias reference we emit for legacy decorators. Prior to this fix, static initializers would run before the class alias was initialized when the target is ES2022 or greater since the static fields would be preserved and initialized inline in the class, as opposed to after the class which would be the case for ES2021 and lower targets.

Fixes #52004
Fixes #44908