### PR TITLE
Ensure GHA jobs fail fast in scripts

### DIFF
--- a/.github/workflows/accept-baselines-fix-lints.yaml
+++ b/.github/workflows/accept-baselines-fix-lints.yaml
@@ -6,6 +6,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest

--- a/.github/workflows/ensure-related-repos-run-crons.yml
+++ b/.github/workflows/ensure-related-repos-run-crons.yml
@@ -14,6 +14,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/error-deltas-watchdog.yaml
+++ b/.github/workflows/error-deltas-watchdog.yaml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check-for-recent:
     runs-on: ubuntu-latest

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rich-navigation.yml
+++ b/.github/workflows/rich-navigation.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   richnav:
     runs-on: windows-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,12 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -5,6 +5,12 @@ on: [gollum]
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -22,6 +22,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   run:
     if: ${{ github.repository == 'microsoft/TypeScript' }}

--- a/.github/workflows/update-lkg.yml
+++ b/.github/workflows/update-lkg.yml
@@ -6,6 +6,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+# Ensure scripts are run with pipefail. See:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Actions has a surprising default; scripts do not get `pipefile` and don't fail-fast when one command fails.

The documented workaround is to set the default to `bash`, which enables this behavior. See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference