### PR TITLE
runtests-watch: Don't try to listen for SIGKILL

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -616,7 +616,6 @@ export const runTestsAndWatch = task({
         });
 
         process.on("SIGINT", endWatchMode);
-        process.on("SIGKILL", endWatchMode);
         process.on("beforeExit", endWatchMode);
         watchTestsEmitter.on("rebuild", onRebuild);
         testCaseWatcher.on("all", onChange);


### PR DESCRIPTION
It's not possible (because a SIGKILL ends the process immediately, before the process can do anything to respond to it), and in current versions of Node attempting to will throw `Error: uv_signal_start EINVAL`. Thus, removing this "listener" removes no actual functionality; it only stops the task from immediately erroring on newer versions of Node.

See also: https://stackoverflow.com/questions/16311347/node-script-throws-uv-signal-start-einval

Fixes #54113

(I've ignored a bunch of PR process that didn't seem to apply to a tooling fix like this, but please let me know if there's anything I should do differently.)