### PR TITLE
JS declaration emit uses `this` for method returns

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9543,6 +9543,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 initializer: Expression | undefined
             ) => T, methodKind: SignatureDeclaration["kind"], useAccessors: boolean): (p: Symbol, isStatic: boolean, baseType: Type | undefined) => (T | AccessorDeclaration | (T | AccessorDeclaration)[]) {
                 return function serializePropertySymbol(p: Symbol, isStatic: boolean, baseType: Type | undefined): (T | AccessorDeclaration | (T | AccessorDeclaration)[]) {
+                    if (methodKind === SyntaxKind.MethodDeclaration && getCheckFlags(p) & CheckFlags.Instantiated) {
+                        p = getSymbolLinks(p).target!;
+                    }
                     const modifierFlags = getDeclarationModifierFlagsFromSymbol(p);
                     const isPrivate = !!(modifierFlags & ModifierFlags.Private);
                     if (isStatic && (p.flags & (SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias))) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9123,7 +9123,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 context.enclosingDeclaration = originalDecl || oldEnclosing;
                 const localParams = getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(symbol);
                 const typeParamDecls = map(localParams, p => typeParameterToDeclaration(p, context));
-                const classType = getDeclaredTypeOfClassOrInterface(symbol);
+                const classType = getTypeWithThisArgument(getDeclaredTypeOfClassOrInterface(symbol)) as InterfaceType;
                 const baseTypes = getBaseTypes(classType);
                 const originalImplements = originalDecl && getEffectiveImplementsTypeNodes(originalDecl);
                 const implementsExpressions = originalImplements && sanitizeJSDocImplements(originalImplements)
@@ -9543,9 +9543,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 initializer: Expression | undefined
             ) => T, methodKind: SignatureDeclaration["kind"], useAccessors: boolean): (p: Symbol, isStatic: boolean, baseType: Type | undefined) => (T | AccessorDeclaration | (T | AccessorDeclaration)[]) {
                 return function serializePropertySymbol(p: Symbol, isStatic: boolean, baseType: Type | undefined): (T | AccessorDeclaration | (T | AccessorDeclaration)[]) {
-                    if (methodKind === SyntaxKind.MethodDeclaration && getCheckFlags(p) & CheckFlags.Instantiated) {
-                        p = getSymbolLinks(p).target!;
-                    }
                     const modifierFlags = getDeclarationModifierFlagsFromSymbol(p);
                     const isPrivate = !!(modifierFlags & ModifierFlags.Private);
                     if (isStatic && (p.flags & (SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias))) {

--- a/tests/baselines/reference/jsFileMethodOverloads2.js
+++ b/tests/baselines/reference/jsFileMethodOverloads2.js
@@ -102,5 +102,5 @@ declare class Example<T> {
     getTypeName(this: Example<number>): 'number';
     getTypeName(this: Example<string>): 'string';
     transform<U>(fn: (y: T) => U): U;
-    transform<U_1>(): T;
+    transform<U>(): T;
 }

--- a/tests/baselines/reference/thisPropertyAssignmentInherited.js
+++ b/tests/baselines/reference/thisPropertyAssignmentInherited.js
@@ -28,7 +28,7 @@ export class Element {
      * @returns {String}
      */
     get textContent(): string;
-    cloneNode(): Element;
+    cloneNode(): this;
 }
 export class HTMLElement extends Element {
 }


### PR DESCRIPTION
Previously it used the instantiation of `this`, which is the containing class type.

I'm not at all sure this is right, so I would love to know the right way to do this.

Fixes #53051
