### PR TITLE
Fix `isGenericReducibleType` to allow HKT technique to function again

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14078,7 +14078,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             else if (type !== firstType) {
                 checkFlags |= CheckFlags.HasNonUniformType;
             }
-            if (isLiteralType(type) || isPatternLiteralType(type) || type === uniqueLiteralType) {
+            if (isLiteralType(type) || isPatternLiteralType(type)) {
                 checkFlags |= CheckFlags.HasLiteralType;
             }
             if (type.flags & TypeFlags.Never && type !== uniqueLiteralType) {
@@ -17685,7 +17685,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // eagerly using the constraint type of 'this' at the given location.
         if (isGenericIndexType(indexType) || (accessNode && accessNode.kind !== SyntaxKind.IndexedAccessType ?
             isGenericTupleType(objectType) && !indexTypeLessThan(indexType, objectType.target.fixedLength) :
-            isGenericObjectType(objectType) && !(isTupleType(objectType) && indexTypeLessThan(indexType, objectType.target.fixedLength)) || !(accessFlags & AccessFlags.ResolveReducibleTypes) && isGenericReducibleType(objectType))) {
+            isGenericObjectType(objectType) && !(isTupleType(objectType) && indexTypeLessThan(indexType, objectType.target.fixedLength)) || isGenericReducibleType(objectType))) {
             if (objectType.flags & TypeFlags.AnyOrUnknown) {
                 return objectType;
             }
@@ -24509,15 +24509,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         if (simplified && simplified !== target) {
                             inferFromTypes(source, simplified);
                         }
-                    }
-                }
-                // The following is a targeted fix to allow higher-kinded types to be emulated using the technique in #53970.
-                // Specifically, when an indexed access type was deferred because it has a reducible object type, here we force
-                // resolution of the type and then infer to the result.
-                if (target.flags & TypeFlags.IndexedAccess && isGenericReducibleType((target as IndexedAccessType).objectType)) {
-                    const instantiated = getIndexedAccessType((target as IndexedAccessType).objectType, (target as IndexedAccessType).indexType, AccessFlags.ResolveReducibleTypes);
-                    if (instantiated && instantiated !== target) {
-                        inferFromTypes(source, instantiated);
                     }
                 }
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17685,7 +17685,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // eagerly using the constraint type of 'this' at the given location.
         if (isGenericIndexType(indexType) || (accessNode && accessNode.kind !== SyntaxKind.IndexedAccessType ?
             isGenericTupleType(objectType) && !indexTypeLessThan(indexType, objectType.target.fixedLength) :
-            isGenericObjectType(objectType) && !(isTupleType(objectType) && indexTypeLessThan(indexType, objectType.target.fixedLength)) || isGenericReducibleType(objectType))) {
+            isGenericObjectType(objectType) && !(isTupleType(objectType) && indexTypeLessThan(indexType, objectType.target.fixedLength)) || !(accessFlags & AccessFlags.ResolveReducibleTypes) && isGenericReducibleType(objectType))) {
             if (objectType.flags & TypeFlags.AnyOrUnknown) {
                 return objectType;
             }
@@ -24509,6 +24509,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         if (simplified && simplified !== target) {
                             inferFromTypes(source, simplified);
                         }
+                    }
+                }
+                // The following is a targeted fix to allow higher-kinded types to be emulated using the technique in #53970.
+                // Specifically, when an indexed access type was deferred because it has a reducible object type, here we force
+                // resolution of the type and then infer to the result.
+                if (target.flags & TypeFlags.IndexedAccess && isGenericReducibleType((target as IndexedAccessType).objectType)) {
+                    const instantiated = getIndexedAccessType((target as IndexedAccessType).objectType, (target as IndexedAccessType).indexType, AccessFlags.ResolveReducibleTypes);
+                    if (instantiated && instantiated !== target) {
+                        inferFromTypes(source, instantiated);
                     }
                 }
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6593,15 +6593,16 @@ export interface TypeParameter extends InstantiableType {
 export const enum AccessFlags {
     None = 0,
     IncludeUndefined = 1 << 0,
-    NoIndexSignatures = 1 << 1,
-    Writing = 1 << 2,
-    CacheSymbol = 1 << 3,
-    NoTupleBoundsCheck = 1 << 4,
-    ExpressionPosition = 1 << 5,
-    ReportDeprecated = 1 << 6,
-    SuppressNoImplicitAnyError = 1 << 7,
-    Contextual = 1 << 8,
-    Persistent = IncludeUndefined,
+    ResolveReducibleTypes = 1 << 1,
+    NoIndexSignatures = 1 << 2,
+    Writing = 1 << 3,
+    CacheSymbol = 1 << 4,
+    NoTupleBoundsCheck = 1 << 5,
+    ExpressionPosition = 1 << 6,
+    ReportDeprecated = 1 << 7,
+    SuppressNoImplicitAnyError = 1 << 8,
+    Contextual = 1 << 9,
+    Persistent = IncludeUndefined | ResolveReducibleTypes,
 }
 
 // Indexed access types (TypeFlags.IndexedAccess)

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6593,16 +6593,15 @@ export interface TypeParameter extends InstantiableType {
 export const enum AccessFlags {
     None = 0,
     IncludeUndefined = 1 << 0,
-    ResolveReducibleTypes = 1 << 1,
-    NoIndexSignatures = 1 << 2,
-    Writing = 1 << 3,
-    CacheSymbol = 1 << 4,
-    NoTupleBoundsCheck = 1 << 5,
-    ExpressionPosition = 1 << 6,
-    ReportDeprecated = 1 << 7,
-    SuppressNoImplicitAnyError = 1 << 8,
-    Contextual = 1 << 9,
-    Persistent = IncludeUndefined | ResolveReducibleTypes,
+    NoIndexSignatures = 1 << 1,
+    Writing = 1 << 2,
+    CacheSymbol = 1 << 3,
+    NoTupleBoundsCheck = 1 << 4,
+    ExpressionPosition = 1 << 5,
+    ReportDeprecated = 1 << 6,
+    SuppressNoImplicitAnyError = 1 << 7,
+    Contextual = 1 << 8,
+    Persistent = IncludeUndefined,
 }
 
 // Indexed access types (TypeFlags.IndexedAccess)

--- a/tests/baselines/reference/inferenceAndHKTs.symbols
+++ b/tests/baselines/reference/inferenceAndHKTs.symbols
@@ -1,0 +1,100 @@
+=== tests/cases/compiler/inferenceAndHKTs.ts ===
+// Repro from #53970
+
+export interface TypeLambda {
+>TypeLambda : Symbol(TypeLambda, Decl(inferenceAndHKTs.ts, 0, 0))
+
+    readonly A: unknown;
+>A : Symbol(TypeLambda.A, Decl(inferenceAndHKTs.ts, 2, 29))
+}
+
+export interface TypeClass<F extends TypeLambda> {
+>TypeClass : Symbol(TypeClass, Decl(inferenceAndHKTs.ts, 4, 1))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 6, 27))
+>TypeLambda : Symbol(TypeLambda, Decl(inferenceAndHKTs.ts, 0, 0))
+
+    readonly _F: F;
+>_F : Symbol(TypeClass._F, Decl(inferenceAndHKTs.ts, 6, 50))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 6, 27))
+}
+
+export type Apply<F extends TypeLambda, A> = F extends { readonly type: unknown }
+>Apply : Symbol(Apply, Decl(inferenceAndHKTs.ts, 8, 1))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 10, 18))
+>TypeLambda : Symbol(TypeLambda, Decl(inferenceAndHKTs.ts, 0, 0))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 10, 39))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 10, 18))
+>type : Symbol(type, Decl(inferenceAndHKTs.ts, 10, 56))
+
+    ? (F & { readonly A: A })['type']
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 10, 18))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 11, 12))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 10, 39))
+
+    : { readonly F: F, readonly A: A };
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 12, 7))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 10, 18))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 12, 22))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 10, 39))
+
+export interface T<A> {
+>T : Symbol(T, Decl(inferenceAndHKTs.ts, 12, 39))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 14, 19))
+
+    value: A;
+>value : Symbol(T.value, Decl(inferenceAndHKTs.ts, 14, 23))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 14, 19))
+}
+
+export interface TTypeLambda extends TypeLambda {
+>TTypeLambda : Symbol(TTypeLambda, Decl(inferenceAndHKTs.ts, 16, 1))
+>TypeLambda : Symbol(TypeLambda, Decl(inferenceAndHKTs.ts, 0, 0))
+
+    readonly type: T<this["A"]>;
+>type : Symbol(TTypeLambda.type, Decl(inferenceAndHKTs.ts, 18, 49))
+>T : Symbol(T, Decl(inferenceAndHKTs.ts, 12, 39))
+}
+
+export declare const map: <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>;
+>map : Symbol(map, Decl(inferenceAndHKTs.ts, 22, 20))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 22, 27), Decl(inferenceAndHKTs.ts, 22, 49))
+>TypeLambda : Symbol(TypeLambda, Decl(inferenceAndHKTs.ts, 0, 0))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 22, 27), Decl(inferenceAndHKTs.ts, 22, 49))
+>TypeClass : Symbol(TypeClass, Decl(inferenceAndHKTs.ts, 4, 1))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 22, 27), Decl(inferenceAndHKTs.ts, 22, 49))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 22, 70))
+>B : Symbol(B, Decl(inferenceAndHKTs.ts, 22, 72))
+>a : Symbol(a, Decl(inferenceAndHKTs.ts, 22, 76))
+>Apply : Symbol(Apply, Decl(inferenceAndHKTs.ts, 8, 1))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 22, 27), Decl(inferenceAndHKTs.ts, 22, 49))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 22, 70))
+>f : Symbol(f, Decl(inferenceAndHKTs.ts, 22, 91))
+>a : Symbol(a, Decl(inferenceAndHKTs.ts, 22, 96))
+>A : Symbol(A, Decl(inferenceAndHKTs.ts, 22, 70))
+>B : Symbol(B, Decl(inferenceAndHKTs.ts, 22, 72))
+>Apply : Symbol(Apply, Decl(inferenceAndHKTs.ts, 8, 1))
+>F : Symbol(F, Decl(inferenceAndHKTs.ts, 22, 27), Decl(inferenceAndHKTs.ts, 22, 49))
+>B : Symbol(B, Decl(inferenceAndHKTs.ts, 22, 72))
+
+declare const typeClass: TypeClass<TTypeLambda>;
+>typeClass : Symbol(typeClass, Decl(inferenceAndHKTs.ts, 24, 13))
+>TypeClass : Symbol(TypeClass, Decl(inferenceAndHKTs.ts, 4, 1))
+>TTypeLambda : Symbol(TTypeLambda, Decl(inferenceAndHKTs.ts, 16, 1))
+
+declare const a: T<number>;
+>a : Symbol(a, Decl(inferenceAndHKTs.ts, 26, 13))
+>T : Symbol(T, Decl(inferenceAndHKTs.ts, 12, 39))
+
+const x1 = map(typeClass);
+>x1 : Symbol(x1, Decl(inferenceAndHKTs.ts, 28, 5))
+>map : Symbol(map, Decl(inferenceAndHKTs.ts, 22, 20))
+>typeClass : Symbol(typeClass, Decl(inferenceAndHKTs.ts, 24, 13))
+
+const x2 = map(typeClass)(a, (_) => _);  // T<number>
+>x2 : Symbol(x2, Decl(inferenceAndHKTs.ts, 29, 5))
+>map : Symbol(map, Decl(inferenceAndHKTs.ts, 22, 20))
+>typeClass : Symbol(typeClass, Decl(inferenceAndHKTs.ts, 24, 13))
+>a : Symbol(a, Decl(inferenceAndHKTs.ts, 26, 13))
+>_ : Symbol(_, Decl(inferenceAndHKTs.ts, 29, 30))
+>_ : Symbol(_, Decl(inferenceAndHKTs.ts, 29, 30))
+

--- a/tests/baselines/reference/inferenceAndHKTs.types
+++ b/tests/baselines/reference/inferenceAndHKTs.types
@@ -46,15 +46,15 @@ declare const a: T<number>;
 >a : T<number>
 
 const x1 = map(typeClass);
->x1 : <A, B>(a: (TTypeLambda & { readonly A: A; })["type"], f: (a: A) => B) => (TTypeLambda & { readonly A: B; })["type"]
->map(typeClass) : <A, B>(a: (TTypeLambda & { readonly A: A; })["type"], f: (a: A) => B) => (TTypeLambda & { readonly A: B; })["type"]
+>x1 : <A, B>(a: T<A>, f: (a: A) => B) => T<B>
+>map(typeClass) : <A, B>(a: T<A>, f: (a: A) => B) => T<B>
 >map : <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>
 >typeClass : TypeClass<TTypeLambda>
 
 const x2 = map(typeClass)(a, (_) => _);  // T<number>
 >x2 : T<number>
 >map(typeClass)(a, (_) => _) : T<number>
->map(typeClass) : <A, B>(a: (TTypeLambda & { readonly A: A; })["type"], f: (a: A) => B) => (TTypeLambda & { readonly A: B; })["type"]
+>map(typeClass) : <A, B>(a: T<A>, f: (a: A) => B) => T<B>
 >map : <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>
 >typeClass : TypeClass<TTypeLambda>
 >a : T<number>

--- a/tests/baselines/reference/inferenceAndHKTs.types
+++ b/tests/baselines/reference/inferenceAndHKTs.types
@@ -1,0 +1,64 @@
+=== tests/cases/compiler/inferenceAndHKTs.ts ===
+// Repro from #53970
+
+export interface TypeLambda {
+    readonly A: unknown;
+>A : unknown
+}
+
+export interface TypeClass<F extends TypeLambda> {
+    readonly _F: F;
+>_F : F
+}
+
+export type Apply<F extends TypeLambda, A> = F extends { readonly type: unknown }
+>Apply : Apply<F, A>
+>type : unknown
+
+    ? (F & { readonly A: A })['type']
+>A : A
+
+    : { readonly F: F, readonly A: A };
+>F : F
+>A : A
+
+export interface T<A> {
+    value: A;
+>value : A
+}
+
+export interface TTypeLambda extends TypeLambda {
+    readonly type: T<this["A"]>;
+>type : T<this["A"]>
+}
+
+export declare const map: <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>;
+>map : <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>
+>F : TypeClass<F>
+>a : Apply<F, A>
+>f : (a: A) => B
+>a : A
+
+declare const typeClass: TypeClass<TTypeLambda>;
+>typeClass : TypeClass<TTypeLambda>
+
+declare const a: T<number>;
+>a : T<number>
+
+const x1 = map(typeClass);
+>x1 : <A, B>(a: (TTypeLambda & { readonly A: A; })["type"], f: (a: A) => B) => (TTypeLambda & { readonly A: B; })["type"]
+>map(typeClass) : <A, B>(a: (TTypeLambda & { readonly A: A; })["type"], f: (a: A) => B) => (TTypeLambda & { readonly A: B; })["type"]
+>map : <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>
+>typeClass : TypeClass<TTypeLambda>
+
+const x2 = map(typeClass)(a, (_) => _);  // T<number>
+>x2 : T<number>
+>map(typeClass)(a, (_) => _) : T<number>
+>map(typeClass) : <A, B>(a: (TTypeLambda & { readonly A: A; })["type"], f: (a: A) => B) => (TTypeLambda & { readonly A: B; })["type"]
+>map : <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>
+>typeClass : TypeClass<TTypeLambda>
+>a : T<number>
+>(_) => _ : (_: number) => number
+>_ : number
+>_ : number
+

--- a/tests/cases/compiler/inferenceAndHKTs.ts
+++ b/tests/cases/compiler/inferenceAndHKTs.ts
@@ -1,0 +1,33 @@
+// @strict: true
+// @noEmit: true
+
+// Repro from #53970
+
+export interface TypeLambda {
+    readonly A: unknown;
+}
+
+export interface TypeClass<F extends TypeLambda> {
+    readonly _F: F;
+}
+
+export type Apply<F extends TypeLambda, A> = F extends { readonly type: unknown }
+    ? (F & { readonly A: A })['type']
+    : { readonly F: F, readonly A: A };
+
+export interface T<A> {
+    value: A;
+}
+
+export interface TTypeLambda extends TypeLambda {
+    readonly type: T<this["A"]>;
+}
+
+export declare const map: <F extends TypeLambda>(F: TypeClass<F>) => <A, B>(a: Apply<F, A>, f: (a: A) => B) => Apply<F, B>;
+
+declare const typeClass: TypeClass<TTypeLambda>;
+
+declare const a: T<number>;
+
+const x1 = map(typeClass);
+const x2 = map(typeClass)(a, (_) => _);  // T<number>


### PR DESCRIPTION
Fixes #53970.