### PR TITLE
fix issue 53775, do not always narrow to property signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7173,6 +7173,25 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
             else {
+                if(propertySymbol.flags & SymbolFlags.Accessor && propertySymbol.declarations && propertySymbol.declarations.length === 2) {
+                    const getter = isGetAccessor(propertySymbol.declarations[0]) ? propertySymbol.declarations[0] : isGetAccessor(propertySymbol.declarations[1]) ? propertySymbol.declarations[1] : undefined;
+                    const setter = isSetAccessor(propertySymbol.declarations[0]) ? propertySymbol.declarations[0] : isSetAccessor(propertySymbol.declarations[1]) ? propertySymbol.declarations[1] : undefined;
+                    if(getter && setter) {
+                        const getterReturnType = getter.type && getTypeFromTypeNode(getter.type);
+                        let setterParameterType: Type | undefined;
+                        if(setter.parameters.length === 1) {
+                            setterParameterType = setter.parameters[0].type && getTypeFromTypeNode(setter.parameters[0].type);
+                        }
+                        else if (setter.parameters.length === 2 && isThisIdentifier(setter.parameters[0].name)) {
+                            setterParameterType = setter.parameters[1].type && getTypeFromTypeNode(setter.parameters[1].type);
+                        }
+                        if(setter.parameters.length > 2 || (setterParameterType && getterReturnType && !isTypeIdenticalTo(setterParameterType, getterReturnType))) {
+                            typeElements.push(factory.createGetAccessorDeclaration(/*modifiers*/ undefined, getter.name, getter.parameters, /*type*/ getter.type, /*body*/ undefined));
+                            typeElements.push(factory.createSetAccessorDeclaration(/*modifiers*/ undefined, setter.name, setter.parameters, /*body*/ undefined));
+                            return;
+                        }
+                    }
+                }
                 let propertyTypeNode: TypeNode;
                 if (shouldUsePlaceholderForProperty(propertySymbol, context)) {
                     propertyTypeNode = createElidedInformationPlaceholder(context);

--- a/tests/baselines/reference/divergentAccessors1.types
+++ b/tests/baselines/reference/divergentAccessors1.types
@@ -31,7 +31,7 @@
 
 {
     type T_HasGetSet = {
->T_HasGetSet : { foo: number; }
+>T_HasGetSet : { get foo(): number; set foo(v: number | string); }
 
         get foo(): number;
 >foo : number
@@ -42,20 +42,20 @@
     }
     
     const t_hgs: T_HasGetSet = null as any;
->t_hgs : { foo: number; }
+>t_hgs : { get foo(): number; set foo(v: number | string); }
 >null as any : any
 
     t_hgs.foo = "32";
 >t_hgs.foo = "32" : "32"
 >t_hgs.foo : string | number
->t_hgs : { foo: number; }
+>t_hgs : { get foo(): number; set foo(v: number | string); }
 >foo : string | number
 >"32" : "32"
 
     let r_t_hgs_foo: number = t_hgs.foo;
 >r_t_hgs_foo : number
 >t_hgs.foo : number
->t_hgs : { foo: number; }
+>t_hgs : { get foo(): number; set foo(v: number | string); }
 >foo : number
 }
 

--- a/tests/baselines/reference/divergentAccessorsTypes1.types
+++ b/tests/baselines/reference/divergentAccessorsTypes1.types
@@ -48,7 +48,7 @@ interface Test2 {
 }
 
 type Test3 = {
->Test3 : { foo: string; bar: string | number; }
+>Test3 : { get foo(): string; set foo(s: string | number); get bar(): string | number; set bar(s: string | number | boolean); }
 
     get foo(): string;
 >foo : string

--- a/tests/baselines/reference/divergentAccessorsTypes6.types
+++ b/tests/baselines/reference/divergentAccessorsTypes6.types
@@ -51,8 +51,8 @@ interface I1 {
 >value : string
 }
 const o1 = {
->o1 : { x: number; }
->{    get x(): number { return 0; },    set x(value: Fail<string>) {}} : { x: number; }
+>o1 : { get x(): number; set x(value: Fail<string>); }
+>{    get x(): number { return 0; },    set x(value: Fail<string>) {}} : { get x(): number; set x(value: Fail<string>); }
 
     get x(): number { return 0; },
 >x : number
@@ -66,8 +66,8 @@ const o1 = {
 // A setter annotation still implies the getter return type.
 
 const o2 = {
->o2 : { p1: string; p2: number; }
->{    get p1() { return 0; }, // error - no annotation means type is implied from the setter annotation    set p1(value: string) {},    get p2(): number { return 0; }, // ok - explicit annotation    set p2(value: string) {},} : { p1: string; p2: number; }
+>o2 : { p1: string; get p2(): number; set p2(value: string); }
+>{    get p1() { return 0; }, // error - no annotation means type is implied from the setter annotation    set p1(value: string) {},    get p2(): number { return 0; }, // ok - explicit annotation    set p2(value: string) {},} : { p1: string; get p2(): number; set p2(value: string); }
 
     get p1() { return 0; }, // error - no annotation means type is implied from the setter annotation
 >p1 : string

--- a/tests/baselines/reference/objectLiteralErrors.types
+++ b/tests/baselines/reference/objectLiteralErrors.types
@@ -295,8 +295,8 @@ var f17 = { a: 0, get b() { return 1; }, get a() { return 0; } };
 
 // Get and set accessor with mismatched type annotations (only g2 is an error after #43662 implemented)
 var g1 = { get a(): number { return 4; }, set a(n: string) { } };
->g1 : { a: number; }
->{ get a(): number { return 4; }, set a(n: string) { } } : { a: number; }
+>g1 : { get a(): number; set a(n: string); }
+>{ get a(): number { return 4; }, set a(n: string) { } } : { get a(): number; set a(n: string); }
 >a : number
 >4 : 4
 >a : number
@@ -311,8 +311,8 @@ var g2 = { get a() { return 4; }, set a(n: string) { } };
 >n : string
 
 var g3 = { get a(): number { return undefined; }, set a(n: string) { } };
->g3 : { a: number; }
->{ get a(): number { return undefined; }, set a(n: string) { } } : { a: number; }
+>g3 : { get a(): number; set a(n: string); }
+>{ get a(): number { return undefined; }, set a(n: string) { } } : { get a(): number; set a(n: string); }
 >a : number
 >undefined : undefined
 >a : number

--- a/tests/baselines/reference/shouldNotToPropertySignatureAccessor.js
+++ b/tests/baselines/reference/shouldNotToPropertySignatureAccessor.js
@@ -1,0 +1,30 @@
+//// [shouldNotToPropertySignatureAccessor.ts]
+export const Foo0 = {
+    get bar(): number { return 0; },
+    set bar(value: number | string) { }
+};
+
+export const Foo1: {
+    get bar(): number
+    set bar(value: number | string)
+} = Foo0; // Reuse Foo0 for conciseness
+
+
+
+//// [shouldNotToPropertySignatureAccessor.js]
+export const Foo0 = {
+    get bar() { return 0; },
+    set bar(value) { }
+};
+export const Foo1 = Foo0; // Reuse Foo0 for conciseness
+
+
+//// [shouldNotToPropertySignatureAccessor.d.ts]
+export declare const Foo0: {
+    get bar(): number;
+    set bar(value: number | string);
+};
+export declare const Foo1: {
+    get bar(): number;
+    set bar(value: number | string);
+};

--- a/tests/baselines/reference/shouldNotToPropertySignatureAccessor.symbols
+++ b/tests/baselines/reference/shouldNotToPropertySignatureAccessor.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/declarationEmit/shouldNotToPropertySignatureAccessor.ts ===
+export const Foo0 = {
+>Foo0 : Symbol(Foo0, Decl(shouldNotToPropertySignatureAccessor.ts, 0, 12))
+
+    get bar(): number { return 0; },
+>bar : Symbol(bar, Decl(shouldNotToPropertySignatureAccessor.ts, 0, 21), Decl(shouldNotToPropertySignatureAccessor.ts, 1, 36))
+
+    set bar(value: number | string) { }
+>bar : Symbol(bar, Decl(shouldNotToPropertySignatureAccessor.ts, 0, 21), Decl(shouldNotToPropertySignatureAccessor.ts, 1, 36))
+>value : Symbol(value, Decl(shouldNotToPropertySignatureAccessor.ts, 2, 12))
+
+};
+
+export const Foo1: {
+>Foo1 : Symbol(Foo1, Decl(shouldNotToPropertySignatureAccessor.ts, 5, 12))
+
+    get bar(): number
+>bar : Symbol(bar, Decl(shouldNotToPropertySignatureAccessor.ts, 5, 20), Decl(shouldNotToPropertySignatureAccessor.ts, 6, 21))
+
+    set bar(value: number | string)
+>bar : Symbol(bar, Decl(shouldNotToPropertySignatureAccessor.ts, 5, 20), Decl(shouldNotToPropertySignatureAccessor.ts, 6, 21))
+>value : Symbol(value, Decl(shouldNotToPropertySignatureAccessor.ts, 7, 12))
+
+} = Foo0; // Reuse Foo0 for conciseness
+>Foo0 : Symbol(Foo0, Decl(shouldNotToPropertySignatureAccessor.ts, 0, 12))
+
+

--- a/tests/baselines/reference/shouldNotToPropertySignatureAccessor.types
+++ b/tests/baselines/reference/shouldNotToPropertySignatureAccessor.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/declarationEmit/shouldNotToPropertySignatureAccessor.ts ===
+export const Foo0 = {
+>Foo0 : { get bar(): number; set bar(value: number | string); }
+>{    get bar(): number { return 0; },    set bar(value: number | string) { }} : { get bar(): number; set bar(value: number | string); }
+
+    get bar(): number { return 0; },
+>bar : number
+>0 : 0
+
+    set bar(value: number | string) { }
+>bar : number
+>value : string | number
+
+};
+
+export const Foo1: {
+>Foo1 : { get bar(): number; set bar(value: number | string); }
+
+    get bar(): number
+>bar : number
+
+    set bar(value: number | string)
+>bar : number
+>value : string | number
+
+} = Foo0; // Reuse Foo0 for conciseness
+>Foo0 : { get bar(): number; set bar(value: number | string); }
+
+

--- a/tests/cases/conformance/declarationEmit/shouldNotToPropertySignatureAccessor.ts
+++ b/tests/cases/conformance/declarationEmit/shouldNotToPropertySignatureAccessor.ts
@@ -1,0 +1,12 @@
+// @declaration: true
+// @target: es2017
+export const Foo0 = {
+    get bar(): number { return 0; },
+    set bar(value: number | string) { }
+};
+
+export const Foo1: {
+    get bar(): number
+    set bar(value: number | string)
+} = Foo0; // Reuse Foo0 for conciseness
+


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53775 

add one more case when transforming AST in emit stage.
in this case, we will check if accessor symbol's by following rule
```tsx
// if (
//     propertySymbol is accessor &&
//.    This syombol has two declarations ( gettter and setter) &&
//     (
//       setter just has two more parameters ||
//       setter has two parameters, first one is this keyword, second parameter's type and getter's return type is not identical ||
//       setter has one parameter, setter's the only parameter's type and getter's return type is not identical
//     )
// ) {
//   In this case, this mean we can't narrow symbol to just one PropertySignature, it needs to be two types.
//   So we push two typeNode, one is gettter TypeNode, the other is setter's typeNode to TypeElements Array
// }
// else fall to generic case (just add one typeNode to TypeElements)
```
this additional case will change some original test case's type file, because sometimes we wouldn't narrow setter and getter to just one PropertySignature.


  

