### PR TITLE
Fix crash in getAwaitedType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2036,7 +2036,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         getGlobalIterableType: getGlobalAsyncIterableType,
         getGlobalIterableIteratorType: getGlobalAsyncIterableIteratorType,
         getGlobalGeneratorType: getGlobalAsyncGeneratorType,
-        resolveIterationType: getAwaitedType,
+        resolveIterationType: (type, errorNode) => getAwaitedType(type, errorNode, Diagnostics.Type_of_await_operand_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member),
         mustHaveANextMethodDiagnostic: Diagnostics.An_async_iterator_must_have_a_next_method,
         mustBeAMethodDiagnostic: Diagnostics.The_0_property_of_an_async_iterator_must_be_a_method,
         mustHaveAValueDiagnostic: Diagnostics.The_type_returned_by_the_0_method_of_an_async_iterator_must_be_a_promise_for_a_type_with_a_value_property,

--- a/tests/baselines/reference/crashInYieldStarInAsyncFunction.errors.txt
+++ b/tests/baselines/reference/crashInYieldStarInAsyncFunction.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/crashInYieldStarInAsyncFunction.ts(13,12): error TS1320: Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.
+
+
+==== tests/cases/compiler/crashInYieldStarInAsyncFunction.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/53145
+    var obj = {
+        [Symbol.asyncIterator]() {
+            return {
+                next() {
+                    return { then() { } };
+                }
+            };
+        }
+    };
+    
+    async function* g() {
+        yield* obj;
+               ~~~
+!!! error TS1320: Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.
+    }

--- a/tests/baselines/reference/crashInYieldStarInAsyncFunction.js
+++ b/tests/baselines/reference/crashInYieldStarInAsyncFunction.js
@@ -1,0 +1,30 @@
+//// [crashInYieldStarInAsyncFunction.ts]
+// https://github.com/microsoft/TypeScript/issues/53145
+var obj = {
+    [Symbol.asyncIterator]() {
+        return {
+            next() {
+                return { then() { } };
+            }
+        };
+    }
+};
+
+async function* g() {
+    yield* obj;
+}
+
+//// [crashInYieldStarInAsyncFunction.js]
+// https://github.com/microsoft/TypeScript/issues/53145
+var obj = {
+    [Symbol.asyncIterator]() {
+        return {
+            next() {
+                return { then() { } };
+            }
+        };
+    }
+};
+async function* g() {
+    yield* obj;
+}

--- a/tests/baselines/reference/crashInYieldStarInAsyncFunction.symbols
+++ b/tests/baselines/reference/crashInYieldStarInAsyncFunction.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/crashInYieldStarInAsyncFunction.ts ===
+// https://github.com/microsoft/TypeScript/issues/53145
+var obj = {
+>obj : Symbol(obj, Decl(crashInYieldStarInAsyncFunction.ts, 1, 3))
+
+    [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : Symbol([Symbol.asyncIterator], Decl(crashInYieldStarInAsyncFunction.ts, 1, 11))
+>Symbol.asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        return {
+            next() {
+>next : Symbol(next, Decl(crashInYieldStarInAsyncFunction.ts, 3, 16))
+
+                return { then() { } };
+>then : Symbol(then, Decl(crashInYieldStarInAsyncFunction.ts, 5, 24))
+            }
+        };
+    }
+};
+
+async function* g() {
+>g : Symbol(g, Decl(crashInYieldStarInAsyncFunction.ts, 9, 2))
+
+    yield* obj;
+>obj : Symbol(obj, Decl(crashInYieldStarInAsyncFunction.ts, 1, 3))
+}

--- a/tests/baselines/reference/crashInYieldStarInAsyncFunction.types
+++ b/tests/baselines/reference/crashInYieldStarInAsyncFunction.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/crashInYieldStarInAsyncFunction.ts ===
+// https://github.com/microsoft/TypeScript/issues/53145
+var obj = {
+>obj : { [Symbol.asyncIterator](): { next(): { then(): void; }; }; }
+>{    [Symbol.asyncIterator]() {        return {            next() {                return { then() { } };            }        };    }} : { [Symbol.asyncIterator](): { next(): { then(): void; }; }; }
+
+    [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : () => { next(): { then(): void; }; }
+>Symbol.asyncIterator : unique symbol
+>Symbol : SymbolConstructor
+>asyncIterator : unique symbol
+
+        return {
+>{            next() {                return { then() { } };            }        } : { next(): { then(): void; }; }
+
+            next() {
+>next : () => { then(): void; }
+
+                return { then() { } };
+>{ then() { } } : { then(): void; }
+>then : () => void
+            }
+        };
+    }
+};
+
+async function* g() {
+>g : () => AsyncGenerator<any, void, unknown>
+
+    yield* obj;
+>yield* obj : any
+>obj : { [Symbol.asyncIterator](): { next(): { then(): void; }; }; }
+}

--- a/tests/cases/compiler/crashInYieldStarInAsyncFunction.ts
+++ b/tests/cases/compiler/crashInYieldStarInAsyncFunction.ts
@@ -1,0 +1,16 @@
+// @target: esnext
+
+// https://github.com/microsoft/TypeScript/issues/53145
+var obj = {
+    [Symbol.asyncIterator]() {
+        return {
+            next() {
+                return { then() { } };
+            }
+        };
+    }
+};
+
+async function* g() {
+    yield* obj;
+}


### PR DESCRIPTION
Fixes a crash in `getAwaitedType` due to a missing diagnostic message.

Fixes #53145
