### PR TITLE
fix(54068): Organize Imports removes first deprecated JSDoc comment

### DIFF
--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -60,7 +60,6 @@ import {
     SortKind,
     SourceFile,
     stableSort,
-    suppressLeadingTrivia,
     SyntaxKind,
     textChanges,
     TransformFlags,
@@ -137,7 +136,7 @@ export function organizeImports(
         // on the first import because it is probably the header comment for the file.
         // Consider: we could do a more careful check that this trivia is actually a header,
         // but the consequences of being wrong are very minor.
-        suppressLeadingTrivia(oldImportDecls[0]);
+        setEmitFlags(oldImportDecls[0], EmitFlags.NoLeadingComments);
 
         const oldImportGroups = shouldCombine
             ? group(oldImportDecls, importDecl => getExternalModuleName(importDecl.moduleSpecifier)!)

--- a/tests/cases/fourslash/organizeImports21.ts
+++ b/tests/cases/fourslash/organizeImports21.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: /a.ts
+////export interface LocationDefinitions {}
+////export interface PersonDefinitions {}
+
+// @filename: /b.ts
+////export {
+////    /** @deprecated Use LocationDefinitions instead */
+////    LocationDefinitions as AddressDefinitions,
+////    LocationDefinitions,
+////    /** @deprecated Use PersonDefinitions instead */
+////    PersonDefinitions as NameDefinitions,
+////    PersonDefinitions,
+////} from './a';
+
+goTo.file("/b.ts");
+verify.organizeImports(
+`export {
+    /** @deprecated Use LocationDefinitions instead */
+    LocationDefinitions as AddressDefinitions,
+    LocationDefinitions,
+    /** @deprecated Use PersonDefinitions instead */
+    PersonDefinitions as NameDefinitions,
+    PersonDefinitions
+} from './a';
+`);


### PR DESCRIPTION
Fixes #54068