### PR TITLE
JS declaration emit includes identical overrides

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9550,11 +9550,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // need to be merged namespace members
                         return [];
                     }
-                    if (p.flags & SymbolFlags.Prototype || p.escapedName === "constructor" ||
-                        (baseType && getPropertyOfType(baseType, p.escapedName)
-                         && isReadonlySymbol(getPropertyOfType(baseType, p.escapedName)!) === isReadonlySymbol(p)
-                         && (p.flags & SymbolFlags.Optional) === (getPropertyOfType(baseType, p.escapedName)!.flags & SymbolFlags.Optional)
-                         && isTypeIdenticalTo(getTypeOfSymbol(p), getTypeOfPropertyOfType(baseType, p.escapedName)!))) {
+                    if (p.flags & SymbolFlags.Prototype ||
+                        p.escapedName === "constructor" ||
+                        baseType && getPropertyOfType(baseType, p.escapedName) === p) {
                         return [];
                     }
                     const flag = (modifierFlags & ~ModifierFlags.Async) | (isStatic ? ModifierFlags.Static : 0);

--- a/tests/baselines/reference/jsDeclarationsInheritedTypes.js
+++ b/tests/baselines/reference/jsDeclarationsInheritedTypes.js
@@ -49,6 +49,10 @@ declare class C1 {
     value: A;
 }
 declare class C2 extends C1 {
+    /**
+     * @type {A}
+     */
+    value: A;
 }
 declare class C3 extends C1 {
     /**

--- a/tests/baselines/reference/jsDeclarationsInterfaces.js
+++ b/tests/baselines/reference/jsDeclarationsInterfaces.js
@@ -164,6 +164,7 @@ export interface M<T_1> {
 }
 export interface N<U_1> extends M<U_1> {
     other: U_1;
+    field: U_1;
 }
 export interface O {
     [idx: string]: string;


### PR DESCRIPTION
The existing rule is too complicated and doesn't match what Typescript does.

Fixes #54061
