### PR TITLE
Use union types for all common classes of AST nodes

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -5,7 +5,6 @@ import {
     append,
     appendIfUnique,
     ArrayBindingElement,
-    ArrayLiteralExpression,
     ArrowFunction,
     AssignmentDeclarationKind,
     BinaryExpression,
@@ -17,7 +16,6 @@ import {
     BindableStaticNameExpression,
     BindableStaticPropertyAssignmentExpression,
     BindingElement,
-    Block,
     BreakOrContinueStatement,
     CallChain,
     CallExpression,
@@ -53,7 +51,6 @@ import {
     DoStatement,
     DynamicNamedDeclaration,
     ElementAccessChain,
-    ElementAccessExpression,
     EntityNameExpression,
     EnumDeclaration,
     escapeLeadingUnderscores,
@@ -225,8 +222,6 @@ import {
     JSDocCallbackTag,
     JSDocClassTag,
     JSDocEnumTag,
-    JSDocFunctionType,
-    JSDocOverloadTag,
     JSDocParameterTag,
     JSDocPropertyLikeTag,
     JSDocSignature,
@@ -241,7 +236,6 @@ import {
     MetaProperty,
     MethodDeclaration,
     ModifierFlags,
-    ModuleBlock,
     ModuleDeclaration,
     Mutable,
     NamespaceExportDeclaration,
@@ -257,7 +251,6 @@ import {
     ObjectLiteralExpression,
     OptionalChain,
     ParameterDeclaration,
-    ParenthesizedExpression,
     Pattern,
     PatternAmbientModule,
     perfLogger,
@@ -269,7 +262,6 @@ import {
     PropertyAccessExpression,
     PropertyDeclaration,
     PropertySignature,
-    QualifiedName,
     removeFileExtension,
     ReturnStatement,
     ScriptTarget,
@@ -285,7 +277,6 @@ import {
     sliceAfter,
     some,
     SourceFile,
-    SpreadElement,
     Statement,
     StringLiteral,
     SuperExpression,
@@ -305,7 +296,6 @@ import {
     tryParsePattern,
     TryStatement,
     TypeLiteralNode,
-    TypeOfExpression,
     TypeParameterDeclaration,
     unescapeLeadingUnderscores,
     unreachableCodeIsError,
@@ -361,7 +351,7 @@ function getModuleInstanceStateWorker(node: Node, visited: Map<number, ModuleIns
             return ModuleInstanceState.NonInstantiated;
         // 2. const enum declarations
         case SyntaxKind.EnumDeclaration:
-            if (isEnumConst(node as EnumDeclaration)) {
+            if (isEnumConst(node)) {
                 return ModuleInstanceState.ConstEnumOnly;
             }
             break;
@@ -374,7 +364,7 @@ function getModuleInstanceStateWorker(node: Node, visited: Map<number, ModuleIns
             break;
         // 4. Export alias declarations pointing at only uninstantiated modules or things uninstantiated modules contain
         case SyntaxKind.ExportDeclaration:
-            const exportDeclaration = node as ExportDeclaration;
+            const exportDeclaration = node ;
             if (!exportDeclaration.moduleSpecifier && exportDeclaration.exportClause && exportDeclaration.exportClause.kind === SyntaxKind.NamedExports) {
                 let state = ModuleInstanceState.NonInstantiated;
                 for (const specifier of exportDeclaration.exportClause.elements) {
@@ -413,7 +403,7 @@ function getModuleInstanceStateWorker(node: Node, visited: Map<number, ModuleIns
             return state;
         }
         case SyntaxKind.ModuleDeclaration:
-            return getModuleInstanceState(node as ModuleDeclaration, visited);
+            return getModuleInstanceState(node , visited);
         case SyntaxKind.Identifier:
             // Only jsdoc typedef definition can exist in jsdoc namespace, and it should
             // be considered the same as type alias
@@ -426,7 +416,7 @@ function getModuleInstanceStateWorker(node: Node, visited: Map<number, ModuleIns
 
 function getModuleInstanceStateForAliasTarget(specifier: ExportSpecifier, visited: Map<number, ModuleInstanceState | undefined>) {
     const name = specifier.propertyName || specifier.name;
-    let p: Node | undefined = specifier.parent;
+    let p: Node | undefined = specifier.parent.parent;
     while (p) {
         if (isBlock(p) || isModuleBlock(p) || isSourceFile(p)) {
             const statements = p.statements;
@@ -649,7 +639,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     // unless it is a well known Symbol.
     function getDeclarationName(node: Declaration): __String | undefined {
         if (node.kind === SyntaxKind.ExportAssignment) {
-            return (node as ExportAssignment).isExportEquals ? InternalSymbolName.ExportEquals : InternalSymbolName.Default;
+            return (node).isExportEquals ? InternalSymbolName.ExportEquals : InternalSymbolName.Default;
         }
 
         const name = getNameOfDeclaration(node);
@@ -705,7 +695,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 // module.exports = ...
                 return InternalSymbolName.ExportEquals;
             case SyntaxKind.BinaryExpression:
-                if (getAssignmentDeclarationKind(node as BinaryExpression) === AssignmentDeclarationKind.ModuleExports) {
+                if (getAssignmentDeclarationKind(node) === AssignmentDeclarationKind.ModuleExports) {
                     // module.exports = ...
                     return InternalSymbolName.ExportEquals;
                 }
@@ -717,8 +707,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 // Parameters with names are handled at the top of this function.  Parameters
                 // without names can only come from JSDocFunctionTypes.
                 Debug.assert(node.parent.kind === SyntaxKind.JSDocFunctionType, "Impossible parameter parent kind", () => `parent is: ${Debug.formatSyntaxKind(node.parent.kind)}, expected JSDocFunctionType`);
-                const functionType = node.parent as JSDocFunctionType;
-                const index = functionType.parameters.indexOf(node as ParameterDeclaration);
+                const functionType = node.parent ;
+                const index = functionType.parameters.indexOf(node);
                 return "arg" + index as __String;
         }
     }
@@ -826,7 +816,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                             // 1. multiple export default of class declaration or function declaration by checking NodeFlags.Default
                             // 2. multiple export default of export assignment. This one doesn't have NodeFlags.Default on (as export default doesn't considered as modifiers)
                             if (symbol.declarations && symbol.declarations.length &&
-                                (node.kind === SyntaxKind.ExportAssignment && !(node as ExportAssignment).isExportEquals)) {
+                                (node.kind === SyntaxKind.ExportAssignment && !(node).isExportEquals)) {
                                 message = Diagnostics.A_module_cannot_have_multiple_default_exports;
                                 messageNeedsName = false;
                                 multipleDefaultExports = true;
@@ -1086,52 +1076,52 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         }
         switch (node.kind) {
             case SyntaxKind.WhileStatement:
-                bindWhileStatement(node as WhileStatement);
+                bindWhileStatement(node);
                 break;
             case SyntaxKind.DoStatement:
-                bindDoStatement(node as DoStatement);
+                bindDoStatement(node);
                 break;
             case SyntaxKind.ForStatement:
-                bindForStatement(node as ForStatement);
+                bindForStatement(node);
                 break;
             case SyntaxKind.ForInStatement:
             case SyntaxKind.ForOfStatement:
                 bindForInOrForOfStatement(node as ForInOrOfStatement);
                 break;
             case SyntaxKind.IfStatement:
-                bindIfStatement(node as IfStatement);
+                bindIfStatement(node);
                 break;
             case SyntaxKind.ReturnStatement:
             case SyntaxKind.ThrowStatement:
-                bindReturnOrThrow(node as ReturnStatement | ThrowStatement);
+                bindReturnOrThrow(node);
                 break;
             case SyntaxKind.BreakStatement:
             case SyntaxKind.ContinueStatement:
                 bindBreakOrContinueStatement(node as BreakOrContinueStatement);
                 break;
             case SyntaxKind.TryStatement:
-                bindTryStatement(node as TryStatement);
+                bindTryStatement(node);
                 break;
             case SyntaxKind.SwitchStatement:
-                bindSwitchStatement(node as SwitchStatement);
+                bindSwitchStatement(node);
                 break;
             case SyntaxKind.CaseBlock:
-                bindCaseBlock(node as CaseBlock);
+                bindCaseBlock(node);
                 break;
             case SyntaxKind.CaseClause:
-                bindCaseClause(node as CaseClause);
+                bindCaseClause(node);
                 break;
             case SyntaxKind.ExpressionStatement:
-                bindExpressionStatement(node as ExpressionStatement);
+                bindExpressionStatement(node);
                 break;
             case SyntaxKind.LabeledStatement:
-                bindLabeledStatement(node as LabeledStatement);
+                bindLabeledStatement(node);
                 break;
             case SyntaxKind.PrefixUnaryExpression:
-                bindPrefixUnaryExpressionFlow(node as PrefixUnaryExpression);
+                bindPrefixUnaryExpressionFlow(node);
                 break;
             case SyntaxKind.PostfixUnaryExpression:
-                bindPostfixUnaryExpressionFlow(node as PostfixUnaryExpression);
+                bindPostfixUnaryExpressionFlow(node);
                 break;
             case SyntaxKind.BinaryExpression:
                 if (isDestructuringAssignment(node)) {
@@ -1141,47 +1131,47 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                     bindDestructuringAssignmentFlow(node);
                     return;
                 }
-                bindBinaryExpressionFlow(node as BinaryExpression);
+                bindBinaryExpressionFlow(node);
                 break;
             case SyntaxKind.DeleteExpression:
-                bindDeleteExpressionFlow(node as DeleteExpression);
+                bindDeleteExpressionFlow(node);
                 break;
             case SyntaxKind.ConditionalExpression:
-                bindConditionalExpressionFlow(node as ConditionalExpression);
+                bindConditionalExpressionFlow(node);
                 break;
             case SyntaxKind.VariableDeclaration:
-                bindVariableDeclarationFlow(node as VariableDeclaration);
+                bindVariableDeclarationFlow(node);
                 break;
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression:
                 bindAccessExpressionFlow(node as AccessExpression);
                 break;
             case SyntaxKind.CallExpression:
-                bindCallExpressionFlow(node as CallExpression);
+                bindCallExpressionFlow(node);
                 break;
             case SyntaxKind.NonNullExpression:
-                bindNonNullExpressionFlow(node as NonNullExpression);
+                bindNonNullExpressionFlow(node);
                 break;
             case SyntaxKind.JSDocTypedefTag:
             case SyntaxKind.JSDocCallbackTag:
             case SyntaxKind.JSDocEnumTag:
-                bindJSDocTypeAlias(node as JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag);
+                bindJSDocTypeAlias(node);
                 break;
             // In source files and blocks, bind functions first to match hoisting that occurs at runtime
             case SyntaxKind.SourceFile: {
-                bindEachFunctionsFirst((node as SourceFile).statements);
-                bind((node as SourceFile).endOfFileToken);
+                bindEachFunctionsFirst(node.statements);
+                bind(node.endOfFileToken);
                 break;
             }
             case SyntaxKind.Block:
             case SyntaxKind.ModuleBlock:
-                bindEachFunctionsFirst((node as Block).statements);
+                bindEachFunctionsFirst(node.statements);
                 break;
             case SyntaxKind.BindingElement:
-                bindBindingElementFlow(node as BindingElement);
+                bindBindingElementFlow(node);
                 break;
             case SyntaxKind.Parameter:
-                bindParameterFlow(node as ParameterDeclaration);
+                bindParameterFlow(node);
                 break;
             case SyntaxKind.ObjectLiteralExpression:
             case SyntaxKind.ArrayLiteralExpression:
@@ -1208,16 +1198,16 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             case SyntaxKind.ElementAccessExpression:
                 return containsNarrowableReference(expr);
             case SyntaxKind.CallExpression:
-                return hasNarrowableArgument(expr as CallExpression);
+                return hasNarrowableArgument(expr);
             case SyntaxKind.ParenthesizedExpression:
             case SyntaxKind.NonNullExpression:
-                return isNarrowingExpression((expr as ParenthesizedExpression | NonNullExpression).expression);
+                return isNarrowingExpression((expr).expression);
             case SyntaxKind.BinaryExpression:
-                return isNarrowingBinaryExpression(expr as BinaryExpression);
+                return isNarrowingBinaryExpression(expr);
             case SyntaxKind.PrefixUnaryExpression:
-                return (expr as PrefixUnaryExpression).operator === SyntaxKind.ExclamationToken && isNarrowingExpression((expr as PrefixUnaryExpression).operand);
+                return (expr).operator === SyntaxKind.ExclamationToken && isNarrowingExpression((expr).operand);
             case SyntaxKind.TypeOfExpression:
-                return isNarrowingExpression((expr as TypeOfExpression).expression);
+                return isNarrowingExpression((expr).expression);
         }
         return false;
     }
@@ -1243,7 +1233,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             }
         }
         if (expr.expression.kind === SyntaxKind.PropertyAccessExpression &&
-            containsNarrowableReference((expr.expression as PropertyAccessExpression).expression)) {
+            containsNarrowableReference((expr.expression).expression)) {
             return true;
         }
         return false;
@@ -1279,13 +1269,13 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     function isNarrowableOperand(expr: Expression): boolean {
         switch (expr.kind) {
             case SyntaxKind.ParenthesizedExpression:
-                return isNarrowableOperand((expr as ParenthesizedExpression).expression);
+                return isNarrowableOperand((expr).expression);
             case SyntaxKind.BinaryExpression:
-                switch ((expr as BinaryExpression).operatorToken.kind) {
+                switch ((expr).operatorToken.kind) {
                     case SyntaxKind.EqualsToken:
-                        return isNarrowableOperand((expr as BinaryExpression).left);
+                        return isNarrowableOperand((expr).left);
                     case SyntaxKind.CommaToken:
-                        return isNarrowableOperand((expr as BinaryExpression).right);
+                        return isNarrowableOperand((expr).right);
                 }
         }
         return containsNarrowableReference(expr);
@@ -1370,10 +1360,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             case SyntaxKind.IfStatement:
             case SyntaxKind.WhileStatement:
             case SyntaxKind.DoStatement:
-                return (parent as IfStatement | WhileStatement | DoStatement).expression === node;
+                return (parent).expression === node;
             case SyntaxKind.ForStatement:
             case SyntaxKind.ConditionalExpression:
-                return (parent as ForStatement | ConditionalExpression).condition === node;
+                return (parent).condition === node;
         }
         return false;
     }
@@ -1381,10 +1371,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     function isLogicalExpression(node: Node) {
         while (true) {
             if (node.kind === SyntaxKind.ParenthesizedExpression) {
-                node = (node as ParenthesizedExpression).expression;
+                node = (node).expression;
             }
-            else if (node.kind === SyntaxKind.PrefixUnaryExpression && (node as PrefixUnaryExpression).operator === SyntaxKind.ExclamationToken) {
-                node = (node as PrefixUnaryExpression).operand;
+            else if (node.kind === SyntaxKind.PrefixUnaryExpression && (node).operator === SyntaxKind.ExclamationToken) {
+                node = (node).operand;
             }
             else {
                 return isLogicalOrCoalescingBinaryExpression(node);
@@ -1700,7 +1690,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         // A top level or comma expression call expression with a dotted function name and at least one argument
         // is potentially an assertion and is therefore included in the control flow.
         if (node.kind === SyntaxKind.CallExpression) {
-            const call = node as CallExpression;
+            const call = node ;
             if (call.expression.kind !== SyntaxKind.SuperKeyword && isDottedName(call.expression)) {
                 currentFlow = createFlowCall(currentFlow, call);
             }
@@ -1727,8 +1717,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     }
 
     function bindDestructuringTargetFlow(node: Expression) {
-        if (node.kind === SyntaxKind.BinaryExpression && (node as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken) {
-            bindAssignmentTargetFlow((node as BinaryExpression).left);
+        if (node.kind === SyntaxKind.BinaryExpression && (node).operatorToken.kind === SyntaxKind.EqualsToken) {
+            bindAssignmentTargetFlow((node).left);
         }
         else {
             bindAssignmentTargetFlow(node);
@@ -1740,9 +1730,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             currentFlow = createFlowMutation(FlowFlags.Assignment, currentFlow, node);
         }
         else if (node.kind === SyntaxKind.ArrayLiteralExpression) {
-            for (const e of (node as ArrayLiteralExpression).elements) {
+            for (const e of (node).elements) {
                 if (e.kind === SyntaxKind.SpreadElement) {
-                    bindAssignmentTargetFlow((e as SpreadElement).expression);
+                    bindAssignmentTargetFlow((e).expression);
                 }
                 else {
                     bindDestructuringTargetFlow(e);
@@ -1750,7 +1740,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             }
         }
         else if (node.kind === SyntaxKind.ObjectLiteralExpression) {
-            for (const p of (node as ObjectLiteralExpression).properties) {
+            for (const p of (node).properties) {
                 if (p.kind === SyntaxKind.PropertyAssignment) {
                     bindDestructuringTargetFlow(p.initializer);
                 }
@@ -1911,7 +1901,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 if (isAssignmentOperator(operator) && !isAssignmentTarget(node)) {
                     bindAssignmentTargetFlow(node.left);
                     if (operator === SyntaxKind.EqualsToken && node.left.kind === SyntaxKind.ElementAccessExpression) {
-                        const elementAccess = node.left as ElementAccessExpression;
+                        const elementAccess = node.left ;
                         if (isNarrowableOperand(elementAccess.expression)) {
                             currentFlow = createFlowMutation(FlowFlags.ArrayMutation, currentFlow, node);
                         }
@@ -2138,7 +2128,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             }
         }
         if (node.expression.kind === SyntaxKind.PropertyAccessExpression) {
-            const propertyAccess = node.expression as PropertyAccessExpression;
+            const propertyAccess = node.expression ;
             if (isIdentifier(propertyAccess.name) && isNarrowableOperand(propertyAccess.expression) && isPushOrUnshiftIdentifier(propertyAccess.name)) {
                 currentFlow = createFlowMutation(FlowFlags.ArrayMutation, currentFlow, node);
             }
@@ -2514,7 +2504,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
 
     function checkStrictModeEvalOrArguments(contextNode: Node, name: Node | undefined) {
         if (name && name.kind === SyntaxKind.Identifier) {
-            const identifier = name as Identifier;
+            const identifier = name ;
             if (isEvalOrArgumentsIdentifier(identifier)) {
                 // We check first if the name is inside class declaration or class expression; if so give explicit message
                 // otherwise report generic error message.
@@ -2753,7 +2743,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 return checkContextualIdentifier(node as Identifier);
             case SyntaxKind.QualifiedName:
                 if (currentFlow && isPartOfTypeQuery(node)) {
-                    (node as QualifiedName).flowNode = currentFlow;
+                    (node).flowNode = currentFlow;
                 }
                 break;
             case SyntaxKind.MetaProperty:
@@ -2761,10 +2751,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 (node as MetaProperty | SuperExpression).flowNode = currentFlow;
                 break;
             case SyntaxKind.PrivateIdentifier:
-                return checkPrivateIdentifier(node as PrivateIdentifier);
+                return checkPrivateIdentifier(node);
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression:
-                const expr = node as PropertyAccessExpression | ElementAccessExpression;
+                const expr = node ;
                 if (currentFlow && isNarrowableReference(expr)) {
                     expr.flowNode = currentFlow;
                 }
@@ -2780,7 +2770,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 }
                 break;
             case SyntaxKind.BinaryExpression:
-                const specialKind = getAssignmentDeclarationKind(node as BinaryExpression);
+                const specialKind = getAssignmentDeclarationKind(node);
                 switch (specialKind) {
                     case AssignmentDeclarationKind.ExportsProperty:
                         bindExportsPropertyAssignment(node as BindableStaticPropertyAssignmentExpression);
@@ -2798,7 +2788,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                         bindThisPropertyAssignment(node as BindablePropertyAssignmentExpression);
                         break;
                     case AssignmentDeclarationKind.Property:
-                        const expression = ((node as BinaryExpression).left as AccessExpression).expression;
+                        const expression = ((node).left as AccessExpression).expression;
                         if (isInJSFile(node) && isIdentifier(expression)) {
                             const symbol = lookupSymbolForName(blockScopeContainer, expression.escapedText);
                             if (isThisInitializedDeclaration(symbol?.valueDeclaration)) {
@@ -2814,36 +2804,36 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                     default:
                         Debug.fail("Unknown binary expression special property assignment kind");
                 }
-                return checkStrictModeBinaryExpression(node as BinaryExpression);
+                return checkStrictModeBinaryExpression(node);
             case SyntaxKind.CatchClause:
-                return checkStrictModeCatchClause(node as CatchClause);
+                return checkStrictModeCatchClause(node);
             case SyntaxKind.DeleteExpression:
-                return checkStrictModeDeleteExpression(node as DeleteExpression);
+                return checkStrictModeDeleteExpression(node);
             case SyntaxKind.PostfixUnaryExpression:
-                return checkStrictModePostfixUnaryExpression(node as PostfixUnaryExpression);
+                return checkStrictModePostfixUnaryExpression(node);
             case SyntaxKind.PrefixUnaryExpression:
-                return checkStrictModePrefixUnaryExpression(node as PrefixUnaryExpression);
+                return checkStrictModePrefixUnaryExpression(node);
             case SyntaxKind.WithStatement:
-                return checkStrictModeWithStatement(node as WithStatement);
+                return checkStrictModeWithStatement(node);
             case SyntaxKind.LabeledStatement:
-                return checkStrictModeLabeledStatement(node as LabeledStatement);
+                return checkStrictModeLabeledStatement(node);
             case SyntaxKind.ThisType:
                 seenThisKeyword = true;
                 return;
             case SyntaxKind.TypePredicate:
                 break; // Binding the children will handle everything
             case SyntaxKind.TypeParameter:
-                return bindTypeParameter(node as TypeParameterDeclaration);
+                return bindTypeParameter(node);
             case SyntaxKind.Parameter:
-                return bindParameter(node as ParameterDeclaration);
+                return bindParameter(node);
             case SyntaxKind.VariableDeclaration:
-                return bindVariableDeclarationOrBindingElement(node as VariableDeclaration);
+                return bindVariableDeclarationOrBindingElement(node);
             case SyntaxKind.BindingElement:
-                (node as BindingElement).flowNode = currentFlow;
-                return bindVariableDeclarationOrBindingElement(node as BindingElement);
+                (node).flowNode = currentFlow;
+                return bindVariableDeclarationOrBindingElement(node);
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:
-                return bindPropertyWorker(node as PropertyDeclaration | PropertySignature);
+                return bindPropertyWorker(node);
             case SyntaxKind.PropertyAssignment:
             case SyntaxKind.ShorthandPropertyAssignment:
                 return bindPropertyOrMethodOrAccessor(node as Declaration, SymbolFlags.Property, SymbolFlags.PropertyExcludes);
@@ -2863,7 +2853,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 return bindPropertyOrMethodOrAccessor(node as Declaration, SymbolFlags.Method | ((node as MethodDeclaration).questionToken ? SymbolFlags.Optional : SymbolFlags.None),
                     isObjectLiteralMethod(node) ? SymbolFlags.PropertyExcludes : SymbolFlags.MethodExcludes);
             case SyntaxKind.FunctionDeclaration:
-                return bindFunctionDeclaration(node as FunctionDeclaration);
+                return bindFunctionDeclaration(node);
             case SyntaxKind.Constructor:
                 return declareSymbolAndAddToSymbolTable(node as Declaration, SymbolFlags.Constructor, /*symbolExcludes:*/ SymbolFlags.None);
             case SyntaxKind.GetAccessor:
@@ -2878,17 +2868,17 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             case SyntaxKind.TypeLiteral:
             case SyntaxKind.JSDocTypeLiteral:
             case SyntaxKind.MappedType:
-                return bindAnonymousTypeWorker(node as TypeLiteralNode | MappedTypeNode | JSDocTypeLiteral);
+                return bindAnonymousTypeWorker(node);
             case SyntaxKind.JSDocClassTag:
-                return bindJSDocClassTag(node as JSDocClassTag);
+                return bindJSDocClassTag(node);
             case SyntaxKind.ObjectLiteralExpression:
-                return bindObjectLiteralExpression(node as ObjectLiteralExpression);
+                return bindObjectLiteralExpression(node);
             case SyntaxKind.FunctionExpression:
             case SyntaxKind.ArrowFunction:
-                return bindFunctionExpression(node as FunctionExpression | ArrowFunction);
+                return bindFunctionExpression(node);
 
             case SyntaxKind.CallExpression:
-                const assignmentKind = getAssignmentDeclarationKind(node as CallExpression);
+                const assignmentKind = getAssignmentDeclarationKind(node);
                 switch (assignmentKind) {
                     case AssignmentDeclarationKind.ObjectDefinePropertyValue:
                         return bindObjectDefinePropertyAssignment(node as BindableObjectDefinePropertyCall);
@@ -2902,7 +2892,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                         return Debug.fail("Unknown call expression assignment declaration kind");
                 }
                 if (isInJSFile(node)) {
-                    bindCallExpression(node as CallExpression);
+                    bindCallExpression(node);
                 }
                 break;
 
@@ -2917,14 +2907,14 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             case SyntaxKind.TypeAliasDeclaration:
                 return bindBlockScopedDeclaration(node as Declaration, SymbolFlags.TypeAlias, SymbolFlags.TypeAliasExcludes);
             case SyntaxKind.EnumDeclaration:
-                return bindEnumDeclaration(node as EnumDeclaration);
+                return bindEnumDeclaration(node);
             case SyntaxKind.ModuleDeclaration:
-                return bindModuleDeclaration(node as ModuleDeclaration);
+                return bindModuleDeclaration(node);
             // Jsx-attributes
             case SyntaxKind.JsxAttributes:
-                return bindJsxAttributes(node as JsxAttributes);
+                return bindJsxAttributes(node);
             case SyntaxKind.JsxAttribute:
-                return bindJsxAttribute(node as JsxAttribute, SymbolFlags.Property, SymbolFlags.PropertyExcludes);
+                return bindJsxAttribute(node, SymbolFlags.Property, SymbolFlags.PropertyExcludes);
 
             // Imports and exports
             case SyntaxKind.ImportEqualsDeclaration:
@@ -2933,15 +2923,15 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             case SyntaxKind.ExportSpecifier:
                 return declareSymbolAndAddToSymbolTable(node as Declaration, SymbolFlags.Alias, SymbolFlags.AliasExcludes);
             case SyntaxKind.NamespaceExportDeclaration:
-                return bindNamespaceExportDeclaration(node as NamespaceExportDeclaration);
+                return bindNamespaceExportDeclaration(node);
             case SyntaxKind.ImportClause:
-                return bindImportClause(node as ImportClause);
+                return bindImportClause(node);
             case SyntaxKind.ExportDeclaration:
-                return bindExportDeclaration(node as ExportDeclaration);
+                return bindExportDeclaration(node);
             case SyntaxKind.ExportAssignment:
-                return bindExportAssignment(node as ExportAssignment);
+                return bindExportAssignment(node);
             case SyntaxKind.SourceFile:
-                updateStrictModeStatementList((node as SourceFile).statements);
+                updateStrictModeStatementList((node).statements);
                 return bindSourceFileIfExternalModule();
             case SyntaxKind.Block:
                 if (!isFunctionLikeOrClassStaticBlockDeclaration(node.parent)) {
@@ -2949,11 +2939,11 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 }
                 // falls through
             case SyntaxKind.ModuleBlock:
-                return updateStrictModeStatementList((node as Block | ModuleBlock).statements);
+                return updateStrictModeStatementList((node).statements);
 
             case SyntaxKind.JSDocParameterTag:
                 if (node.parent.kind === SyntaxKind.JSDocSignature) {
-                    return bindParameter(node as JSDocParameterTag);
+                    return bindParameter(node);
                 }
                 if (node.parent.kind !== SyntaxKind.JSDocTypeLiteral) {
                     break;
@@ -2968,9 +2958,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             case SyntaxKind.JSDocTypedefTag:
             case SyntaxKind.JSDocCallbackTag:
             case SyntaxKind.JSDocEnumTag:
-                return (delayedTypeAliases || (delayedTypeAliases = [])).push(node as JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag);
+                return (delayedTypeAliases || (delayedTypeAliases = [])).push(node);
             case SyntaxKind.JSDocOverloadTag:
-                return bind((node as JSDocOverloadTag).typeExpression);
+                return bind(node.typeExpression);
         }
     }
 
@@ -3678,7 +3668,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 // report error on class declarations
                 node.kind === SyntaxKind.ClassDeclaration ||
                 // report error on instantiated modules or const-enums only modules if preserveConstEnums is set
-                (node.kind === SyntaxKind.ModuleDeclaration && shouldReportErrorOnModuleDeclaration(node as ModuleDeclaration));
+                (node.kind === SyntaxKind.ModuleDeclaration && shouldReportErrorOnModuleDeclaration(node));
 
             if (reportError) {
                 currentFlow = reportedUnreachableFlow;
@@ -3734,7 +3724,7 @@ function isPurelyTypeDeclaration(s: Statement): boolean {
         case SyntaxKind.TypeAliasDeclaration:
             return true;
         case SyntaxKind.ModuleDeclaration:
-            return getModuleInstanceState(s as ModuleDeclaration) !== ModuleInstanceState.Instantiated;
+            return getModuleInstanceState(s) !== ModuleInstanceState.Instantiated;
         case SyntaxKind.EnumDeclaration:
             return hasSyntacticModifier(s, ModifierFlags.Const);
         default:
@@ -3817,7 +3807,7 @@ function getContainerFlags(node: Node): ContainerFlags {
         case SyntaxKind.ModuleBlock:
             return ContainerFlags.IsControlFlowContainer;
         case SyntaxKind.PropertyDeclaration:
-            return (node as PropertyDeclaration).initializer ? ContainerFlags.IsControlFlowContainer : 0;
+            return (node).initializer ? ContainerFlags.IsControlFlowContainer : 0;
 
         case SyntaxKind.CatchClause:
         case SyntaxKind.ForStatement:

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -88,14 +88,12 @@ import {
     nodeNextJsonConfigResolver,
     normalizePath,
     normalizeSlashes,
-    NumericLiteral,
     ObjectLiteralExpression,
     ParseConfigHost,
     ParsedCommandLine,
     parseJsonText,
     Path,
     PollingWatchKind,
-    PrefixUnaryExpression,
     ProjectReference,
     PropertyAssignment,
     PropertyName,
@@ -104,7 +102,6 @@ import {
     ScriptTarget,
     startsWith,
     stringContains,
-    StringLiteral,
     SyntaxKind,
     sys,
     toFileNameLowerCase,
@@ -2360,19 +2357,19 @@ export function convertToJson(
                 if (!isDoubleQuotedString(valueExpression)) {
                     errors.push(createDiagnosticForNodeInSourceFile(sourceFile, valueExpression, Diagnostics.String_literal_with_double_quotes_expected));
                 }
-                return (valueExpression as StringLiteral).text;
+                return (valueExpression).text;
 
             case SyntaxKind.NumericLiteral:
-                return Number((valueExpression as NumericLiteral).text);
+                return Number((valueExpression).text);
 
             case SyntaxKind.PrefixUnaryExpression:
-                if ((valueExpression as PrefixUnaryExpression).operator !== SyntaxKind.MinusToken || (valueExpression as PrefixUnaryExpression).operand.kind !== SyntaxKind.NumericLiteral) {
+                if ((valueExpression).operator !== SyntaxKind.MinusToken || (valueExpression).operand.kind !== SyntaxKind.NumericLiteral) {
                     break; // not valid JSON syntax
                 }
-                return -Number(((valueExpression as PrefixUnaryExpression).operand as NumericLiteral).text);
+                return -Number(((valueExpression).operand).text);
 
             case SyntaxKind.ObjectLiteralExpression:
-                const objectLiteralExpression = valueExpression as ObjectLiteralExpression;
+                const objectLiteralExpression = valueExpression ;
 
                 // Currently having element option declaration in the tsconfig with type "object"
                 // determines if it needs onSetValidOptionKeyValueInParent callback or not
@@ -2384,7 +2381,7 @@ export function convertToJson(
 
             case SyntaxKind.ArrayLiteralExpression:
                 return convertArrayLiteralExpressionToJson(
-                    (valueExpression as ArrayLiteralExpression).elements,
+                    (valueExpression).elements,
                     option && (option as CommandLineOptionOfListType).element);
         }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -404,7 +404,6 @@ import {
     stableSort,
     Statement,
     stringContains,
-    StringLiteral,
     supportedJSExtensionsFlat,
     SwitchStatement,
     Symbol,
@@ -960,7 +959,7 @@ export function emitFiles(resolver: EmitResolver, host: EmitHost, targetSourceFi
     function collectLinkedAliases(node: Node) {
         if (isExportAssignment(node)) {
             if (node.expression.kind === SyntaxKind.Identifier) {
-                resolver.collectLinkedAliases(node.expression as Identifier, /*setVisibility*/ true);
+                resolver.collectLinkedAliases(node.expression , /*setVisibility*/ true);
             }
             return;
         }
@@ -1468,9 +1467,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 break;
         }
         switch (node.kind) {
-            case SyntaxKind.SourceFile: return printFile(node as SourceFile);
-            case SyntaxKind.Bundle: return printBundle(node as Bundle);
-            case SyntaxKind.UnparsedSource: return printUnparsedSource(node as UnparsedSource);
+            case SyntaxKind.SourceFile: return printFile(node);
+            case SyntaxKind.Bundle: return printBundle(node);
+            case SyntaxKind.UnparsedSource: return printUnparsedSource(node);
         }
         writeNode(hint, node, sourceFile, beginPrint());
         return endPrint();
@@ -1840,218 +1839,218 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 case SyntaxKind.TemplateHead:
                 case SyntaxKind.TemplateMiddle:
                 case SyntaxKind.TemplateTail:
-                    return emitLiteral(node as LiteralExpression, /*jsxAttributeEscape*/ false);
+                    return emitLiteral(node, /*jsxAttributeEscape*/ false);
 
                 // Identifiers
                 case SyntaxKind.Identifier:
-                    return emitIdentifier(node as Identifier);
+                    return emitIdentifier(node);
 
                 // PrivateIdentifiers
                 case SyntaxKind.PrivateIdentifier:
-                    return emitPrivateIdentifier(node as PrivateIdentifier);
+                    return emitPrivateIdentifier(node);
 
                 // Parse tree nodes
                 // Names
                 case SyntaxKind.QualifiedName:
-                    return emitQualifiedName(node as QualifiedName);
+                    return emitQualifiedName(node);
                 case SyntaxKind.ComputedPropertyName:
-                    return emitComputedPropertyName(node as ComputedPropertyName);
+                    return emitComputedPropertyName(node);
 
                 // Signature elements
                 case SyntaxKind.TypeParameter:
-                    return emitTypeParameter(node as TypeParameterDeclaration);
+                    return emitTypeParameter(node);
                 case SyntaxKind.Parameter:
-                    return emitParameter(node as ParameterDeclaration);
+                    return emitParameter(node);
                 case SyntaxKind.Decorator:
-                    return emitDecorator(node as Decorator);
+                    return emitDecorator(node);
 
                 // Type members
                 case SyntaxKind.PropertySignature:
-                    return emitPropertySignature(node as PropertySignature);
+                    return emitPropertySignature(node);
                 case SyntaxKind.PropertyDeclaration:
-                    return emitPropertyDeclaration(node as PropertyDeclaration);
+                    return emitPropertyDeclaration(node);
                 case SyntaxKind.MethodSignature:
-                    return emitMethodSignature(node as MethodSignature);
+                    return emitMethodSignature(node);
                 case SyntaxKind.MethodDeclaration:
-                    return emitMethodDeclaration(node as MethodDeclaration);
+                    return emitMethodDeclaration(node);
                 case SyntaxKind.ClassStaticBlockDeclaration:
-                    return emitClassStaticBlockDeclaration(node as ClassStaticBlockDeclaration);
+                    return emitClassStaticBlockDeclaration(node);
                 case SyntaxKind.Constructor:
-                    return emitConstructor(node as ConstructorDeclaration);
+                    return emitConstructor(node);
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
                     return emitAccessorDeclaration(node as AccessorDeclaration);
                 case SyntaxKind.CallSignature:
-                    return emitCallSignature(node as CallSignatureDeclaration);
+                    return emitCallSignature(node);
                 case SyntaxKind.ConstructSignature:
-                    return emitConstructSignature(node as ConstructSignatureDeclaration);
+                    return emitConstructSignature(node);
                 case SyntaxKind.IndexSignature:
-                    return emitIndexSignature(node as IndexSignatureDeclaration);
+                    return emitIndexSignature(node);
 
                 // Types
                 case SyntaxKind.TypePredicate:
-                    return emitTypePredicate(node as TypePredicateNode);
+                    return emitTypePredicate(node);
                 case SyntaxKind.TypeReference:
-                    return emitTypeReference(node as TypeReferenceNode);
+                    return emitTypeReference(node);
                 case SyntaxKind.FunctionType:
-                    return emitFunctionType(node as FunctionTypeNode);
+                    return emitFunctionType(node);
                 case SyntaxKind.ConstructorType:
-                    return emitConstructorType(node as ConstructorTypeNode);
+                    return emitConstructorType(node);
                 case SyntaxKind.TypeQuery:
-                    return emitTypeQuery(node as TypeQueryNode);
+                    return emitTypeQuery(node);
                 case SyntaxKind.TypeLiteral:
-                    return emitTypeLiteral(node as TypeLiteralNode);
+                    return emitTypeLiteral(node);
                 case SyntaxKind.ArrayType:
-                    return emitArrayType(node as ArrayTypeNode);
+                    return emitArrayType(node);
                 case SyntaxKind.TupleType:
-                    return emitTupleType(node as TupleTypeNode);
+                    return emitTupleType(node);
                 case SyntaxKind.OptionalType:
-                    return emitOptionalType(node as OptionalTypeNode);
+                    return emitOptionalType(node);
                 // SyntaxKind.RestType is handled below
                 case SyntaxKind.UnionType:
-                    return emitUnionType(node as UnionTypeNode);
+                    return emitUnionType(node);
                 case SyntaxKind.IntersectionType:
-                    return emitIntersectionType(node as IntersectionTypeNode);
+                    return emitIntersectionType(node);
                 case SyntaxKind.ConditionalType:
-                    return emitConditionalType(node as ConditionalTypeNode);
+                    return emitConditionalType(node);
                 case SyntaxKind.InferType:
-                    return emitInferType(node as InferTypeNode);
+                    return emitInferType(node);
                 case SyntaxKind.ParenthesizedType:
-                    return emitParenthesizedType(node as ParenthesizedTypeNode);
+                    return emitParenthesizedType(node);
                 case SyntaxKind.ExpressionWithTypeArguments:
-                    return emitExpressionWithTypeArguments(node as ExpressionWithTypeArguments);
+                    return emitExpressionWithTypeArguments(node);
                 case SyntaxKind.ThisType:
                     return emitThisType();
                 case SyntaxKind.TypeOperator:
-                    return emitTypeOperator(node as TypeOperatorNode);
+                    return emitTypeOperator(node);
                 case SyntaxKind.IndexedAccessType:
-                    return emitIndexedAccessType(node as IndexedAccessTypeNode);
+                    return emitIndexedAccessType(node);
                 case SyntaxKind.MappedType:
-                    return emitMappedType(node as MappedTypeNode);
+                    return emitMappedType(node);
                 case SyntaxKind.LiteralType:
-                    return emitLiteralType(node as LiteralTypeNode);
+                    return emitLiteralType(node);
                 case SyntaxKind.NamedTupleMember:
-                    return emitNamedTupleMember(node as NamedTupleMember);
+                    return emitNamedTupleMember(node);
                 case SyntaxKind.TemplateLiteralType:
-                    return emitTemplateType(node as TemplateLiteralTypeNode);
+                    return emitTemplateType(node);
                 case SyntaxKind.TemplateLiteralTypeSpan:
-                    return emitTemplateTypeSpan(node as TemplateLiteralTypeSpan);
+                    return emitTemplateTypeSpan(node);
                 case SyntaxKind.ImportType:
-                    return emitImportTypeNode(node as ImportTypeNode);
+                    return emitImportTypeNode(node);
 
                 // Binding patterns
                 case SyntaxKind.ObjectBindingPattern:
-                    return emitObjectBindingPattern(node as ObjectBindingPattern);
+                    return emitObjectBindingPattern(node);
                 case SyntaxKind.ArrayBindingPattern:
-                    return emitArrayBindingPattern(node as ArrayBindingPattern);
+                    return emitArrayBindingPattern(node);
                 case SyntaxKind.BindingElement:
-                    return emitBindingElement(node as BindingElement);
+                    return emitBindingElement(node);
 
                 // Misc
                 case SyntaxKind.TemplateSpan:
-                    return emitTemplateSpan(node as TemplateSpan);
+                    return emitTemplateSpan(node);
                 case SyntaxKind.SemicolonClassElement:
                     return emitSemicolonClassElement();
 
                 // Statements
                 case SyntaxKind.Block:
-                    return emitBlock(node as Block);
+                    return emitBlock(node);
                 case SyntaxKind.VariableStatement:
-                    return emitVariableStatement(node as VariableStatement);
+                    return emitVariableStatement(node);
                 case SyntaxKind.EmptyStatement:
                     return emitEmptyStatement(/*isEmbeddedStatement*/ false);
                 case SyntaxKind.ExpressionStatement:
-                    return emitExpressionStatement(node as ExpressionStatement);
+                    return emitExpressionStatement(node);
                 case SyntaxKind.IfStatement:
-                    return emitIfStatement(node as IfStatement);
+                    return emitIfStatement(node);
                 case SyntaxKind.DoStatement:
-                    return emitDoStatement(node as DoStatement);
+                    return emitDoStatement(node);
                 case SyntaxKind.WhileStatement:
-                    return emitWhileStatement(node as WhileStatement);
+                    return emitWhileStatement(node);
                 case SyntaxKind.ForStatement:
-                    return emitForStatement(node as ForStatement);
+                    return emitForStatement(node);
                 case SyntaxKind.ForInStatement:
-                    return emitForInStatement(node as ForInStatement);
+                    return emitForInStatement(node);
                 case SyntaxKind.ForOfStatement:
-                    return emitForOfStatement(node as ForOfStatement);
+                    return emitForOfStatement(node);
                 case SyntaxKind.ContinueStatement:
-                    return emitContinueStatement(node as ContinueStatement);
+                    return emitContinueStatement(node);
                 case SyntaxKind.BreakStatement:
-                    return emitBreakStatement(node as BreakStatement);
+                    return emitBreakStatement(node);
                 case SyntaxKind.ReturnStatement:
-                    return emitReturnStatement(node as ReturnStatement);
+                    return emitReturnStatement(node);
                 case SyntaxKind.WithStatement:
-                    return emitWithStatement(node as WithStatement);
+                    return emitWithStatement(node);
                 case SyntaxKind.SwitchStatement:
-                    return emitSwitchStatement(node as SwitchStatement);
+                    return emitSwitchStatement(node);
                 case SyntaxKind.LabeledStatement:
-                    return emitLabeledStatement(node as LabeledStatement);
+                    return emitLabeledStatement(node);
                 case SyntaxKind.ThrowStatement:
-                    return emitThrowStatement(node as ThrowStatement);
+                    return emitThrowStatement(node);
                 case SyntaxKind.TryStatement:
-                    return emitTryStatement(node as TryStatement);
+                    return emitTryStatement(node);
                 case SyntaxKind.DebuggerStatement:
-                    return emitDebuggerStatement(node as DebuggerStatement);
+                    return emitDebuggerStatement(node);
 
                 // Declarations
                 case SyntaxKind.VariableDeclaration:
-                    return emitVariableDeclaration(node as VariableDeclaration);
+                    return emitVariableDeclaration(node);
                 case SyntaxKind.VariableDeclarationList:
-                    return emitVariableDeclarationList(node as VariableDeclarationList);
+                    return emitVariableDeclarationList(node);
                 case SyntaxKind.FunctionDeclaration:
-                    return emitFunctionDeclaration(node as FunctionDeclaration);
+                    return emitFunctionDeclaration(node);
                 case SyntaxKind.ClassDeclaration:
-                    return emitClassDeclaration(node as ClassDeclaration);
+                    return emitClassDeclaration(node);
                 case SyntaxKind.InterfaceDeclaration:
-                    return emitInterfaceDeclaration(node as InterfaceDeclaration);
+                    return emitInterfaceDeclaration(node);
                 case SyntaxKind.TypeAliasDeclaration:
-                    return emitTypeAliasDeclaration(node as TypeAliasDeclaration);
+                    return emitTypeAliasDeclaration(node);
                 case SyntaxKind.EnumDeclaration:
-                    return emitEnumDeclaration(node as EnumDeclaration);
+                    return emitEnumDeclaration(node);
                 case SyntaxKind.ModuleDeclaration:
-                    return emitModuleDeclaration(node as ModuleDeclaration);
+                    return emitModuleDeclaration(node);
                 case SyntaxKind.ModuleBlock:
-                    return emitModuleBlock(node as ModuleBlock);
+                    return emitModuleBlock(node);
                 case SyntaxKind.CaseBlock:
-                    return emitCaseBlock(node as CaseBlock);
+                    return emitCaseBlock(node);
                 case SyntaxKind.NamespaceExportDeclaration:
-                    return emitNamespaceExportDeclaration(node as NamespaceExportDeclaration);
+                    return emitNamespaceExportDeclaration(node);
                 case SyntaxKind.ImportEqualsDeclaration:
-                    return emitImportEqualsDeclaration(node as ImportEqualsDeclaration);
+                    return emitImportEqualsDeclaration(node);
                 case SyntaxKind.ImportDeclaration:
-                    return emitImportDeclaration(node as ImportDeclaration);
+                    return emitImportDeclaration(node);
                 case SyntaxKind.ImportClause:
-                    return emitImportClause(node as ImportClause);
+                    return emitImportClause(node);
                 case SyntaxKind.NamespaceImport:
-                    return emitNamespaceImport(node as NamespaceImport);
+                    return emitNamespaceImport(node);
                 case SyntaxKind.NamespaceExport:
-                    return emitNamespaceExport(node as NamespaceExport);
+                    return emitNamespaceExport(node);
                 case SyntaxKind.NamedImports:
-                    return emitNamedImports(node as NamedImports);
+                    return emitNamedImports(node);
                 case SyntaxKind.ImportSpecifier:
-                    return emitImportSpecifier(node as ImportSpecifier);
+                    return emitImportSpecifier(node);
                 case SyntaxKind.ExportAssignment:
-                    return emitExportAssignment(node as ExportAssignment);
+                    return emitExportAssignment(node);
                 case SyntaxKind.ExportDeclaration:
-                    return emitExportDeclaration(node as ExportDeclaration);
+                    return emitExportDeclaration(node);
                 case SyntaxKind.NamedExports:
-                    return emitNamedExports(node as NamedExports);
+                    return emitNamedExports(node);
                 case SyntaxKind.ExportSpecifier:
-                    return emitExportSpecifier(node as ExportSpecifier);
+                    return emitExportSpecifier(node);
                 case SyntaxKind.AssertClause:
-                    return emitAssertClause(node as AssertClause);
+                    return emitAssertClause(node);
                 case SyntaxKind.AssertEntry:
-                    return emitAssertEntry(node as AssertEntry);
+                    return emitAssertEntry(node);
                 case SyntaxKind.MissingDeclaration:
                     return;
 
                 // Module references
                 case SyntaxKind.ExternalModuleReference:
-                    return emitExternalModuleReference(node as ExternalModuleReference);
+                    return emitExternalModuleReference(node);
 
                 // JSX (non-expression)
                 case SyntaxKind.JsxText:
-                    return emitJsxText(node as JsxText);
+                    return emitJsxText(node);
                 case SyntaxKind.JsxOpeningElement:
                 case SyntaxKind.JsxOpeningFragment:
                     return emitJsxOpeningElementOrFragment(node as JsxOpeningElement);
@@ -2059,35 +2058,35 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 case SyntaxKind.JsxClosingFragment:
                     return emitJsxClosingElementOrFragment(node as JsxClosingElement);
                 case SyntaxKind.JsxAttribute:
-                    return emitJsxAttribute(node as JsxAttribute);
+                    return emitJsxAttribute(node);
                 case SyntaxKind.JsxAttributes:
-                    return emitJsxAttributes(node as JsxAttributes);
+                    return emitJsxAttributes(node);
                 case SyntaxKind.JsxSpreadAttribute:
-                    return emitJsxSpreadAttribute(node as JsxSpreadAttribute);
+                    return emitJsxSpreadAttribute(node);
                 case SyntaxKind.JsxExpression:
-                    return emitJsxExpression(node as JsxExpression);
+                    return emitJsxExpression(node);
 
                 // Clauses
                 case SyntaxKind.CaseClause:
-                    return emitCaseClause(node as CaseClause);
+                    return emitCaseClause(node);
                 case SyntaxKind.DefaultClause:
-                    return emitDefaultClause(node as DefaultClause);
+                    return emitDefaultClause(node);
                 case SyntaxKind.HeritageClause:
-                    return emitHeritageClause(node as HeritageClause);
+                    return emitHeritageClause(node);
                 case SyntaxKind.CatchClause:
-                    return emitCatchClause(node as CatchClause);
+                    return emitCatchClause(node);
 
                 // Property assignments
                 case SyntaxKind.PropertyAssignment:
-                    return emitPropertyAssignment(node as PropertyAssignment);
+                    return emitPropertyAssignment(node);
                 case SyntaxKind.ShorthandPropertyAssignment:
-                    return emitShorthandPropertyAssignment(node as ShorthandPropertyAssignment);
+                    return emitShorthandPropertyAssignment(node);
                 case SyntaxKind.SpreadAssignment:
-                    return emitSpreadAssignment(node as SpreadAssignment);
+                    return emitSpreadAssignment(node);
 
                 // Enum
                 case SyntaxKind.EnumMember:
-                    return emitEnumMember(node as EnumMember);
+                    return emitEnumMember(node);
 
                 // Unparsed
                 case SyntaxKind.UnparsedPrologue:
@@ -2097,13 +2096,13 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                     return emitUnparsedSourceOrPrepend(node as UnparsedSource);
                 case SyntaxKind.UnparsedText:
                 case SyntaxKind.UnparsedInternalText:
-                    return emitUnparsedTextLike(node as UnparsedTextLike);
+                    return emitUnparsedTextLike(node);
                 case SyntaxKind.UnparsedSyntheticReference:
-                    return emitUnparsedSyntheticReference(node as UnparsedSyntheticReference);
+                    return emitUnparsedSyntheticReference(node);
 
                 // Top-level nodes
                 case SyntaxKind.SourceFile:
-                    return emitSourceFile(node as SourceFile);
+                    return emitSourceFile(node);
                 case SyntaxKind.Bundle:
                     return Debug.fail("Bundles should be printed using printBundle");
                 // SyntaxKind.UnparsedSource (handled above)
@@ -2112,39 +2111,39 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
                 // JSDoc nodes (only used in codefixes currently)
                 case SyntaxKind.JSDocTypeExpression:
-                    return emitJSDocTypeExpression(node as JSDocTypeExpression);
+                    return emitJSDocTypeExpression(node);
                 case SyntaxKind.JSDocNameReference:
-                    return emitJSDocNameReference(node as JSDocNameReference);
+                    return emitJSDocNameReference(node);
                 case SyntaxKind.JSDocAllType:
                     return writePunctuation("*");
                 case SyntaxKind.JSDocUnknownType:
                     return writePunctuation("?");
                 case SyntaxKind.JSDocNullableType:
-                    return emitJSDocNullableType(node as JSDocNullableType);
+                    return emitJSDocNullableType(node);
                 case SyntaxKind.JSDocNonNullableType:
-                    return emitJSDocNonNullableType(node as JSDocNonNullableType);
+                    return emitJSDocNonNullableType(node);
                 case SyntaxKind.JSDocOptionalType:
-                    return emitJSDocOptionalType(node as JSDocOptionalType);
+                    return emitJSDocOptionalType(node);
                 case SyntaxKind.JSDocFunctionType:
-                    return emitJSDocFunctionType(node as JSDocFunctionType);
+                    return emitJSDocFunctionType(node);
                 case SyntaxKind.RestType:
                 case SyntaxKind.JSDocVariadicType:
-                    return emitRestOrJSDocVariadicType(node as RestTypeNode | JSDocVariadicType);
+                    return emitRestOrJSDocVariadicType(node);
                 case SyntaxKind.JSDocNamepathType:
                     return;
                 case SyntaxKind.JSDoc:
-                    return emitJSDoc(node as JSDoc);
+                    return emitJSDoc(node);
                 case SyntaxKind.JSDocTypeLiteral:
-                    return emitJSDocTypeLiteral(node as JSDocTypeLiteral);
+                    return emitJSDocTypeLiteral(node);
                 case SyntaxKind.JSDocSignature:
-                    return emitJSDocSignature(node as JSDocSignature);
+                    return emitJSDocSignature(node);
                 case SyntaxKind.JSDocTag:
                 case SyntaxKind.JSDocClassTag:
                 case SyntaxKind.JSDocOverrideTag:
                     return emitJSDocSimpleTag(node as JSDocTag);
                 case SyntaxKind.JSDocAugmentsTag:
                 case SyntaxKind.JSDocImplementsTag:
-                    return emitJSDocHeritageTag(node as JSDocImplementsTag | JSDocAugmentsTag);
+                    return emitJSDocHeritageTag(node);
                 case SyntaxKind.JSDocAuthorTag:
                 case SyntaxKind.JSDocDeprecatedTag:
                     return;
@@ -2155,9 +2154,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 case SyntaxKind.JSDocReadonlyTag:
                     return;
                 case SyntaxKind.JSDocCallbackTag:
-                    return emitJSDocCallbackTag(node as JSDocCallbackTag);
+                    return emitJSDocCallbackTag(node);
                 case SyntaxKind.JSDocOverloadTag:
-                    return emitJSDocOverloadTag(node as JSDocOverloadTag);
+                    return emitJSDocOverloadTag(node);
                 // SyntaxKind.JSDocEnumTag (see below)
                 case SyntaxKind.JSDocParameterTag:
                 case SyntaxKind.JSDocPropertyTag:
@@ -2170,11 +2169,11 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 case SyntaxKind.JSDocSatisfiesTag:
                     return emitJSDocSimpleTypedTag(node as JSDocTypeTag | JSDocReturnTag | JSDocThisTag | JSDocTypeTag | JSDocThrowsTag | JSDocSatisfiesTag);
                 case SyntaxKind.JSDocTemplateTag:
-                    return emitJSDocTemplateTag(node as JSDocTemplateTag);
+                    return emitJSDocTemplateTag(node);
                 case SyntaxKind.JSDocTypedefTag:
-                    return emitJSDocTypedefTag(node as JSDocTypedefTag);
+                    return emitJSDocTypedefTag(node);
                 case SyntaxKind.JSDocSeeTag:
-                    return emitJSDocSeeTag(node as JSDocSeeTag);
+                    return emitJSDocSeeTag(node);
                 // SyntaxKind.JSDocPropertyTag (see JSDocParameterTag, above)
 
                 // Transformation nodes
@@ -2199,7 +2198,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 // Literals
                 case SyntaxKind.NumericLiteral:
                 case SyntaxKind.BigIntLiteral:
-                    return emitNumericOrBigIntLiteral(node as NumericLiteral | BigIntLiteral);
+                    return emitNumericOrBigIntLiteral(node);
 
                 case SyntaxKind.StringLiteral:
                 case SyntaxKind.RegularExpressionLiteral:
@@ -2208,69 +2207,69 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
                 // Identifiers
                 case SyntaxKind.Identifier:
-                    return emitIdentifier(node as Identifier);
+                    return emitIdentifier(node);
                 case SyntaxKind.PrivateIdentifier:
-                    return emitPrivateIdentifier(node as PrivateIdentifier);
+                    return emitPrivateIdentifier(node);
 
                 // Expressions
                 case SyntaxKind.ArrayLiteralExpression:
-                    return emitArrayLiteralExpression(node as ArrayLiteralExpression);
+                    return emitArrayLiteralExpression(node);
                 case SyntaxKind.ObjectLiteralExpression:
-                    return emitObjectLiteralExpression(node as ObjectLiteralExpression);
+                    return emitObjectLiteralExpression(node);
                 case SyntaxKind.PropertyAccessExpression:
-                    return emitPropertyAccessExpression(node as PropertyAccessExpression);
+                    return emitPropertyAccessExpression(node);
                 case SyntaxKind.ElementAccessExpression:
-                    return emitElementAccessExpression(node as ElementAccessExpression);
+                    return emitElementAccessExpression(node);
                 case SyntaxKind.CallExpression:
-                    return emitCallExpression(node as CallExpression);
+                    return emitCallExpression(node);
                 case SyntaxKind.NewExpression:
-                    return emitNewExpression(node as NewExpression);
+                    return emitNewExpression(node);
                 case SyntaxKind.TaggedTemplateExpression:
-                    return emitTaggedTemplateExpression(node as TaggedTemplateExpression);
+                    return emitTaggedTemplateExpression(node);
                 case SyntaxKind.TypeAssertionExpression:
-                    return emitTypeAssertionExpression(node as TypeAssertion);
+                    return emitTypeAssertionExpression(node);
                 case SyntaxKind.ParenthesizedExpression:
-                    return emitParenthesizedExpression(node as ParenthesizedExpression);
+                    return emitParenthesizedExpression(node);
                 case SyntaxKind.FunctionExpression:
-                    return emitFunctionExpression(node as FunctionExpression);
+                    return emitFunctionExpression(node);
                 case SyntaxKind.ArrowFunction:
-                    return emitArrowFunction(node as ArrowFunction);
+                    return emitArrowFunction(node);
                 case SyntaxKind.DeleteExpression:
-                    return emitDeleteExpression(node as DeleteExpression);
+                    return emitDeleteExpression(node);
                 case SyntaxKind.TypeOfExpression:
-                    return emitTypeOfExpression(node as TypeOfExpression);
+                    return emitTypeOfExpression(node);
                 case SyntaxKind.VoidExpression:
-                    return emitVoidExpression(node as VoidExpression);
+                    return emitVoidExpression(node);
                 case SyntaxKind.AwaitExpression:
-                    return emitAwaitExpression(node as AwaitExpression);
+                    return emitAwaitExpression(node);
                 case SyntaxKind.PrefixUnaryExpression:
-                    return emitPrefixUnaryExpression(node as PrefixUnaryExpression);
+                    return emitPrefixUnaryExpression(node);
                 case SyntaxKind.PostfixUnaryExpression:
-                    return emitPostfixUnaryExpression(node as PostfixUnaryExpression);
+                    return emitPostfixUnaryExpression(node);
                 case SyntaxKind.BinaryExpression:
-                    return emitBinaryExpression(node as BinaryExpression);
+                    return emitBinaryExpression(node);
                 case SyntaxKind.ConditionalExpression:
-                    return emitConditionalExpression(node as ConditionalExpression);
+                    return emitConditionalExpression(node);
                 case SyntaxKind.TemplateExpression:
-                    return emitTemplateExpression(node as TemplateExpression);
+                    return emitTemplateExpression(node);
                 case SyntaxKind.YieldExpression:
-                    return emitYieldExpression(node as YieldExpression);
+                    return emitYieldExpression(node);
                 case SyntaxKind.SpreadElement:
-                    return emitSpreadElement(node as SpreadElement);
+                    return emitSpreadElement(node);
                 case SyntaxKind.ClassExpression:
-                    return emitClassExpression(node as ClassExpression);
+                    return emitClassExpression(node);
                 case SyntaxKind.OmittedExpression:
                     return;
                 case SyntaxKind.AsExpression:
-                    return emitAsExpression(node as AsExpression);
+                    return emitAsExpression(node);
                 case SyntaxKind.NonNullExpression:
-                    return emitNonNullExpression(node as NonNullExpression);
+                    return emitNonNullExpression(node);
                 case SyntaxKind.ExpressionWithTypeArguments:
-                    return emitExpressionWithTypeArguments(node as ExpressionWithTypeArguments);
+                    return emitExpressionWithTypeArguments(node);
                 case SyntaxKind.SatisfiesExpression:
-                    return emitSatisfiesExpression(node as SatisfiesExpression);
+                    return emitSatisfiesExpression(node);
                 case SyntaxKind.MetaProperty:
-                    return emitMetaProperty(node as MetaProperty);
+                    return emitMetaProperty(node);
                 case SyntaxKind.SyntheticExpression:
                     return Debug.fail("SyntheticExpression should never be printed.");
                 case SyntaxKind.MissingDeclaration:
@@ -2278,13 +2277,13 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
                 // JSX
                 case SyntaxKind.JsxElement:
-                    return emitJsxElement(node as JsxElement);
+                    return emitJsxElement(node);
                 case SyntaxKind.JsxSelfClosingElement:
-                    return emitJsxSelfClosingElement(node as JsxSelfClosingElement);
+                    return emitJsxSelfClosingElement(node);
                 case SyntaxKind.JsxFragment:
-                    return emitJsxFragment(node as JsxFragment);
+                    return emitJsxFragment(node);
                 case SyntaxKind.JsxNamespacedName:
-                    return emitJsxNamespacedName(node as JsxNamespacedName);
+                    return emitJsxNamespacedName(node);
 
                 // Synthesized list
                 case SyntaxKind.SyntaxList:
@@ -2294,9 +2293,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 case SyntaxKind.NotEmittedStatement:
                     return;
                 case SyntaxKind.PartiallyEmittedExpression:
-                    return emitPartiallyEmittedExpression(node as PartiallyEmittedExpression);
+                    return emitPartiallyEmittedExpression(node);
                 case SyntaxKind.CommaListExpression:
-                    return emitCommaList(node as CommaListExpression);
+                    return emitCommaList(node);
                 case SyntaxKind.SyntheticReferenceExpression:
                     return Debug.fail("SyntheticReferenceExpression should not be printed");
             }
@@ -2345,7 +2344,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
     function emitHelpers(node: Node) {
         let helpersEmitted = false;
-        const bundle = node.kind === SyntaxKind.Bundle ? node as Bundle : undefined;
+        const bundle = node.kind === SyntaxKind.Bundle ? node : undefined;
         if (bundle && moduleKind === ModuleKind.None) {
             return;
         }
@@ -3196,8 +3195,8 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         // The same is true of minus of course.
         const operand = node.operand;
         return operand.kind === SyntaxKind.PrefixUnaryExpression
-            && ((node.operator === SyntaxKind.PlusToken && ((operand as PrefixUnaryExpression).operator === SyntaxKind.PlusToken || (operand as PrefixUnaryExpression).operator === SyntaxKind.PlusPlusToken))
-                || (node.operator === SyntaxKind.MinusToken && ((operand as PrefixUnaryExpression).operator === SyntaxKind.MinusToken || (operand as PrefixUnaryExpression).operator === SyntaxKind.MinusMinusToken)));
+            && ((node.operator === SyntaxKind.PlusToken && ((operand).operator === SyntaxKind.PlusToken || (operand).operator === SyntaxKind.PlusPlusToken))
+                || (node.operator === SyntaxKind.MinusToken && ((operand).operator === SyntaxKind.MinusToken || (operand).operator === SyntaxKind.MinusMinusToken)));
     }
 
     function emitPostfixUnaryExpression(node: PostfixUnaryExpression) {
@@ -5522,7 +5521,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
     function skipSynthesizedParentheses(node: Node) {
         while (node.kind === SyntaxKind.ParenthesizedExpression && nodeIsSynthesized(node)) {
-            node = (node as ParenthesizedExpression).expression;
+            node = (node).expression;
         }
 
         return node;
@@ -5552,8 +5551,8 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     }
 
     function getLiteralTextOfNode(node: LiteralLikeNode, neverAsciiEscape: boolean | undefined, jsxAttributeEscape: boolean): string {
-        if (node.kind === SyntaxKind.StringLiteral && (node as StringLiteral).textSourceNode) {
-            const textSourceNode = (node as StringLiteral).textSourceNode!;
+        if (node.kind === SyntaxKind.StringLiteral && (node).textSourceNode) {
+            const textSourceNode = (node).textSourceNode;
             if (isIdentifier(textSourceNode) || isPrivateIdentifier(textSourceNode) || isNumericLiteral(textSourceNode)) {
                 const text = isNumericLiteral(textSourceNode) ? textSourceNode.text : getTextOfNode(textSourceNode);
                 return jsxAttributeEscape ? `"${escapeJsxAttributeString(text)}"` :
@@ -5635,17 +5634,17 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (!node) return;
         switch (node.kind) {
             case SyntaxKind.Block:
-                forEach((node as Block).statements, generateNames);
+                forEach((node).statements, generateNames);
                 break;
             case SyntaxKind.LabeledStatement:
             case SyntaxKind.WithStatement:
             case SyntaxKind.DoStatement:
             case SyntaxKind.WhileStatement:
-                generateNames((node as LabeledStatement | WithStatement | DoStatement | WhileStatement).statement);
+                generateNames((node).statement);
                 break;
             case SyntaxKind.IfStatement:
-                generateNames((node as IfStatement).thenStatement);
-                generateNames((node as IfStatement).elseStatement);
+                generateNames((node).thenStatement);
+                generateNames((node).elseStatement);
                 break;
             case SyntaxKind.ForStatement:
             case SyntaxKind.ForOfStatement:
@@ -5654,29 +5653,29 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 generateNames((node as ForStatement | ForInOrOfStatement).statement);
                 break;
             case SyntaxKind.SwitchStatement:
-                generateNames((node as SwitchStatement).caseBlock);
+                generateNames((node).caseBlock);
                 break;
             case SyntaxKind.CaseBlock:
-                forEach((node as CaseBlock).clauses, generateNames);
+                forEach((node).clauses, generateNames);
                 break;
             case SyntaxKind.CaseClause:
             case SyntaxKind.DefaultClause:
                 forEach((node as CaseOrDefaultClause).statements, generateNames);
                 break;
             case SyntaxKind.TryStatement:
-                generateNames((node as TryStatement).tryBlock);
-                generateNames((node as TryStatement).catchClause);
-                generateNames((node as TryStatement).finallyBlock);
+                generateNames((node).tryBlock);
+                generateNames((node).catchClause);
+                generateNames((node).finallyBlock);
                 break;
             case SyntaxKind.CatchClause:
-                generateNames((node as CatchClause).variableDeclaration);
-                generateNames((node as CatchClause).block);
+                generateNames((node).variableDeclaration);
+                generateNames((node).block);
                 break;
             case SyntaxKind.VariableStatement:
-                generateNames((node as VariableStatement).declarationList);
+                generateNames((node).declarationList);
                 break;
             case SyntaxKind.VariableDeclarationList:
-                forEach((node as VariableDeclarationList).declarations, generateNames);
+                forEach((node).declarations, generateNames);
                 break;
             case SyntaxKind.VariableDeclaration:
             case SyntaxKind.Parameter:
@@ -5685,10 +5684,10 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 generateNameIfNeeded((node as NamedDeclaration).name);
                 break;
             case SyntaxKind.FunctionDeclaration:
-                generateNameIfNeeded((node as FunctionDeclaration).name);
+                generateNameIfNeeded((node).name);
                 if (getEmitFlags(node) & EmitFlags.ReuseTempVariableScope) {
-                    forEach((node as FunctionDeclaration).parameters, generateNames);
-                    generateNames((node as FunctionDeclaration).body);
+                    forEach((node).parameters, generateNames);
+                    generateNames((node).body);
                 }
                 break;
             case SyntaxKind.ObjectBindingPattern:
@@ -5696,23 +5695,23 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 forEach((node as BindingPattern).elements, generateNames);
                 break;
             case SyntaxKind.ImportDeclaration:
-                generateNames((node as ImportDeclaration).importClause);
+                generateNames((node).importClause);
                 break;
             case SyntaxKind.ImportClause:
-                generateNameIfNeeded((node as ImportClause).name);
-                generateNames((node as ImportClause).namedBindings);
+                generateNameIfNeeded((node).name);
+                generateNames((node).namedBindings);
                 break;
             case SyntaxKind.NamespaceImport:
-                generateNameIfNeeded((node as NamespaceImport).name);
+                generateNameIfNeeded((node).name);
                 break;
             case SyntaxKind.NamespaceExport:
-                generateNameIfNeeded((node as NamespaceExport).name);
+                generateNameIfNeeded((node).name);
                 break;
             case SyntaxKind.NamedImports:
-                forEach((node as NamedImports).elements, generateNames);
+                forEach((node).elements, generateNames);
                 break;
             case SyntaxKind.ImportSpecifier:
-                generateNameIfNeeded((node as ImportSpecifier).propertyName || (node as ImportSpecifier).name);
+                generateNameIfNeeded((node).propertyName || (node).name);
                 break;
         }
     }
@@ -6000,15 +5999,15 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
             case SyntaxKind.ModuleDeclaration:
             case SyntaxKind.EnumDeclaration:
                 Debug.assert(!prefix && !suffix && !privateName);
-                return generateNameForModuleOrEnum(node as ModuleDeclaration | EnumDeclaration);
+                return generateNameForModuleOrEnum(node);
             case SyntaxKind.ImportDeclaration:
             case SyntaxKind.ExportDeclaration:
                 Debug.assert(!prefix && !suffix && !privateName);
-                return generateNameForImportOrExportDeclaration(node as ImportDeclaration | ExportDeclaration);
+                return generateNameForImportOrExportDeclaration(node);
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.ClassDeclaration: {
                 Debug.assert(!prefix && !suffix && !privateName);
-                const name = (node as ClassDeclaration | FunctionDeclaration).name;
+                const name = (node).name;
                 if (name && !isGeneratedIdentifier(name)) {
                     return generateNameForNode(name, /*privateName*/ false, flags, prefix, suffix);
                 }

--- a/src/compiler/factory/parenthesizerRules.ts
+++ b/src/compiler/factory/parenthesizerRules.ts
@@ -35,7 +35,6 @@ import {
     last,
     LeftHandSideExpression,
     NamedTupleMember,
-    NewExpression,
     NodeArray,
     NodeFactory,
     OperatorPrecedence,
@@ -252,14 +251,14 @@ export function createParenthesizerRules(factory: NodeFactory): ParenthesizerRul
             return node.kind;
         }
 
-        if (node.kind === SyntaxKind.BinaryExpression && (node as BinaryExpression).operatorToken.kind === SyntaxKind.PlusToken) {
+        if (node.kind === SyntaxKind.BinaryExpression && (node).operatorToken.kind === SyntaxKind.PlusToken) {
             if ((node as BinaryPlusExpression).cachedLiteralKind !== undefined) {
                 return (node as BinaryPlusExpression).cachedLiteralKind;
             }
 
-            const leftKind = getLiteralKindOfBinaryPlusOperand((node as BinaryExpression).left);
+            const leftKind = getLiteralKindOfBinaryPlusOperand((node).left);
             const literalKind = isLiteralKind(leftKind)
-                && leftKind === getLiteralKindOfBinaryPlusOperand((node as BinaryExpression).right)
+                && leftKind === getLiteralKindOfBinaryPlusOperand((node).right)
                     ? leftKind
                     : SyntaxKind.Unknown;
 
@@ -360,7 +359,7 @@ export function createParenthesizerRules(factory: NodeFactory): ParenthesizerRul
                 return factory.createParenthesizedExpression(expression);
 
             case SyntaxKind.NewExpression:
-                return !(leftmostExpr as NewExpression).arguments
+                return !(leftmostExpr).arguments
                     ? factory.createParenthesizedExpression(expression)
                     : expression as LeftHandSideExpression; // TODO(rbuckton): Verify this assertion holds
         }
@@ -381,7 +380,7 @@ export function createParenthesizerRules(factory: NodeFactory): ParenthesizerRul
         //
         const emittedExpression = skipPartiallyEmittedExpressions(expression);
         if (isLeftHandSideExpression(emittedExpression)
-            && (emittedExpression.kind !== SyntaxKind.NewExpression || (emittedExpression as NewExpression).arguments)
+            && (emittedExpression.kind !== SyntaxKind.NewExpression || (emittedExpression).arguments)
             && (optionalChain || !isOptionalChain(emittedExpression))) {
             // TODO(rbuckton): Verify whether this assertion holds.
             return expression as LeftHandSideExpression;

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -612,7 +612,7 @@ export function startsWithUseStrict(statements: readonly Statement[]) {
 
 /** @internal */
 export function isCommaExpression(node: Expression): node is BinaryExpression & { operatorToken: Token<SyntaxKind.CommaToken> } {
-    return node.kind === SyntaxKind.BinaryExpression && (node as BinaryExpression).operatorToken.kind === SyntaxKind.CommaToken;
+    return node.kind === SyntaxKind.BinaryExpression && (node).operatorToken.kind === SyntaxKind.CommaToken;
 }
 
 /** @internal */
@@ -660,7 +660,7 @@ export function skipOuterExpressions(node: Expression, kinds?: OuterExpressionKi
 /** @internal */
 export function skipOuterExpressions(node: Node, kinds?: OuterExpressionKinds): Node;
 /** @internal */
-export function skipOuterExpressions(node: Node, kinds = OuterExpressionKinds.All) {
+export function skipOuterExpressions(node: Node, kinds = OuterExpressionKinds.All): Node {
     while (isOuterExpression(node, kinds)) {
         node = node.expression;
     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -6,7 +6,6 @@ import {
     append,
     arrayFrom,
     arrayIsEqualTo,
-    AsExpression,
     AssertClause,
     BuilderProgram,
     CancellationToken,
@@ -76,7 +75,6 @@ import {
     equateStringsCaseInsensitive,
     equateStringsCaseSensitive,
     explainIfFileIsRedirectAndImpliedFormat,
-    ExportAssignment,
     ExportDeclaration,
     Extension,
     extensionFromPath,
@@ -164,10 +162,8 @@ import {
     hasProperty,
     hasSyntacticModifier,
     hasZeroOrOneAsteriskCharacter,
-    HeritageClause,
     Identifier,
     identity,
-    ImportClause,
     ImportDeclaration,
     ImportOrExportSpecifier,
     InputFiles,
@@ -218,7 +214,6 @@ import {
     mapDefinedIterator,
     maybeBind,
     memoize,
-    MethodDeclaration,
     ModeAwareCache,
     ModeAwareCacheKey,
     ModifierFlags,
@@ -283,7 +278,6 @@ import {
     resolveTypeReferenceDirective,
     returnFalse,
     returnUndefined,
-    SatisfiesExpression,
     ScriptKind,
     ScriptTarget,
     setParent,
@@ -2918,7 +2912,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                     case SyntaxKind.Parameter:
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.MethodDeclaration:
-                        if ((parent as ParameterDeclaration | PropertyDeclaration | MethodDeclaration).questionToken === node) {
+                        if ((parent).questionToken === node) {
                             diagnostics.push(createDiagnosticForNode(node, Diagnostics.The_0_modifier_can_only_be_used_in_TypeScript_files, "?"));
                             return "skip";
                         }
@@ -2940,13 +2934,13 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
                 switch (node.kind) {
                     case SyntaxKind.ImportClause:
-                        if ((node as ImportClause).isTypeOnly) {
+                        if ((node).isTypeOnly) {
                             diagnostics.push(createDiagnosticForNode(parent, Diagnostics._0_declarations_can_only_be_used_in_TypeScript_files, "import type"));
                             return "skip";
                         }
                         break;
                     case SyntaxKind.ExportDeclaration:
-                        if ((node as ExportDeclaration).isTypeOnly) {
+                        if ((node).isTypeOnly) {
                             diagnostics.push(createDiagnosticForNode(node, Diagnostics._0_declarations_can_only_be_used_in_TypeScript_files, "export type"));
                             return "skip";
                         }
@@ -2962,13 +2956,13 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                         diagnostics.push(createDiagnosticForNode(node, Diagnostics.import_can_only_be_used_in_TypeScript_files));
                         return "skip";
                     case SyntaxKind.ExportAssignment:
-                        if ((node as ExportAssignment).isExportEquals) {
+                        if ((node).isExportEquals) {
                             diagnostics.push(createDiagnosticForNode(node, Diagnostics.export_can_only_be_used_in_TypeScript_files));
                             return "skip";
                         }
                         break;
                     case SyntaxKind.HeritageClause:
-                        const heritageClause = node as HeritageClause;
+                        const heritageClause = node ;
                         if (heritageClause.token === SyntaxKind.ImplementsKeyword) {
                             diagnostics.push(createDiagnosticForNode(node, Diagnostics.implements_clauses_can_only_be_used_in_TypeScript_files));
                             return "skip";
@@ -2995,10 +2989,10 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                         diagnostics.push(createDiagnosticForNode(node, Diagnostics.Non_null_assertions_can_only_be_used_in_TypeScript_files));
                         return "skip";
                     case SyntaxKind.AsExpression:
-                        diagnostics.push(createDiagnosticForNode((node as AsExpression).type, Diagnostics.Type_assertion_expressions_can_only_be_used_in_TypeScript_files));
+                        diagnostics.push(createDiagnosticForNode((node).type, Diagnostics.Type_assertion_expressions_can_only_be_used_in_TypeScript_files));
                         return "skip";
                     case SyntaxKind.SatisfiesExpression:
-                        diagnostics.push(createDiagnosticForNode((node as SatisfiesExpression).type, Diagnostics.Type_satisfaction_expressions_can_only_be_used_in_TypeScript_files));
+                        diagnostics.push(createDiagnosticForNode((node).type, Diagnostics.Type_satisfaction_expressions_can_only_be_used_in_TypeScript_files));
                         return "skip";
                     case SyntaxKind.TypeAssertionExpression:
                         Debug.fail(); // Won't parse these in a JS file anyway, as they are interpreted as JSX.
@@ -3068,7 +3062,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                         break;
                     case SyntaxKind.PropertyDeclaration:
                         // Check modifiers of property declaration
-                        if (nodes === (parent as PropertyDeclaration).modifiers) {
+                        if (nodes === (parent).modifiers) {
                             for (const modifier of nodes as NodeArray<ModifierLike>) {
                                 if (isModifier(modifier)
                                     && modifier.kind !== SyntaxKind.StaticKeyword
@@ -3081,7 +3075,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                         break;
                     case SyntaxKind.Parameter:
                         // Check modifiers of parameter declaration
-                        if (nodes === (parent as ParameterDeclaration).modifiers && some(nodes, isModifier)) {
+                        if (nodes === (parent).modifiers && some(nodes, isModifier)) {
                             diagnostics.push(createDiagnosticForNodeArray(nodes, Diagnostics.Parameter_modifiers_can_only_be_used_in_TypeScript_files));
                             return "skip";
                         }
@@ -3348,14 +3342,14 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
         /** Returns a token if position is in [start-of-leading-trivia, end), includes JSDoc only in JS files */
         function getNodeAtPosition(sourceFile: SourceFile, position: number): Node {
-            let current: Node = sourceFile;
+            let current: Node = sourceFile as Node; // TODO: Incorrect control flow makes `current` never in the loop below without this cast
             const getContainingChild = (child: Node) => {
                 if (child.pos <= position && (position < child.end || (position === child.end && (child.kind === SyntaxKind.EndOfFileToken)))) {
                     return child;
                 }
             };
             while (true) {
-                const child = isJavaScriptFile && hasJSDocNodes(current) && forEach(current.jsDoc, getContainingChild) || forEachChild(current, getContainingChild);
+                const child: Node | undefined = isJavaScriptFile && hasJSDocNodes(current) && forEach(current.jsDoc, getContainingChild) || forEachChild(current, getContainingChild);
                 if (!child) {
                     return current;
                 }

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -348,8 +348,9 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
         diagnostics
     };
 
-    function transformRoot(node: T) {
-        return node && (!isSourceFile(node) || !node.isDeclarationFile) ? transformation(node) : node;
+    function transformRoot(node: T): T {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        return node && (!isSourceFile(node) || !node.isDeclarationFile) ? transformation(node) : node as SourceFile as T; // TODO: GH#54146
     }
 
     /**

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -456,45 +456,45 @@ export function transformClassFields(context: TransformationContext): (x: Source
             case SyntaxKind.AccessorKeyword:
                 return Debug.fail("Use `modifierVisitor` instead.");
             case SyntaxKind.ClassDeclaration:
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
             case SyntaxKind.ClassExpression:
-                return visitClassExpression(node as ClassExpression, /*referencedName*/ undefined);
+                return visitClassExpression(node , /*referencedName*/ undefined);
             case SyntaxKind.ClassStaticBlockDeclaration:
             case SyntaxKind.PropertyDeclaration:
                 return Debug.fail("Use `classElementVisitor` instead.");
             case SyntaxKind.PropertyAssignment:
-                return visitPropertyAssignment(node as PropertyAssignment);
+                return visitPropertyAssignment(node);
             case SyntaxKind.VariableStatement:
-                return visitVariableStatement(node as VariableStatement);
+                return visitVariableStatement(node);
             case SyntaxKind.VariableDeclaration:
-                return visitVariableDeclaration(node as VariableDeclaration);
+                return visitVariableDeclaration(node);
             case SyntaxKind.Parameter:
-                return visitParameterDeclaration(node as ParameterDeclaration);
+                return visitParameterDeclaration(node);
             case SyntaxKind.BindingElement:
-                return visitBindingElement(node as BindingElement);
+                return visitBindingElement(node);
             case SyntaxKind.ExportAssignment:
-                return visitExportAssignment(node as ExportAssignment);
+                return visitExportAssignment(node);
             case SyntaxKind.PrivateIdentifier:
-                return visitPrivateIdentifier(node as PrivateIdentifier);
+                return visitPrivateIdentifier(node);
             case SyntaxKind.PropertyAccessExpression:
-                return visitPropertyAccessExpression(node as PropertyAccessExpression);
+                return visitPropertyAccessExpression(node);
             case SyntaxKind.ElementAccessExpression:
-                return visitElementAccessExpression(node as ElementAccessExpression);
+                return visitElementAccessExpression(node);
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
-                return visitPreOrPostfixUnaryExpression(node as PrefixUnaryExpression | PostfixUnaryExpression, /*discarded*/ false);
+                return visitPreOrPostfixUnaryExpression(node , /*discarded*/ false);
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression, /*discarded*/ false);
+                return visitBinaryExpression(node , /*discarded*/ false);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, /*discarded*/ false, /*referencedName*/ undefined);
+                return visitParenthesizedExpression(node , /*discarded*/ false, /*referencedName*/ undefined);
             case SyntaxKind.CallExpression:
-                return visitCallExpression(node as CallExpression);
+                return visitCallExpression(node);
             case SyntaxKind.ExpressionStatement:
-                return visitExpressionStatement(node as ExpressionStatement);
+                return visitExpressionStatement(node);
             case SyntaxKind.TaggedTemplateExpression:
-                return visitTaggedTemplateExpression(node as TaggedTemplateExpression);
+                return visitTaggedTemplateExpression(node);
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement);
+                return visitForStatement(node);
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
             case SyntaxKind.Constructor:
@@ -520,11 +520,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function namedEvaluationVisitor(node: Node, referencedName: Expression): VisitResult<Node> {
         switch (node.kind) {
             case SyntaxKind.PartiallyEmittedExpression:
-                return visitPartiallyEmittedExpression(node as PartiallyEmittedExpression, /*discarded*/ false, referencedName);
+                return visitPartiallyEmittedExpression(node , /*discarded*/ false, referencedName);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, /*discarded*/ false, referencedName);
+                return visitParenthesizedExpression(node , /*discarded*/ false, referencedName);
             case SyntaxKind.ClassExpression:
-                return visitClassExpression(node as ClassExpression, referencedName);
+                return visitClassExpression(node , referencedName);
             default:
                 return visitor(node);
         }
@@ -537,13 +537,13 @@ export function transformClassFields(context: TransformationContext): (x: Source
         switch (node.kind) {
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
-                return visitPreOrPostfixUnaryExpression(node as PrefixUnaryExpression | PostfixUnaryExpression, /*discarded*/ true);
+                return visitPreOrPostfixUnaryExpression(node , /*discarded*/ true);
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression, /*discarded*/ true);
+                return visitBinaryExpression(node , /*discarded*/ true);
             case SyntaxKind.CommaListExpression:
-                return visitCommaListExpression(node as CommaListExpression, /*discarded*/ true);
+                return visitCommaListExpression(node , /*discarded*/ true);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, /*discarded*/ true, /*referencedName*/ undefined);
+                return visitParenthesizedExpression(node , /*discarded*/ true, /*referencedName*/ undefined);
             default:
                 return visitor(node);
         }
@@ -557,7 +557,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
             case SyntaxKind.HeritageClause:
                 return visitEachChild(node, heritageClauseVisitor, context);
             case SyntaxKind.ExpressionWithTypeArguments:
-                return visitExpressionWithTypeArgumentsInHeritageClause(node as ExpressionWithTypeArguments);
+                return visitExpressionWithTypeArgumentsInHeritageClause(node);
             default:
                 return visitor(node);
         }
@@ -582,7 +582,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function classElementVisitor(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.Constructor:
-                return visitConstructorDeclaration(node as ConstructorDeclaration);
+                return visitConstructorDeclaration(node);
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
             case SyntaxKind.MethodDeclaration:
@@ -594,11 +594,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 return setCurrentStaticPropertyDeclarationOrStaticBlockAnd(
                     /*current*/ undefined,
                     visitPropertyDeclaration,
-                    node as PropertyDeclaration);
+                    node);
             case SyntaxKind.ClassStaticBlockDeclaration:
-                return visitClassStaticBlockDeclaration(node as ClassStaticBlockDeclaration);
+                return visitClassStaticBlockDeclaration(node);
             case SyntaxKind.ComputedPropertyName:
-                return visitComputedPropertyName(node as ComputedPropertyName);
+                return visitComputedPropertyName(node);
             case SyntaxKind.SemicolonClassElement:
                 return node;
             default:
@@ -612,7 +612,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function propertyNameVisitor(node: Node): VisitResult<Node> {
         switch (node.kind) {
             case SyntaxKind.ComputedPropertyName:
-                return visitComputedPropertyName(node as ComputedPropertyName);
+                return visitComputedPropertyName(node);
             default:
                 return visitor(node);
         }
@@ -624,7 +624,7 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function accessorFieldResultVisitor(node: Node) {
         switch (node.kind) {
             case SyntaxKind.PropertyDeclaration:
-                return transformFieldInitializer(node as PropertyDeclaration);
+                return transformFieldInitializer(node);
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
                 return classElementVisitor(node);
@@ -3173,9 +3173,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function substituteExpression(node: Expression) {
         switch (node.kind) {
             case SyntaxKind.Identifier:
-                return substituteExpressionIdentifier(node as Identifier);
+                return substituteExpressionIdentifier(node);
             case SyntaxKind.ThisKeyword:
-                return substituteThisExpression(node as ThisExpression);
+                return substituteThisExpression(node);
         }
         return node;
     }

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -76,7 +76,6 @@ import {
     hasSyntacticModifier,
     Identifier,
     idText,
-    IfStatement,
     insertStatementAfterCustomPrologue,
     insertStatementsAfterCustomPrologue,
     insertStatementsAfterStandardPrologue,
@@ -557,7 +556,7 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
     function isReturnVoidStatementInConstructorWithCapturedSuper(node: Node): boolean {
         return (hierarchyFacts & HierarchyFacts.ConstructorWithCapturedSuper) !== 0
             && node.kind === SyntaxKind.ReturnStatement
-            && !(node as ReturnStatement).expression;
+            && !(node).expression;
     }
 
     function isOrMayContainReturnCompletion(node: Node) {
@@ -622,93 +621,93 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
                 return undefined; // elide static keyword
 
             case SyntaxKind.ClassDeclaration:
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
 
             case SyntaxKind.ClassExpression:
-                return visitClassExpression(node as ClassExpression);
+                return visitClassExpression(node);
 
             case SyntaxKind.Parameter:
-                return visitParameter(node as ParameterDeclaration);
+                return visitParameter(node);
 
             case SyntaxKind.FunctionDeclaration:
-                return visitFunctionDeclaration(node as FunctionDeclaration);
+                return visitFunctionDeclaration(node);
 
             case SyntaxKind.ArrowFunction:
-                return visitArrowFunction(node as ArrowFunction);
+                return visitArrowFunction(node);
 
             case SyntaxKind.FunctionExpression:
-                return visitFunctionExpression(node as FunctionExpression);
+                return visitFunctionExpression(node);
 
             case SyntaxKind.VariableDeclaration:
-                return visitVariableDeclaration(node as VariableDeclaration);
+                return visitVariableDeclaration(node);
 
             case SyntaxKind.Identifier:
-                return visitIdentifier(node as Identifier);
+                return visitIdentifier(node);
 
             case SyntaxKind.VariableDeclarationList:
-                return visitVariableDeclarationList(node as VariableDeclarationList);
+                return visitVariableDeclarationList(node);
 
             case SyntaxKind.SwitchStatement:
-                return visitSwitchStatement(node as SwitchStatement);
+                return visitSwitchStatement(node);
 
             case SyntaxKind.CaseBlock:
-                return visitCaseBlock(node as CaseBlock);
+                return visitCaseBlock(node);
 
             case SyntaxKind.Block:
-                return visitBlock(node as Block, /*isFunctionBody*/ false);
+                return visitBlock(node , /*isFunctionBody*/ false);
 
             case SyntaxKind.BreakStatement:
             case SyntaxKind.ContinueStatement:
                 return visitBreakOrContinueStatement(node as BreakOrContinueStatement);
 
             case SyntaxKind.LabeledStatement:
-                return visitLabeledStatement(node as LabeledStatement);
+                return visitLabeledStatement(node);
 
             case SyntaxKind.DoStatement:
             case SyntaxKind.WhileStatement:
-                return visitDoOrWhileStatement(node as DoStatement | WhileStatement, /*outermostLabeledStatement*/ undefined);
+                return visitDoOrWhileStatement(node , /*outermostLabeledStatement*/ undefined);
 
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement, /*outermostLabeledStatement*/ undefined);
+                return visitForStatement(node , /*outermostLabeledStatement*/ undefined);
 
             case SyntaxKind.ForInStatement:
-                return visitForInStatement(node as ForInStatement, /*outermostLabeledStatement*/ undefined);
+                return visitForInStatement(node , /*outermostLabeledStatement*/ undefined);
 
             case SyntaxKind.ForOfStatement:
-                return visitForOfStatement(node as ForOfStatement, /*outermostLabeledStatement*/ undefined);
+                return visitForOfStatement(node , /*outermostLabeledStatement*/ undefined);
 
             case SyntaxKind.ExpressionStatement:
-                return visitExpressionStatement(node as ExpressionStatement);
+                return visitExpressionStatement(node);
 
             case SyntaxKind.ObjectLiteralExpression:
-                return visitObjectLiteralExpression(node as ObjectLiteralExpression);
+                return visitObjectLiteralExpression(node);
 
             case SyntaxKind.CatchClause:
-                return visitCatchClause(node as CatchClause);
+                return visitCatchClause(node);
 
             case SyntaxKind.ShorthandPropertyAssignment:
-                return visitShorthandPropertyAssignment(node as ShorthandPropertyAssignment);
+                return visitShorthandPropertyAssignment(node);
 
             case SyntaxKind.ComputedPropertyName:
-                return visitComputedPropertyName(node as ComputedPropertyName);
+                return visitComputedPropertyName(node);
 
             case SyntaxKind.ArrayLiteralExpression:
-                return visitArrayLiteralExpression(node as ArrayLiteralExpression);
+                return visitArrayLiteralExpression(node);
 
             case SyntaxKind.CallExpression:
-                return visitCallExpression(node as CallExpression);
+                return visitCallExpression(node);
 
             case SyntaxKind.NewExpression:
-                return visitNewExpression(node as NewExpression);
+                return visitNewExpression(node);
 
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, expressionResultIsUnused);
+                return visitParenthesizedExpression(node , expressionResultIsUnused);
 
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression, expressionResultIsUnused);
+                return visitBinaryExpression(node , expressionResultIsUnused);
 
             case SyntaxKind.CommaListExpression:
-                return visitCommaListExpression(node as CommaListExpression, expressionResultIsUnused);
+                return visitCommaListExpression(node , expressionResultIsUnused);
 
             case SyntaxKind.NoSubstitutionTemplateLiteral:
             case SyntaxKind.TemplateHead:
@@ -717,22 +716,22 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
                 return visitTemplateLiteral(node as LiteralExpression);
 
             case SyntaxKind.StringLiteral:
-                return visitStringLiteral(node as StringLiteral);
+                return visitStringLiteral(node);
 
             case SyntaxKind.NumericLiteral:
-                return visitNumericLiteral(node as NumericLiteral);
+                return visitNumericLiteral(node);
 
             case SyntaxKind.TaggedTemplateExpression:
-                return visitTaggedTemplateExpression(node as TaggedTemplateExpression);
+                return visitTaggedTemplateExpression(node);
 
             case SyntaxKind.TemplateExpression:
-                return visitTemplateExpression(node as TemplateExpression);
+                return visitTemplateExpression(node);
 
             case SyntaxKind.YieldExpression:
-                return visitYieldExpression(node as YieldExpression);
+                return visitYieldExpression(node);
 
             case SyntaxKind.SpreadElement:
-                return visitSpreadElement(node as SpreadElement);
+                return visitSpreadElement(node);
 
             case SyntaxKind.SuperKeyword:
                 return visitSuperKeyword(/*isExpressionOfCall*/ false);
@@ -741,23 +740,23 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
                 return visitThisKeyword(node);
 
             case SyntaxKind.MetaProperty:
-                return visitMetaProperty(node as MetaProperty);
+                return visitMetaProperty(node);
 
             case SyntaxKind.MethodDeclaration:
-                return visitMethodDeclaration(node as MethodDeclaration);
+                return visitMethodDeclaration(node);
 
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
                 return visitAccessorDeclaration(node as AccessorDeclaration);
 
             case SyntaxKind.VariableStatement:
-                return visitVariableStatement(node as VariableStatement);
+                return visitVariableStatement(node);
 
             case SyntaxKind.ReturnStatement:
-                return visitReturnStatement(node as ReturnStatement);
+                return visitReturnStatement(node);
 
             case SyntaxKind.VoidExpression:
-                return visitVoidExpression(node as VoidExpression);
+                return visitVoidExpression(node);
 
             default:
                 return visitEachChild(node, visitor, context);
@@ -1396,7 +1395,7 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         }
         // An if-statement with two covered branches is covered.
         else if (statement.kind === SyntaxKind.IfStatement) {
-            const ifStatement = statement as IfStatement;
+            const ifStatement = statement ;
             if (ifStatement.elseStatement) {
                 return isSufficientlyCoveredByReturnStatements(ifStatement.thenStatement) &&
                     isSufficientlyCoveredByReturnStatements(ifStatement.elseStatement);
@@ -1404,7 +1403,7 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         }
         // A block is covered if it has a last statement which is covered.
         else if (statement.kind === SyntaxKind.Block) {
-            const lastStatement = lastOrUndefined((statement as Block).statements);
+            const lastStatement = lastOrUndefined((statement).statements);
             if (lastStatement && isSufficientlyCoveredByReturnStatements(lastStatement)) {
                 return true;
             }
@@ -1875,11 +1874,11 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         for (const member of node.members) {
             switch (member.kind) {
                 case SyntaxKind.SemicolonClassElement:
-                    statements.push(transformSemicolonClassElementToStatement(member as SemicolonClassElement));
+                    statements.push(transformSemicolonClassElementToStatement(member));
                     break;
 
                 case SyntaxKind.MethodDeclaration:
-                    statements.push(transformClassMethodDeclarationToStatement(getClassMemberPrefix(node, member), member as MethodDeclaration, node));
+                    statements.push(transformClassMethodDeclarationToStatement(getClassMemberPrefix(node, member), member , node));
                     break;
 
                 case SyntaxKind.GetAccessor:
@@ -2570,13 +2569,13 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         switch (node.kind) {
             case SyntaxKind.DoStatement:
             case SyntaxKind.WhileStatement:
-                return visitDoOrWhileStatement(node as DoStatement | WhileStatement, outermostLabeledStatement);
+                return visitDoOrWhileStatement(node , outermostLabeledStatement);
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement, outermostLabeledStatement);
+                return visitForStatement(node , outermostLabeledStatement);
             case SyntaxKind.ForInStatement:
-                return visitForInStatement(node as ForInStatement, outermostLabeledStatement);
+                return visitForInStatement(node , outermostLabeledStatement);
             case SyntaxKind.ForOfStatement:
-                return visitForOfStatement(node as ForOfStatement, outermostLabeledStatement);
+                return visitForOfStatement(node , outermostLabeledStatement);
         }
     }
 
@@ -3094,11 +3093,11 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
 
     function convertIterationStatementCore(node: IterationStatement, initializerFunction: IterationStatementPartFunction<VariableDeclarationList> | undefined, convertedLoopBody: Statement) {
         switch (node.kind) {
-            case SyntaxKind.ForStatement: return convertForStatement(node as ForStatement, initializerFunction, convertedLoopBody);
-            case SyntaxKind.ForInStatement: return convertForInStatement(node as ForInStatement, convertedLoopBody);
-            case SyntaxKind.ForOfStatement: return convertForOfStatement(node as ForOfStatement, convertedLoopBody);
-            case SyntaxKind.DoStatement: return convertDoStatement(node as DoStatement, convertedLoopBody);
-            case SyntaxKind.WhileStatement: return convertWhileStatement(node as WhileStatement, convertedLoopBody);
+            case SyntaxKind.ForStatement: return convertForStatement(node , initializerFunction, convertedLoopBody);
+            case SyntaxKind.ForInStatement: return convertForInStatement(node , convertedLoopBody);
+            case SyntaxKind.ForOfStatement: return convertForOfStatement(node , convertedLoopBody);
+            case SyntaxKind.DoStatement: return convertDoStatement(node , convertedLoopBody);
+            case SyntaxKind.WhileStatement: return convertWhileStatement(node , convertedLoopBody);
             default: return Debug.failBadSyntaxKind(node, "IterationStatement expected");
         }
     }
@@ -3152,9 +3151,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
             case SyntaxKind.ForStatement:
             case SyntaxKind.ForInStatement:
             case SyntaxKind.ForOfStatement:
-                const initializer = (node as ForStatement | ForInStatement | ForOfStatement).initializer;
+                const initializer = (node).initializer;
                 if (initializer && initializer.kind === SyntaxKind.VariableDeclarationList) {
-                    loopInitializer = initializer as VariableDeclarationList;
+                    loopInitializer = initializer ;
                 }
                 break;
         }
@@ -4541,7 +4540,7 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
     function substituteExpression(node: Node) {
         switch (node.kind) {
             case SyntaxKind.Identifier:
-                return substituteExpressionIdentifier(node as Identifier);
+                return substituteExpressionIdentifier(node);
 
             case SyntaxKind.ThisKeyword:
                 return substituteThisKeyword(node as PrimaryExpression);
@@ -4623,22 +4622,22 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
             return false;
         }
 
-        const statementExpression = (statement as ExpressionStatement).expression;
+        const statementExpression = (statement).expression;
         if (!nodeIsSynthesized(statementExpression) || statementExpression.kind !== SyntaxKind.CallExpression) {
             return false;
         }
 
-        const callTarget = (statementExpression as CallExpression).expression;
+        const callTarget = (statementExpression).expression;
         if (!nodeIsSynthesized(callTarget) || callTarget.kind !== SyntaxKind.SuperKeyword) {
             return false;
         }
 
-        const callArgument = singleOrUndefined((statementExpression as CallExpression).arguments);
+        const callArgument = singleOrUndefined((statementExpression).arguments);
         if (!callArgument || !nodeIsSynthesized(callArgument) || callArgument.kind !== SyntaxKind.SpreadElement) {
             return false;
         }
 
-        const expression = (callArgument as SpreadElement).expression;
+        const expression = (callArgument).expression;
         return isIdentifier(expression) && expression.escapedText === "arguments";
     }
 }

--- a/src/compiler/transformers/es2016.ts
+++ b/src/compiler/transformers/es2016.ts
@@ -40,7 +40,7 @@ export function transformES2016(context: TransformationContext): (x: SourceFile 
         }
         switch (node.kind) {
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression);
+                return visitBinaryExpression(node);
             default:
                 return visitEachChild(node, visitor, context);
         }

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -213,19 +213,19 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
                 return undefined;
 
             case SyntaxKind.AwaitExpression:
-                return visitAwaitExpression(node as AwaitExpression);
+                return visitAwaitExpression(node);
 
             case SyntaxKind.MethodDeclaration:
-                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitMethodDeclaration, node as MethodDeclaration);
+                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitMethodDeclaration, node);
 
             case SyntaxKind.FunctionDeclaration:
-                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitFunctionDeclaration, node as FunctionDeclaration);
+                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitFunctionDeclaration, node);
 
             case SyntaxKind.FunctionExpression:
-                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitFunctionExpression, node as FunctionExpression);
+                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitFunctionExpression, node);
 
             case SyntaxKind.ArrowFunction:
-                return doWithContext(ContextFlags.NonTopLevel, visitArrowFunction, node as ArrowFunction);
+                return doWithContext(ContextFlags.NonTopLevel, visitArrowFunction, node);
 
             case SyntaxKind.PropertyAccessExpression:
                 if (capturedSuperProperties && isPropertyAccessExpression(node) && node.expression.kind === SyntaxKind.SuperKeyword) {
@@ -234,17 +234,17 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
                 return visitEachChild(node, visitor, context);
 
             case SyntaxKind.ElementAccessExpression:
-                if (capturedSuperProperties && (node as ElementAccessExpression).expression.kind === SyntaxKind.SuperKeyword) {
+                if (capturedSuperProperties && (node).expression.kind === SyntaxKind.SuperKeyword) {
                     hasSuperElementAccess = true;
                 }
                 return visitEachChild(node, visitor, context);
 
             case SyntaxKind.GetAccessor:
-                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitGetAccessorDeclaration, node as GetAccessorDeclaration);
+                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitGetAccessorDeclaration, node);
             case SyntaxKind.SetAccessor:
-                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitSetAccessorDeclaration, node as SetAccessorDeclaration);
+                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitSetAccessorDeclaration, node);
             case SyntaxKind.Constructor:
-                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitConstructorDeclaration, node as ConstructorDeclaration);
+                return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitConstructorDeclaration, node);
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.ClassExpression:
                 return doWithContext(ContextFlags.NonTopLevel | ContextFlags.HasLexicalThis, visitDefault, node);
@@ -816,11 +816,11 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
     function substituteExpression(node: Expression) {
         switch (node.kind) {
             case SyntaxKind.PropertyAccessExpression:
-                return substitutePropertyAccessExpression(node as PropertyAccessExpression);
+                return substitutePropertyAccessExpression(node);
             case SyntaxKind.ElementAccessExpression:
-                return substituteElementAccessExpression(node as ElementAccessExpression);
+                return substituteElementAccessExpression(node);
             case SyntaxKind.CallExpression:
-                return substituteCallExpression(node as CallExpression);
+                return substituteCallExpression(node);
         }
         return node;
     }

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -271,25 +271,25 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
         }
         switch (node.kind) {
             case SyntaxKind.AwaitExpression:
-                return visitAwaitExpression(node as AwaitExpression);
+                return visitAwaitExpression(node);
             case SyntaxKind.YieldExpression:
-                return visitYieldExpression(node as YieldExpression);
+                return visitYieldExpression(node);
             case SyntaxKind.ReturnStatement:
-                return visitReturnStatement(node as ReturnStatement);
+                return visitReturnStatement(node);
             case SyntaxKind.LabeledStatement:
-                return visitLabeledStatement(node as LabeledStatement);
+                return visitLabeledStatement(node);
             case SyntaxKind.ObjectLiteralExpression:
-                return visitObjectLiteralExpression(node as ObjectLiteralExpression);
+                return visitObjectLiteralExpression(node);
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression, expressionResultIsUnused);
+                return visitBinaryExpression(node , expressionResultIsUnused);
             case SyntaxKind.CommaListExpression:
-                return visitCommaListExpression(node as CommaListExpression, expressionResultIsUnused);
+                return visitCommaListExpression(node , expressionResultIsUnused);
             case SyntaxKind.CatchClause:
-                return visitCatchClause(node as CatchClause);
+                return visitCatchClause(node);
             case SyntaxKind.VariableStatement:
-                return visitVariableStatement(node as VariableStatement);
+                return visitVariableStatement(node);
             case SyntaxKind.VariableDeclaration:
-                return visitVariableDeclaration(node as VariableDeclaration);
+                return visitVariableDeclaration(node);
             case SyntaxKind.DoStatement:
             case SyntaxKind.WhileStatement:
             case SyntaxKind.ForInStatement:
@@ -299,72 +299,72 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
                     HierarchyFacts.IterationStatementExcludes,
                     HierarchyFacts.IterationStatementIncludes);
             case SyntaxKind.ForOfStatement:
-                return visitForOfStatement(node as ForOfStatement, /*outermostLabeledStatement*/ undefined);
+                return visitForOfStatement(node , /*outermostLabeledStatement*/ undefined);
             case SyntaxKind.ForStatement:
                 return doWithHierarchyFacts(
                     visitForStatement,
-                    node as ForStatement,
+                    node ,
                     HierarchyFacts.IterationStatementExcludes,
                     HierarchyFacts.IterationStatementIncludes);
             case SyntaxKind.VoidExpression:
-                return visitVoidExpression(node as VoidExpression);
+                return visitVoidExpression(node);
             case SyntaxKind.Constructor:
                 return doWithHierarchyFacts(
                     visitConstructorDeclaration,
-                    node as ConstructorDeclaration,
+                    node ,
                     HierarchyFacts.ClassOrFunctionExcludes,
                     HierarchyFacts.ClassOrFunctionIncludes);
             case SyntaxKind.MethodDeclaration:
                 return doWithHierarchyFacts(
                     visitMethodDeclaration,
-                    node as MethodDeclaration,
+                    node ,
                     HierarchyFacts.ClassOrFunctionExcludes,
                     HierarchyFacts.ClassOrFunctionIncludes);
             case SyntaxKind.GetAccessor:
                 return doWithHierarchyFacts(
                     visitGetAccessorDeclaration,
-                    node as GetAccessorDeclaration,
+                    node ,
                     HierarchyFacts.ClassOrFunctionExcludes,
                     HierarchyFacts.ClassOrFunctionIncludes);
             case SyntaxKind.SetAccessor:
                 return doWithHierarchyFacts(
                     visitSetAccessorDeclaration,
-                    node as SetAccessorDeclaration,
+                    node ,
                     HierarchyFacts.ClassOrFunctionExcludes,
                     HierarchyFacts.ClassOrFunctionIncludes);
             case SyntaxKind.FunctionDeclaration:
                 return doWithHierarchyFacts(
                     visitFunctionDeclaration,
-                    node as FunctionDeclaration,
+                    node ,
                     HierarchyFacts.ClassOrFunctionExcludes,
                     HierarchyFacts.ClassOrFunctionIncludes);
             case SyntaxKind.FunctionExpression:
                 return doWithHierarchyFacts(
                     visitFunctionExpression,
-                    node as FunctionExpression,
+                    node ,
                     HierarchyFacts.ClassOrFunctionExcludes,
                     HierarchyFacts.ClassOrFunctionIncludes);
             case SyntaxKind.ArrowFunction:
                 return doWithHierarchyFacts(
                     visitArrowFunction,
-                    node as ArrowFunction,
+                    node ,
                     HierarchyFacts.ArrowFunctionExcludes,
                     HierarchyFacts.ArrowFunctionIncludes);
             case SyntaxKind.Parameter:
-                return visitParameter(node as ParameterDeclaration);
+                return visitParameter(node);
             case SyntaxKind.ExpressionStatement:
-                return visitExpressionStatement(node as ExpressionStatement);
+                return visitExpressionStatement(node);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, expressionResultIsUnused);
+                return visitParenthesizedExpression(node , expressionResultIsUnused);
             case SyntaxKind.TaggedTemplateExpression:
-                return visitTaggedTemplateExpression(node as TaggedTemplateExpression);
+                return visitTaggedTemplateExpression(node);
             case SyntaxKind.PropertyAccessExpression:
                 if (capturedSuperProperties && isPropertyAccessExpression(node) && node.expression.kind === SyntaxKind.SuperKeyword) {
                     capturedSuperProperties.add(node.name.escapedText);
                 }
                 return visitEachChild(node, visitor, context);
             case SyntaxKind.ElementAccessExpression:
-                if (capturedSuperProperties && (node as ElementAccessExpression).expression.kind === SyntaxKind.SuperKeyword) {
+                if (capturedSuperProperties && (node).expression.kind === SyntaxKind.SuperKeyword) {
                     hasSuperElementAccess = true;
                 }
                 return visitEachChild(node, visitor, context);
@@ -456,8 +456,8 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
     function visitLabeledStatement(node: LabeledStatement) {
         if (enclosingFunctionFlags & FunctionFlags.Async) {
             const statement = unwrapInnermostStatementOfLabel(node);
-            if (statement.kind === SyntaxKind.ForOfStatement && (statement as ForOfStatement).awaitModifier) {
-                return visitForOfStatement(statement as ForOfStatement, node);
+            if (statement.kind === SyntaxKind.ForOfStatement && (statement).awaitModifier) {
+                return visitForOfStatement(statement , node);
             }
             return factory.restoreEnclosingLabel(visitNode(statement, visitor, isStatement, factory.liftToBlock), node);
         }
@@ -1348,11 +1348,11 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
     function substituteExpression(node: Expression) {
         switch (node.kind) {
             case SyntaxKind.PropertyAccessExpression:
-                return substitutePropertyAccessExpression(node as PropertyAccessExpression);
+                return substitutePropertyAccessExpression(node);
             case SyntaxKind.ElementAccessExpression:
-                return substituteElementAccessExpression(node as ElementAccessExpression);
+                return substituteElementAccessExpression(node);
             case SyntaxKind.CallExpression:
-                return substituteCallExpression(node as CallExpression);
+                return substituteCallExpression(node);
         }
         return node;
     }

--- a/src/compiler/transformers/es2019.ts
+++ b/src/compiler/transformers/es2019.ts
@@ -32,7 +32,7 @@ export function transformES2019(context: TransformationContext): (x: SourceFile 
         }
         switch (node.kind) {
             case SyntaxKind.CatchClause:
-                return visitCatchClause(node as CatchClause);
+                return visitCatchClause(node);
             default:
                 return visitEachChild(node, visitor, context);
         }

--- a/src/compiler/transformers/es2020.ts
+++ b/src/compiler/transformers/es2020.ts
@@ -61,7 +61,7 @@ export function transformES2020(context: TransformationContext): (x: SourceFile 
         }
         switch (node.kind) {
             case SyntaxKind.CallExpression: {
-                const updated = visitNonOptionalCallExpression(node as CallExpression, /*captureThisArg*/ false);
+                const updated = visitNonOptionalCallExpression(node , /*captureThisArg*/ false);
                 Debug.assertNotNode(updated, isSyntheticReference);
                 return updated;
             }
@@ -74,12 +74,12 @@ export function transformES2020(context: TransformationContext): (x: SourceFile 
                 }
                 return visitEachChild(node, visitor, context);
             case SyntaxKind.BinaryExpression:
-                if ((node as BinaryExpression).operatorToken.kind === SyntaxKind.QuestionQuestionToken) {
-                    return transformNullishCoalescingExpression(node as BinaryExpression);
+                if ((node).operatorToken.kind === SyntaxKind.QuestionQuestionToken) {
+                    return transformNullishCoalescingExpression(node);
                 }
                 return visitEachChild(node, visitor, context);
             case SyntaxKind.DeleteExpression:
-                return visitDeleteExpression(node as DeleteExpression);
+                return visitDeleteExpression(node);
             default:
                 return visitEachChild(node, visitor, context);
         }
@@ -151,10 +151,10 @@ export function transformES2020(context: TransformationContext): (x: SourceFile 
 
     function visitNonOptionalExpression(node: Expression, captureThisArg: boolean, isDelete: boolean): Expression {
         switch (node.kind) {
-            case SyntaxKind.ParenthesizedExpression: return visitNonOptionalParenthesizedExpression(node as ParenthesizedExpression, captureThisArg, isDelete);
+            case SyntaxKind.ParenthesizedExpression: return visitNonOptionalParenthesizedExpression(node , captureThisArg, isDelete);
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression: return visitNonOptionalPropertyOrElementAccessExpression(node as AccessExpression, captureThisArg, isDelete);
-            case SyntaxKind.CallExpression: return visitNonOptionalCallExpression(node as CallExpression, captureThisArg);
+            case SyntaxKind.CallExpression: return visitNonOptionalCallExpression(node , captureThisArg);
             default: return visitNode(node, visitor, isExpression);
         }
     }

--- a/src/compiler/transformers/es5.ts
+++ b/src/compiler/transformers/es5.ts
@@ -10,10 +10,7 @@ import {
     isPrivateIdentifier,
     isPropertyAccessExpression,
     isPropertyAssignment,
-    JsxClosingElement,
     JsxEmit,
-    JsxOpeningElement,
-    JsxSelfClosingElement,
     Node,
     PropertyAccessExpression,
     PropertyAssignment,
@@ -73,7 +70,7 @@ export function transformES5(context: TransformationContext): (x: SourceFile | B
             case SyntaxKind.JsxOpeningElement:
             case SyntaxKind.JsxClosingElement:
             case SyntaxKind.JsxSelfClosingElement:
-                const tagName = (node as JsxOpeningElement | JsxClosingElement | JsxSelfClosingElement).tagName;
+                const tagName = (node).tagName;
                 noSubstitution[getOriginalNodeId(tagName)] = true;
                 break;
         }

--- a/src/compiler/transformers/esDecorators.ts
+++ b/src/compiler/transformers/esDecorators.ts
@@ -410,52 +410,52 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
             case SyntaxKind.Decorator: // elided, will be emitted as part of `visitClassDeclaration`
                 return Debug.fail("Use `modifierVisitor` instead.");
             case SyntaxKind.ClassDeclaration:
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
             case SyntaxKind.ClassExpression:
-                return visitClassExpression(node as ClassExpression, /*referencedName*/ undefined);
+                return visitClassExpression(node , /*referencedName*/ undefined);
             case SyntaxKind.Constructor:
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.ClassStaticBlockDeclaration:
                 return Debug.fail("Not supported outside of a class. Use 'classElementVisitor' instead.");
             case SyntaxKind.Parameter:
-                return visitParameterDeclaration(node as ParameterDeclaration);
+                return visitParameterDeclaration(node);
 
             // Support NamedEvaluation to ensure the correct class name for class expressions.
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression, /*discarded*/ false);
+                return visitBinaryExpression(node , /*discarded*/ false);
             case SyntaxKind.PropertyAssignment:
-                return visitPropertyAssignment(node as PropertyAssignment);
+                return visitPropertyAssignment(node);
             case SyntaxKind.VariableDeclaration:
-                return visitVariableDeclaration(node as VariableDeclaration);
+                return visitVariableDeclaration(node);
             case SyntaxKind.BindingElement:
-                return visitBindingElement(node as BindingElement);
+                return visitBindingElement(node);
             case SyntaxKind.ExportAssignment:
-                return visitExportAssignment(node as ExportAssignment);
+                return visitExportAssignment(node);
             case SyntaxKind.ThisKeyword:
                 return visitThisExpression(node as ThisExpression);
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement);
+                return visitForStatement(node);
             case SyntaxKind.ExpressionStatement:
-                return visitExpressionStatement(node as ExpressionStatement);
+                return visitExpressionStatement(node);
             case SyntaxKind.CommaListExpression:
-                return visitCommaListExpression(node as CommaListExpression, /*discarded*/ false);
+                return visitCommaListExpression(node , /*discarded*/ false);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, /*discarded*/ false, /*referencedName*/ undefined);
+                return visitParenthesizedExpression(node , /*discarded*/ false, /*referencedName*/ undefined);
             case SyntaxKind.PartiallyEmittedExpression:
-                return visitPartiallyEmittedExpression(node as PartiallyEmittedExpression, /*discarded*/ false, /*referencedName*/ undefined);
+                return visitPartiallyEmittedExpression(node , /*discarded*/ false, /*referencedName*/ undefined);
             case SyntaxKind.CallExpression:
-                return visitCallExpression(node as CallExpression);
+                return visitCallExpression(node);
             case SyntaxKind.TaggedTemplateExpression:
-                return visitTaggedTemplateExpression(node as TaggedTemplateExpression);
+                return visitTaggedTemplateExpression(node);
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
-                return visitPreOrPostfixUnaryExpression(node as PrefixUnaryExpression | PostfixUnaryExpression, /*discarded*/ false);
+                return visitPreOrPostfixUnaryExpression(node , /*discarded*/ false);
             case SyntaxKind.PropertyAccessExpression:
-                return visitPropertyAccessExpression(node as PropertyAccessExpression);
+                return visitPropertyAccessExpression(node);
             case SyntaxKind.ElementAccessExpression:
-                return visitElementAccessExpression(node as ElementAccessExpression);
+                return visitElementAccessExpression(node);
             case SyntaxKind.ComputedPropertyName:
-                return visitComputedPropertyName(node as ComputedPropertyName);
+                return visitComputedPropertyName(node);
 
             case SyntaxKind.MethodDeclaration: // object literal methods and accessors
             case SyntaxKind.SetAccessor:
@@ -494,17 +494,17 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
     function classElementVisitor(node: Node) {
         switch (node.kind) {
             case SyntaxKind.Constructor:
-                return visitConstructorDeclaration(node as ConstructorDeclaration);
+                return visitConstructorDeclaration(node);
             case SyntaxKind.MethodDeclaration:
-                return visitMethodDeclaration(node as MethodDeclaration);
+                return visitMethodDeclaration(node);
             case SyntaxKind.GetAccessor:
-                return visitGetAccessorDeclaration(node as GetAccessorDeclaration);
+                return visitGetAccessorDeclaration(node);
             case SyntaxKind.SetAccessor:
-                return visitSetAccessorDeclaration(node as SetAccessorDeclaration);
+                return visitSetAccessorDeclaration(node);
             case SyntaxKind.PropertyDeclaration:
-                return visitPropertyDeclaration(node as PropertyDeclaration);
+                return visitPropertyDeclaration(node);
             case SyntaxKind.ClassStaticBlockDeclaration:
-                return visitClassStaticBlockDeclaration(node as ClassStaticBlockDeclaration);
+                return visitClassStaticBlockDeclaration(node);
             default:
                 return visitor(node);
         }
@@ -513,11 +513,11 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
     function namedEvaluationVisitor(node: Node, referencedName: Expression): VisitResult<Node> {
         switch (node.kind) {
             case SyntaxKind.PartiallyEmittedExpression:
-                return visitPartiallyEmittedExpression(node as PartiallyEmittedExpression, /*discarded*/ false, referencedName);
+                return visitPartiallyEmittedExpression(node , /*discarded*/ false, referencedName);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, /*discarded*/ false, referencedName);
+                return visitParenthesizedExpression(node , /*discarded*/ false, referencedName);
             case SyntaxKind.ClassExpression:
-                return visitClassExpression(node as ClassExpression, referencedName);
+                return visitClassExpression(node , referencedName);
             default:
                 return visitor(node);
         }
@@ -527,13 +527,13 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
         switch (node.kind) {
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
-                return visitPreOrPostfixUnaryExpression(node as PrefixUnaryExpression | PostfixUnaryExpression, /*discarded*/ true);
+                return visitPreOrPostfixUnaryExpression(node , /*discarded*/ true);
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression, /*discarded*/ true);
+                return visitBinaryExpression(node , /*discarded*/ true);
             case SyntaxKind.CommaListExpression:
-                return visitCommaListExpression(node as CommaListExpression, /*discarded*/ true);
+                return visitCommaListExpression(node , /*discarded*/ true);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, /*discarded*/ true, /*referencedName*/ undefined);
+                return visitParenthesizedExpression(node , /*discarded*/ true, /*referencedName*/ undefined);
             default:
                 return visitor(node);
         }

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -64,7 +64,6 @@ import {
     NumericLiteral,
     ObjectLiteralElementLike,
     ObjectLiteralExpression,
-    PropertyAccessExpression,
     reduceLeft,
     ReturnStatement,
     setCommentRange,
@@ -435,13 +434,13 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
     function visitJavaScriptInStatementContainingYield(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.DoStatement:
-                return visitDoStatement(node as DoStatement);
+                return visitDoStatement(node);
             case SyntaxKind.WhileStatement:
-                return visitWhileStatement(node as WhileStatement);
+                return visitWhileStatement(node);
             case SyntaxKind.SwitchStatement:
-                return visitSwitchStatement(node as SwitchStatement);
+                return visitSwitchStatement(node);
             case SyntaxKind.LabeledStatement:
-                return visitLabeledStatement(node as LabeledStatement);
+                return visitLabeledStatement(node);
             default:
                 return visitJavaScriptInGeneratorFunctionBody(node);
         }
@@ -455,24 +454,24 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
     function visitJavaScriptInGeneratorFunctionBody(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.FunctionDeclaration:
-                return visitFunctionDeclaration(node as FunctionDeclaration);
+                return visitFunctionDeclaration(node);
             case SyntaxKind.FunctionExpression:
-                return visitFunctionExpression(node as FunctionExpression);
+                return visitFunctionExpression(node);
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
                 return visitAccessorDeclaration(node as AccessorDeclaration);
             case SyntaxKind.VariableStatement:
-                return visitVariableStatement(node as VariableStatement);
+                return visitVariableStatement(node);
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement);
+                return visitForStatement(node);
             case SyntaxKind.ForInStatement:
-                return visitForInStatement(node as ForInStatement);
+                return visitForInStatement(node);
             case SyntaxKind.BreakStatement:
-                return visitBreakStatement(node as BreakStatement);
+                return visitBreakStatement(node);
             case SyntaxKind.ContinueStatement:
-                return visitContinueStatement(node as ContinueStatement);
+                return visitContinueStatement(node);
             case SyntaxKind.ReturnStatement:
-                return visitReturnStatement(node as ReturnStatement);
+                return visitReturnStatement(node);
             default:
                 if (node.transformFlags & TransformFlags.ContainsYield) {
                     return visitJavaScriptContainingYield(node);
@@ -494,23 +493,23 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
     function visitJavaScriptContainingYield(node: Node): VisitResult<Node> {
         switch (node.kind) {
             case SyntaxKind.BinaryExpression:
-                return visitBinaryExpression(node as BinaryExpression);
+                return visitBinaryExpression(node);
             case SyntaxKind.CommaListExpression:
-                return visitCommaListExpression(node as CommaListExpression);
+                return visitCommaListExpression(node);
             case SyntaxKind.ConditionalExpression:
-                return visitConditionalExpression(node as ConditionalExpression);
+                return visitConditionalExpression(node);
             case SyntaxKind.YieldExpression:
-                return visitYieldExpression(node as YieldExpression);
+                return visitYieldExpression(node);
             case SyntaxKind.ArrayLiteralExpression:
-                return visitArrayLiteralExpression(node as ArrayLiteralExpression);
+                return visitArrayLiteralExpression(node);
             case SyntaxKind.ObjectLiteralExpression:
-                return visitObjectLiteralExpression(node as ObjectLiteralExpression);
+                return visitObjectLiteralExpression(node);
             case SyntaxKind.ElementAccessExpression:
-                return visitElementAccessExpression(node as ElementAccessExpression);
+                return visitElementAccessExpression(node);
             case SyntaxKind.CallExpression:
-                return visitCallExpression(node as CallExpression);
+                return visitCallExpression(node);
             case SyntaxKind.NewExpression:
-                return visitNewExpression(node as NewExpression);
+                return visitNewExpression(node);
             default:
                 return visitEachChild(node, visitor, context);
         }
@@ -524,10 +523,10 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
     function visitGenerator(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.FunctionDeclaration:
-                return visitFunctionDeclaration(node as FunctionDeclaration);
+                return visitFunctionDeclaration(node);
 
             case SyntaxKind.FunctionExpression:
-                return visitFunctionExpression(node as FunctionExpression);
+                return visitFunctionExpression(node);
 
             default:
                 return Debug.failBadSyntaxKind(node);
@@ -790,9 +789,9 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
                     //      _a.b = %sent%;
 
                     target = factory.updatePropertyAccessExpression(
-                        left as PropertyAccessExpression,
-                        cacheExpression(Debug.checkDefined(visitNode((left as PropertyAccessExpression).expression, visitor, isLeftHandSideExpression))),
-                        (left as PropertyAccessExpression).name
+                        left ,
+                        cacheExpression(Debug.checkDefined(visitNode((left).expression, visitor, isLeftHandSideExpression))),
+                        (left).name
                     );
                     break;
 
@@ -808,9 +807,9 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
                     //  .mark resumeLabel
                     //      _a[_b] = %sent%;
 
-                    target = factory.updateElementAccessExpression(left as ElementAccessExpression,
-                        cacheExpression(Debug.checkDefined(visitNode((left as ElementAccessExpression).expression, visitor, isLeftHandSideExpression))),
-                        cacheExpression(Debug.checkDefined(visitNode((left as ElementAccessExpression).argumentExpression, visitor, isExpression)))
+                    target = factory.updateElementAccessExpression(left ,
+                        cacheExpression(Debug.checkDefined(visitNode((left).expression, visitor, isLeftHandSideExpression))),
+                        cacheExpression(Debug.checkDefined(visitNode((left).argumentExpression, visitor, isExpression)))
                     );
                     break;
 
@@ -1306,35 +1305,35 @@ export function transformGenerators(context: TransformationContext): (x: SourceF
     function transformAndEmitStatementWorker(node: Statement): void {
         switch (node.kind) {
             case SyntaxKind.Block:
-                return transformAndEmitBlock(node as Block);
+                return transformAndEmitBlock(node);
             case SyntaxKind.ExpressionStatement:
-                return transformAndEmitExpressionStatement(node as ExpressionStatement);
+                return transformAndEmitExpressionStatement(node);
             case SyntaxKind.IfStatement:
-                return transformAndEmitIfStatement(node as IfStatement);
+                return transformAndEmitIfStatement(node);
             case SyntaxKind.DoStatement:
-                return transformAndEmitDoStatement(node as DoStatement);
+                return transformAndEmitDoStatement(node);
             case SyntaxKind.WhileStatement:
-                return transformAndEmitWhileStatement(node as WhileStatement);
+                return transformAndEmitWhileStatement(node);
             case SyntaxKind.ForStatement:
-                return transformAndEmitForStatement(node as ForStatement);
+                return transformAndEmitForStatement(node);
             case SyntaxKind.ForInStatement:
-                return transformAndEmitForInStatement(node as ForInStatement);
+                return transformAndEmitForInStatement(node);
             case SyntaxKind.ContinueStatement:
-                return transformAndEmitContinueStatement(node as ContinueStatement);
+                return transformAndEmitContinueStatement(node);
             case SyntaxKind.BreakStatement:
-                return transformAndEmitBreakStatement(node as BreakStatement);
+                return transformAndEmitBreakStatement(node);
             case SyntaxKind.ReturnStatement:
-                return transformAndEmitReturnStatement(node as ReturnStatement);
+                return transformAndEmitReturnStatement(node);
             case SyntaxKind.WithStatement:
-                return transformAndEmitWithStatement(node as WithStatement);
+                return transformAndEmitWithStatement(node);
             case SyntaxKind.SwitchStatement:
-                return transformAndEmitSwitchStatement(node as SwitchStatement);
+                return transformAndEmitSwitchStatement(node);
             case SyntaxKind.LabeledStatement:
-                return transformAndEmitLabeledStatement(node as LabeledStatement);
+                return transformAndEmitLabeledStatement(node);
             case SyntaxKind.ThrowStatement:
-                return transformAndEmitThrowStatement(node as ThrowStatement);
+                return transformAndEmitThrowStatement(node);
             case SyntaxKind.TryStatement:
-                return transformAndEmitTryStatement(node as TryStatement);
+                return transformAndEmitTryStatement(node);
             default:
                 return emitStatement(visitNode(node, visitor, isStatement));
         }

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -211,16 +211,16 @@ export function transformJsx(context: TransformationContext): (x: SourceFile | B
     function visitorWorker(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.JsxElement:
-                return visitJsxElement(node as JsxElement, /*isChild*/ false);
+                return visitJsxElement(node , /*isChild*/ false);
 
             case SyntaxKind.JsxSelfClosingElement:
-                return visitJsxSelfClosingElement(node as JsxSelfClosingElement, /*isChild*/ false);
+                return visitJsxSelfClosingElement(node , /*isChild*/ false);
 
             case SyntaxKind.JsxFragment:
-                return visitJsxFragment(node as JsxFragment, /*isChild*/ false);
+                return visitJsxFragment(node , /*isChild*/ false);
 
             case SyntaxKind.JsxExpression:
-                return visitJsxExpression(node as JsxExpression);
+                return visitJsxExpression(node);
 
             default:
                 return visitEachChild(node, visitor, context);

--- a/src/compiler/transformers/legacyDecorators.ts
+++ b/src/compiler/transformers/legacyDecorators.ts
@@ -131,21 +131,21 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
                 // Decorators are elided. They will be emitted as part of `visitClassDeclaration`.
                 return undefined;
             case SyntaxKind.ClassDeclaration:
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
             case SyntaxKind.ClassExpression:
-                return visitClassExpression(node as ClassExpression);
+                return visitClassExpression(node);
             case SyntaxKind.Constructor:
-                return visitConstructorDeclaration(node as ConstructorDeclaration);
+                return visitConstructorDeclaration(node);
             case SyntaxKind.MethodDeclaration:
-                return visitMethodDeclaration(node as MethodDeclaration);
+                return visitMethodDeclaration(node);
             case SyntaxKind.SetAccessor:
-                return visitSetAccessorDeclaration(node as SetAccessorDeclaration);
+                return visitSetAccessorDeclaration(node);
             case SyntaxKind.GetAccessor:
-                return visitGetAccessorDeclaration(node as GetAccessorDeclaration);
+                return visitGetAccessorDeclaration(node);
             case SyntaxKind.PropertyDeclaration:
-                return visitPropertyDeclaration(node as PropertyDeclaration);
+                return visitPropertyDeclaration(node);
             case SyntaxKind.Parameter:
-                return visitParameterDeclaration(node as ParameterDeclaration);
+                return visitParameterDeclaration(node);
             default:
                 return visitEachChild(node, visitor, context);
         }
@@ -803,7 +803,7 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
     function substituteExpression(node: Expression) {
         switch (node.kind) {
             case SyntaxKind.Identifier:
-                return substituteExpressionIdentifier(node as Identifier);
+                return substituteExpressionIdentifier(node);
         }
 
         return node;

--- a/src/compiler/transformers/module/esnextAnd2015.ts
+++ b/src/compiler/transformers/module/esnextAnd2015.ts
@@ -123,11 +123,11 @@ export function transformECMAScriptModule(context: TransformationContext): (x: S
                 // Though an error in es2020 modules, in node-flavor es2020 modules, we can helpfully transform this to a synthetic `require` call
                 // To give easy access to a synchronous `require` in node-flavor esm. We do the transform even in scenarios where we error, but `import.meta.url`
                 // is available, just because the output is reasonable for a node-like runtime.
-                return getEmitModuleKind(compilerOptions) >= ModuleKind.Node16 ? visitImportEqualsDeclaration(node as ImportEqualsDeclaration) : undefined;
+                return getEmitModuleKind(compilerOptions) >= ModuleKind.Node16 ? visitImportEqualsDeclaration(node) : undefined;
             case SyntaxKind.ExportAssignment:
-                return visitExportAssignment(node as ExportAssignment);
+                return visitExportAssignment(node);
             case SyntaxKind.ExportDeclaration:
-                const exportDecl = (node as ExportDeclaration);
+                const exportDecl = (node);
                 return visitExportDeclaration(exportDecl);
         }
 

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -668,22 +668,22 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
     function topLevelVisitor(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.ImportDeclaration:
-                return visitImportDeclaration(node as ImportDeclaration);
+                return visitImportDeclaration(node);
 
             case SyntaxKind.ImportEqualsDeclaration:
-                return visitImportEqualsDeclaration(node as ImportEqualsDeclaration);
+                return visitImportEqualsDeclaration(node);
 
             case SyntaxKind.ExportDeclaration:
-                return visitExportDeclaration(node as ExportDeclaration);
+                return visitExportDeclaration(node);
 
             case SyntaxKind.ExportAssignment:
-                return visitExportAssignment(node as ExportAssignment);
+                return visitExportAssignment(node);
 
             case SyntaxKind.FunctionDeclaration:
-                return visitFunctionDeclaration(node as FunctionDeclaration);
+                return visitFunctionDeclaration(node);
 
             case SyntaxKind.ClassDeclaration:
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
 
             default:
                 return topLevelNestedVisitor(node);
@@ -698,58 +698,58 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
     function topLevelNestedVisitor(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.VariableStatement:
-                return visitVariableStatement(node as VariableStatement);
+                return visitVariableStatement(node);
 
             case SyntaxKind.FunctionDeclaration:
-                return visitFunctionDeclaration(node as FunctionDeclaration);
+                return visitFunctionDeclaration(node);
 
             case SyntaxKind.ClassDeclaration:
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
 
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement, /*isTopLevel*/ true);
+                return visitForStatement(node , /*isTopLevel*/ true);
 
             case SyntaxKind.ForInStatement:
-                return visitForInStatement(node as ForInStatement);
+                return visitForInStatement(node);
 
             case SyntaxKind.ForOfStatement:
-                return visitForOfStatement(node as ForOfStatement);
+                return visitForOfStatement(node);
 
             case SyntaxKind.DoStatement:
-                return visitDoStatement(node as DoStatement);
+                return visitDoStatement(node);
 
             case SyntaxKind.WhileStatement:
-                return visitWhileStatement(node as WhileStatement);
+                return visitWhileStatement(node);
 
             case SyntaxKind.LabeledStatement:
-                return visitLabeledStatement(node as LabeledStatement);
+                return visitLabeledStatement(node);
 
             case SyntaxKind.WithStatement:
-                return visitWithStatement(node as WithStatement);
+                return visitWithStatement(node);
 
             case SyntaxKind.IfStatement:
-                return visitIfStatement(node as IfStatement);
+                return visitIfStatement(node);
 
             case SyntaxKind.SwitchStatement:
-                return visitSwitchStatement(node as SwitchStatement);
+                return visitSwitchStatement(node);
 
             case SyntaxKind.CaseBlock:
-                return visitCaseBlock(node as CaseBlock);
+                return visitCaseBlock(node);
 
             case SyntaxKind.CaseClause:
-                return visitCaseClause(node as CaseClause);
+                return visitCaseClause(node);
 
             case SyntaxKind.DefaultClause:
-                return visitDefaultClause(node as DefaultClause);
+                return visitDefaultClause(node);
 
             case SyntaxKind.TryStatement:
-                return visitTryStatement(node as TryStatement);
+                return visitTryStatement(node);
 
             case SyntaxKind.CatchClause:
-                return visitCatchClause(node as CatchClause);
+                return visitCatchClause(node);
 
             case SyntaxKind.Block:
-                return visitBlock(node as Block);
+                return visitBlock(node);
 
             default:
                 return visitor(node);
@@ -765,13 +765,13 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
 
         switch (node.kind) {
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement, /*isTopLevel*/ false);
+                return visitForStatement(node , /*isTopLevel*/ false);
             case SyntaxKind.ExpressionStatement:
-                return visitExpressionStatement(node as ExpressionStatement);
+                return visitExpressionStatement(node);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, valueIsDiscarded);
+                return visitParenthesizedExpression(node , valueIsDiscarded);
             case SyntaxKind.PartiallyEmittedExpression:
-                return visitPartiallyEmittedExpression(node as PartiallyEmittedExpression, valueIsDiscarded);
+                return visitPartiallyEmittedExpression(node , valueIsDiscarded);
             case SyntaxKind.CallExpression:
                 if (isImportCall(node) && currentSourceFile.impliedNodeFormat === undefined) {
                     return visitImportCallExpression(node);
@@ -784,7 +784,7 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
                 break;
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
-                return visitPreOrPostfixUnaryExpression(node as PrefixUnaryExpression | PostfixUnaryExpression, valueIsDiscarded);
+                return visitPreOrPostfixUnaryExpression(node , valueIsDiscarded);
         }
 
         return visitEachChild(node, visitor, context);
@@ -2164,7 +2164,7 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
      */
     function onEmitNode(hint: EmitHint, node: Node, emitCallback: (hint: EmitHint, node: Node) => void): void {
         if (node.kind === SyntaxKind.SourceFile) {
-            currentSourceFile = node as SourceFile;
+            currentSourceFile = node ;
             currentModuleInfo = moduleInfoMap[getOriginalNodeId(currentSourceFile)];
 
             previousOnEmitNode(hint, node, emitCallback);
@@ -2232,13 +2232,13 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
     function substituteExpression(node: Expression) {
         switch (node.kind) {
             case SyntaxKind.Identifier:
-                return substituteExpressionIdentifier(node as Identifier);
+                return substituteExpressionIdentifier(node);
             case SyntaxKind.CallExpression:
-                return substituteCallExpression(node as CallExpression);
+                return substituteCallExpression(node);
             case SyntaxKind.TaggedTemplateExpression:
-                return substituteTaggedTemplateExpression(node as TaggedTemplateExpression);
+                return substituteTaggedTemplateExpression(node);
             case SyntaxKind.BinaryExpression:
-                return substituteBinaryExpression(node as BinaryExpression);
+                return substituteBinaryExpression(node);
         }
 
         return node;

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -708,16 +708,16 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
     function topLevelVisitor(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.ImportDeclaration:
-                return visitImportDeclaration(node as ImportDeclaration);
+                return visitImportDeclaration(node);
 
             case SyntaxKind.ImportEqualsDeclaration:
-                return visitImportEqualsDeclaration(node as ImportEqualsDeclaration);
+                return visitImportEqualsDeclaration(node);
 
             case SyntaxKind.ExportDeclaration:
-                return visitExportDeclaration(node as ExportDeclaration);
+                return visitExportDeclaration(node);
 
             case SyntaxKind.ExportAssignment:
-                return visitExportAssignment(node as ExportAssignment);
+                return visitExportAssignment(node);
 
             default:
                 return topLevelNestedVisitor(node);
@@ -1182,58 +1182,58 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
     function topLevelNestedVisitor(node: Node): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.VariableStatement:
-                return visitVariableStatement(node as VariableStatement);
+                return visitVariableStatement(node);
 
             case SyntaxKind.FunctionDeclaration:
-                return visitFunctionDeclaration(node as FunctionDeclaration);
+                return visitFunctionDeclaration(node);
 
             case SyntaxKind.ClassDeclaration:
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
 
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement, /*isTopLevel*/ true);
+                return visitForStatement(node , /*isTopLevel*/ true);
 
             case SyntaxKind.ForInStatement:
-                return visitForInStatement(node as ForInStatement);
+                return visitForInStatement(node);
 
             case SyntaxKind.ForOfStatement:
-                return visitForOfStatement(node as ForOfStatement);
+                return visitForOfStatement(node);
 
             case SyntaxKind.DoStatement:
-                return visitDoStatement(node as DoStatement);
+                return visitDoStatement(node);
 
             case SyntaxKind.WhileStatement:
-                return visitWhileStatement(node as WhileStatement);
+                return visitWhileStatement(node);
 
             case SyntaxKind.LabeledStatement:
-                return visitLabeledStatement(node as LabeledStatement);
+                return visitLabeledStatement(node);
 
             case SyntaxKind.WithStatement:
-                return visitWithStatement(node as WithStatement);
+                return visitWithStatement(node);
 
             case SyntaxKind.IfStatement:
-                return visitIfStatement(node as IfStatement);
+                return visitIfStatement(node);
 
             case SyntaxKind.SwitchStatement:
-                return visitSwitchStatement(node as SwitchStatement);
+                return visitSwitchStatement(node);
 
             case SyntaxKind.CaseBlock:
-                return visitCaseBlock(node as CaseBlock);
+                return visitCaseBlock(node);
 
             case SyntaxKind.CaseClause:
-                return visitCaseClause(node as CaseClause);
+                return visitCaseClause(node);
 
             case SyntaxKind.DefaultClause:
-                return visitDefaultClause(node as DefaultClause);
+                return visitDefaultClause(node);
 
             case SyntaxKind.TryStatement:
-                return visitTryStatement(node as TryStatement);
+                return visitTryStatement(node);
 
             case SyntaxKind.CatchClause:
-                return visitCatchClause(node as CatchClause);
+                return visitCatchClause(node);
 
             case SyntaxKind.Block:
-                return visitBlock(node as Block);
+                return visitBlock(node);
 
             default:
                 return visitor(node);
@@ -1512,13 +1512,13 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
         }
         switch (node.kind) {
             case SyntaxKind.ForStatement:
-                return visitForStatement(node as ForStatement, /*isTopLevel*/ false);
+                return visitForStatement(node , /*isTopLevel*/ false);
             case SyntaxKind.ExpressionStatement:
-                return visitExpressionStatement(node as ExpressionStatement);
+                return visitExpressionStatement(node);
             case SyntaxKind.ParenthesizedExpression:
-                return visitParenthesizedExpression(node as ParenthesizedExpression, valueIsDiscarded);
+                return visitParenthesizedExpression(node , valueIsDiscarded);
             case SyntaxKind.PartiallyEmittedExpression:
-                return visitPartiallyEmittedExpression(node as PartiallyEmittedExpression, valueIsDiscarded);
+                return visitPartiallyEmittedExpression(node , valueIsDiscarded);
             case SyntaxKind.BinaryExpression:
                 if (isDestructuringAssignment(node)) {
                     return visitDestructuringAssignment(node, valueIsDiscarded);
@@ -1531,7 +1531,7 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
                 break;
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
-                return visitPrefixOrPostfixUnaryExpression(node as PrefixUnaryExpression | PostfixUnaryExpression, valueIsDiscarded);
+                return visitPrefixOrPostfixUnaryExpression(node , valueIsDiscarded);
         }
         return visitEachChild(node, visitor, context);
     }
@@ -1718,7 +1718,7 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
     function onEmitNode(hint: EmitHint, node: Node, emitCallback: (hint: EmitHint, node: Node) => void): void {
         if (node.kind === SyntaxKind.SourceFile) {
             const id = getOriginalNodeId(node);
-            currentSourceFile = node as SourceFile;
+            currentSourceFile = node ;
             moduleInfo = moduleInfoMap[id];
             exportFunction = exportFunctionsMap[id];
             noSubstitution = noSubstitutionMap[id];
@@ -1775,7 +1775,7 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
     function substituteUnspecified(node: Node) {
         switch (node.kind) {
             case SyntaxKind.ShorthandPropertyAssignment:
-                return substituteShorthandPropertyAssignment(node as ShorthandPropertyAssignment);
+                return substituteShorthandPropertyAssignment(node);
         }
         return node;
     }
@@ -1827,11 +1827,11 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
     function substituteExpression(node: Expression) {
         switch (node.kind) {
             case SyntaxKind.Identifier:
-                return substituteExpressionIdentifier(node as Identifier);
+                return substituteExpressionIdentifier(node);
             case SyntaxKind.BinaryExpression:
-                return substituteBinaryExpression(node as BinaryExpression);
+                return substituteBinaryExpression(node);
             case SyntaxKind.MetaProperty:
-                return substituteMetaProperty(node as MetaProperty);
+                return substituteMetaProperty(node);
         }
 
         return node;

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -348,7 +348,7 @@ export function transformTypeScript(context: TransformationContext) {
             case SyntaxKind.CaseBlock:
             case SyntaxKind.ModuleBlock:
             case SyntaxKind.Block:
-                currentLexicalScope = node as SourceFile | CaseBlock | ModuleBlock | Block;
+                currentLexicalScope = node ;
                 currentScopeFirstDeclarationsOfName = undefined;
                 break;
 
@@ -359,8 +359,8 @@ export function transformTypeScript(context: TransformationContext) {
                 }
 
                 // Record these declarations provided that they have a name.
-                if ((node as ClassDeclaration | FunctionDeclaration).name) {
-                    recordEmittedDeclarationInScope(node as ClassDeclaration | FunctionDeclaration);
+                if ((node).name) {
+                    recordEmittedDeclarationInScope(node);
                 }
                 else {
                     // These nodes should always have names unless they are default-exports;
@@ -414,7 +414,7 @@ export function transformTypeScript(context: TransformationContext) {
             case SyntaxKind.ImportEqualsDeclaration:
             case SyntaxKind.ExportAssignment:
             case SyntaxKind.ExportDeclaration:
-                return visitElidableStatement(node as ImportDeclaration | ImportEqualsDeclaration | ExportAssignment | ExportDeclaration);
+                return visitElidableStatement(node);
             default:
                 return visitorWorker(node);
         }
@@ -467,7 +467,7 @@ export function transformTypeScript(context: TransformationContext) {
             node.kind === SyntaxKind.ImportDeclaration ||
             node.kind === SyntaxKind.ImportClause ||
             (node.kind === SyntaxKind.ImportEqualsDeclaration &&
-             (node as ImportEqualsDeclaration).moduleReference.kind === SyntaxKind.ExternalModuleReference)) {
+             (node).moduleReference.kind === SyntaxKind.ExternalModuleReference)) {
             // do not emit ES6 imports and exports since they are illegal inside a namespace
             return undefined;
         }
@@ -495,25 +495,25 @@ export function transformTypeScript(context: TransformationContext) {
     function classElementVisitorWorker(node: Node, parent: ClassLikeDeclaration): VisitResult<Node | undefined> {
         switch (node.kind) {
             case SyntaxKind.Constructor:
-                return visitConstructor(node as ConstructorDeclaration);
+                return visitConstructor(node);
 
             case SyntaxKind.PropertyDeclaration:
                 // Property declarations are not TypeScript syntax, but they must be visited
                 // for the decorator transformation.
-                return visitPropertyDeclaration(node as PropertyDeclaration, parent);
+                return visitPropertyDeclaration(node , parent);
 
             case SyntaxKind.GetAccessor:
                 // Get Accessors can have TypeScript modifiers, decorators, and type annotations.
-                return visitGetAccessor(node as GetAccessorDeclaration, parent);
+                return visitGetAccessor(node , parent);
 
             case SyntaxKind.SetAccessor:
                 // Set Accessors can have TypeScript modifiers and type annotations.
-                return visitSetAccessor(node as SetAccessorDeclaration, parent);
+                return visitSetAccessor(node , parent);
 
             case SyntaxKind.MethodDeclaration:
                 // TypeScript method declarations may have decorators, modifiers
                 // or type annotations.
-                return visitMethodDeclaration(node as MethodDeclaration, parent);
+                return visitMethodDeclaration(node , parent);
 
             case SyntaxKind.ClassStaticBlockDeclaration:
                 return visitEachChild(node, visitor, context);
@@ -543,16 +543,16 @@ export function transformTypeScript(context: TransformationContext) {
 
             case SyntaxKind.GetAccessor:
                 // Get Accessors can have TypeScript modifiers, decorators, and type annotations.
-                return visitGetAccessor(node as GetAccessorDeclaration, parent);
+                return visitGetAccessor(node , parent);
 
             case SyntaxKind.SetAccessor:
                 // Set Accessors can have TypeScript modifiers and type annotations.
-                return visitSetAccessor(node as SetAccessorDeclaration, parent);
+                return visitSetAccessor(node , parent);
 
             case SyntaxKind.MethodDeclaration:
                 // TypeScript method declarations may have decorators, modifiers
                 // or type annotations.
-                return visitMethodDeclaration(node as MethodDeclaration, parent);
+                return visitMethodDeclaration(node , parent);
 
             default:
                 return Debug.failBadSyntaxKind(node);
@@ -666,7 +666,7 @@ export function transformTypeScript(context: TransformationContext) {
                 // - parameter property assignments in the constructor
                 // - index signatures
                 // - method overload signatures
-                return visitClassDeclaration(node as ClassDeclaration);
+                return visitClassDeclaration(node);
 
             case SyntaxKind.ClassExpression:
                 // This may be a class expression with TypeScript syntax extensions.
@@ -677,21 +677,21 @@ export function transformTypeScript(context: TransformationContext) {
                 // - parameter property assignments in the constructor
                 // - index signatures
                 // - method overload signatures
-                return visitClassExpression(node as ClassExpression);
+                return visitClassExpression(node);
 
             case SyntaxKind.HeritageClause:
                 // This may be a heritage clause with TypeScript syntax extensions.
                 //
                 // TypeScript heritage clause extensions include:
                 // - `implements` clause
-                return visitHeritageClause(node as HeritageClause);
+                return visitHeritageClause(node);
 
             case SyntaxKind.ExpressionWithTypeArguments:
                 // TypeScript supports type arguments on an expression in an `extends` heritage clause.
-                return visitExpressionWithTypeArguments(node as ExpressionWithTypeArguments);
+                return visitExpressionWithTypeArguments(node);
 
             case SyntaxKind.ObjectLiteralExpression:
-                return visitObjectLiteralExpression(node as ObjectLiteralExpression);
+                return visitObjectLiteralExpression(node);
 
             case SyntaxKind.Constructor:
             case SyntaxKind.PropertyDeclaration:
@@ -703,15 +703,15 @@ export function transformTypeScript(context: TransformationContext) {
 
             case SyntaxKind.FunctionDeclaration:
                 // Typescript function declarations can have modifiers, decorators, and type annotations.
-                return visitFunctionDeclaration(node as FunctionDeclaration);
+                return visitFunctionDeclaration(node);
 
             case SyntaxKind.FunctionExpression:
                 // TypeScript function expressions can have modifiers and type annotations.
-                return visitFunctionExpression(node as FunctionExpression);
+                return visitFunctionExpression(node);
 
             case SyntaxKind.ArrowFunction:
                 // TypeScript arrow functions can have modifiers and type annotations.
-                return visitArrowFunction(node as ArrowFunction);
+                return visitArrowFunction(node);
 
             case SyntaxKind.Parameter:
                 // This may be a parameter declaration with TypeScript syntax extensions.
@@ -722,12 +722,12 @@ export function transformTypeScript(context: TransformationContext) {
                 // - the question mark (?) token for optional parameters
                 // - type annotations
                 // - this parameters
-                return visitParameter(node as ParameterDeclaration);
+                return visitParameter(node);
 
             case SyntaxKind.ParenthesizedExpression:
                 // ParenthesizedExpressions are TypeScript if their expression is a
                 // TypeAssertion or AsExpression
-                return visitParenthesizedExpression(node as ParenthesizedExpression);
+                return visitParenthesizedExpression(node);
 
             case SyntaxKind.TypeAssertionExpression:
             case SyntaxKind.AsExpression:
@@ -735,45 +735,45 @@ export function transformTypeScript(context: TransformationContext) {
                 return visitAssertionExpression(node as AssertionExpression);
 
             case SyntaxKind.SatisfiesExpression:
-                return visitSatisfiesExpression(node as SatisfiesExpression);
+                return visitSatisfiesExpression(node);
 
             case SyntaxKind.CallExpression:
-                return visitCallExpression(node as CallExpression);
+                return visitCallExpression(node);
 
             case SyntaxKind.NewExpression:
-                return visitNewExpression(node as NewExpression);
+                return visitNewExpression(node);
 
             case SyntaxKind.TaggedTemplateExpression:
-                return visitTaggedTemplateExpression(node as TaggedTemplateExpression);
+                return visitTaggedTemplateExpression(node);
 
             case SyntaxKind.NonNullExpression:
                 // TypeScript non-null expressions are removed, but their subtrees are preserved.
-                return visitNonNullExpression(node as NonNullExpression);
+                return visitNonNullExpression(node);
 
             case SyntaxKind.EnumDeclaration:
                 // TypeScript enum declarations do not exist in ES6 and must be rewritten.
-                return visitEnumDeclaration(node as EnumDeclaration);
+                return visitEnumDeclaration(node);
 
             case SyntaxKind.VariableStatement:
                 // TypeScript namespace exports for variable statements must be transformed.
-                return visitVariableStatement(node as VariableStatement);
+                return visitVariableStatement(node);
 
             case SyntaxKind.VariableDeclaration:
-                return visitVariableDeclaration(node as VariableDeclaration);
+                return visitVariableDeclaration(node);
 
             case SyntaxKind.ModuleDeclaration:
                 // TypeScript namespace declarations must be transformed.
-                return visitModuleDeclaration(node as ModuleDeclaration);
+                return visitModuleDeclaration(node);
 
             case SyntaxKind.ImportEqualsDeclaration:
                 // TypeScript namespace or external module import.
-                return visitImportEqualsDeclaration(node as ImportEqualsDeclaration);
+                return visitImportEqualsDeclaration(node);
 
             case SyntaxKind.JsxSelfClosingElement:
-                return visitJsxSelfClosingElement(node as JsxSelfClosingElement);
+                return visitJsxSelfClosingElement(node);
 
             case SyntaxKind.JsxOpeningElement:
-                return visitJsxJsxOpeningElement(node as JsxOpeningElement);
+                return visitJsxJsxOpeningElement(node);
 
             default:
                 // node contains some other TypeScript syntax
@@ -2606,11 +2606,11 @@ export function transformTypeScript(context: TransformationContext) {
     function substituteExpression(node: Expression) {
         switch (node.kind) {
             case SyntaxKind.Identifier:
-                return substituteExpressionIdentifier(node as Identifier);
+                return substituteExpressionIdentifier(node);
             case SyntaxKind.PropertyAccessExpression:
-                return substitutePropertyAccessExpression(node as PropertyAccessExpression);
+                return substitutePropertyAccessExpression(node);
             case SyntaxKind.ElementAccessExpression:
-                return substituteElementAccessExpression(node as ElementAccessExpression);
+                return substituteElementAccessExpression(node);
         }
 
         return node;

--- a/src/compiler/transformers/typeSerializer.ts
+++ b/src/compiler/transformers/typeSerializer.ts
@@ -1,13 +1,11 @@
 import {
     AccessorDeclaration,
     ArrayLiteralExpression,
-    BigIntLiteral,
     BinaryExpression,
     Block,
     CaseBlock,
     ClassLikeDeclaration,
     ConditionalExpression,
-    ConditionalTypeNode,
     Debug,
     EntityName,
     Expression,
@@ -37,18 +35,13 @@ import {
     isStringLiteral,
     isTypeOfExpression,
     isVoidExpression,
-    JSDocNonNullableType,
-    JSDocNullableType,
-    JSDocOptionalType,
     LiteralTypeNode,
     MethodDeclaration,
     ModuleBlock,
     Node,
     nodeIsPresent,
-    NumericLiteral,
     ParameterDeclaration,
     parseNodeFactory,
-    PrefixUnaryExpression,
     PropertyAccessEntityNameExpression,
     PropertyDeclaration,
     QualifiedName,
@@ -61,8 +54,6 @@ import {
     SyntaxKind,
     TransformationContext,
     TypeNode,
-    TypeOperatorNode,
-    TypePredicateNode,
     TypeReferenceNode,
     TypeReferenceSerializationKind,
     UnionOrIntersectionTypeNode,
@@ -296,7 +287,7 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
                 return factory.createIdentifier("Array");
 
             case SyntaxKind.TypePredicate:
-                return (node as TypePredicateNode).assertsModifier ?
+                return (node).assertsModifier ?
                     factory.createVoidZero() :
                     factory.createIdentifier("Boolean");
 
@@ -311,7 +302,7 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
                 return factory.createIdentifier("Object");
 
             case SyntaxKind.LiteralType:
-                return serializeLiteralOfLiteralTypeNode((node as LiteralTypeNode).literal);
+                return serializeLiteralOfLiteralTypeNode((node).literal);
 
             case SyntaxKind.NumberKeyword:
                 return factory.createIdentifier("Number");
@@ -323,7 +314,7 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
                 return getGlobalConstructor("Symbol", ScriptTarget.ES2015);
 
             case SyntaxKind.TypeReference:
-                return serializeTypeReferenceNode(node as TypeReferenceNode);
+                return serializeTypeReferenceNode(node);
 
             case SyntaxKind.IntersectionType:
                 return serializeUnionOrIntersectionConstituents((node as UnionOrIntersectionTypeNode).types, /*isIntersection*/ true);
@@ -332,11 +323,11 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
                 return serializeUnionOrIntersectionConstituents((node as UnionOrIntersectionTypeNode).types, /*isIntersection*/ false);
 
             case SyntaxKind.ConditionalType:
-                return serializeUnionOrIntersectionConstituents([(node as ConditionalTypeNode).trueType, (node as ConditionalTypeNode).falseType], /*isIntersection*/ false);
+                return serializeUnionOrIntersectionConstituents([(node).trueType, (node).falseType], /*isIntersection*/ false);
 
             case SyntaxKind.TypeOperator:
-                if ((node as TypeOperatorNode).operator === SyntaxKind.ReadonlyKeyword) {
-                    return serializeTypeNode((node as TypeOperatorNode).type);
+                if ((node).operator === SyntaxKind.ReadonlyKeyword) {
+                    return serializeTypeNode((node).type);
                 }
                 break;
 
@@ -361,7 +352,7 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
             case SyntaxKind.JSDocNullableType:
             case SyntaxKind.JSDocNonNullableType:
             case SyntaxKind.JSDocOptionalType:
-                return serializeTypeNode((node as JSDocNullableType | JSDocNonNullableType | JSDocOptionalType).type);
+                return serializeTypeNode((node).type);
 
             default:
                 return Debug.failBadSyntaxKind(node);
@@ -377,11 +368,11 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
                 return factory.createIdentifier("String");
 
             case SyntaxKind.PrefixUnaryExpression: {
-                const operand = (node as PrefixUnaryExpression).operand;
+                const operand = (node).operand;
                 switch (operand.kind) {
                     case SyntaxKind.NumericLiteral:
                     case SyntaxKind.BigIntLiteral:
-                        return serializeLiteralOfLiteralTypeNode(operand as NumericLiteral | BigIntLiteral);
+                        return serializeLiteralOfLiteralTypeNode(operand);
                     default:
                         return Debug.failBadSyntaxKind(operand);
                 }

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -24,7 +24,6 @@ import {
     ExportSpecifier,
     Expression,
     filter,
-    FunctionDeclaration,
     FunctionLikeDeclaration,
     getAllAccessorDeclarations,
     getDecorators,
@@ -67,7 +66,6 @@ import {
     MethodDeclaration,
     ModifierFlags,
     NamedImportBindings,
-    NamespaceExport,
     Node,
     NodeArray,
     parameterIsThisKeyword,
@@ -84,7 +82,6 @@ import {
     SyntaxKind,
     TransformationContext,
     VariableDeclaration,
-    VariableStatement,
 } from "../_namespaces/ts";
 
 /** @internal */
@@ -178,39 +175,39 @@ export function collectExternalModuleInfo(context: TransformationContext, source
                 // import x from "mod"
                 // import * as x from "mod"
                 // import { x, y } from "mod"
-                externalImports.push(node as ImportDeclaration);
-                if (!hasImportStar && getImportNeedsImportStarHelper(node as ImportDeclaration)) {
+                externalImports.push(node);
+                if (!hasImportStar && getImportNeedsImportStarHelper(node)) {
                     hasImportStar = true;
                 }
-                if (!hasImportDefault && getImportNeedsImportDefaultHelper(node as ImportDeclaration)) {
+                if (!hasImportDefault && getImportNeedsImportDefaultHelper(node)) {
                     hasImportDefault = true;
                 }
                 break;
 
             case SyntaxKind.ImportEqualsDeclaration:
-                if ((node as ImportEqualsDeclaration).moduleReference.kind === SyntaxKind.ExternalModuleReference) {
+                if ((node).moduleReference.kind === SyntaxKind.ExternalModuleReference) {
                     // import x = require("mod")
-                    externalImports.push(node as ImportEqualsDeclaration);
+                    externalImports.push(node);
                 }
 
                 break;
 
             case SyntaxKind.ExportDeclaration:
-                if ((node as ExportDeclaration).moduleSpecifier) {
-                    if (!(node as ExportDeclaration).exportClause) {
+                if ((node).moduleSpecifier) {
+                    if (!(node).exportClause) {
                         // export * from "mod"
-                        externalImports.push(node as ExportDeclaration);
+                        externalImports.push(node);
                         hasExportStarsToExportValues = true;
                     }
                     else {
                         // export * as ns from "mod"
                         // export { x, y } from "mod"
-                        externalImports.push(node as ExportDeclaration);
-                        if (isNamedExports((node as ExportDeclaration).exportClause!)) {
-                            addExportedNamesForExportDeclaration(node as ExportDeclaration);
+                        externalImports.push(node);
+                        if (isNamedExports((node).exportClause)) {
+                            addExportedNamesForExportDeclaration(node);
                         }
                         else {
-                            const name = ((node as ExportDeclaration).exportClause as NamespaceExport).name;
+                            const name = ((node).exportClause).name;
                             if (!uniqueExports.get(idText(name))) {
                                 multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), name);
                                 uniqueExports.set(idText(name), true);
@@ -223,20 +220,20 @@ export function collectExternalModuleInfo(context: TransformationContext, source
                 }
                 else {
                     // export { x, y }
-                    addExportedNamesForExportDeclaration(node as ExportDeclaration);
+                    addExportedNamesForExportDeclaration(node);
                 }
                 break;
 
             case SyntaxKind.ExportAssignment:
-                if ((node as ExportAssignment).isExportEquals && !exportEquals) {
+                if ((node).isExportEquals && !exportEquals) {
                     // export = x
-                    exportEquals = node as ExportAssignment;
+                    exportEquals = node ;
                 }
                 break;
 
             case SyntaxKind.VariableStatement:
                 if (hasSyntacticModifier(node, ModifierFlags.Export)) {
-                    for (const decl of (node as VariableStatement).declarationList.declarations) {
+                    for (const decl of (node).declarationList.declarations) {
                         exportedNames = collectExportedVariableInfo(decl, uniqueExports, exportedNames, exportedBindings);
                     }
                 }
@@ -247,13 +244,13 @@ export function collectExternalModuleInfo(context: TransformationContext, source
                     if (hasSyntacticModifier(node, ModifierFlags.Default)) {
                         // export default function() { }
                         if (!hasExportDefault) {
-                            multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), context.factory.getDeclarationName(node as FunctionDeclaration));
+                            multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), context.factory.getDeclarationName(node));
                             hasExportDefault = true;
                         }
                     }
                     else {
                         // export function x() { }
-                        const name = (node as FunctionDeclaration).name!;
+                        const name = (node).name!;
                         if (!uniqueExports.get(idText(name))) {
                             multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), name);
                             uniqueExports.set(idText(name), true);
@@ -268,13 +265,13 @@ export function collectExternalModuleInfo(context: TransformationContext, source
                     if (hasSyntacticModifier(node, ModifierFlags.Default)) {
                         // export default class { }
                         if (!hasExportDefault) {
-                            multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), context.factory.getDeclarationName(node as ClassDeclaration));
+                            multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), context.factory.getDeclarationName(node));
                             hasExportDefault = true;
                         }
                     }
                     else {
                         // export class x { }
-                        const name = (node as ClassDeclaration).name;
+                        const name = (node).name;
                         if (name && !uniqueExports.get(idText(name))) {
                             multiMapSparseArrayAdd(exportedBindings, getOriginalNodeId(node), name);
                             uniqueExports.set(idText(name), true);
@@ -489,7 +486,7 @@ function isStaticPropertyDeclaration(member: ClassElement) {
  */
 export function isInitializedProperty(member: ClassElement): member is PropertyDeclaration & { initializer: Expression; } {
     return member.kind === SyntaxKind.PropertyDeclaration
-        && (member as PropertyDeclaration).initializer !== undefined;
+        && (member).initializer !== undefined;
 }
 
 /**
@@ -570,10 +567,10 @@ export function getAllDecoratorsOfClassElement(member: ClassElement, parent: Cla
             return getAllDecoratorsOfAccessors(member as AccessorDeclaration, parent);
 
         case SyntaxKind.MethodDeclaration:
-            return getAllDecoratorsOfMethod(member as MethodDeclaration);
+            return getAllDecoratorsOfMethod(member);
 
         case SyntaxKind.PropertyDeclaration:
-            return getAllDecoratorsOfProperty(member as PropertyDeclaration);
+            return getAllDecoratorsOfProperty(member);
 
         default:
             return undefined;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -786,6 +786,701 @@ export type JSDocSyntaxKind =
     | KeywordSyntaxKind
     ;
 
+export interface SyntaxKindToNode {
+    [SyntaxKind.Unknown]: Token<SyntaxKind.Unknown>,
+    [SyntaxKind.EndOfFileToken]: EndOfFileToken,
+    [SyntaxKind.SingleLineCommentTrivia]: Token<SyntaxKind.SingleLineCommentTrivia>,
+    [SyntaxKind.MultiLineCommentTrivia]: Token<SyntaxKind.MultiLineCommentTrivia>,
+    [SyntaxKind.NewLineTrivia]: Token<SyntaxKind.NewLineTrivia>,
+    [SyntaxKind.WhitespaceTrivia]: Token<SyntaxKind.WhitespaceTrivia>,
+    [SyntaxKind.ShebangTrivia]: Token<SyntaxKind.ShebangTrivia>,
+    [SyntaxKind.ConflictMarkerTrivia]: Token<SyntaxKind.ConflictMarkerTrivia>,
+    [SyntaxKind.NonTextFileMarkerTrivia]: Token<SyntaxKind.NonTextFileMarkerTrivia>,
+    [SyntaxKind.NumericLiteral]: NumericLiteral,
+    [SyntaxKind.BigIntLiteral]: BigIntLiteral,
+    [SyntaxKind.StringLiteral]: StringLiteral,
+    [SyntaxKind.JsxText]: JsxText,
+    [SyntaxKind.JsxTextAllWhiteSpaces]: Token<SyntaxKind.JsxTextAllWhiteSpaces>,
+    [SyntaxKind.RegularExpressionLiteral]: RegularExpressionLiteral,
+    [SyntaxKind.NoSubstitutionTemplateLiteral]: NoSubstitutionTemplateLiteral,
+    [SyntaxKind.TemplateHead]: TemplateHead,
+    [SyntaxKind.TemplateMiddle]: TemplateMiddle,
+    [SyntaxKind.TemplateTail]: TemplateTail,
+    [SyntaxKind.OpenBraceToken]: Token<SyntaxKind.OpenBraceToken>,
+    [SyntaxKind.CloseBraceToken]: Token<SyntaxKind.CloseBraceToken>,
+    [SyntaxKind.OpenParenToken]: Token<SyntaxKind.OpenParenToken>,
+    [SyntaxKind.CloseParenToken]: Token<SyntaxKind.CloseParenToken>,
+    [SyntaxKind.OpenBracketToken]: Token<SyntaxKind.OpenBracketToken>,
+    [SyntaxKind.CloseBracketToken]: Token<SyntaxKind.CloseBracketToken>,
+    [SyntaxKind.DotToken]: DotToken,
+    [SyntaxKind.DotDotDotToken]: DotDotDotToken,
+    [SyntaxKind.SemicolonToken]: Token<SyntaxKind.SemicolonToken>,
+    [SyntaxKind.CommaToken]: Token<SyntaxKind.CommaToken>,
+    [SyntaxKind.QuestionDotToken]: QuestionDotToken,
+    [SyntaxKind.LessThanToken]: Token<SyntaxKind.LessThanToken>,
+    [SyntaxKind.LessThanSlashToken]: Token<SyntaxKind.LessThanSlashToken>,
+    [SyntaxKind.GreaterThanToken]: Token<SyntaxKind.GreaterThanToken>,
+    [SyntaxKind.LessThanEqualsToken]: Token<SyntaxKind.LessThanEqualsToken>,
+    [SyntaxKind.GreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanEqualsToken>,
+    [SyntaxKind.EqualsEqualsToken]: Token<SyntaxKind.EqualsEqualsToken>,
+    [SyntaxKind.ExclamationEqualsToken]: Token<SyntaxKind.ExclamationEqualsToken>,
+    [SyntaxKind.EqualsEqualsEqualsToken]: Token<SyntaxKind.EqualsEqualsEqualsToken>,
+    [SyntaxKind.ExclamationEqualsEqualsToken]: Token<SyntaxKind.ExclamationEqualsEqualsToken>,
+    [SyntaxKind.EqualsGreaterThanToken]: Token<SyntaxKind.EqualsGreaterThanToken>,
+    [SyntaxKind.PlusToken]: PlusToken,
+    [SyntaxKind.MinusToken]: MinusToken,
+    [SyntaxKind.AsteriskToken]: AsteriskToken,
+    [SyntaxKind.AsteriskAsteriskToken]: Token<SyntaxKind.AsteriskAsteriskToken>,
+    [SyntaxKind.SlashToken]: Token<SyntaxKind.SlashToken>,
+    [SyntaxKind.PercentToken]: Token<SyntaxKind.PercentToken>,
+    [SyntaxKind.PlusPlusToken]: Token<SyntaxKind.PlusPlusToken>,
+    [SyntaxKind.MinusMinusToken]: Token<SyntaxKind.MinusMinusToken>,
+    [SyntaxKind.LessThanLessThanToken]: Token<SyntaxKind.LessThanLessThanToken>,
+    [SyntaxKind.GreaterThanGreaterThanToken]: Token<SyntaxKind.GreaterThanGreaterThanToken>,
+    [SyntaxKind.GreaterThanGreaterThanGreaterThanToken]: Token<SyntaxKind.GreaterThanGreaterThanGreaterThanToken>,
+    [SyntaxKind.AmpersandToken]: Token<SyntaxKind.AmpersandToken>,
+    [SyntaxKind.BarToken]: Token<SyntaxKind.BarToken>,
+    [SyntaxKind.CaretToken]: Token<SyntaxKind.CaretToken>,
+    [SyntaxKind.ExclamationToken]: Token<SyntaxKind.ExclamationToken>,
+    [SyntaxKind.TildeToken]: Token<SyntaxKind.TildeToken>,
+    [SyntaxKind.AmpersandAmpersandToken]: Token<SyntaxKind.AmpersandAmpersandToken>,
+    [SyntaxKind.BarBarToken]: Token<SyntaxKind.BarBarToken>,
+    [SyntaxKind.QuestionToken]: QuestionToken,
+    [SyntaxKind.ColonToken]: ColonToken,
+    [SyntaxKind.AtToken]: Token<SyntaxKind.AtToken>,
+    [SyntaxKind.QuestionQuestionToken]: Token<SyntaxKind.QuestionQuestionToken>,
+    [SyntaxKind.BacktickToken]: Token<SyntaxKind.BacktickToken>,
+    [SyntaxKind.HashToken]: Token<SyntaxKind.HashToken>,
+    [SyntaxKind.EqualsToken]: EqualsToken,
+    [SyntaxKind.PlusEqualsToken]: Token<SyntaxKind.PlusEqualsToken>,
+    [SyntaxKind.MinusEqualsToken]: Token<SyntaxKind.MinusEqualsToken>,
+    [SyntaxKind.AsteriskEqualsToken]: Token<SyntaxKind.AsteriskEqualsToken>,
+    [SyntaxKind.AsteriskAsteriskEqualsToken]: Token<SyntaxKind.AsteriskAsteriskEqualsToken>,
+    [SyntaxKind.SlashEqualsToken]: Token<SyntaxKind.SlashEqualsToken>,
+    [SyntaxKind.PercentEqualsToken]: Token<SyntaxKind.PercentEqualsToken>,
+    [SyntaxKind.LessThanLessThanEqualsToken]: Token<SyntaxKind.LessThanLessThanEqualsToken>,
+    [SyntaxKind.GreaterThanGreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanGreaterThanEqualsToken>,
+    [SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken>,
+    [SyntaxKind.AmpersandEqualsToken]: Token<SyntaxKind.AmpersandEqualsToken>,
+    [SyntaxKind.BarEqualsToken]: Token<SyntaxKind.BarEqualsToken>,
+    [SyntaxKind.BarBarEqualsToken]: BarBarEqualsToken,
+    [SyntaxKind.AmpersandAmpersandEqualsToken]: AmpersandAmpersandEqualsToken,
+    [SyntaxKind.QuestionQuestionEqualsToken]: QuestionQuestionEqualsToken,
+    [SyntaxKind.CaretEqualsToken]: Token<SyntaxKind.CaretEqualsToken>,
+    [SyntaxKind.Identifier]: Identifier,
+    [SyntaxKind.PrivateIdentifier]: PrivateIdentifier,
+    /** @internal */[SyntaxKind.JSDocCommentTextToken]: Token<SyntaxKind.JSDocCommentTextToken>,
+    [SyntaxKind.BreakKeyword]: KeywordToken<SyntaxKind.BreakKeyword>,
+    [SyntaxKind.CaseKeyword]: KeywordToken<SyntaxKind.CaseKeyword>,
+    [SyntaxKind.CatchKeyword]: KeywordToken<SyntaxKind.CatchKeyword>,
+    [SyntaxKind.ClassKeyword]: KeywordToken<SyntaxKind.ClassKeyword>,
+    [SyntaxKind.ConstKeyword]: KeywordToken<SyntaxKind.ConstKeyword>,
+    [SyntaxKind.ContinueKeyword]: KeywordToken<SyntaxKind.ContinueKeyword>,
+    [SyntaxKind.DebuggerKeyword]: KeywordToken<SyntaxKind.DebuggerKeyword>,
+    [SyntaxKind.DefaultKeyword]: KeywordToken<SyntaxKind.DefaultKeyword>,
+    [SyntaxKind.DeleteKeyword]: KeywordToken<SyntaxKind.DeleteKeyword>,
+    [SyntaxKind.DoKeyword]: KeywordToken<SyntaxKind.DoKeyword>,
+    [SyntaxKind.ElseKeyword]: KeywordToken<SyntaxKind.ElseKeyword>,
+    [SyntaxKind.EnumKeyword]: KeywordToken<SyntaxKind.EnumKeyword>,
+    [SyntaxKind.ExportKeyword]: KeywordToken<SyntaxKind.ExportKeyword>,
+    [SyntaxKind.ExtendsKeyword]: KeywordToken<SyntaxKind.ExtendsKeyword>,
+    [SyntaxKind.FalseKeyword]: KeywordToken<SyntaxKind.FalseKeyword>,
+    [SyntaxKind.FinallyKeyword]: KeywordToken<SyntaxKind.FinallyKeyword>,
+    [SyntaxKind.ForKeyword]: KeywordToken<SyntaxKind.ForKeyword>,
+    [SyntaxKind.FunctionKeyword]: KeywordToken<SyntaxKind.FunctionKeyword>,
+    [SyntaxKind.IfKeyword]: KeywordToken<SyntaxKind.IfKeyword>,
+    [SyntaxKind.ImportKeyword]: KeywordToken<SyntaxKind.ImportKeyword>,
+    [SyntaxKind.InKeyword]: KeywordToken<SyntaxKind.InKeyword>,
+    [SyntaxKind.InstanceOfKeyword]: KeywordToken<SyntaxKind.InstanceOfKeyword>,
+    [SyntaxKind.NewKeyword]: KeywordToken<SyntaxKind.NewKeyword>,
+    [SyntaxKind.NullKeyword]: KeywordToken<SyntaxKind.NullKeyword>,
+    [SyntaxKind.ReturnKeyword]: KeywordToken<SyntaxKind.ReturnKeyword>,
+    [SyntaxKind.SuperKeyword]: KeywordToken<SyntaxKind.SuperKeyword>,
+    [SyntaxKind.SwitchKeyword]: KeywordToken<SyntaxKind.SwitchKeyword>,
+    [SyntaxKind.ThisKeyword]: KeywordToken<SyntaxKind.ThisKeyword>,
+    [SyntaxKind.ThrowKeyword]: KeywordToken<SyntaxKind.ThrowKeyword>,
+    [SyntaxKind.TrueKeyword]: KeywordToken<SyntaxKind.TrueKeyword>,
+    [SyntaxKind.TryKeyword]: KeywordToken<SyntaxKind.TryKeyword>,
+    [SyntaxKind.TypeOfKeyword]: KeywordToken<SyntaxKind.TypeOfKeyword>,
+    [SyntaxKind.VarKeyword]: KeywordToken<SyntaxKind.VarKeyword>,
+    [SyntaxKind.VoidKeyword]: KeywordToken<SyntaxKind.VoidKeyword>,
+    [SyntaxKind.WhileKeyword]: KeywordToken<SyntaxKind.WhileKeyword>,
+    [SyntaxKind.WithKeyword]: KeywordToken<SyntaxKind.WithKeyword>,
+    [SyntaxKind.ImplementsKeyword]: KeywordToken<SyntaxKind.ImplementsKeyword>,
+    [SyntaxKind.InterfaceKeyword]: KeywordToken<SyntaxKind.InterfaceKeyword>,
+    [SyntaxKind.LetKeyword]: KeywordToken<SyntaxKind.LetKeyword>,
+    [SyntaxKind.PackageKeyword]: KeywordToken<SyntaxKind.PackageKeyword>,
+    [SyntaxKind.PrivateKeyword]: KeywordToken<SyntaxKind.PrivateKeyword>,
+    [SyntaxKind.ProtectedKeyword]: KeywordToken<SyntaxKind.ProtectedKeyword>,
+    [SyntaxKind.PublicKeyword]: KeywordToken<SyntaxKind.PublicKeyword>,
+    [SyntaxKind.StaticKeyword]: KeywordToken<SyntaxKind.StaticKeyword>,
+    [SyntaxKind.YieldKeyword]: KeywordToken<SyntaxKind.YieldKeyword>,
+    [SyntaxKind.AbstractKeyword]: KeywordToken<SyntaxKind.AbstractKeyword>,
+    [SyntaxKind.AccessorKeyword]: KeywordToken<SyntaxKind.AccessorKeyword>,
+    [SyntaxKind.AsKeyword]: KeywordToken<SyntaxKind.AsKeyword>,
+    [SyntaxKind.AssertsKeyword]: KeywordToken<SyntaxKind.AssertsKeyword>,
+    [SyntaxKind.AssertKeyword]: KeywordToken<SyntaxKind.AssertKeyword>,
+    [SyntaxKind.AnyKeyword]: KeywordToken<SyntaxKind.AnyKeyword>,
+    [SyntaxKind.AsyncKeyword]: KeywordToken<SyntaxKind.AsyncKeyword>,
+    [SyntaxKind.AwaitKeyword]: KeywordToken<SyntaxKind.AwaitKeyword>,
+    [SyntaxKind.BooleanKeyword]: KeywordToken<SyntaxKind.BooleanKeyword>,
+    [SyntaxKind.ConstructorKeyword]: KeywordToken<SyntaxKind.ConstructorKeyword>,
+    [SyntaxKind.DeclareKeyword]: KeywordToken<SyntaxKind.DeclareKeyword>,
+    [SyntaxKind.GetKeyword]: KeywordToken<SyntaxKind.GetKeyword>,
+    [SyntaxKind.InferKeyword]: KeywordToken<SyntaxKind.InferKeyword>,
+    [SyntaxKind.IntrinsicKeyword]: KeywordToken<SyntaxKind.IntrinsicKeyword>,
+    [SyntaxKind.IsKeyword]: KeywordToken<SyntaxKind.IsKeyword>,
+    [SyntaxKind.KeyOfKeyword]: KeywordToken<SyntaxKind.KeyOfKeyword>,
+    [SyntaxKind.ModuleKeyword]: KeywordToken<SyntaxKind.ModuleKeyword>,
+    [SyntaxKind.NamespaceKeyword]: KeywordToken<SyntaxKind.NamespaceKeyword>,
+    [SyntaxKind.NeverKeyword]: KeywordToken<SyntaxKind.NeverKeyword>,
+    [SyntaxKind.OutKeyword]: KeywordToken<SyntaxKind.OutKeyword>,
+    [SyntaxKind.ReadonlyKeyword]: KeywordToken<SyntaxKind.ReadonlyKeyword>,
+    [SyntaxKind.RequireKeyword]: KeywordToken<SyntaxKind.RequireKeyword>,
+    [SyntaxKind.NumberKeyword]: KeywordToken<SyntaxKind.NumberKeyword>,
+    [SyntaxKind.ObjectKeyword]: KeywordToken<SyntaxKind.ObjectKeyword>,
+    [SyntaxKind.SatisfiesKeyword]: KeywordToken<SyntaxKind.SatisfiesKeyword>,
+    [SyntaxKind.SetKeyword]: KeywordToken<SyntaxKind.SetKeyword>,
+    [SyntaxKind.StringKeyword]: KeywordToken<SyntaxKind.StringKeyword>,
+    [SyntaxKind.SymbolKeyword]: KeywordToken<SyntaxKind.SymbolKeyword>,
+    [SyntaxKind.TypeKeyword]: KeywordToken<SyntaxKind.TypeKeyword>,
+    [SyntaxKind.UndefinedKeyword]: KeywordToken<SyntaxKind.UndefinedKeyword>,
+    [SyntaxKind.UniqueKeyword]: KeywordToken<SyntaxKind.UniqueKeyword>,
+    [SyntaxKind.UnknownKeyword]: KeywordToken<SyntaxKind.UnknownKeyword>,
+    [SyntaxKind.FromKeyword]: KeywordToken<SyntaxKind.FromKeyword>,
+    [SyntaxKind.GlobalKeyword]: KeywordToken<SyntaxKind.GlobalKeyword>,
+    [SyntaxKind.BigIntKeyword]: KeywordToken<SyntaxKind.BigIntKeyword>,
+    [SyntaxKind.OverrideKeyword]: KeywordToken<SyntaxKind.OverrideKeyword>,
+    [SyntaxKind.OfKeyword]: KeywordToken<SyntaxKind.OfKeyword>,
+    [SyntaxKind.QualifiedName]: QualifiedName,
+    [SyntaxKind.ComputedPropertyName]: ComputedPropertyName,
+    [SyntaxKind.TypeParameter]: TypeParameterDeclaration,
+    [SyntaxKind.Parameter]: ParameterDeclaration,
+    [SyntaxKind.Decorator]: Decorator,
+    [SyntaxKind.PropertySignature]: PropertySignature,
+    [SyntaxKind.PropertyDeclaration]: PropertyDeclaration,
+    [SyntaxKind.MethodSignature]: MethodSignature,
+    [SyntaxKind.MethodDeclaration]: MethodDeclaration,
+    [SyntaxKind.ClassStaticBlockDeclaration]: ClassStaticBlockDeclaration,
+    [SyntaxKind.Constructor]: ConstructorDeclaration,
+    [SyntaxKind.GetAccessor]: GetAccessorDeclaration,
+    [SyntaxKind.SetAccessor]: SetAccessorDeclaration,
+    [SyntaxKind.CallSignature]: CallSignatureDeclaration,
+    [SyntaxKind.ConstructSignature]: ConstructSignatureDeclaration,
+    [SyntaxKind.IndexSignature]: IndexSignatureDeclaration,
+    [SyntaxKind.TypePredicate]: TypePredicateNode,
+    [SyntaxKind.TypeReference]: TypeReferenceNode,
+    [SyntaxKind.FunctionType]: FunctionTypeNode,
+    [SyntaxKind.ConstructorType]: ConstructorTypeNode,
+    [SyntaxKind.TypeQuery]: TypeQueryNode,
+    [SyntaxKind.TypeLiteral]: TypeLiteralNode,
+    [SyntaxKind.ArrayType]: ArrayTypeNode,
+    [SyntaxKind.TupleType]: TupleTypeNode,
+    [SyntaxKind.OptionalType]: OptionalTypeNode,
+    [SyntaxKind.RestType]: RestTypeNode,
+    [SyntaxKind.UnionType]: UnionTypeNode,
+    [SyntaxKind.IntersectionType]: IntersectionTypeNode,
+    [SyntaxKind.ConditionalType]: ConditionalTypeNode,
+    [SyntaxKind.InferType]: InferTypeNode,
+    [SyntaxKind.ParenthesizedType]: ParenthesizedTypeNode,
+    [SyntaxKind.ThisType]: ThisTypeNode,
+    [SyntaxKind.TypeOperator]: TypeOperatorNode,
+    [SyntaxKind.IndexedAccessType]: IndexedAccessTypeNode,
+    [SyntaxKind.MappedType]: MappedTypeNode,
+    [SyntaxKind.LiteralType]: LiteralTypeNode,
+    [SyntaxKind.NamedTupleMember]: NamedTupleMember,
+    [SyntaxKind.TemplateLiteralType]: TemplateLiteralTypeNode,
+    [SyntaxKind.TemplateLiteralTypeSpan]: TemplateLiteralTypeSpan,
+    [SyntaxKind.ImportType]: ImportTypeNode,
+    [SyntaxKind.ObjectBindingPattern]: ObjectBindingPattern,
+    [SyntaxKind.ArrayBindingPattern]: ArrayBindingPattern,
+    [SyntaxKind.BindingElement]: BindingElement,
+    [SyntaxKind.ArrayLiteralExpression]: ArrayLiteralExpression,
+    [SyntaxKind.ObjectLiteralExpression]: ObjectLiteralExpression,
+    [SyntaxKind.PropertyAccessExpression]: PropertyAccessExpression,
+    [SyntaxKind.ElementAccessExpression]: ElementAccessExpression,
+    [SyntaxKind.CallExpression]: CallExpression,
+    [SyntaxKind.NewExpression]: NewExpression,
+    [SyntaxKind.TaggedTemplateExpression]: TaggedTemplateExpression,
+    [SyntaxKind.TypeAssertionExpression]: TypeAssertion,
+    [SyntaxKind.ParenthesizedExpression]: ParenthesizedExpression,
+    [SyntaxKind.FunctionExpression]: FunctionExpression,
+    [SyntaxKind.ArrowFunction]: ArrowFunction,
+    [SyntaxKind.DeleteExpression]: DeleteExpression,
+    [SyntaxKind.TypeOfExpression]: TypeOfExpression,
+    [SyntaxKind.VoidExpression]: VoidExpression,
+    [SyntaxKind.AwaitExpression]: AwaitExpression,
+    [SyntaxKind.PrefixUnaryExpression]: PrefixUnaryExpression,
+    [SyntaxKind.PostfixUnaryExpression]: PostfixUnaryExpression,
+    [SyntaxKind.BinaryExpression]: BinaryExpression,
+    [SyntaxKind.ConditionalExpression]: ConditionalExpression,
+    [SyntaxKind.TemplateExpression]: TemplateExpression,
+    [SyntaxKind.YieldExpression]: YieldExpression,
+    [SyntaxKind.SpreadElement]: SpreadElement,
+    [SyntaxKind.ClassExpression]: ClassExpression,
+    [SyntaxKind.OmittedExpression]: OmittedExpression,
+    [SyntaxKind.ExpressionWithTypeArguments]: ExpressionWithTypeArguments,
+    [SyntaxKind.AsExpression]: AsExpression,
+    [SyntaxKind.NonNullExpression]: NonNullExpression,
+    [SyntaxKind.MetaProperty]: MetaProperty,
+    [SyntaxKind.SyntheticExpression]: SyntheticExpression,
+    [SyntaxKind.SatisfiesExpression]: SatisfiesExpression,
+    [SyntaxKind.TemplateSpan]: TemplateSpan,
+    [SyntaxKind.SemicolonClassElement]: SemicolonClassElement,
+    [SyntaxKind.Block]: Block,
+    [SyntaxKind.EmptyStatement]: EmptyStatement,
+    [SyntaxKind.VariableStatement]: VariableStatement,
+    [SyntaxKind.ExpressionStatement]: ExpressionStatement,
+    [SyntaxKind.IfStatement]: IfStatement,
+    [SyntaxKind.DoStatement]: DoStatement,
+    [SyntaxKind.WhileStatement]: WhileStatement,
+    [SyntaxKind.ForStatement]: ForStatement,
+    [SyntaxKind.ForInStatement]: ForInStatement,
+    [SyntaxKind.ForOfStatement]: ForOfStatement,
+    [SyntaxKind.ContinueStatement]: ContinueStatement,
+    [SyntaxKind.BreakStatement]: BreakStatement,
+    [SyntaxKind.ReturnStatement]: ReturnStatement,
+    [SyntaxKind.WithStatement]: WithStatement,
+    [SyntaxKind.SwitchStatement]: SwitchStatement,
+    [SyntaxKind.LabeledStatement]: LabeledStatement,
+    [SyntaxKind.ThrowStatement]: ThrowStatement,
+    [SyntaxKind.TryStatement]: TryStatement,
+    [SyntaxKind.DebuggerStatement]: DebuggerStatement,
+    [SyntaxKind.VariableDeclaration]: VariableDeclaration,
+    [SyntaxKind.VariableDeclarationList]: VariableDeclarationList,
+    [SyntaxKind.FunctionDeclaration]: FunctionDeclaration,
+    [SyntaxKind.ClassDeclaration]: ClassDeclaration,
+    [SyntaxKind.InterfaceDeclaration]: InterfaceDeclaration,
+    [SyntaxKind.TypeAliasDeclaration]: TypeAliasDeclaration,
+    [SyntaxKind.EnumDeclaration]: EnumDeclaration,
+    [SyntaxKind.ModuleDeclaration]: ModuleDeclaration,
+    [SyntaxKind.ModuleBlock]: ModuleBlock,
+    [SyntaxKind.CaseBlock]: CaseBlock,
+    [SyntaxKind.NamespaceExportDeclaration]: NamespaceExportDeclaration,
+    [SyntaxKind.ImportEqualsDeclaration]: ImportEqualsDeclaration,
+    [SyntaxKind.ImportDeclaration]: ImportDeclaration,
+    [SyntaxKind.ImportClause]: ImportClause,
+    [SyntaxKind.NamespaceImport]: NamespaceImport,
+    [SyntaxKind.NamedImports]: NamedImports,
+    [SyntaxKind.ImportSpecifier]: ImportSpecifier,
+    [SyntaxKind.ExportAssignment]: ExportAssignment,
+    [SyntaxKind.ExportDeclaration]: ExportDeclaration,
+    [SyntaxKind.NamedExports]: NamedExports,
+    [SyntaxKind.NamespaceExport]: NamespaceExport,
+    [SyntaxKind.ExportSpecifier]: ExportSpecifier,
+    [SyntaxKind.MissingDeclaration]: MissingDeclaration,
+    [SyntaxKind.ExternalModuleReference]: ExternalModuleReference,
+    [SyntaxKind.JsxElement]: JsxElement,
+    [SyntaxKind.JsxSelfClosingElement]: JsxSelfClosingElement,
+    [SyntaxKind.JsxOpeningElement]: JsxOpeningElement,
+    [SyntaxKind.JsxClosingElement]: JsxClosingElement,
+    [SyntaxKind.JsxFragment]: JsxFragment,
+    [SyntaxKind.JsxOpeningFragment]: JsxOpeningFragment,
+    [SyntaxKind.JsxClosingFragment]: JsxClosingFragment,
+    [SyntaxKind.JsxAttribute]: JsxAttribute,
+    [SyntaxKind.JsxAttributes]: JsxAttributes,
+    [SyntaxKind.JsxSpreadAttribute]: JsxSpreadAttribute,
+    [SyntaxKind.JsxExpression]: JsxExpression,
+    [SyntaxKind.JsxNamespacedName]: JsxNamespacedName,
+    [SyntaxKind.CaseClause]: CaseClause,
+    [SyntaxKind.DefaultClause]: DefaultClause,
+    [SyntaxKind.HeritageClause]: HeritageClause,
+    [SyntaxKind.CatchClause]: CatchClause,
+    [SyntaxKind.AssertClause]: AssertClause,
+    [SyntaxKind.AssertEntry]: AssertEntry,
+    [SyntaxKind.ImportTypeAssertionContainer]: ImportTypeAssertionContainer,
+    [SyntaxKind.PropertyAssignment]: PropertyAssignment,
+    [SyntaxKind.ShorthandPropertyAssignment]: ShorthandPropertyAssignment,
+    [SyntaxKind.SpreadAssignment]: SpreadAssignment,
+    [SyntaxKind.EnumMember]: EnumMember,
+    /** @deprecated */ [SyntaxKind.UnparsedPrologue]: UnparsedPrologue,
+    /** @deprecated */ [SyntaxKind.UnparsedPrepend]: UnparsedPrepend,
+    /** @deprecated */ [SyntaxKind.UnparsedText]: UnparsedTextLike,
+    /** @deprecated */ [SyntaxKind.UnparsedInternalText]: UnparsedTextLike,
+    /** @deprecated */ [SyntaxKind.UnparsedSyntheticReference]: UnparsedSyntheticReference,
+    [SyntaxKind.SourceFile]: SourceFile,
+    [SyntaxKind.Bundle]: Bundle,
+    /** @deprecated */ [SyntaxKind.UnparsedSource]: UnparsedSource,
+    /** @deprecated */ [SyntaxKind.InputFiles]: InputFiles,
+    [SyntaxKind.JSDocTypeExpression]: JSDocTypeExpression,
+    [SyntaxKind.JSDocNameReference]: JSDocNameReference,
+    [SyntaxKind.JSDocMemberName]: JSDocMemberName,
+    [SyntaxKind.JSDocAllType]: JSDocAllType,
+    [SyntaxKind.JSDocUnknownType]: JSDocUnknownType,
+    [SyntaxKind.JSDocNullableType]: JSDocNullableType,
+    [SyntaxKind.JSDocNonNullableType]: JSDocNonNullableType,
+    [SyntaxKind.JSDocOptionalType]: JSDocOptionalType,
+    [SyntaxKind.JSDocFunctionType]: JSDocFunctionType,
+    [SyntaxKind.JSDocVariadicType]: JSDocVariadicType,
+    [SyntaxKind.JSDocNamepathType]: JSDocNamepathType,
+    [SyntaxKind.JSDoc]: JSDoc,
+    [SyntaxKind.JSDocText]: JSDocText,
+    [SyntaxKind.JSDocTypeLiteral]: JSDocTypeLiteral,
+    [SyntaxKind.JSDocSignature]: JSDocSignature,
+    [SyntaxKind.JSDocLink]: JSDocLink,
+    [SyntaxKind.JSDocLinkCode]: JSDocLinkCode,
+    [SyntaxKind.JSDocLinkPlain]: JSDocLinkPlain,
+    [SyntaxKind.JSDocTag]: JSDocUnknownTag,
+    [SyntaxKind.JSDocAugmentsTag]: JSDocAugmentsTag,
+    [SyntaxKind.JSDocImplementsTag]: JSDocImplementsTag,
+    [SyntaxKind.JSDocAuthorTag]: JSDocAuthorTag,
+    [SyntaxKind.JSDocDeprecatedTag]: JSDocDeprecatedTag,
+    [SyntaxKind.JSDocClassTag]: JSDocClassTag,
+    [SyntaxKind.JSDocPublicTag]: JSDocPublicTag,
+    [SyntaxKind.JSDocPrivateTag]: JSDocPrivateTag,
+    [SyntaxKind.JSDocProtectedTag]: JSDocProtectedTag,
+    [SyntaxKind.JSDocReadonlyTag]: JSDocReadonlyTag,
+    [SyntaxKind.JSDocOverrideTag]: JSDocOverrideTag,
+    [SyntaxKind.JSDocCallbackTag]: JSDocCallbackTag,
+    [SyntaxKind.JSDocOverloadTag]: JSDocOverloadTag,
+    [SyntaxKind.JSDocEnumTag]: JSDocEnumTag,
+    [SyntaxKind.JSDocParameterTag]: JSDocParameterTag,
+    [SyntaxKind.JSDocReturnTag]: JSDocReturnTag,
+    [SyntaxKind.JSDocThisTag]: JSDocThisTag,
+    [SyntaxKind.JSDocTypeTag]: JSDocTypeTag,
+    [SyntaxKind.JSDocTemplateTag]: JSDocTemplateTag,
+    [SyntaxKind.JSDocTypedefTag]: JSDocTypedefTag,
+    [SyntaxKind.JSDocSeeTag]: JSDocSeeTag,
+    [SyntaxKind.JSDocPropertyTag]: JSDocPropertyTag,
+    [SyntaxKind.JSDocThrowsTag]: JSDocThrowsTag,
+    [SyntaxKind.JSDocSatisfiesTag]: JSDocSatisfiesTag,
+    [SyntaxKind.SyntaxList]: SyntaxList,
+    [SyntaxKind.NotEmittedStatement]: NotEmittedStatement,
+    [SyntaxKind.PartiallyEmittedExpression]: PartiallyEmittedExpression,
+    [SyntaxKind.CommaListExpression]: CommaListExpression,
+    [SyntaxKind.SyntheticReferenceExpression]: SyntheticReferenceExpression,
+}
+
+export type Node = SyntaxKindToNode[keyof SyntaxKindToNode];
+
+type SyntaxKindLessCount<T extends SyntaxKind = SyntaxKind> = T extends SyntaxKind.Count ? never : T;
+type TestNodeKindIsExhaustive<T extends SyntaxKindLessCount = Node["kind"], U extends Node["kind"] = SyntaxKindLessCount> = [T, U] | 0;
+void (0 as TestNodeKindIsExhaustive);
+
+type TestKindIsNotSyntaxKind<T extends {readonly kind: SyntaxKind}> = SyntaxKind.Count extends T["kind"] ? T : never;
+// This noop cast will only type-check if the argument to TestKindIsNotSyntaxKind's `kind` member does _not_ contain `SyntaxKind.Count`
+// - since `Count` isn't a node type, but rather a marker, it should never be a node kind; so its' presence in the type indicates it has regressed to
+// the unspecific `SyntaxKind` type, rather than a union of exact members, which should be considered a bug in the types that should be fixed.
+void (0 as TestKindIsNotSyntaxKind<Node>);
+
+export type Declaration =
+    | Identifier
+    | NamedDeclaration
+    | TypeLiteralNode
+    | NamedTupleMember
+    | MappedTypeNode
+    | StringLiteral
+    | BinaryExpression
+    | NoSubstitutionTemplateLiteral
+    | NumericLiteral
+    | ObjectLiteralExpression
+    | ElementAccessExpression
+    | CallExpression
+    | NewExpression
+    | JsxAttributes
+    | JsxAttribute
+    | JSDocEnumTag
+    | JSDocSignature
+    | JSDocPropertyLikeTag
+    | JSDocTypeLiteral
+    | SourceFile
+    ;
+void (0 as TestKindIsNotSyntaxKind<Declaration>);
+
+export type NamedDeclaration =
+    | DeclarationStatement
+    | TypeParameterDeclaration
+    | SignatureDeclaration
+    | VariableDeclaration
+    | ParameterDeclaration
+    | BindingElement
+    | ObjectLiteralElement
+    | PropertyAccessExpression
+    | ClassDeclaration
+    | ClassExpression
+    | ClassElement
+    | TypeElement
+    | EnumMember
+    | ImportClause
+    | NamespaceImport
+    | NamespaceExport
+    | ImportSpecifier
+    | ExportSpecifier
+    | JSDocTypedefTag
+    | JSDocCallbackTag
+    ;
+void (0 as TestKindIsNotSyntaxKind<NamedDeclaration>);
+
+export type DeclarationStatement =
+    | FunctionDeclaration
+    | MissingDeclaration
+    | ClassDeclaration
+    | InterfaceDeclaration
+    | TypeAliasDeclaration
+    | EnumDeclaration
+    | ModuleDeclaration
+    | ImportEqualsDeclaration
+    | NamespaceExportDeclaration
+    | ExportDeclaration
+    | ExportAssignment
+    ;
+void (0 as TestKindIsNotSyntaxKind<DeclarationStatement>);
+
+export type Statement =
+    | DeclarationStatement
+    | NotEmittedStatement
+    | EmptyStatement
+    | DebuggerStatement
+    | Block
+    | VariableStatement
+    | ExpressionStatement
+    | IfStatement
+    | IterationStatement
+    | BreakStatement
+    | ContinueStatement
+    | ReturnStatement
+    | WithStatement
+    | SwitchStatement
+    | LabeledStatement
+    | ThrowStatement
+    | TryStatement
+    | ModuleBlock
+    | ImportDeclaration
+    ;
+void (0 as TestKindIsNotSyntaxKind<Statement>);
+
+export type IterationStatement =
+    | DoStatement
+    | WhileStatement
+    | ForStatement
+    | ForInStatement
+    | ForOfStatement
+    ;
+void (0 as TestKindIsNotSyntaxKind<IterationStatement>);
+
+export type TypeElement =
+    | CallSignatureDeclaration
+    | ConstructSignatureDeclaration
+    | PropertySignature
+    | MethodSignature
+    | GetAccessorDeclaration
+    | SetAccessorDeclaration
+    | IndexSignatureDeclaration
+    ;
+void (0 as TestKindIsNotSyntaxKind<TypeElement>);
+
+export type ClassElement =
+    | PropertyDeclaration
+    | MethodDeclaration
+    | ConstructorDeclaration
+    | SemicolonClassElement
+    | GetAccessorDeclaration
+    | SetAccessorDeclaration
+    | IndexSignatureDeclaration
+    | ClassStaticBlockDeclaration
+    ;
+void (0 as TestKindIsNotSyntaxKind<ClassElement>);
+
+export type ObjectLiteralElement =
+    | PropertyAssignment
+    | ShorthandPropertyAssignment
+    | SpreadAssignment
+    | MethodDeclaration
+    | GetAccessorDeclaration
+    | SetAccessorDeclaration
+    | JsxSpreadAttribute
+    ;
+void (0 as TestKindIsNotSyntaxKind<ObjectLiteralElement>);
+
+export type TypeNode =
+    | KeywordTypeNode
+    | ThisTypeNode
+    | FunctionTypeNode
+    | ConstructorTypeNode
+    | NodeWithTypeArguments
+    | TypePredicateNode
+    | TypeLiteralNode
+    | ArrayTypeNode
+    | TupleTypeNode
+    | NamedTupleMember
+    | OptionalTypeNode
+    | RestTypeNode
+    | UnionTypeNode
+    | IntersectionTypeNode
+    | ConditionalTypeNode
+    | InferTypeNode
+    | ParenthesizedTypeNode
+    | TypeOperatorNode
+    | IndexedAccessTypeNode
+    | MappedTypeNode
+    | LiteralTypeNode
+    | TemplateLiteralTypeNode
+    | TemplateLiteralTypeSpan
+    | JSDocTypeExpression
+    | JSDocType
+    ;
+void (0 as TestKindIsNotSyntaxKind<TypeNode>);
+
+export type JSDocType =
+    | JSDocAllType
+    | JSDocUnknownType
+    | JSDocNonNullableType
+    | JSDocNullableType
+    | JSDocOptionalType
+    | JSDocFunctionType
+    | JSDocVariadicType
+    | JSDocNamepathType
+    | JSDocSignature
+    | JSDocTypeLiteral
+    ;
+void (0 as TestKindIsNotSyntaxKind<JSDocType>);
+
+export type NodeWithTypeArguments =
+    | ImportTypeNode
+    | TypeReferenceNode
+    | TypeQueryNode
+    | ExpressionWithTypeArguments
+    ;
+void (0 as TestKindIsNotSyntaxKind<NodeWithTypeArguments>);
+
+export type JSDocTag =
+    | JSDocUnknownTag
+    | JSDocAugmentsTag
+    | JSDocImplementsTag
+    | JSDocAuthorTag
+    | JSDocDeprecatedTag
+    | JSDocClassTag
+    | JSDocPublicTag
+    | JSDocPrivateTag
+    | JSDocProtectedTag
+    | JSDocReadonlyTag
+    | JSDocOverrideTag
+    | JSDocOverloadTag
+    | JSDocEnumTag
+    | JSDocThisTag
+    | JSDocTemplateTag
+    | JSDocSeeTag
+    | JSDocReturnTag
+    | JSDocTypeTag
+    | JSDocTypedefTag
+    | JSDocCallbackTag
+    | JSDocThrowsTag
+    | JSDocPropertyLikeTag
+    | JSDocSatisfiesTag
+    ;
+void (0 as TestKindIsNotSyntaxKind<JSDocTag>);
+
+export type Expression =
+    | OmittedExpression
+    | UnaryExpression
+    | YieldExpression
+    | SyntheticExpression
+    | BinaryExpression
+    | ConditionalExpression
+    | ArrowFunction
+    | SpreadElement
+    | AsExpression
+    | SatisfiesExpression
+    | JsxOpeningElement
+    | JsxOpeningFragment
+    | JsxClosingFragment
+    | JsxExpression
+    | CommaListExpression
+    ;
+void (0 as TestKindIsNotSyntaxKind<Expression>);
+
+export type UnaryExpression =
+    | UpdateExpression
+    | DeleteExpression
+    | TypeOfExpression
+    | VoidExpression
+    | AwaitExpression
+    | TypeAssertion
+    ;
+void (0 as TestKindIsNotSyntaxKind<UnaryExpression>);
+
+export type UpdateExpression =
+    | PrefixUnaryExpression
+    | PostfixUnaryExpression
+    | LeftHandSideExpression
+    ;
+void (0 as TestKindIsNotSyntaxKind<UpdateExpression>);
+
+export type LeftHandSideExpression =
+    | PartiallyEmittedExpression
+    | MemberExpression
+    | CallExpression
+    | NonNullExpression
+    | SyntheticReferenceExpression
+    ;
+void (0 as TestKindIsNotSyntaxKind<LeftHandSideExpression>);
+
+export type MemberExpression =
+    | PrimaryExpression
+    | PropertyAccessExpression
+    | ElementAccessExpression
+    | ExpressionWithTypeArguments
+    | TaggedTemplateExpression
+    ;
+void (0 as TestKindIsNotSyntaxKind<MemberExpression>);
+
+export type PrimaryExpression =
+    | Identifier
+    | PrivateIdentifier
+    | NullLiteral
+    | TrueLiteral
+    | FalseLiteral
+    | ThisExpression
+    | SuperExpression
+    | ImportExpression
+    | FunctionExpression
+    | LiteralExpression
+    | TemplateExpression
+    | ParenthesizedExpression
+    | ArrayLiteralExpression
+    | ObjectLiteralExpression
+    | NewExpression
+    | MetaProperty
+    | JsxElement
+    | JsxAttributes
+    | JsxNamespacedName
+    | JsxSelfClosingElement
+    | JsxFragment
+    | MissingDeclaration
+    | ClassExpression
+    ;
+void (0 as TestKindIsNotSyntaxKind<PrimaryExpression>);
+
+export type LiteralExpression =
+    | StringLiteral
+    | RegularExpressionLiteral
+    | NoSubstitutionTemplateLiteral
+    | NumericLiteral
+    | BigIntLiteral
+    ;
+void (0 as TestKindIsNotSyntaxKind<LiteralExpression>);
+
+export type JSDocPropertyLikeTag =
+    | JSDocPropertyTag
+    | JSDocParameterTag
+    ;
+void (0 as TestKindIsNotSyntaxKind<JSDocPropertyLikeTag>);
+
+export type LiteralLikeNode =
+    | TemplateLiteralLikeNode
+    | LiteralExpression
+    | JsxText
+    ;
+void (0 as TestKindIsNotSyntaxKind<LiteralLikeNode>);
+
+export type TemplateLiteralLikeNode =
+    | NoSubstitutionTemplateLiteral
+    | TemplateHead
+    | TemplateMiddle
+    | TemplateTail
+    ;
+void (0 as TestKindIsNotSyntaxKind<TemplateLiteralLikeNode>);
+
 export const enum NodeFlags {
     None               = 0,
     Let                = 1 << 0,  // Variable declaration
@@ -908,7 +1603,7 @@ export const enum RelationComparisonResult {
 /** @internal */
 export type NodeId = number;
 
-export interface Node extends ReadonlyTextRange {
+export interface NodeBase extends ReadonlyTextRange {
     readonly kind: SyntaxKind;
     readonly flags: NodeFlags;
     /** @internal */ modifierFlagsCache: ModifierFlags;
@@ -923,7 +1618,7 @@ export interface Node extends ReadonlyTextRange {
     //       see: https://github.com/microsoft/TypeScript/pull/51682
 }
 
-export interface JSDocContainer extends Node {
+export interface JSDocContainer extends NodeBase {
     _jsdocContainerBrand: any;
     /** @internal */ jsDoc?: JSDocArray;                   // JSDoc that directly precedes this node
 }
@@ -933,13 +1628,13 @@ export interface JSDocArray extends Array<JSDoc> {
     jsDocCache?: readonly JSDocTag[];                      // Cache for getJSDocTags
 }
 
-export interface LocalsContainer extends Node {
+export interface LocalsContainer extends NodeBase {
     _localsContainerBrand: any;
     /** @internal */ locals?: SymbolTable;                 // Locals associated with node (initialized by binding)
     /** @internal */ nextContainer?: HasLocals;            // Next container in declaration order (initialized by binding)
 }
 
-export interface FlowContainer extends Node {
+export interface FlowContainer extends NodeBase {
     _flowContainerBrand: any;
     /** @internal */ flowNode?: FlowNode;                  // Associated FlowNode (initialized by binding)
 }
@@ -1232,6 +1927,7 @@ export type HasJSDoc =
     | WhileStatement
     | WithStatement
     ;
+void (0 as TestKindIsNotSyntaxKind<HasJSDoc>);
 
 export type HasType =
     | SignatureDeclaration
@@ -1251,6 +1947,7 @@ export type HasType =
     | JSDocOptionalType
     | JSDocVariadicType
     ;
+void (0 as TestKindIsNotSyntaxKind<HasType>);
 
 // NOTE: Changing the following list requires changes to:
 // - `canHaveIllegalType` in factory/utilities.ts
@@ -1573,7 +2270,7 @@ export interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTex
 }
 
 // TODO(rbuckton): Constraint 'TKind' to 'TokenSyntaxKind'
-export interface Token<TKind extends SyntaxKind> extends Node {
+export interface Token<TKind extends SyntaxKind> extends NodeBase {
     readonly kind: TKind;
 }
 
@@ -1682,7 +2379,7 @@ export const enum GeneratedIdentifierFlags {
     AllowNameSubstitution = 1 << 6, // Used by `module.ts` to indicate generated nodes which can have substitutions performed upon them (as they were generated by an earlier transform phase)
 }
 
-export interface Identifier extends PrimaryExpression, Declaration, JSDocContainer, FlowContainer {
+export interface Identifier extends PrimaryExpressionBase, DeclarationBase, JSDocContainer, FlowContainer {
     readonly kind: SyntaxKind.Identifier;
     /**
      * Prefer to use `id.unescapedText`. (Note: This is available only in services, not internally to the TypeScript compiler.)
@@ -1709,7 +2406,7 @@ export interface GeneratedIdentifier extends Identifier {
     readonly emitNode: EmitNode & { autoGenerate: AutoGenerateInfo; };
 }
 
-export interface QualifiedName extends Node, FlowContainer {
+export interface QualifiedName extends NodeBase, FlowContainer {
     readonly kind: SyntaxKind.QualifiedName;
     readonly left: EntityName;
     readonly right: Identifier;
@@ -1731,20 +2428,22 @@ export type DeclarationName =
     | BindingPattern
     | EntityNameExpression;
 
-export interface Declaration extends Node {
+export interface DeclarationBase extends NodeBase {
     _declarationBrand: any;
     /** @internal */ symbol: Symbol;                       // Symbol declared by node (initialized by binding)
     /** @internal */ localSymbol?: Symbol;                 // Local symbol declared by node (initialized by binding only for exported nodes)
 }
 
-export interface NamedDeclaration extends Declaration {
+export interface NamedDeclarationBase extends DeclarationBase {
     readonly name?: DeclarationName;
 }
 
 /** @internal */
-export interface DynamicNamedDeclaration extends NamedDeclaration {
+export interface DynamicNamedDeclarationBase extends NamedDeclarationBase {
     readonly name: ComputedPropertyName;
 }
+/** @internal */
+export type DynamicNamedDeclaration = NamedDeclaration & DynamicNamedDeclarationBase;
 
 /** @internal */
 export interface DynamicNamedBinaryExpression extends BinaryExpression {
@@ -1753,9 +2452,11 @@ export interface DynamicNamedBinaryExpression extends BinaryExpression {
 
 /** @internal */
 // A declaration that supports late-binding (used in checker)
-export interface LateBoundDeclaration extends DynamicNamedDeclaration {
+export interface LateBoundDeclarationBase extends DynamicNamedDeclarationBase {
     readonly name: LateBoundName;
 }
+/** @internal */
+export type LateBoundDeclaration = DynamicNamedDeclaration & LateBoundDeclarationBase;
 
 /** @internal */
 export interface LateBoundBinaryExpressionDeclaration extends DynamicNamedBinaryExpression {
@@ -1767,18 +2468,18 @@ export interface LateBoundElementAccessExpression extends ElementAccessExpressio
     readonly argumentExpression: EntityNameExpression;
 }
 
-export interface DeclarationStatement extends NamedDeclaration, Statement {
+export interface DeclarationStatementBase extends NamedDeclarationBase, StatementBase {
     readonly name?: Identifier | StringLiteral | NumericLiteral;
 }
 
-export interface ComputedPropertyName extends Node {
+export interface ComputedPropertyName extends NodeBase {
     readonly kind: SyntaxKind.ComputedPropertyName;
     readonly parent: Declaration;
     readonly expression: Expression;
 }
 
 // Typed as a PrimaryExpression due to its presence in BinaryExpressions (#field in expr)
-export interface PrivateIdentifier extends PrimaryExpression {
+export interface PrivateIdentifier extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.PrivateIdentifier;
     // escaping not strictly necessary
     // avoids gotchas in transforms and utils
@@ -1796,15 +2497,15 @@ export interface LateBoundName extends ComputedPropertyName {
     readonly expression: EntityNameExpression;
 }
 
-export interface Decorator extends Node {
+export interface Decorator extends NodeBase {
     readonly kind: SyntaxKind.Decorator;
     readonly parent: NamedDeclaration;
     readonly expression: LeftHandSideExpression;
 }
 
-export interface TypeParameterDeclaration extends NamedDeclaration, JSDocContainer {
+export interface TypeParameterDeclaration extends NamedDeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.TypeParameter;
-    readonly parent: DeclarationWithTypeParameterChildren | InferTypeNode;
+    readonly parent: DeclarationWithTypeParameterChildren | InferTypeNode | MappedTypeNode;
     readonly modifiers?: NodeArray<Modifier>;
     readonly name: Identifier;
     /** Note: Consider calling `getEffectiveConstraintOfTypeParameter` */
@@ -1815,7 +2516,7 @@ export interface TypeParameterDeclaration extends NamedDeclaration, JSDocContain
     expression?: Expression;
 }
 
-export interface SignatureDeclarationBase extends NamedDeclaration, JSDocContainer {
+export interface SignatureDeclarationBase extends NamedDeclarationBase, JSDocContainer {
     readonly kind: SignatureDeclaration["kind"];
     readonly name?: PropertyName;
     readonly typeParameters?: NodeArray<TypeParameterDeclaration> | undefined;
@@ -1839,17 +2540,17 @@ export type SignatureDeclaration =
     | FunctionExpression
     | ArrowFunction;
 
-export interface CallSignatureDeclaration extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+export interface CallSignatureDeclaration extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
     readonly kind: SyntaxKind.CallSignature;
 }
 
-export interface ConstructSignatureDeclaration extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+export interface ConstructSignatureDeclaration extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
     readonly kind: SyntaxKind.ConstructSignature;
 }
 
 export type BindingName = Identifier | BindingPattern;
 
-export interface VariableDeclaration extends NamedDeclaration, JSDocContainer {
+export interface VariableDeclaration extends NamedDeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.VariableDeclaration;
     readonly parent: VariableDeclarationList | CatchClause;
     readonly name: BindingName;                    // Declared variable name
@@ -1861,13 +2562,13 @@ export interface VariableDeclaration extends NamedDeclaration, JSDocContainer {
 /** @internal */
 export type InitializedVariableDeclaration = VariableDeclaration & { readonly initializer: Expression };
 
-export interface VariableDeclarationList extends Node {
+export interface VariableDeclarationList extends NodeBase {
     readonly kind: SyntaxKind.VariableDeclarationList;
     readonly parent: VariableStatement | ForStatement | ForOfStatement | ForInStatement;
     readonly declarations: NodeArray<VariableDeclaration>;
 }
 
-export interface ParameterDeclaration extends NamedDeclaration, JSDocContainer {
+export interface ParameterDeclaration extends NamedDeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.Parameter;
     readonly parent: SignatureDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -1878,7 +2579,7 @@ export interface ParameterDeclaration extends NamedDeclaration, JSDocContainer {
     readonly initializer?: Expression;           // Optional initializer
 }
 
-export interface BindingElement extends NamedDeclaration, FlowContainer {
+export interface BindingElement extends NamedDeclarationBase, FlowContainer {
     readonly kind: SyntaxKind.BindingElement;
     readonly parent: BindingPattern;
     readonly propertyName?: PropertyName;        // Binding property name (in object binding pattern)
@@ -1890,7 +2591,7 @@ export interface BindingElement extends NamedDeclaration, FlowContainer {
 /** @internal */
 export type BindingElementGrandparent = BindingElement["parent"]["parent"];
 
-export interface PropertySignature extends TypeElement, JSDocContainer {
+export interface PropertySignature extends TypeElementBase, JSDocContainer {
     readonly kind: SyntaxKind.PropertySignature;
     readonly parent: TypeLiteralNode | InterfaceDeclaration;
     readonly modifiers?: NodeArray<Modifier>;
@@ -1902,7 +2603,7 @@ export interface PropertySignature extends TypeElement, JSDocContainer {
     /** @internal */ readonly initializer?: Expression | undefined; // A property signature cannot have an initializer
 }
 
-export interface PropertyDeclaration extends ClassElement, JSDocContainer {
+export interface PropertyDeclaration extends ClassElementBase, JSDocContainer {
     readonly kind: SyntaxKind.PropertyDeclaration;
     readonly parent: ClassLikeDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -1950,7 +2651,7 @@ export type PrivateClassElementDeclaration =
 /** @internal */
 export type InitializedPropertyDeclaration = PropertyDeclaration & { readonly initializer: Expression };
 
-export interface ObjectLiteralElement extends NamedDeclaration {
+export interface ObjectLiteralElementBase extends NamedDeclarationBase {
     _objectLiteralBrand: any;
     readonly name?: PropertyName;
 }
@@ -1964,7 +2665,7 @@ export type ObjectLiteralElementLike
     | AccessorDeclaration
     ;
 
-export interface PropertyAssignment extends ObjectLiteralElement, JSDocContainer {
+export interface PropertyAssignment extends ObjectLiteralElementBase, JSDocContainer {
     readonly kind: SyntaxKind.PropertyAssignment;
     readonly parent: ObjectLiteralExpression;
     readonly name: PropertyName;
@@ -1976,7 +2677,7 @@ export interface PropertyAssignment extends ObjectLiteralElement, JSDocContainer
     /** @internal */ readonly exclamationToken?: ExclamationToken | undefined; // property assignment cannot have an exclamation token
 }
 
-export interface ShorthandPropertyAssignment extends ObjectLiteralElement, JSDocContainer {
+export interface ShorthandPropertyAssignment extends ObjectLiteralElementBase, JSDocContainer {
     readonly kind: SyntaxKind.ShorthandPropertyAssignment;
     readonly parent: ObjectLiteralExpression;
     readonly name: Identifier;
@@ -1991,7 +2692,7 @@ export interface ShorthandPropertyAssignment extends ObjectLiteralElement, JSDoc
     /** @internal */ readonly exclamationToken?: ExclamationToken | undefined; // shorthand property assignment cannot have an exclamation token
 }
 
-export interface SpreadAssignment extends ObjectLiteralElement, JSDocContainer {
+export interface SpreadAssignment extends ObjectLiteralElementBase, JSDocContainer {
     readonly kind: SyntaxKind.SpreadAssignment;
     readonly parent: ObjectLiteralExpression;
     readonly expression: Expression;
@@ -2010,13 +2711,13 @@ export type VariableLikeDeclaration =
     | JSDocPropertyTag
     | JSDocParameterTag;
 
-export interface ObjectBindingPattern extends Node {
+export interface ObjectBindingPattern extends NodeBase {
     readonly kind: SyntaxKind.ObjectBindingPattern;
     readonly parent: VariableDeclaration | ParameterDeclaration | BindingElement;
     readonly elements: NodeArray<BindingElement>;
 }
 
-export interface ArrayBindingPattern extends Node {
+export interface ArrayBindingPattern extends NodeBase {
     readonly kind: SyntaxKind.ArrayBindingPattern;
     readonly parent: VariableDeclaration | ParameterDeclaration | BindingElement;
     readonly elements: NodeArray<ArrayBindingElement>;
@@ -2056,14 +2757,14 @@ export type FunctionLikeDeclaration =
 /** @deprecated Use SignatureDeclaration */
 export type FunctionLike = SignatureDeclaration;
 
-export interface FunctionDeclaration extends FunctionLikeDeclarationBase, DeclarationStatement, LocalsContainer {
+export interface FunctionDeclaration extends FunctionLikeDeclarationBase, DeclarationStatementBase, LocalsContainer {
     readonly kind: SyntaxKind.FunctionDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
     readonly name?: Identifier;
     readonly body?: FunctionBody;
 }
 
-export interface MethodSignature extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+export interface MethodSignature extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
     readonly kind: SyntaxKind.MethodSignature;
     readonly parent: TypeLiteralNode | InterfaceDeclaration;
     readonly modifiers?: NodeArray<Modifier>;
@@ -2079,7 +2780,7 @@ export interface MethodSignature extends SignatureDeclarationBase, TypeElement, 
 // Because of this, it may be necessary to determine what sort of MethodDeclaration you have
 // at later stages of the compiler pipeline.  In that case, you can either check the parent kind
 // of the method, or use helpers like isObjectLiteralMethodDeclaration
-export interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+export interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.MethodDeclaration;
     readonly parent: ClassLikeDeclaration | ObjectLiteralExpression;
     readonly modifiers?: NodeArray<ModifierLike> | undefined;
@@ -2090,7 +2791,7 @@ export interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassEle
     /** @internal */ readonly exclamationToken?: ExclamationToken | undefined; // A method cannot have an exclamation token
 }
 
-export interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElement, JSDocContainer, LocalsContainer {
+export interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, JSDocContainer, LocalsContainer {
     readonly kind: SyntaxKind.Constructor;
     readonly parent: ClassLikeDeclaration;
     readonly modifiers?: NodeArray<ModifierLike> | undefined;
@@ -2102,14 +2803,14 @@ export interface ConstructorDeclaration extends FunctionLikeDeclarationBase, Cla
 }
 
 /** For when we encounter a semicolon in a class declaration. ES6 allows these as class elements. */
-export interface SemicolonClassElement extends ClassElement, JSDocContainer {
+export interface SemicolonClassElement extends ClassElementBase, JSDocContainer {
     readonly kind: SyntaxKind.SemicolonClassElement;
     readonly parent: ClassLikeDeclaration;
 }
 
 // See the comment on MethodDeclaration for the intuition behind GetAccessorDeclaration being a
 // ClassElement and an ObjectLiteralElement.
-export interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, TypeElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+export interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, TypeElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.GetAccessor;
     readonly parent: ClassLikeDeclaration | ObjectLiteralExpression | TypeLiteralNode | InterfaceDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -2122,7 +2823,7 @@ export interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, Cla
 
 // See the comment on MethodDeclaration for the intuition behind SetAccessorDeclaration being a
 // ClassElement and an ObjectLiteralElement.
-export interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, TypeElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+export interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, TypeElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.SetAccessor;
     readonly parent: ClassLikeDeclaration | ObjectLiteralExpression | TypeLiteralNode | InterfaceDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -2136,14 +2837,14 @@ export interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, Cla
 
 export type AccessorDeclaration = GetAccessorDeclaration | SetAccessorDeclaration;
 
-export interface IndexSignatureDeclaration extends SignatureDeclarationBase, ClassElement, TypeElement, LocalsContainer {
+export interface IndexSignatureDeclaration extends SignatureDeclarationBase, ClassElementBase, TypeElementBase, LocalsContainer {
     readonly kind: SyntaxKind.IndexSignature;
     readonly parent: ObjectTypeDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
     readonly type: TypeNode;
 }
 
-export interface ClassStaticBlockDeclaration extends ClassElement, JSDocContainer, LocalsContainer {
+export interface ClassStaticBlockDeclaration extends ClassElementBase, JSDocContainer, LocalsContainer {
     readonly kind: SyntaxKind.ClassStaticBlockDeclaration;
     readonly parent: ClassDeclaration | ClassExpression;
     readonly body: Block;
@@ -2155,27 +2856,27 @@ export interface ClassStaticBlockDeclaration extends ClassElement, JSDocContaine
     /** @internal */ readonly modifiers?: NodeArray<ModifierLike> | undefined;
 }
 
-export interface TypeNode extends Node {
+export interface TypeNodeBase extends NodeBase {
     _typeNodeBrand: any;
 }
 
 /** @internal */
-export interface TypeNode extends Node {
+export interface TypeNodeBase extends NodeBase {
     readonly kind: TypeNodeSyntaxKind;
 }
 
-export interface KeywordTypeNode<TKind extends KeywordTypeSyntaxKind = KeywordTypeSyntaxKind> extends KeywordToken<TKind>, TypeNode {
+export interface KeywordTypeNode<TKind extends KeywordTypeSyntaxKind = KeywordTypeSyntaxKind> extends KeywordToken<TKind>, TypeNodeBase {
     readonly kind: TKind;
 }
 
-export interface ImportTypeAssertionContainer extends Node {
+export interface ImportTypeAssertionContainer extends NodeBase {
     readonly kind: SyntaxKind.ImportTypeAssertionContainer;
     readonly parent: ImportTypeNode;
     readonly assertClause: AssertClause;
     readonly multiLine?: boolean;
 }
 
-export interface ImportTypeNode extends NodeWithTypeArguments {
+export interface ImportTypeNode extends NodeWithTypeArgumentsBase {
     readonly kind: SyntaxKind.ImportType;
     readonly isTypeOf: boolean;
     readonly argument: TypeNode;
@@ -2186,13 +2887,13 @@ export interface ImportTypeNode extends NodeWithTypeArguments {
 /** @internal */
 export type LiteralImportTypeNode = ImportTypeNode & { readonly argument: LiteralTypeNode & { readonly literal: StringLiteral } };
 
-export interface ThisTypeNode extends TypeNode {
+export interface ThisTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.ThisType;
 }
 
 export type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode;
 
-export interface FunctionOrConstructorTypeNodeBase extends TypeNode, SignatureDeclarationBase {
+export interface FunctionOrConstructorTypeNodeBase extends TypeNodeBase, SignatureDeclarationBase {
     readonly kind: SyntaxKind.FunctionType | SyntaxKind.ConstructorType;
     readonly type: TypeNode;
 }
@@ -2209,18 +2910,18 @@ export interface ConstructorTypeNode extends FunctionOrConstructorTypeNodeBase, 
     readonly modifiers?: NodeArray<Modifier>;
 }
 
-export interface NodeWithTypeArguments extends TypeNode {
+export interface NodeWithTypeArgumentsBase extends TypeNodeBase {
     readonly typeArguments?: NodeArray<TypeNode>;
 }
 
 export type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
 
-export interface TypeReferenceNode extends NodeWithTypeArguments {
+export interface TypeReferenceNode extends NodeWithTypeArgumentsBase {
     readonly kind: SyntaxKind.TypeReference;
     readonly typeName: EntityName;
 }
 
-export interface TypePredicateNode extends TypeNode {
+export interface TypePredicateNode extends TypeNodeBase {
     readonly kind: SyntaxKind.TypePredicate;
     readonly parent: SignatureDeclaration | JSDocTypeExpression;
     readonly assertsModifier?: AssertsKeyword;
@@ -2228,28 +2929,28 @@ export interface TypePredicateNode extends TypeNode {
     readonly type?: TypeNode;
 }
 
-export interface TypeQueryNode extends NodeWithTypeArguments {
+export interface TypeQueryNode extends NodeWithTypeArgumentsBase {
     readonly kind: SyntaxKind.TypeQuery;
     readonly exprName: EntityName;
 }
 
 // A TypeLiteral is the declaration node for an anonymous symbol.
-export interface TypeLiteralNode extends TypeNode, Declaration {
+export interface TypeLiteralNode extends TypeNodeBase, DeclarationBase {
     readonly kind: SyntaxKind.TypeLiteral;
     readonly members: NodeArray<TypeElement>;
 }
 
-export interface ArrayTypeNode extends TypeNode {
+export interface ArrayTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.ArrayType;
     readonly elementType: TypeNode;
 }
 
-export interface TupleTypeNode extends TypeNode {
+export interface TupleTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.TupleType;
     readonly elements: NodeArray<TypeNode | NamedTupleMember>;
 }
 
-export interface NamedTupleMember extends TypeNode, Declaration, JSDocContainer {
+export interface NamedTupleMember extends TypeNodeBase, DeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.NamedTupleMember;
     readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
     readonly name: Identifier;
@@ -2257,29 +2958,29 @@ export interface NamedTupleMember extends TypeNode, Declaration, JSDocContainer 
     readonly type: TypeNode;
 }
 
-export interface OptionalTypeNode extends TypeNode {
+export interface OptionalTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.OptionalType;
     readonly type: TypeNode;
 }
 
-export interface RestTypeNode extends TypeNode {
+export interface RestTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.RestType;
     readonly type: TypeNode;
 }
 
 export type UnionOrIntersectionTypeNode = UnionTypeNode | IntersectionTypeNode;
 
-export interface UnionTypeNode extends TypeNode {
+export interface UnionTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.UnionType;
     readonly types: NodeArray<TypeNode>;
 }
 
-export interface IntersectionTypeNode extends TypeNode {
+export interface IntersectionTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.IntersectionType;
     readonly types: NodeArray<TypeNode>;
 }
 
-export interface ConditionalTypeNode extends TypeNode, LocalsContainer {
+export interface ConditionalTypeNode extends TypeNodeBase, LocalsContainer {
     readonly kind: SyntaxKind.ConditionalType;
     readonly checkType: TypeNode;
     readonly extendsType: TypeNode;
@@ -2287,17 +2988,17 @@ export interface ConditionalTypeNode extends TypeNode, LocalsContainer {
     readonly falseType: TypeNode;
 }
 
-export interface InferTypeNode extends TypeNode {
+export interface InferTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.InferType;
     readonly typeParameter: TypeParameterDeclaration;
 }
 
-export interface ParenthesizedTypeNode extends TypeNode {
+export interface ParenthesizedTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.ParenthesizedType;
     readonly type: TypeNode;
 }
 
-export interface TypeOperatorNode extends TypeNode {
+export interface TypeOperatorNode extends TypeNodeBase {
     readonly kind: SyntaxKind.TypeOperator;
     readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword;
     readonly type: TypeNode;
@@ -2308,13 +3009,13 @@ export interface UniqueTypeOperatorNode extends TypeOperatorNode {
     readonly operator: SyntaxKind.UniqueKeyword;
 }
 
-export interface IndexedAccessTypeNode extends TypeNode {
+export interface IndexedAccessTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.IndexedAccessType;
     readonly objectType: TypeNode;
     readonly indexType: TypeNode;
 }
 
-export interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer {
+export interface MappedTypeNode extends TypeNodeBase, DeclarationBase, LocalsContainer {
     readonly kind: SyntaxKind.MappedType;
     readonly readonlyToken?: ReadonlyKeyword | PlusToken | MinusToken;
     readonly typeParameter: TypeParameterDeclaration;
@@ -2325,12 +3026,12 @@ export interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer {
     readonly members?: NodeArray<TypeElement>;
 }
 
-export interface LiteralTypeNode extends TypeNode {
+export interface LiteralTypeNode extends TypeNodeBase {
     readonly kind: SyntaxKind.LiteralType;
     readonly literal: NullLiteral | BooleanLiteral | LiteralExpression | PrefixUnaryExpression;
 }
 
-export interface StringLiteral extends LiteralExpression, Declaration {
+export interface StringLiteral extends LiteralExpressionBase, DeclarationBase {
     readonly kind: SyntaxKind.StringLiteral;
     /** @internal */ readonly textSourceNode?: Identifier | StringLiteralLike | NumericLiteral | PrivateIdentifier; // Allows a StringLiteral to get its text from another node (used by transforms).
     /**
@@ -2344,13 +3045,13 @@ export interface StringLiteral extends LiteralExpression, Declaration {
 export type StringLiteralLike = StringLiteral | NoSubstitutionTemplateLiteral;
 export type PropertyNameLiteral = Identifier | StringLiteralLike | NumericLiteral;
 
-export interface TemplateLiteralTypeNode extends TypeNode {
+export interface TemplateLiteralTypeNode extends TypeNodeBase {
     kind: SyntaxKind.TemplateLiteralType,
     readonly head: TemplateHead;
     readonly templateSpans: NodeArray<TemplateLiteralTypeSpan>;
 }
 
-export interface TemplateLiteralTypeSpan extends TypeNode {
+export interface TemplateLiteralTypeSpan extends TypeNodeBase {
     readonly kind: SyntaxKind.TemplateLiteralTypeSpan,
     readonly parent: TemplateLiteralTypeNode;
     readonly type: TypeNode;
@@ -2364,28 +3065,28 @@ export interface TemplateLiteralTypeSpan extends TypeNode {
 // checker actually thinks you have something of the right type.  Note: the brands are
 // never actually given values.  At runtime they have zero cost.
 
-export interface Expression extends Node {
+export interface ExpressionBase extends NodeBase {
     _expressionBrand: any;
 }
 
-export interface OmittedExpression extends Expression {
+export interface OmittedExpression extends ExpressionBase {
     readonly kind: SyntaxKind.OmittedExpression;
 }
 
 // Represents an expression that is elided as part of a transformation to emit comments on a
 // not-emitted node. The 'expression' property of a PartiallyEmittedExpression should be emitted.
-export interface PartiallyEmittedExpression extends LeftHandSideExpression {
+export interface PartiallyEmittedExpression extends LeftHandSideExpressionBase {
     readonly kind: SyntaxKind.PartiallyEmittedExpression;
     readonly expression: Expression;
 }
 
-export interface UnaryExpression extends Expression {
+export interface UnaryExpressionBase extends ExpressionBase {
     _unaryExpressionBrand: any;
 }
 
 /** Deprecated, please use UpdateExpression */
 export type IncrementExpression = UpdateExpression;
-export interface UpdateExpression extends UnaryExpression {
+export interface UpdateExpressionBase extends UnaryExpressionBase {
     _updateExpressionBrand: any;
 }
 
@@ -2399,7 +3100,7 @@ export type PrefixUnaryOperator
     | SyntaxKind.TildeToken
     | SyntaxKind.ExclamationToken;
 
-export interface PrefixUnaryExpression extends UpdateExpression {
+export interface PrefixUnaryExpression extends UpdateExpressionBase {
     readonly kind: SyntaxKind.PrefixUnaryExpression;
     readonly operator: PrefixUnaryOperator;
     readonly operand: UnaryExpression;
@@ -2411,77 +3112,77 @@ export type PostfixUnaryOperator
     | SyntaxKind.MinusMinusToken
     ;
 
-export interface PostfixUnaryExpression extends UpdateExpression {
+export interface PostfixUnaryExpression extends UpdateExpressionBase {
     readonly kind: SyntaxKind.PostfixUnaryExpression;
     readonly operand: LeftHandSideExpression;
     readonly operator: PostfixUnaryOperator;
 }
 
-export interface LeftHandSideExpression extends UpdateExpression {
+export interface LeftHandSideExpressionBase extends UpdateExpressionBase {
     _leftHandSideExpressionBrand: any;
 }
 
-export interface MemberExpression extends LeftHandSideExpression {
+export interface MemberExpressionBase extends LeftHandSideExpressionBase {
     _memberExpressionBrand: any;
 }
 
-export interface PrimaryExpression extends MemberExpression {
+export interface PrimaryExpressionBase extends MemberExpressionBase {
     _primaryExpressionBrand: any;
 }
 
-export interface NullLiteral extends PrimaryExpression {
+export interface NullLiteral extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.NullKeyword;
 }
 
-export interface TrueLiteral extends PrimaryExpression {
+export interface TrueLiteral extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.TrueKeyword;
 }
 
-export interface FalseLiteral extends PrimaryExpression {
+export interface FalseLiteral extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.FalseKeyword;
 }
 
 export type BooleanLiteral = TrueLiteral | FalseLiteral;
 
-export interface ThisExpression extends PrimaryExpression, FlowContainer {
+export interface ThisExpression extends PrimaryExpressionBase, FlowContainer {
     readonly kind: SyntaxKind.ThisKeyword;
 }
 
-export interface SuperExpression extends PrimaryExpression, FlowContainer {
+export interface SuperExpression extends PrimaryExpressionBase, FlowContainer {
     readonly kind: SyntaxKind.SuperKeyword;
 }
 
-export interface ImportExpression extends PrimaryExpression {
+export interface ImportExpression extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.ImportKeyword;
 }
 
-export interface DeleteExpression extends UnaryExpression {
+export interface DeleteExpression extends UnaryExpressionBase {
     readonly kind: SyntaxKind.DeleteExpression;
     readonly expression: UnaryExpression;
 }
 
-export interface TypeOfExpression extends UnaryExpression {
+export interface TypeOfExpression extends UnaryExpressionBase {
     readonly kind: SyntaxKind.TypeOfExpression;
     readonly expression: UnaryExpression;
 }
 
-export interface VoidExpression extends UnaryExpression {
+export interface VoidExpression extends UnaryExpressionBase {
     readonly kind: SyntaxKind.VoidExpression;
     readonly expression: UnaryExpression;
 }
 
-export interface AwaitExpression extends UnaryExpression {
+export interface AwaitExpression extends UnaryExpressionBase {
     readonly kind: SyntaxKind.AwaitExpression;
     readonly expression: UnaryExpression;
 }
 
-export interface YieldExpression extends Expression {
+export interface YieldExpression extends ExpressionBase {
     readonly kind: SyntaxKind.YieldExpression;
     readonly asteriskToken?: AsteriskToken;
     readonly expression?: Expression;
 }
 
-export interface SyntheticExpression extends Expression {
+export interface SyntheticExpression extends ExpressionBase {
     readonly kind: SyntaxKind.SyntheticExpression;
     readonly isSpread: boolean;
     readonly type: Type;
@@ -2635,9 +3336,9 @@ export type LogicalOrCoalescingAssignmentOperator
     | SyntaxKind.QuestionQuestionEqualsToken
     ;
 
-export type BinaryOperatorToken = Token<BinaryOperator>;
+export type BinaryOperatorToken<TOperator extends BinaryOperator = BinaryOperator> = TOperator extends SyntaxKind ? Token<TOperator> : never;
 
-export interface BinaryExpression extends Expression, Declaration, JSDocContainer {
+export interface BinaryExpression extends ExpressionBase, DeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.BinaryExpression;
     readonly left: Expression;
     readonly operatorToken: BinaryOperatorToken;
@@ -2726,7 +3427,7 @@ export type AssignmentPattern = ObjectLiteralExpression | ArrayLiteralExpression
 
 export type BindingOrAssignmentPattern = ObjectBindingOrAssignmentPattern | ArrayBindingOrAssignmentPattern;
 
-export interface ConditionalExpression extends Expression {
+export interface ConditionalExpression extends ExpressionBase {
     readonly kind: SyntaxKind.ConditionalExpression;
     readonly condition: Expression;
     readonly questionToken: QuestionToken;
@@ -2738,14 +3439,14 @@ export interface ConditionalExpression extends Expression {
 export type FunctionBody = Block;
 export type ConciseBody = FunctionBody | Expression;
 
-export interface FunctionExpression extends PrimaryExpression, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
+export interface FunctionExpression extends PrimaryExpressionBase, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.FunctionExpression;
     readonly modifiers?: NodeArray<Modifier>;
     readonly name?: Identifier;
     readonly body: FunctionBody;  // Required, whereas the member inherited from FunctionDeclaration is optional
 }
 
-export interface ArrowFunction extends Expression, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
+export interface ArrowFunction extends ExpressionBase, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.ArrowFunction;
     readonly modifiers?: NodeArray<Modifier>;
     readonly equalsGreaterThanToken: EqualsGreaterThanToken;
@@ -2756,13 +3457,13 @@ export interface ArrowFunction extends Expression, FunctionLikeDeclarationBase, 
 // The text property of a LiteralExpression stores the interpreted value of the literal in text form. For a StringLiteral,
 // or any literal of a template, this means quotes have been removed and escapes have been converted to actual characters.
 // For a NumericLiteral, the stored value is the toString() representation of the number. For example 1, 1.00, and 1e0 are all stored as just "1".
-export interface LiteralLikeNode extends Node {
+export interface LiteralLikeNodeBase extends NodeBase {
     text: string;
     isUnterminated?: boolean;
     hasExtendedUnicodeEscape?: boolean;
 }
 
-export interface TemplateLiteralLikeNode extends LiteralLikeNode {
+export interface TemplateLiteralLikeNodeBase extends LiteralLikeNodeBase {
     rawText?: string;
     /** @internal */
     templateFlags?: TokenFlags;
@@ -2771,15 +3472,15 @@ export interface TemplateLiteralLikeNode extends LiteralLikeNode {
 // The text property of a LiteralExpression stores the interpreted value of the literal in text form. For a StringLiteral,
 // or any literal of a template, this means quotes have been removed and escapes have been converted to actual characters.
 // For a NumericLiteral, the stored value is the toString() representation of the number. For example 1, 1.00, and 1e0 are all stored as just "1".
-export interface LiteralExpression extends LiteralLikeNode, PrimaryExpression {
+export interface LiteralExpressionBase extends LiteralLikeNodeBase, PrimaryExpressionBase {
     _literalExpressionBrand: any;
 }
 
-export interface RegularExpressionLiteral extends LiteralExpression {
+export interface RegularExpressionLiteral extends LiteralExpressionBase {
     readonly kind: SyntaxKind.RegularExpressionLiteral;
 }
 
-export interface NoSubstitutionTemplateLiteral extends LiteralExpression, TemplateLiteralLikeNode, Declaration {
+export interface NoSubstitutionTemplateLiteral extends LiteralExpressionBase, TemplateLiteralLikeNodeBase, DeclarationBase {
     readonly kind: SyntaxKind.NoSubstitutionTemplateLiteral;
     /** @internal */
     templateFlags?: TokenFlags;
@@ -2826,13 +3527,13 @@ export const enum TokenFlags {
     IsInvalid = Octal | ContainsLeadingZero | ContainsInvalidSeparator | ContainsInvalidEscape,
 }
 
-export interface NumericLiteral extends LiteralExpression, Declaration {
+export interface NumericLiteral extends LiteralExpressionBase, DeclarationBase {
     readonly kind: SyntaxKind.NumericLiteral;
     /** @internal */
     readonly numericLiteralFlags: TokenFlags;
 }
 
-export interface BigIntLiteral extends LiteralExpression {
+export interface BigIntLiteral extends LiteralExpressionBase {
     readonly kind: SyntaxKind.BigIntLiteral;
 }
 
@@ -2845,21 +3546,21 @@ export type LiteralToken =
     | NoSubstitutionTemplateLiteral
     ;
 
-export interface TemplateHead extends TemplateLiteralLikeNode {
+export interface TemplateHead extends TemplateLiteralLikeNodeBase {
     readonly kind: SyntaxKind.TemplateHead;
     readonly parent: TemplateExpression | TemplateLiteralTypeNode;
     /** @internal */
     templateFlags?: TokenFlags;
 }
 
-export interface TemplateMiddle extends TemplateLiteralLikeNode {
+export interface TemplateMiddle extends TemplateLiteralLikeNodeBase {
     readonly kind: SyntaxKind.TemplateMiddle;
     readonly parent: TemplateSpan | TemplateLiteralTypeSpan;
     /** @internal */
     templateFlags?: TokenFlags;
 }
 
-export interface TemplateTail extends TemplateLiteralLikeNode {
+export interface TemplateTail extends TemplateLiteralLikeNodeBase {
     readonly kind: SyntaxKind.TemplateTail;
     readonly parent: TemplateSpan | TemplateLiteralTypeSpan;
     /** @internal */
@@ -2877,7 +3578,7 @@ export type TemplateLiteralToken =
     | PseudoLiteralToken
     ;
 
-export interface TemplateExpression extends PrimaryExpression {
+export interface TemplateExpression extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.TemplateExpression;
     readonly head: TemplateHead;
     readonly templateSpans: NodeArray<TemplateSpan>;
@@ -2890,14 +3591,14 @@ export type TemplateLiteral =
 
 // Each of these corresponds to a substitution expression and a template literal, in that order.
 // The template literal must have kind TemplateMiddleLiteral or TemplateTailLiteral.
-export interface TemplateSpan extends Node {
+export interface TemplateSpan extends NodeBase {
     readonly kind: SyntaxKind.TemplateSpan;
     readonly parent: TemplateExpression;
     readonly expression: Expression;
     readonly literal: TemplateMiddle | TemplateTail;
 }
 
-export interface ParenthesizedExpression extends PrimaryExpression, JSDocContainer {
+export interface ParenthesizedExpression extends PrimaryExpressionBase, JSDocContainer {
     readonly kind: SyntaxKind.ParenthesizedExpression;
     readonly expression: Expression;
 }
@@ -2907,14 +3608,14 @@ export interface JSDocTypeAssertion extends ParenthesizedExpression {
     readonly _jsDocTypeAssertionBrand: never;
 }
 
-export interface ArrayLiteralExpression extends PrimaryExpression {
+export interface ArrayLiteralExpression extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.ArrayLiteralExpression;
     readonly elements: NodeArray<Expression>;
     /** @internal */
     multiLine?: boolean;
 }
 
-export interface SpreadElement extends Expression {
+export interface SpreadElement extends ExpressionBase {
     readonly kind: SyntaxKind.SpreadElement;
     readonly parent: ArrayLiteralExpression | CallExpression | NewExpression;
     readonly expression: Expression;
@@ -2926,7 +3627,7 @@ export interface SpreadElement extends Expression {
  * JSXAttribute or JSXSpreadAttribute. ObjectLiteralExpression, on the other hand, can only have properties of type
  * ObjectLiteralElement (e.g. PropertyAssignment, ShorthandPropertyAssignment etc.)
  */
-export interface ObjectLiteralExpressionBase<T extends ObjectLiteralElement> extends PrimaryExpression, Declaration {
+export interface ObjectLiteralExpressionBase<T extends ObjectLiteralElement> extends PrimaryExpressionBase, DeclarationBase {
     readonly properties: NodeArray<T>;
 }
 
@@ -2941,7 +3642,7 @@ export type EntityNameExpression = Identifier | PropertyAccessEntityNameExpressi
 export type EntityNameOrEntityNameExpression = EntityName | EntityNameExpression;
 export type AccessExpression = PropertyAccessExpression | ElementAccessExpression;
 
-export interface PropertyAccessExpression extends MemberExpression, NamedDeclaration, JSDocContainer, FlowContainer {
+export interface PropertyAccessExpression extends MemberExpressionBase, NamedDeclarationBase, JSDocContainer, FlowContainer {
     readonly kind: SyntaxKind.PropertyAccessExpression;
     readonly expression: LeftHandSideExpression;
     readonly questionDotToken?: QuestionDotToken;
@@ -2974,7 +3675,7 @@ export interface PropertyAccessEntityNameExpression extends PropertyAccessExpres
     readonly name: Identifier;
 }
 
-export interface ElementAccessExpression extends MemberExpression, Declaration, JSDocContainer, FlowContainer {
+export interface ElementAccessExpression extends MemberExpressionBase, DeclarationBase, JSDocContainer, FlowContainer {
     readonly kind: SyntaxKind.ElementAccessExpression;
     readonly expression: LeftHandSideExpression;
     readonly questionDotToken?: QuestionDotToken;
@@ -2997,7 +3698,7 @@ export interface SuperElementAccessExpression extends ElementAccessExpression {
 // see: https://tc39.github.io/ecma262/#prod-SuperProperty
 export type SuperProperty = SuperPropertyAccessExpression | SuperElementAccessExpression;
 
-export interface CallExpression extends LeftHandSideExpression, Declaration {
+export interface CallExpression extends LeftHandSideExpressionBase, DeclarationBase {
     readonly kind: SyntaxKind.CallExpression;
     readonly expression: LeftHandSideExpression;
     readonly questionDotToken?: QuestionDotToken;
@@ -3040,7 +3741,7 @@ export type BindableStaticNameExpression =
     ;
 
 /** @internal */
-export type LiteralLikeElementAccessExpression = ElementAccessExpression & Declaration & {
+export type LiteralLikeElementAccessExpression = ElementAccessExpression & {
     readonly argumentExpression: StringLiteralLike | NumericLiteral;
 };
 
@@ -3085,19 +3786,19 @@ export interface ImportCall extends CallExpression {
     readonly expression: ImportExpression;
 }
 
-export interface ExpressionWithTypeArguments extends MemberExpression, NodeWithTypeArguments {
+export interface ExpressionWithTypeArguments extends MemberExpressionBase, NodeWithTypeArgumentsBase {
     readonly kind: SyntaxKind.ExpressionWithTypeArguments;
     readonly expression: LeftHandSideExpression;
 }
 
-export interface NewExpression extends PrimaryExpression, Declaration {
+export interface NewExpression extends PrimaryExpressionBase, DeclarationBase {
     readonly kind: SyntaxKind.NewExpression;
     readonly expression: LeftHandSideExpression;
     readonly typeArguments?: NodeArray<TypeNode>;
     readonly arguments?: NodeArray<Expression>;
 }
 
-export interface TaggedTemplateExpression extends MemberExpression {
+export interface TaggedTemplateExpression extends MemberExpressionBase {
     readonly kind: SyntaxKind.TaggedTemplateExpression;
     readonly tag: LeftHandSideExpression;
     readonly typeArguments?: NodeArray<TypeNode>;
@@ -3113,19 +3814,19 @@ export type CallLikeExpression =
     | JsxOpeningLikeElement
     ;
 
-export interface AsExpression extends Expression {
+export interface AsExpression extends ExpressionBase {
     readonly kind: SyntaxKind.AsExpression;
     readonly expression: Expression;
     readonly type: TypeNode;
 }
 
-export interface TypeAssertion extends UnaryExpression {
+export interface TypeAssertion extends UnaryExpressionBase {
     readonly kind: SyntaxKind.TypeAssertionExpression;
     readonly type: TypeNode;
     readonly expression: UnaryExpression;
 }
 
-export interface SatisfiesExpression extends Expression {
+export interface SatisfiesExpression extends ExpressionBase {
     readonly kind: SyntaxKind.SatisfiesExpression;
     readonly expression: Expression;
     readonly type: TypeNode;
@@ -3136,7 +3837,7 @@ export type AssertionExpression =
     | AsExpression
     ;
 
-export interface NonNullExpression extends LeftHandSideExpression {
+export interface NonNullExpression extends LeftHandSideExpressionBase {
     readonly kind: SyntaxKind.NonNullExpression;
     readonly expression: Expression;
 }
@@ -3147,7 +3848,7 @@ export interface NonNullChain extends NonNullExpression {
 
 // NOTE: MetaProperty is really a MemberExpression, but we consider it a PrimaryExpression
 //       for the same reasons we treat NewExpression as a PrimaryExpression.
-export interface MetaProperty extends PrimaryExpression, FlowContainer {
+export interface MetaProperty extends PrimaryExpressionBase, FlowContainer {
     readonly kind: SyntaxKind.MetaProperty;
     readonly keywordToken: SyntaxKind.NewKeyword | SyntaxKind.ImportKeyword;
     readonly name: Identifier;
@@ -3160,7 +3861,7 @@ export interface ImportMetaProperty extends MetaProperty {
 }
 
 /// A JSX expression of the form <TagName attrs>...</TagName>
-export interface JsxElement extends PrimaryExpression {
+export interface JsxElement extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.JsxElement;
     readonly openingElement: JsxOpeningElement;
     readonly children: NodeArray<JsxChild>;
@@ -3194,20 +3895,20 @@ export interface JsxTagNamePropertyAccess extends PropertyAccessExpression {
     readonly expression: JsxTagNameExpression;
 }
 
-export interface JsxAttributes extends PrimaryExpression, Declaration {
+export interface JsxAttributes extends PrimaryExpressionBase, DeclarationBase {
     readonly properties: NodeArray<JsxAttributeLike>;
     readonly kind: SyntaxKind.JsxAttributes;
     readonly parent: JsxOpeningLikeElement;
 }
 
-export interface JsxNamespacedName extends PrimaryExpression {
+export interface JsxNamespacedName extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.JsxNamespacedName;
     readonly name: Identifier;
     readonly namespace: Identifier;
 }
 
 /// The opening element of a <Tag>...</Tag> JsxElement
-export interface JsxOpeningElement extends Expression {
+export interface JsxOpeningElement extends ExpressionBase {
     readonly kind: SyntaxKind.JsxOpeningElement;
     readonly parent: JsxElement;
     readonly tagName: JsxTagNameExpression;
@@ -3216,7 +3917,7 @@ export interface JsxOpeningElement extends Expression {
 }
 
 /// A JSX expression of the form <TagName attrs />
-export interface JsxSelfClosingElement extends PrimaryExpression {
+export interface JsxSelfClosingElement extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.JsxSelfClosingElement;
     readonly tagName: JsxTagNameExpression;
     readonly typeArguments?: NodeArray<TypeNode>;
@@ -3224,7 +3925,7 @@ export interface JsxSelfClosingElement extends PrimaryExpression {
 }
 
 /// A JSX expression of the form <>...</>
-export interface JsxFragment extends PrimaryExpression {
+export interface JsxFragment extends PrimaryExpressionBase {
     readonly kind: SyntaxKind.JsxFragment;
     readonly openingFragment: JsxOpeningFragment;
     readonly children: NodeArray<JsxChild>;
@@ -3232,18 +3933,18 @@ export interface JsxFragment extends PrimaryExpression {
 }
 
 /// The opening element of a <>...</> JsxFragment
-export interface JsxOpeningFragment extends Expression {
+export interface JsxOpeningFragment extends ExpressionBase {
     readonly kind: SyntaxKind.JsxOpeningFragment;
     readonly parent: JsxFragment;
 }
 
 /// The closing element of a <>...</> JsxFragment
-export interface JsxClosingFragment extends Expression {
+export interface JsxClosingFragment extends ExpressionBase {
     readonly kind: SyntaxKind.JsxClosingFragment;
     readonly parent: JsxFragment;
 }
 
-export interface JsxAttribute extends Declaration {
+export interface JsxAttribute extends DeclarationBase {
     readonly kind: SyntaxKind.JsxAttribute;
     readonly parent: JsxAttributes;
     readonly name: JsxAttributeName;
@@ -3258,27 +3959,27 @@ export type JsxAttributeValue =
     | JsxSelfClosingElement
     | JsxFragment;
 
-export interface JsxSpreadAttribute extends ObjectLiteralElement {
+export interface JsxSpreadAttribute extends ObjectLiteralElementBase {
     readonly kind: SyntaxKind.JsxSpreadAttribute;
     readonly name: PropertyName;
     readonly parent: JsxAttributes;
     readonly expression: Expression;
 }
 
-export interface JsxClosingElement extends Node {
+export interface JsxClosingElement extends NodeBase {
     readonly kind: SyntaxKind.JsxClosingElement;
     readonly parent: JsxElement;
     readonly tagName: JsxTagNameExpression;
 }
 
-export interface JsxExpression extends Expression {
+export interface JsxExpression extends ExpressionBase {
     readonly kind: SyntaxKind.JsxExpression;
     readonly parent: JsxElement | JsxFragment | JsxAttributeLike;
     readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
     readonly expression?: Expression;
 }
 
-export interface JsxText extends LiteralLikeNode {
+export interface JsxText extends LiteralLikeNodeBase {
     readonly kind: SyntaxKind.JsxText;
     readonly parent: JsxElement | JsxFragment;
     readonly containsOnlyTriviaWhiteSpaces: boolean;
@@ -3292,41 +3993,42 @@ export type JsxChild =
     | JsxFragment
     ;
 
-export interface Statement extends Node, JSDocContainer {
+export interface StatementBase extends NodeBase, JSDocContainer {
     _statementBrand: any;
 }
 
 // Represents a statement that is elided as part of a transformation to emit comments on a
 // not-emitted node.
-export interface NotEmittedStatement extends Statement {
+export interface NotEmittedStatement extends StatementBase {
     readonly kind: SyntaxKind.NotEmittedStatement;
 }
 
 /**
  * A list of comma-separated expressions. This node is only created by transformations.
  */
-export interface CommaListExpression extends Expression {
+export interface CommaListExpression extends ExpressionBase {
     readonly kind: SyntaxKind.CommaListExpression;
     readonly elements: NodeArray<Expression>;
 }
 
 
-/** @internal */
-export interface SyntheticReferenceExpression extends LeftHandSideExpression {
+export interface SyntheticReferenceExpression extends LeftHandSideExpressionBase {
     readonly kind: SyntaxKind.SyntheticReferenceExpression;
+    /** @internal */
     readonly expression: Expression;
+    /** @internal */
     readonly thisArg: Expression;
 }
 
-export interface EmptyStatement extends Statement {
+export interface EmptyStatement extends StatementBase {
     readonly kind: SyntaxKind.EmptyStatement;
 }
 
-export interface DebuggerStatement extends Statement, FlowContainer {
+export interface DebuggerStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.DebuggerStatement;
 }
 
-export interface MissingDeclaration extends DeclarationStatement, PrimaryExpression {
+export interface MissingDeclaration extends DeclarationStatementBase, PrimaryExpressionBase {
     readonly kind: SyntaxKind.MissingDeclaration;
     readonly name?: Identifier;
 
@@ -3341,19 +4043,19 @@ export type BlockLike =
     | CaseOrDefaultClause
     ;
 
-export interface Block extends Statement, LocalsContainer {
+export interface Block extends StatementBase, LocalsContainer {
     readonly kind: SyntaxKind.Block;
     readonly statements: NodeArray<Statement>;
     /** @internal */ multiLine?: boolean;
 }
 
-export interface VariableStatement extends Statement, FlowContainer {
+export interface VariableStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.VariableStatement;
     readonly modifiers?: NodeArray<ModifierLike>;
     readonly declarationList: VariableDeclarationList;
 }
 
-export interface ExpressionStatement extends Statement, FlowContainer {
+export interface ExpressionStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.ExpressionStatement;
     readonly expression: Expression;
 }
@@ -3363,23 +4065,23 @@ export interface PrologueDirective extends ExpressionStatement {
     readonly expression: StringLiteral;
 }
 
-export interface IfStatement extends Statement, FlowContainer {
+export interface IfStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.IfStatement;
     readonly expression: Expression;
     readonly thenStatement: Statement;
     readonly elseStatement?: Statement;
 }
 
-export interface IterationStatement extends Statement {
+export interface IterationStatementBase extends StatementBase {
     readonly statement: Statement;
 }
 
-export interface DoStatement extends IterationStatement, FlowContainer {
+export interface DoStatement extends IterationStatementBase, FlowContainer {
     readonly kind: SyntaxKind.DoStatement;
     readonly expression: Expression;
 }
 
-export interface WhileStatement extends IterationStatement, FlowContainer {
+export interface WhileStatement extends IterationStatementBase, FlowContainer {
     readonly kind: SyntaxKind.WhileStatement;
     readonly expression: Expression;
 }
@@ -3389,7 +4091,7 @@ export type ForInitializer =
     | Expression
     ;
 
-export interface ForStatement extends IterationStatement, LocalsContainer, FlowContainer {
+export interface ForStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.ForStatement;
     readonly initializer?: ForInitializer;
     readonly condition?: Expression;
@@ -3401,25 +4103,25 @@ export type ForInOrOfStatement =
     | ForOfStatement
     ;
 
-export interface ForInStatement extends IterationStatement, LocalsContainer, FlowContainer {
+export interface ForInStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.ForInStatement;
     readonly initializer: ForInitializer;
     readonly expression: Expression;
 }
 
-export interface ForOfStatement extends IterationStatement, LocalsContainer, FlowContainer {
+export interface ForOfStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
     readonly kind: SyntaxKind.ForOfStatement;
     readonly awaitModifier?: AwaitKeyword;
     readonly initializer: ForInitializer;
     readonly expression: Expression;
 }
 
-export interface BreakStatement extends Statement, FlowContainer {
+export interface BreakStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.BreakStatement;
     readonly label?: Identifier;
 }
 
-export interface ContinueStatement extends Statement, FlowContainer {
+export interface ContinueStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.ContinueStatement;
     readonly label?: Identifier;
 }
@@ -3429,31 +4131,31 @@ export type BreakOrContinueStatement =
     | ContinueStatement
     ;
 
-export interface ReturnStatement extends Statement, FlowContainer {
+export interface ReturnStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.ReturnStatement;
     readonly expression?: Expression;
 }
 
-export interface WithStatement extends Statement, FlowContainer {
+export interface WithStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.WithStatement;
     readonly expression: Expression;
     readonly statement: Statement;
 }
 
-export interface SwitchStatement extends Statement, FlowContainer {
+export interface SwitchStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.SwitchStatement;
     readonly expression: Expression;
     readonly caseBlock: CaseBlock;
     possiblyExhaustive?: boolean; // initialized by binding
 }
 
-export interface CaseBlock extends Node, LocalsContainer {
+export interface CaseBlock extends NodeBase, LocalsContainer {
     readonly kind: SyntaxKind.CaseBlock;
     readonly parent: SwitchStatement;
     readonly clauses: NodeArray<CaseOrDefaultClause>;
 }
 
-export interface CaseClause extends Node, JSDocContainer {
+export interface CaseClause extends NodeBase, JSDocContainer {
     readonly kind: SyntaxKind.CaseClause;
     readonly parent: CaseBlock;
     readonly expression: Expression;
@@ -3461,7 +4163,7 @@ export interface CaseClause extends Node, JSDocContainer {
     /** @internal */ fallthroughFlowNode?: FlowNode;
 }
 
-export interface DefaultClause extends Node {
+export interface DefaultClause extends NodeBase {
     readonly kind: SyntaxKind.DefaultClause;
     readonly parent: CaseBlock;
     readonly statements: NodeArray<Statement>;
@@ -3473,25 +4175,25 @@ export type CaseOrDefaultClause =
     | DefaultClause
     ;
 
-export interface LabeledStatement extends Statement, FlowContainer {
+export interface LabeledStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.LabeledStatement;
     readonly label: Identifier;
     readonly statement: Statement;
 }
 
-export interface ThrowStatement extends Statement, FlowContainer {
+export interface ThrowStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.ThrowStatement;
     readonly expression: Expression;
 }
 
-export interface TryStatement extends Statement, FlowContainer {
+export interface TryStatement extends StatementBase, FlowContainer {
     readonly kind: SyntaxKind.TryStatement;
     readonly tryBlock: Block;
     readonly catchClause?: CatchClause;
     readonly finallyBlock?: Block;
 }
 
-export interface CatchClause extends Node, LocalsContainer {
+export interface CatchClause extends NodeBase, LocalsContainer {
     readonly kind: SyntaxKind.CatchClause;
     readonly parent: TryStatement;
     readonly variableDeclaration?: VariableDeclaration;
@@ -3519,7 +4221,7 @@ export type DeclarationWithTypeParameterChildren =
     | JSDocTemplateTag
     ;
 
-export interface ClassLikeDeclarationBase extends NamedDeclaration, JSDocContainer {
+export interface ClassLikeDeclarationBase extends NamedDeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.ClassDeclaration | SyntaxKind.ClassExpression;
     readonly name?: Identifier;
     readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
@@ -3527,14 +4229,14 @@ export interface ClassLikeDeclarationBase extends NamedDeclaration, JSDocContain
     readonly members: NodeArray<ClassElement>;
 }
 
-export interface ClassDeclaration extends ClassLikeDeclarationBase, DeclarationStatement {
+export interface ClassDeclaration extends ClassLikeDeclarationBase, DeclarationStatementBase {
     readonly kind: SyntaxKind.ClassDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
     /** May be undefined in `export default class { ... }`. */
     readonly name?: Identifier;
 }
 
-export interface ClassExpression extends ClassLikeDeclarationBase, PrimaryExpression {
+export interface ClassExpression extends ClassLikeDeclarationBase, PrimaryExpressionBase {
     readonly kind: SyntaxKind.ClassExpression;
     readonly modifiers?: NodeArray<ModifierLike>;
 }
@@ -3544,18 +4246,18 @@ export type ClassLikeDeclaration =
     | ClassExpression
     ;
 
-export interface ClassElement extends NamedDeclaration {
+export interface ClassElementBase extends NamedDeclarationBase {
     _classElementBrand: any;
     readonly name?: PropertyName;
 }
 
-export interface TypeElement extends NamedDeclaration {
+export interface TypeElementBase extends NamedDeclarationBase {
     _typeElementBrand: any;
     readonly name?: PropertyName;
     readonly questionToken?: QuestionToken | undefined;
 }
 
-export interface InterfaceDeclaration extends DeclarationStatement, JSDocContainer {
+export interface InterfaceDeclaration extends DeclarationStatementBase, JSDocContainer {
     readonly kind: SyntaxKind.InterfaceDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
     readonly name: Identifier;
@@ -3564,14 +4266,14 @@ export interface InterfaceDeclaration extends DeclarationStatement, JSDocContain
     readonly members: NodeArray<TypeElement>;
 }
 
-export interface HeritageClause extends Node {
+export interface HeritageClause extends NodeBase {
     readonly kind: SyntaxKind.HeritageClause;
     readonly parent: InterfaceDeclaration | ClassLikeDeclaration;
     readonly token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword;
     readonly types: NodeArray<ExpressionWithTypeArguments>;
 }
 
-export interface TypeAliasDeclaration extends DeclarationStatement, JSDocContainer, LocalsContainer {
+export interface TypeAliasDeclaration extends DeclarationStatementBase, JSDocContainer, LocalsContainer {
     readonly kind: SyntaxKind.TypeAliasDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
     readonly name: Identifier;
@@ -3579,7 +4281,7 @@ export interface TypeAliasDeclaration extends DeclarationStatement, JSDocContain
     readonly type: TypeNode;
 }
 
-export interface EnumMember extends NamedDeclaration, JSDocContainer {
+export interface EnumMember extends NamedDeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.EnumMember;
     readonly parent: EnumDeclaration;
     // This does include ComputedPropertyName, but the parser will give an error
@@ -3588,7 +4290,7 @@ export interface EnumMember extends NamedDeclaration, JSDocContainer {
     readonly initializer?: Expression;
 }
 
-export interface EnumDeclaration extends DeclarationStatement, JSDocContainer {
+export interface EnumDeclaration extends DeclarationStatementBase, JSDocContainer {
     readonly kind: SyntaxKind.EnumDeclaration;
     readonly modifiers?: NodeArray<ModifierLike>;
     readonly name: Identifier;
@@ -3610,7 +4312,7 @@ export interface AmbientModuleDeclaration extends ModuleDeclaration {
     readonly body?: ModuleBlock;
 }
 
-export interface ModuleDeclaration extends DeclarationStatement, JSDocContainer, LocalsContainer {
+export interface ModuleDeclaration extends DeclarationStatementBase, JSDocContainer, LocalsContainer {
     readonly kind: SyntaxKind.ModuleDeclaration;
     readonly parent: ModuleBody | SourceFile;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -3638,7 +4340,7 @@ export interface JSDocNamespaceDeclaration extends ModuleDeclaration {
     readonly body?: JSDocNamespaceBody;
 }
 
-export interface ModuleBlock extends Node, Statement {
+export interface ModuleBlock extends NodeBase, StatementBase {
     readonly kind: SyntaxKind.ModuleBlock;
     readonly parent: ModuleDeclaration;
     readonly statements: NodeArray<Statement>;
@@ -3654,7 +4356,7 @@ export type ModuleReference =
  * - import x = require("mod");
  * - import x = M.x;
  */
-export interface ImportEqualsDeclaration extends DeclarationStatement, JSDocContainer {
+export interface ImportEqualsDeclaration extends DeclarationStatementBase, JSDocContainer {
     readonly kind: SyntaxKind.ImportEqualsDeclaration;
     readonly parent: SourceFile | ModuleBlock;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -3666,7 +4368,7 @@ export interface ImportEqualsDeclaration extends DeclarationStatement, JSDocCont
     readonly moduleReference: ModuleReference;
 }
 
-export interface ExternalModuleReference extends Node {
+export interface ExternalModuleReference extends NodeBase {
     readonly kind: SyntaxKind.ExternalModuleReference;
     readonly parent: ImportEqualsDeclaration;
     readonly expression: Expression;
@@ -3676,7 +4378,7 @@ export interface ExternalModuleReference extends Node {
 // import "mod"  => importClause = undefined, moduleSpecifier = "mod"
 // In rest of the cases, module specifier is string literal corresponding to module
 // ImportClause information is shown at its declaration below.
-export interface ImportDeclaration extends Statement {
+export interface ImportDeclaration extends StatementBase {
     readonly kind: SyntaxKind.ImportDeclaration;
     readonly parent: SourceFile | ModuleBlock;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -3702,7 +4404,7 @@ export type NamedExportBindings =
 // import d, * as ns from "mod" => name = d, namedBinding: NamespaceImport = { name: ns }
 // import { a, b as x } from "mod" => name = undefined, namedBinding: NamedImports = { elements: [{ name: a }, { name: x, propertyName: b}]}
 // import d, { a, b as x } from "mod" => name = d, namedBinding: NamedImports = { elements: [{ name: a }, { name: x, propertyName: b}]}
-export interface ImportClause extends NamedDeclaration {
+export interface ImportClause extends NamedDeclarationBase {
     readonly kind: SyntaxKind.ImportClause;
     readonly parent: ImportDeclaration;
     readonly isTypeOnly: boolean;
@@ -3712,33 +4414,33 @@ export interface ImportClause extends NamedDeclaration {
 
 export type AssertionKey = Identifier | StringLiteral;
 
-export interface AssertEntry extends Node {
+export interface AssertEntry extends NodeBase {
     readonly kind: SyntaxKind.AssertEntry;
     readonly parent: AssertClause;
     readonly name: AssertionKey;
     readonly value: Expression;
 }
 
-export interface AssertClause extends Node {
+export interface AssertClause extends NodeBase {
     readonly kind: SyntaxKind.AssertClause;
     readonly parent: ImportDeclaration | ExportDeclaration
     readonly elements: NodeArray<AssertEntry>;
     readonly multiLine?: boolean;
 }
 
-export interface NamespaceImport extends NamedDeclaration {
+export interface NamespaceImport extends NamedDeclarationBase {
     readonly kind: SyntaxKind.NamespaceImport;
     readonly parent: ImportClause;
     readonly name: Identifier;
 }
 
-export interface NamespaceExport extends NamedDeclaration {
+export interface NamespaceExport extends NamedDeclarationBase {
     readonly kind: SyntaxKind.NamespaceExport;
     readonly parent: ExportDeclaration;
     readonly name: Identifier
 }
 
-export interface NamespaceExportDeclaration extends DeclarationStatement, JSDocContainer {
+export interface NamespaceExportDeclaration extends DeclarationStatementBase, JSDocContainer {
     readonly kind: SyntaxKind.NamespaceExportDeclaration;
     readonly name: Identifier;
 
@@ -3746,7 +4448,7 @@ export interface NamespaceExportDeclaration extends DeclarationStatement, JSDocC
     /** @internal */ readonly modifiers?: NodeArray<ModifierLike> | undefined;
 }
 
-export interface ExportDeclaration extends DeclarationStatement, JSDocContainer {
+export interface ExportDeclaration extends DeclarationStatementBase, JSDocContainer {
     readonly kind: SyntaxKind.ExportDeclaration;
     readonly parent: SourceFile | ModuleBlock;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -3758,13 +4460,13 @@ export interface ExportDeclaration extends DeclarationStatement, JSDocContainer 
     readonly assertClause?: AssertClause;
 }
 
-export interface NamedImports extends Node {
+export interface NamedImports extends NodeBase {
     readonly kind: SyntaxKind.NamedImports;
     readonly parent: ImportClause;
     readonly elements: NodeArray<ImportSpecifier>;
 }
 
-export interface NamedExports extends Node {
+export interface NamedExports extends NodeBase {
     readonly kind: SyntaxKind.NamedExports;
     readonly parent: ExportDeclaration;
     readonly elements: NodeArray<ExportSpecifier>;
@@ -3772,7 +4474,7 @@ export interface NamedExports extends Node {
 
 export type NamedImportsOrExports = NamedImports | NamedExports;
 
-export interface ImportSpecifier extends NamedDeclaration {
+export interface ImportSpecifier extends NamedDeclarationBase {
     readonly kind: SyntaxKind.ImportSpecifier;
     readonly parent: NamedImports;
     readonly propertyName?: Identifier;  // Name preceding "as" keyword (or undefined when "as" is absent)
@@ -3780,7 +4482,7 @@ export interface ImportSpecifier extends NamedDeclaration {
     readonly isTypeOnly: boolean;
 }
 
-export interface ExportSpecifier extends NamedDeclaration, JSDocContainer {
+export interface ExportSpecifier extends NamedDeclarationBase, JSDocContainer {
     readonly kind: SyntaxKind.ExportSpecifier;
     readonly parent: NamedExports;
     readonly isTypeOnly: boolean;
@@ -3821,7 +4523,7 @@ export type TypeOnlyAliasDeclaration = TypeOnlyImportDeclaration | TypeOnlyExpor
  * This is either an `export =` or an `export default` declaration.
  * Unless `isExportEquals` is set, this node was parsed as an `export default`.
  */
-export interface ExportAssignment extends DeclarationStatement, JSDocContainer {
+export interface ExportAssignment extends DeclarationStatementBase, JSDocContainer {
     readonly kind: SyntaxKind.ExportAssignment;
     readonly parent: SourceFile;
     readonly modifiers?: NodeArray<ModifierLike>;
@@ -3853,62 +4555,62 @@ export interface SynthesizedComment extends CommentRange {
 }
 
 // represents a top level: { type } expression in a JSDoc comment.
-export interface JSDocTypeExpression extends TypeNode {
+export interface JSDocTypeExpression extends TypeNodeBase {
     readonly kind: SyntaxKind.JSDocTypeExpression;
     readonly type: TypeNode;
 }
 
-export interface JSDocNameReference extends Node {
+export interface JSDocNameReference extends NodeBase {
     readonly kind: SyntaxKind.JSDocNameReference;
     readonly name: EntityName | JSDocMemberName;
 }
 
 /** Class#method reference in JSDoc */
-export interface JSDocMemberName extends Node {
+export interface JSDocMemberName extends NodeBase {
     readonly kind: SyntaxKind.JSDocMemberName;
     readonly left: EntityName | JSDocMemberName;
     readonly right: Identifier;
 }
 
-export interface JSDocType extends TypeNode {
+export interface JSDocTypeBase extends TypeNodeBase {
     _jsDocTypeBrand: any;
 }
 
-export interface JSDocAllType extends JSDocType {
+export interface JSDocAllType extends JSDocTypeBase {
     readonly kind: SyntaxKind.JSDocAllType;
 }
 
-export interface JSDocUnknownType extends JSDocType {
+export interface JSDocUnknownType extends JSDocTypeBase {
     readonly kind: SyntaxKind.JSDocUnknownType;
 }
 
-export interface JSDocNonNullableType extends JSDocType {
+export interface JSDocNonNullableType extends JSDocTypeBase {
     readonly kind: SyntaxKind.JSDocNonNullableType;
     readonly type: TypeNode;
     readonly postfix: boolean;
 }
 
-export interface JSDocNullableType extends JSDocType {
+export interface JSDocNullableType extends JSDocTypeBase {
     readonly kind: SyntaxKind.JSDocNullableType;
     readonly type: TypeNode;
     readonly postfix: boolean;
 }
 
-export interface JSDocOptionalType extends JSDocType {
+export interface JSDocOptionalType extends JSDocTypeBase {
     readonly kind: SyntaxKind.JSDocOptionalType;
     readonly type: TypeNode;
 }
 
-export interface JSDocFunctionType extends JSDocType, SignatureDeclarationBase, LocalsContainer {
+export interface JSDocFunctionType extends JSDocTypeBase, SignatureDeclarationBase, LocalsContainer {
     readonly kind: SyntaxKind.JSDocFunctionType;
 }
 
-export interface JSDocVariadicType extends JSDocType {
+export interface JSDocVariadicType extends JSDocTypeBase {
     readonly kind: SyntaxKind.JSDocVariadicType;
     readonly type: TypeNode;
 }
 
-export interface JSDocNamepathType extends JSDocType {
+export interface JSDocNamepathType extends JSDocTypeBase {
     readonly kind: SyntaxKind.JSDocNamepathType;
     readonly type: TypeNode;
 }
@@ -3920,32 +4622,32 @@ export type JSDocTypeReferencingNode =
     | JSDocNonNullableType
     ;
 
-export interface JSDoc extends Node {
+export interface JSDoc extends NodeBase {
     readonly kind: SyntaxKind.JSDoc;
     readonly parent: HasJSDoc;
     readonly tags?: NodeArray<JSDocTag>;
     readonly comment?: string | NodeArray<JSDocComment>;
 }
 
-export interface JSDocTag extends Node {
-    readonly parent: JSDoc | JSDocTypeLiteral;
+export interface JSDocTagBase extends NodeBase {
+    readonly parent: JSDoc | JSDocSignature | JSDocTypeLiteral;
     readonly tagName: Identifier;
     readonly comment?: string | NodeArray<JSDocComment>;
 }
 
-export interface JSDocLink extends Node {
+export interface JSDocLink extends NodeBase {
     readonly kind: SyntaxKind.JSDocLink;
     readonly name?: EntityName | JSDocMemberName;
     text: string;
 }
 
-export interface JSDocLinkCode extends Node {
+export interface JSDocLinkCode extends NodeBase {
     readonly kind: SyntaxKind.JSDocLinkCode;
     readonly name?: EntityName | JSDocMemberName;
     text: string;
 }
 
-export interface JSDocLinkPlain extends Node {
+export interface JSDocLinkPlain extends NodeBase {
     readonly kind: SyntaxKind.JSDocLinkPlain;
     readonly name?: EntityName | JSDocMemberName;
     text: string;
@@ -3953,12 +4655,12 @@ export interface JSDocLinkPlain extends Node {
 
 export type JSDocComment = JSDocText | JSDocLink | JSDocLinkCode | JSDocLinkPlain;
 
-export interface JSDocText extends Node {
+export interface JSDocText extends NodeBase {
     readonly kind: SyntaxKind.JSDocText;
     text: string;
 }
 
-export interface JSDocUnknownTag extends JSDocTag {
+export interface JSDocUnknownTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocTag;
 }
 
@@ -3966,81 +4668,81 @@ export interface JSDocUnknownTag extends JSDocTag {
  * Note that `@extends` is a synonym of `@augments`.
  * Both tags are represented by this interface.
  */
-export interface JSDocAugmentsTag extends JSDocTag {
+export interface JSDocAugmentsTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocAugmentsTag;
     readonly class: ExpressionWithTypeArguments & { readonly expression: Identifier | PropertyAccessEntityNameExpression };
 }
 
-export interface JSDocImplementsTag extends JSDocTag {
+export interface JSDocImplementsTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocImplementsTag;
     readonly class: ExpressionWithTypeArguments & { readonly expression: Identifier | PropertyAccessEntityNameExpression };
 }
 
-export interface JSDocAuthorTag extends JSDocTag {
+export interface JSDocAuthorTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocAuthorTag;
 }
 
-export interface JSDocDeprecatedTag extends JSDocTag {
+export interface JSDocDeprecatedTag extends JSDocTagBase {
     kind: SyntaxKind.JSDocDeprecatedTag;
 }
 
-export interface JSDocClassTag extends JSDocTag {
+export interface JSDocClassTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocClassTag;
 }
 
-export interface JSDocPublicTag extends JSDocTag {
+export interface JSDocPublicTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocPublicTag;
 }
 
-export interface JSDocPrivateTag extends JSDocTag {
+export interface JSDocPrivateTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocPrivateTag;
 }
 
-export interface JSDocProtectedTag extends JSDocTag {
+export interface JSDocProtectedTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocProtectedTag;
 }
 
-export interface JSDocReadonlyTag extends JSDocTag {
+export interface JSDocReadonlyTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocReadonlyTag;
 }
 
-export interface JSDocOverrideTag extends JSDocTag {
+export interface JSDocOverrideTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocOverrideTag;
 }
 
-export interface JSDocEnumTag extends JSDocTag, Declaration, LocalsContainer {
+export interface JSDocEnumTag extends JSDocTagBase, DeclarationBase, LocalsContainer {
     readonly kind: SyntaxKind.JSDocEnumTag;
     readonly parent: JSDoc;
     readonly typeExpression: JSDocTypeExpression;
 }
 
-export interface JSDocThisTag extends JSDocTag {
+export interface JSDocThisTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocThisTag;
     readonly typeExpression: JSDocTypeExpression;
 }
 
-export interface JSDocTemplateTag extends JSDocTag {
+export interface JSDocTemplateTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocTemplateTag;
     readonly constraint: JSDocTypeExpression | undefined;
     readonly typeParameters: NodeArray<TypeParameterDeclaration>;
 }
 
-export interface JSDocSeeTag extends JSDocTag {
+export interface JSDocSeeTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocSeeTag;
     readonly name?: JSDocNameReference;
 }
 
-export interface JSDocReturnTag extends JSDocTag {
+export interface JSDocReturnTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocReturnTag;
     readonly typeExpression?: JSDocTypeExpression;
 }
 
-export interface JSDocTypeTag extends JSDocTag {
+export interface JSDocTypeTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocTypeTag;
     readonly typeExpression: JSDocTypeExpression;
 }
 
-export interface JSDocTypedefTag extends JSDocTag, NamedDeclaration, LocalsContainer {
+export interface JSDocTypedefTag extends JSDocTagBase, NamedDeclarationBase, LocalsContainer {
     readonly kind: SyntaxKind.JSDocTypedefTag;
     readonly parent: JSDoc;
     readonly fullName?: JSDocNamespaceDeclaration | Identifier;
@@ -4048,7 +4750,7 @@ export interface JSDocTypedefTag extends JSDocTag, NamedDeclaration, LocalsConta
     readonly typeExpression?: JSDocTypeExpression | JSDocTypeLiteral;
 }
 
-export interface JSDocCallbackTag extends JSDocTag, NamedDeclaration, LocalsContainer {
+export interface JSDocCallbackTag extends JSDocTagBase, NamedDeclarationBase, LocalsContainer {
     readonly kind: SyntaxKind.JSDocCallbackTag;
     readonly parent: JSDoc;
     readonly fullName?: JSDocNamespaceDeclaration | Identifier;
@@ -4057,26 +4759,26 @@ export interface JSDocCallbackTag extends JSDocTag, NamedDeclaration, LocalsCont
 }
 
 
-export interface JSDocOverloadTag extends JSDocTag {
+export interface JSDocOverloadTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocOverloadTag;
     readonly parent: JSDoc;
     readonly typeExpression: JSDocSignature;
 }
 
-export interface JSDocThrowsTag extends JSDocTag {
+export interface JSDocThrowsTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocThrowsTag;
     readonly typeExpression?: JSDocTypeExpression;
 }
 
-export interface JSDocSignature extends JSDocType, Declaration, JSDocContainer, LocalsContainer {
+export interface JSDocSignature extends JSDocTypeBase, DeclarationBase, JSDocContainer, LocalsContainer {
     readonly kind: SyntaxKind.JSDocSignature;
     readonly typeParameters?: readonly JSDocTemplateTag[];
     readonly parameters: readonly JSDocParameterTag[];
     readonly type: JSDocReturnTag | undefined;
 }
 
-export interface JSDocPropertyLikeTag extends JSDocTag, Declaration {
-    readonly parent: JSDoc;
+export interface JSDocPropertyLikeTagBase extends JSDocTagBase, DeclarationBase {
+    readonly parent: JSDoc | JSDocSignature | JSDocTypeLiteral;
     readonly name: EntityName;
     readonly typeExpression?: JSDocTypeExpression;
     /** Whether the property name came before the type -- non-standard for JSDoc, but Typescript-like */
@@ -4084,22 +4786,24 @@ export interface JSDocPropertyLikeTag extends JSDocTag, Declaration {
     readonly isBracketed: boolean;
 }
 
-export interface JSDocPropertyTag extends JSDocPropertyLikeTag {
+export interface JSDocPropertyTag extends JSDocPropertyLikeTagBase {
+    readonly parent: JSDocTypeLiteral;
     readonly kind: SyntaxKind.JSDocPropertyTag;
 }
 
-export interface JSDocParameterTag extends JSDocPropertyLikeTag {
+export interface JSDocParameterTag extends JSDocPropertyLikeTagBase {
+    readonly parent: JSDocSignature | JSDoc | JSDocTypeLiteral;
     readonly kind: SyntaxKind.JSDocParameterTag;
 }
 
-export interface JSDocTypeLiteral extends JSDocType, Declaration {
+export interface JSDocTypeLiteral extends JSDocTypeBase, DeclarationBase {
     readonly kind: SyntaxKind.JSDocTypeLiteral;
-    readonly jsDocPropertyTags?: readonly JSDocPropertyLikeTag[];
+    readonly jsDocPropertyTags?: readonly JSDocPropertyTag[];
     /** If true, then this type literal represents an *array* of its type. */
     readonly isArrayType: boolean;
 }
 
-export interface JSDocSatisfiesTag extends JSDocTag {
+export interface JSDocSatisfiesTag extends JSDocTagBase {
     readonly kind: SyntaxKind.JSDocSatisfiesTag;
     readonly typeExpression: JSDocTypeExpression;
 }
@@ -4235,10 +4939,10 @@ export interface RedirectInfo {
 export type ResolutionMode = ModuleKind.ESNext | ModuleKind.CommonJS | undefined;
 
 // Source files are declarations when they are external modules.
-export interface SourceFile extends Declaration, LocalsContainer {
+export interface SourceFile extends DeclarationBase, LocalsContainer {
     readonly kind: SyntaxKind.SourceFile;
     readonly statements: NodeArray<Statement>;
-    readonly endOfFileToken: Token<SyntaxKind.EndOfFileToken>;
+    readonly endOfFileToken: EndOfFileToken;
 
     fileName: string;
     /** @internal */ path: Path;
@@ -4424,7 +5128,7 @@ export const enum CommentDirectiveType {
 /** @internal */
 export type ExportedModulesFromDeclarationEmit = readonly Symbol[];
 
-export interface Bundle extends Node {
+export interface Bundle extends NodeBase {
     readonly kind: SyntaxKind.Bundle;
     /** @deprecated */ readonly prepends: readonly (InputFiles | UnparsedSource)[];
     readonly sourceFiles: readonly SourceFile[];
@@ -4435,7 +5139,7 @@ export interface Bundle extends Node {
 }
 
 /** @deprecated */
-export interface InputFiles extends Node {
+export interface InputFiles extends NodeBase {
     readonly kind: SyntaxKind.InputFiles;
     javascriptPath?: string;
     javascriptText: string;
@@ -4451,7 +5155,7 @@ export interface InputFiles extends Node {
 }
 
 /** @deprecated */
-export interface UnparsedSource extends Node {
+export interface UnparsedSource extends NodeBase {
     readonly kind: SyntaxKind.UnparsedSource;
     fileName: string;
     text: string;
@@ -4489,7 +5193,7 @@ export type UnparsedNode =
     ;
 
 /** @deprecated */
-export interface UnparsedSection extends Node {
+export interface UnparsedSection extends NodeBase {
     readonly kind: SyntaxKind;
     readonly parent: UnparsedSource;
     readonly data?: string;
@@ -5678,7 +6382,7 @@ export interface EmitResolver {
     isTopLevelValueImportEqualsWithEntityName(node: ImportEqualsDeclaration): boolean;
     getNodeCheckFlags(node: Node): NodeCheckFlags;
     isDeclarationVisible(node: Declaration | AnyImportSyntax): boolean;
-    isLateBound(node: Declaration): node is LateBoundDeclaration;
+    isLateBound(node: Declaration): node is Declaration & LateBoundDeclaration;
     collectLinkedAliases(node: Identifier, setVisibility?: boolean): Node[] | undefined;
     isImplementationOfOverload(node: SignatureDeclaration): boolean | undefined;
     isRequiredInitializedParameter(node: ParameterDeclaration): boolean;
@@ -8311,7 +9015,7 @@ export interface NodeFactory {
     createToken<TKind extends KeywordTypeSyntaxKind>(token: TKind): KeywordTypeNode<TKind>;
     createToken<TKind extends ModifierSyntaxKind>(token: TKind): ModifierToken<TKind>;
     createToken<TKind extends KeywordSyntaxKind>(token: TKind): KeywordToken<TKind>;
-    /** @internal */ createToken<TKind extends SyntaxKind>(token: TKind): Token<TKind>;
+    /** @internal */ createToken<TKind extends SyntaxKind>(token: TKind): SyntaxKindToNode[TKind & keyof SyntaxKindToNode];
 
     //
     // Reserved words
@@ -9683,7 +10387,7 @@ export interface DiagnosticCollection {
 }
 
 // SyntaxKind.SyntaxList
-export interface SyntaxList extends Node {
+export interface SyntaxList extends NodeBase {
     kind: SyntaxKind.SyntaxList;
     _children: Node[];
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -15,10 +15,7 @@ import {
     AnyValidImportOrReExport,
     append,
     arrayFrom,
-    ArrayLiteralExpression,
-    ArrayTypeNode,
     ArrowFunction,
-    AsExpression,
     AssertionExpression,
     assertType,
     AssignmentDeclarationKind,
@@ -55,7 +52,6 @@ import {
     ClassLikeDeclaration,
     ClassStaticBlockDeclaration,
     combinePaths,
-    CommaListExpression,
     CommandLineOption,
     CommentDirective,
     CommentDirectivesMap,
@@ -70,7 +66,6 @@ import {
     computeLineOfPosition,
     computeLineStarts,
     concatenate,
-    ConditionalExpression,
     ConstructorDeclaration,
     ConstructSignatureDeclaration,
     contains,
@@ -86,7 +81,6 @@ import {
     DeclarationName,
     DeclarationWithTypeParameterChildren,
     DeclarationWithTypeParameters,
-    Decorator,
     DefaultClause,
     DestructuringAssignment,
     Diagnostic,
@@ -350,7 +344,6 @@ import {
     JSDocParameterTag,
     JSDocPropertyLikeTag,
     JSDocSatisfiesExpression,
-    JSDocSatisfiesTag,
     JSDocSignature,
     JSDocTag,
     JSDocTemplateTag,
@@ -358,13 +351,9 @@ import {
     JsonSourceFile,
     JsxAttributeName,
     JsxChild,
-    JsxElement,
     JsxEmit,
-    JsxFragment,
     JsxNamespacedName,
-    JsxOpeningElement,
     JsxOpeningLikeElement,
-    JsxSelfClosingElement,
     JsxTagNameExpression,
     KeywordSyntaxKind,
     LabeledStatement,
@@ -395,18 +384,14 @@ import {
     moduleResolutionOptionDeclarations,
     MultiMap,
     NamedDeclaration,
-    NamedExports,
-    NamedImports,
     NamedImportsOrExports,
     NamespaceExport,
     NamespaceImport,
-    NewExpression,
     NewLineKind,
     Node,
     NodeArray,
     NodeFlags,
     nodeModulesPathPart,
-    NonNullExpression,
     noop,
     normalizePath,
     NoSubstitutionTemplateLiteral,
@@ -422,14 +407,11 @@ import {
     OuterExpressionKinds,
     PackageId,
     ParameterDeclaration,
-    ParenthesizedExpression,
     ParenthesizedTypeNode,
     parseConfigFileTextToJson,
-    PartiallyEmittedExpression,
     Path,
     pathIsRelative,
     Pattern,
-    PostfixUnaryExpression,
     PrefixUnaryExpression,
     PrinterOptions,
     PrintHandlers,
@@ -460,7 +442,6 @@ import {
     ResolvedTypeReferenceDirective,
     ResolvedTypeReferenceDirectiveWithFailedLookupLocations,
     ReturnStatement,
-    SatisfiesExpression,
     ScriptKind,
     ScriptTarget,
     semanticDiagnosticsOptionDeclarations,
@@ -497,14 +478,13 @@ import {
     SymbolFlags,
     SymbolTable,
     SyntaxKind,
-    SyntaxList,
+    SyntaxKindToNode,
     TaggedTemplateExpression,
     TemplateLiteral,
     TemplateLiteralLikeNode,
-    TemplateLiteralTypeSpan,
-    TemplateSpan,
     TextRange,
     TextSpan,
+    ThisTypeNode,
     ThisTypePredicate,
     Token,
     TokenFlags,
@@ -520,14 +500,11 @@ import {
     tryRemovePrefix,
     TryStatement,
     TsConfigSourceFile,
-    TupleTypeNode,
     Type,
     TypeAliasDeclaration,
-    TypeAssertion,
     TypeChecker,
     TypeElement,
     TypeFlags,
-    TypeLiteralNode,
     TypeNode,
     TypeNodeSyntaxKind,
     TypeParameter,
@@ -1140,8 +1117,8 @@ export function getTokenPosOfNode(node: Node, sourceFile?: SourceFileLike, inclu
     // the syntax list itself considers them as normal trivia. Therefore if we simply skip
     // trivia for the list, we may have skipped the JSDocComment as well. So we should process its
     // first child to determine the actual position of its first token.
-    if (node.kind === SyntaxKind.SyntaxList && (node as SyntaxList)._children.length > 0) {
-        return getTokenPosOfNode((node as SyntaxList)._children[0], sourceFile, includeJsDoc);
+    if (node.kind === SyntaxKind.SyntaxList && node._children.length > 0) {
+        return getTokenPosOfNode(node._children[0], sourceFile, includeJsDoc);
     }
 
     return skipTrivia(
@@ -1658,7 +1635,7 @@ export function getLiteralText(node: LiteralLikeNode, sourceFile: SourceFile | u
             const escapeText = flags & GetLiteralTextFlags.JsxAttributeEscape ? escapeJsxAttributeString :
                 flags & GetLiteralTextFlags.NeverAsciiEscape || (getEmitFlags(node) & EmitFlags.NoAsciiEscaping) ? escapeString :
                 escapeNonAsciiString;
-            if ((node as StringLiteral).singleQuote) {
+            if ((node).singleQuote) {
                 return "'" + escapeText(node.text, CharacterCodes.singleQuote) + "'";
             }
             else {
@@ -1779,7 +1756,7 @@ export function isShorthandAmbientModuleSymbol(moduleSymbol: Symbol): boolean {
 
 function isShorthandAmbientModule(node: Node | undefined): boolean {
     // The only kind of module that can be missing a body is a shorthand ambient module.
-    return !!node && node.kind === SyntaxKind.ModuleDeclaration && (!(node as ModuleDeclaration).body);
+    return !!node && node.kind === SyntaxKind.ModuleDeclaration && (!(node).body);
 }
 
 /** @internal */
@@ -2224,7 +2201,7 @@ export function getErrorSpanForNode(sourceFile: SourceFile, node: Node): TextSpa
             errorNode = (node as NamedDeclaration).name;
             break;
         case SyntaxKind.ArrowFunction:
-            return getErrorSpanForArrowFunction(sourceFile, node as ArrowFunction);
+            return getErrorSpanForArrowFunction(sourceFile, node);
         case SyntaxKind.CaseClause:
         case SyntaxKind.DefaultClause: {
             const start = skipTrivia(sourceFile.text, (node as CaseOrDefaultClause).pos);
@@ -2233,15 +2210,15 @@ export function getErrorSpanForNode(sourceFile: SourceFile, node: Node): TextSpa
         }
         case SyntaxKind.ReturnStatement:
         case SyntaxKind.YieldExpression: {
-            const pos = skipTrivia(sourceFile.text, (node as ReturnStatement | YieldExpression).pos);
+            const pos = skipTrivia(sourceFile.text, (node).pos);
             return getSpanOfTokenAtPosition(sourceFile, pos);
         }
         case SyntaxKind.SatisfiesExpression: {
-            const pos = skipTrivia(sourceFile.text, (node as SatisfiesExpression).expression.end);
+            const pos = skipTrivia(sourceFile.text, (node).expression.end);
             return getSpanOfTokenAtPosition(sourceFile, pos);
         }
         case SyntaxKind.JSDocSatisfiesTag: {
-            const pos = skipTrivia(sourceFile.text, (node as JSDocSatisfiesTag).tagName.pos);
+            const pos = skipTrivia(sourceFile.text, (node).tagName.pos);
             return getSpanOfTokenAtPosition(sourceFile, pos);
         }
     }
@@ -2305,12 +2282,12 @@ export function isLet(node: Node): boolean {
 
 /** @internal */
 export function isSuperCall(n: Node): n is SuperCall {
-    return n.kind === SyntaxKind.CallExpression && (n as CallExpression).expression.kind === SyntaxKind.SuperKeyword;
+    return n.kind === SyntaxKind.CallExpression && (n).expression.kind === SyntaxKind.SuperKeyword;
 }
 
 /** @internal */
 export function isImportCall(n: Node): n is ImportCall {
-    return n.kind === SyntaxKind.CallExpression && (n as CallExpression).expression.kind === SyntaxKind.ImportKeyword;
+    return n.kind === SyntaxKind.CallExpression && (n).expression.kind === SyntaxKind.ImportKeyword;
 }
 
 /** @internal */
@@ -2328,7 +2305,7 @@ export function isLiteralImportTypeNode(n: Node): n is LiteralImportTypeNode {
 /** @internal */
 export function isPrologueDirective(node: Node): node is PrologueDirective {
     return node.kind === SyntaxKind.ExpressionStatement
-        && (node as ExpressionStatement).expression.kind === SyntaxKind.StringLiteral;
+        && (node).expression.kind === SyntaxKind.StringLiteral;
 }
 
 /** @internal */
@@ -2416,10 +2393,10 @@ export function isPartOfTypeNode(node: Node): boolean {
         // above them to find the lowest container
         case SyntaxKind.Identifier:
             // If the identifier is the RHS of a qualified name, then it's a type iff its parent is.
-            if (node.parent.kind === SyntaxKind.QualifiedName && (node.parent as QualifiedName).right === node) {
+            if (node.parent.kind === SyntaxKind.QualifiedName && (node.parent).right === node) {
                 node = node.parent;
             }
-            else if (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).name === node) {
+            else if (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent).name === node) {
                 node = node.parent;
             }
             // At this point, node is either a qualified name or an identifier
@@ -2435,7 +2412,7 @@ export function isPartOfTypeNode(node: Node): boolean {
                 return false;
             }
             if (parent.kind === SyntaxKind.ImportType) {
-                return !(parent as ImportTypeNode).isTypeOf;
+                return !(parent).isTypeOf;
             }
             // Do not recursively call isPartOfTypeNode on the parent. In the example:
             //
@@ -2449,15 +2426,14 @@ export function isPartOfTypeNode(node: Node): boolean {
             switch (parent.kind) {
                 case SyntaxKind.ExpressionWithTypeArguments:
                     return isHeritageClause(parent.parent) && !isExpressionWithTypeArgumentsInClassExtendsClause(parent);
+                // The rest of these probably aren't possible anymore, since `ThisKeyword` is seperate from `ThisTypeNode`, hence the casts
                 case SyntaxKind.TypeParameter:
-                    return node === (parent as TypeParameterDeclaration).constraint;
                 case SyntaxKind.JSDocTemplateTag:
-                    return node === (parent as JSDocTemplateTag).constraint;
+                    return node as Node as ThisTypeNode === parent.constraint;
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.PropertySignature:
                 case SyntaxKind.Parameter:
                 case SyntaxKind.VariableDeclaration:
-                    return node === (parent as HasType).type;
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.FunctionExpression:
                 case SyntaxKind.ArrowFunction:
@@ -2466,17 +2442,15 @@ export function isPartOfTypeNode(node: Node): boolean {
                 case SyntaxKind.MethodSignature:
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
-                    return node === (parent as FunctionLikeDeclaration).type;
                 case SyntaxKind.CallSignature:
                 case SyntaxKind.ConstructSignature:
                 case SyntaxKind.IndexSignature:
-                    return node === (parent as SignatureDeclaration).type;
                 case SyntaxKind.TypeAssertionExpression:
-                    return node === (parent as TypeAssertion).type;
+                    return node as Node as ThisTypeNode === parent.type;
                 case SyntaxKind.CallExpression:
                 case SyntaxKind.NewExpression:
                 case SyntaxKind.TaggedTemplateExpression:
-                    return contains((parent as CallExpression | TaggedTemplateExpression).typeArguments, node);
+                    return contains((parent as CallExpression | TaggedTemplateExpression).typeArguments, node as Node as ThisTypeNode);
             }
         }
     }
@@ -2505,7 +2479,7 @@ export function forEachReturnStatement<T>(body: Block | Statement, visitor: (stm
     function traverse(node: Node): T | undefined {
         switch (node.kind) {
             case SyntaxKind.ReturnStatement:
-                return visitor(node as ReturnStatement);
+                return visitor(node);
             case SyntaxKind.CaseBlock:
             case SyntaxKind.Block:
             case SyntaxKind.IfStatement:
@@ -2534,8 +2508,8 @@ export function forEachYieldExpression(body: Block, visitor: (expr: YieldExpress
     function traverse(node: Node): void {
         switch (node.kind) {
             case SyntaxKind.YieldExpression:
-                visitor(node as YieldExpression);
-                const operand = (node as YieldExpression).expression;
+                visitor(node);
+                const operand = (node).expression;
                 if (operand) {
                     traverse(operand);
                 }
@@ -2575,10 +2549,10 @@ export function forEachYieldExpression(body: Block, visitor: (expr: YieldExpress
  */
 export function getRestParameterElementType(node: TypeNode | undefined) {
     if (node && node.kind === SyntaxKind.ArrayType) {
-        return (node as ArrayTypeNode).elementType;
+        return (node).elementType;
     }
     else if (node && node.kind === SyntaxKind.TypeReference) {
-        return singleOrUndefined((node as TypeReferenceNode).typeArguments);
+        return singleOrUndefined((node).typeArguments);
     }
     else {
         return undefined;
@@ -2594,7 +2568,7 @@ export function getMembersOfDeclaration(node: Declaration): NodeArray<ClassEleme
         case SyntaxKind.TypeLiteral:
             return (node as ObjectTypeDeclaration).members;
         case SyntaxKind.ObjectLiteralExpression:
-            return (node as ObjectLiteralExpression).properties;
+            return (node).properties;
     }
 }
 
@@ -2671,7 +2645,7 @@ export function unwrapInnermostStatementOfLabel(node: LabeledStatement, beforeUn
         if (node.statement.kind !== SyntaxKind.LabeledStatement) {
             return node.statement;
         }
-        node = node.statement as LabeledStatement;
+        node = node.statement ;
     }
 }
 
@@ -2815,7 +2789,7 @@ export function getThisContainer(node: Node, includeArrowFunctions: boolean, inc
                 // A computed property name in a class needs to be a this container
                 // so that we can error on it.
                 if (includeClassComputedPropertyName && isClassLike(node.parent.parent)) {
-                    return node as ComputedPropertyName;
+                    return node ;
                 }
                 // If this is a computed property, then the parent should not
                 // make it a this container. The parent might be a property
@@ -2999,14 +2973,14 @@ export function getSuperContainer(node: Node, stopOnFunctions: boolean) {
 /** @internal */
 export function getImmediatelyInvokedFunctionExpression(func: Node): CallExpression | undefined {
     if (func.kind === SyntaxKind.FunctionExpression || func.kind === SyntaxKind.ArrowFunction) {
-        let prev = func;
+        let prev: Node = func;
         let parent = func.parent;
         while (parent.kind === SyntaxKind.ParenthesizedExpression) {
             prev = parent;
             parent = parent.parent;
         }
-        if (parent.kind === SyntaxKind.CallExpression && (parent as CallExpression).expression === prev) {
-            return parent as CallExpression;
+        if (parent.kind === SyntaxKind.CallExpression && (parent).expression === prev) {
+            return parent ;
         }
     }
 }
@@ -3025,7 +2999,7 @@ export function isSuperOrSuperProperty(node: Node): node is SuperExpression | Su
 export function isSuperProperty(node: Node): node is SuperProperty {
     const kind = node.kind;
     return (kind === SyntaxKind.PropertyAccessExpression || kind === SyntaxKind.ElementAccessExpression)
-        && (node as PropertyAccessExpression | ElementAccessExpression).expression.kind === SyntaxKind.SuperKeyword;
+        && (node).expression.kind === SyntaxKind.SuperKeyword;
 }
 
 /**
@@ -3036,7 +3010,7 @@ export function isSuperProperty(node: Node): node is SuperProperty {
 export function isThisProperty(node: Node): boolean {
     const kind = node.kind;
     return (kind === SyntaxKind.PropertyAccessExpression || kind === SyntaxKind.ElementAccessExpression)
-        && (node as PropertyAccessExpression | ElementAccessExpression).expression.kind === SyntaxKind.ThisKeyword;
+        && (node).expression.kind === SyntaxKind.ThisKeyword;
 }
 
 /** @internal */
@@ -3057,11 +3031,11 @@ export function isThisInitializedObjectBindingExpression(node: Node | undefined)
 export function getEntityNameFromTypeNode(node: TypeNode): EntityNameOrEntityNameExpression | undefined {
     switch (node.kind) {
         case SyntaxKind.TypeReference:
-            return (node as TypeReferenceNode).typeName;
+            return (node).typeName;
 
         case SyntaxKind.ExpressionWithTypeArguments:
-            return isEntityNameExpression((node as ExpressionWithTypeArguments).expression)
-                ? (node as ExpressionWithTypeArguments).expression as EntityNameExpression
+            return isEntityNameExpression((node).expression)
+                ? (node).expression
                 : undefined;
 
         // TODO(rbuckton): These aren't valid TypeNodes, but we treat them as such because of `isPartOfTypeNode`, which returns `true` for things that aren't `TypeNode`s.
@@ -3172,9 +3146,9 @@ export function childIsDecorated(useLegacyDecorators: boolean, node: Node, paren
 export function childIsDecorated(useLegacyDecorators: boolean, node: Node, parent?: Node): boolean {
     switch (node.kind) {
         case SyntaxKind.ClassDeclaration:
-            return some((node as ClassDeclaration).members, m => nodeOrChildIsDecorated(useLegacyDecorators, m, node, parent!));
+            return some((node).members, m => nodeOrChildIsDecorated(useLegacyDecorators, m, node, parent!));
             case SyntaxKind.ClassExpression:
-                return !useLegacyDecorators && some((node as ClassExpression).members, m => nodeOrChildIsDecorated(useLegacyDecorators, m, node, parent!));
+                return !useLegacyDecorators && some((node).members, m => nodeOrChildIsDecorated(useLegacyDecorators, m, node, parent!));
         case SyntaxKind.MethodDeclaration:
         case SyntaxKind.SetAccessor:
         case SyntaxKind.Constructor:
@@ -3339,33 +3313,33 @@ export function isInExpressionContext(node: Node): boolean {
         case SyntaxKind.ThrowStatement:
             return (parent as ExpressionStatement).expression === node;
         case SyntaxKind.ForStatement:
-            const forStatement = parent as ForStatement;
+            const forStatement = parent ;
             return (forStatement.initializer === node && forStatement.initializer.kind !== SyntaxKind.VariableDeclarationList) ||
                 forStatement.condition === node ||
                 forStatement.incrementor === node;
         case SyntaxKind.ForInStatement:
         case SyntaxKind.ForOfStatement:
-            const forInStatement = parent as ForInStatement | ForOfStatement;
+            const forInStatement = parent ;
             return (forInStatement.initializer === node && forInStatement.initializer.kind !== SyntaxKind.VariableDeclarationList) ||
                 forInStatement.expression === node;
         case SyntaxKind.TypeAssertionExpression:
         case SyntaxKind.AsExpression:
             return node === (parent as AssertionExpression).expression;
         case SyntaxKind.TemplateSpan:
-            return node === (parent as TemplateSpan).expression;
+            return node === (parent).expression;
         case SyntaxKind.ComputedPropertyName:
-            return node === (parent as ComputedPropertyName).expression;
+            return node === (parent).expression;
         case SyntaxKind.Decorator:
         case SyntaxKind.JsxExpression:
         case SyntaxKind.JsxSpreadAttribute:
         case SyntaxKind.SpreadAssignment:
             return true;
         case SyntaxKind.ExpressionWithTypeArguments:
-            return (parent as ExpressionWithTypeArguments).expression === node && !isPartOfTypeNode(parent);
+            return (parent).expression === node && !isPartOfTypeNode(parent);
         case SyntaxKind.ShorthandPropertyAssignment:
-            return (parent as ShorthandPropertyAssignment).objectAssignmentInitializer === node;
+            return (parent).objectAssignmentInitializer === node;
         case SyntaxKind.SatisfiesExpression:
-            return node === (parent as SatisfiesExpression).expression;
+            return node === (parent).expression;
         default:
             return isExpressionNode(parent);
     }
@@ -3386,7 +3360,7 @@ export function isNamespaceReexportDeclaration(node: Node): boolean {
 
 /** @internal */
 export function isExternalModuleImportEqualsDeclaration(node: Node): node is ImportEqualsDeclaration & { moduleReference: ExternalModuleReference } {
-    return node.kind === SyntaxKind.ImportEqualsDeclaration && (node as ImportEqualsDeclaration).moduleReference.kind === SyntaxKind.ExternalModuleReference;
+    return node.kind === SyntaxKind.ImportEqualsDeclaration && (node).moduleReference.kind === SyntaxKind.ExternalModuleReference;
 }
 
 /** @internal */
@@ -3402,7 +3376,7 @@ export function getExternalModuleRequireArgument(node: Node) {
 
 /** @internal */
 export function isInternalModuleImportEqualsDeclaration(node: Node): node is ImportEqualsDeclaration {
-    return node.kind === SyntaxKind.ImportEqualsDeclaration && (node as ImportEqualsDeclaration).moduleReference.kind !== SyntaxKind.ExternalModuleReference;
+    return node.kind === SyntaxKind.ImportEqualsDeclaration && (node).moduleReference.kind !== SyntaxKind.ExternalModuleReference;
 }
 
 /** @internal */
@@ -3459,9 +3433,9 @@ export function isRequireCall(callExpression: Node, requireStringLiteralLikeArgu
     if (callExpression.kind !== SyntaxKind.CallExpression) {
         return false;
     }
-    const { expression, arguments: args } = callExpression as CallExpression;
+    const { expression, arguments: args } = callExpression ;
 
-    if (expression.kind !== SyntaxKind.Identifier || (expression as Identifier).escapedText !== "require") {
+    if (expression.kind !== SyntaxKind.Identifier || (expression).escapedText !== "require") {
         return false;
     }
 
@@ -3874,7 +3848,7 @@ export function getAssignmentDeclarationPropertyAccessKind(lhs: AccessExpression
 }
 
 /** @internal */
-export function getInitializerOfBinaryExpression(expr: BinaryExpression) {
+export function getInitializerOfBinaryExpression(expr: BinaryExpression): Expression {
     while (isBinaryExpression(expr.right)) {
         expr = expr.right;
     }
@@ -3956,7 +3930,7 @@ export function tryGetImportFromModuleSpecifier(node: StringLiteralLike): AnyVal
         case SyntaxKind.ExportDeclaration:
             return node.parent as AnyValidImportOrReExport;
         case SyntaxKind.ExternalModuleReference:
-            return (node.parent as ExternalModuleReference).parent as AnyValidImportOrReExport;
+            return (node.parent).parent as AnyValidImportOrReExport;
         case SyntaxKind.CallExpression:
             return isImportCall(node.parent) || isRequireCall(node.parent, /*requireStringLiteralLikeArgument*/ false) ? node.parent as RequireOrImportCall : undefined;
         case SyntaxKind.LiteralType:
@@ -4079,9 +4053,9 @@ export function getSingleInitializerOfVariableStatementOrPropertyDeclaration(nod
             const v = getSingleVariableOfVariableStatement(node);
             return v && v.initializer;
         case SyntaxKind.PropertyDeclaration:
-            return (node as PropertyDeclaration).initializer;
+            return (node).initializer;
         case SyntaxKind.PropertyAssignment:
-            return (node as PropertyAssignment).initializer;
+            return (node).initializer;
     }
 }
 
@@ -4236,11 +4210,11 @@ export function getJSDocCommentsAndTags(hostNode: Node, noCache?: boolean): read
         }
 
         if (node.kind === SyntaxKind.Parameter) {
-            result = addRange(result, (noCache ? getJSDocParameterTagsNoCache : getJSDocParameterTags)(node as ParameterDeclaration));
+            result = addRange(result, (noCache ? getJSDocParameterTagsNoCache : getJSDocParameterTags)(node));
             break;
         }
         if (node.kind === SyntaxKind.TypeParameter) {
-            result = addRange(result, (noCache ? getJSDocTypeParameterTagsNoCache : getJSDocTypeParameterTags)(node as TypeParameterDeclaration));
+            result = addRange(result, (noCache ? getJSDocTypeParameterTagsNoCache : getJSDocTypeParameterTags)(node));
             break;
         }
         node = getNextJSDocCommentLocation(node);
@@ -4269,7 +4243,7 @@ function ownsJSDocTag(hostNode: Node, tag: JSDocTag) {
 }
 
 /** @internal */
-export function getNextJSDocCommentLocation(node: Node) {
+export function getNextJSDocCommentLocation(node: Node): Node | undefined {
     const parent = node.parent;
     if (parent.kind === SyntaxKind.PropertyAssignment ||
         parent.kind === SyntaxKind.ExportAssignment ||
@@ -4401,13 +4375,13 @@ export function getAssignmentTargetKind(node: Node): AssignmentKind {
     while (true) {
         switch (parent.kind) {
             case SyntaxKind.BinaryExpression:
-                const binaryOperator = (parent as BinaryExpression).operatorToken.kind;
-                return isAssignmentOperator(binaryOperator) && (parent as BinaryExpression).left === node ?
+                const binaryOperator = parent.operatorToken.kind;
+                return isAssignmentOperator(binaryOperator) && parent.left === node ?
                     binaryOperator === SyntaxKind.EqualsToken || isLogicalOrCoalescingAssignmentOperator(binaryOperator) ? AssignmentKind.Definite : AssignmentKind.Compound :
                     AssignmentKind.None;
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
-                const unaryOperator = (parent as PrefixUnaryExpression | PostfixUnaryExpression).operator;
+                const unaryOperator = parent.operator;
                 return unaryOperator === SyntaxKind.PlusPlusToken || unaryOperator === SyntaxKind.MinusMinusToken ? AssignmentKind.Compound : AssignmentKind.None;
             case SyntaxKind.ForInStatement:
             case SyntaxKind.ForOfStatement:
@@ -4422,13 +4396,13 @@ export function getAssignmentTargetKind(node: Node): AssignmentKind {
                 node = parent.parent;
                 break;
             case SyntaxKind.ShorthandPropertyAssignment:
-                if ((parent as ShorthandPropertyAssignment).name !== node) {
+                if (parent.name !== node) {
                     return AssignmentKind.None;
                 }
                 node = parent.parent;
                 break;
             case SyntaxKind.PropertyAssignment:
-                if ((parent as ShorthandPropertyAssignment).name === node) {
+                if (parent.name === node) {
                     return AssignmentKind.None;
                 }
                 node = parent.parent;
@@ -4538,7 +4512,7 @@ export function walkUpParenthesizedExpressions(node: Node) {
 export function walkUpParenthesizedTypesAndGetParentAndChild(node: Node): [ParenthesizedTypeNode | undefined, Node] {
     let child: ParenthesizedTypeNode | undefined;
     while (node && node.kind === SyntaxKind.ParenthesizedType) {
-        child = node as ParenthesizedTypeNode;
+        child = node ;
         node = node.parent;
     }
     return [child, node];
@@ -4646,11 +4620,11 @@ export function isIdentifierName(node: Identifier): boolean {
             return (parent as NamedDeclaration | PropertyAccessExpression).name === node;
         case SyntaxKind.QualifiedName:
             // Name on right hand side of dot in a type query or type reference
-            return (parent as QualifiedName).right === node;
+            return (parent).right === node;
         case SyntaxKind.BindingElement:
         case SyntaxKind.ImportSpecifier:
             // Property name in binding element or import specifier
-            return (parent as BindingElement | ImportSpecifier).propertyName === node;
+            return (parent).propertyName === node;
         case SyntaxKind.ExportSpecifier:
         case SyntaxKind.JsxAttribute:
         case SyntaxKind.JsxSelfClosingElement:
@@ -4681,12 +4655,12 @@ export function isIdentifierName(node: Identifier): boolean {
 export function isAliasSymbolDeclaration(node: Node): boolean {
     if (node.kind === SyntaxKind.ImportEqualsDeclaration ||
         node.kind === SyntaxKind.NamespaceExportDeclaration ||
-        node.kind === SyntaxKind.ImportClause && !!(node as ImportClause).name ||
+        node.kind === SyntaxKind.ImportClause && !!(node).name ||
         node.kind === SyntaxKind.NamespaceImport ||
         node.kind === SyntaxKind.NamespaceExport ||
         node.kind === SyntaxKind.ImportSpecifier ||
         node.kind === SyntaxKind.ExportSpecifier ||
-        node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(node as ExportAssignment)
+        node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(node)
     ) {
         return true;
     }
@@ -4713,7 +4687,7 @@ export function getAliasDeclarationFromName(node: EntityName): Declaration | und
             return node.parent as Declaration;
         case SyntaxKind.QualifiedName:
             do {
-                node = node.parent as QualifiedName;
+                node = node.parent ;
             } while (node.parent.kind === SyntaxKind.QualifiedName);
             return getAliasDeclarationFromName(node);
     }
@@ -5027,7 +5001,7 @@ export function isPrivateIdentifierSymbol(symbol: Symbol): boolean {
  * @internal
  */
 export function isESSymbolIdentifier(node: Node): boolean {
-    return node.kind === SyntaxKind.Identifier && (node as Identifier).escapedText === "Symbol";
+    return node.kind === SyntaxKind.Identifier && (node).escapedText === "Symbol";
 }
 
 /**
@@ -5061,7 +5035,7 @@ export function isAnonymousFunctionDefinition(node: Expression, cb?: (node: Anon
     switch (node.kind) {
         case SyntaxKind.ClassExpression:
         case SyntaxKind.FunctionExpression:
-            if ((node as ClassExpression | FunctionExpression).name) {
+            if ((node).name) {
                 return false;
             }
             break;
@@ -5093,24 +5067,24 @@ export type NamedEvaluationSource =
 export function isNamedEvaluationSource(node: Node): node is NamedEvaluationSource {
     switch (node.kind) {
         case SyntaxKind.PropertyAssignment:
-            return !isProtoSetter((node as PropertyAssignment).name);
+            return !isProtoSetter((node).name);
         case SyntaxKind.ShorthandPropertyAssignment:
-            return !!(node as ShorthandPropertyAssignment).objectAssignmentInitializer;
+            return !!(node).objectAssignmentInitializer;
         case SyntaxKind.VariableDeclaration:
-            return isIdentifier((node as VariableDeclaration).name) && !!(node as VariableDeclaration).initializer;
+            return isIdentifier((node).name) && !!(node).initializer;
         case SyntaxKind.Parameter:
-            return isIdentifier((node as ParameterDeclaration).name) && !!(node as VariableDeclaration).initializer && !(node as BindingElement).dotDotDotToken;
+            return isIdentifier((node).name) && !!node.initializer && !node.dotDotDotToken;
         case SyntaxKind.BindingElement:
-            return isIdentifier((node as BindingElement).name) && !!(node as VariableDeclaration).initializer && !(node as BindingElement).dotDotDotToken;
+            return isIdentifier((node).name) && !!node.initializer && !node.dotDotDotToken;
         case SyntaxKind.PropertyDeclaration:
-            return !!(node as PropertyDeclaration).initializer;
+            return !!(node).initializer;
         case SyntaxKind.BinaryExpression:
-            switch ((node as BinaryExpression).operatorToken.kind) {
+            switch ((node).operatorToken.kind) {
                 case SyntaxKind.EqualsToken:
                 case SyntaxKind.AmpersandAmpersandEqualsToken:
                 case SyntaxKind.BarBarEqualsToken:
                 case SyntaxKind.QuestionQuestionEqualsToken:
-                    return isIdentifier((node as BinaryExpression).left);
+                    return isIdentifier((node).left);
             }
             break;
         case SyntaxKind.ExportAssignment:
@@ -5216,7 +5190,7 @@ export const enum Associativity {
 /** @internal */
 export function getExpressionAssociativity(expression: Expression) {
     const operator = getOperator(expression);
-    const hasArguments = expression.kind === SyntaxKind.NewExpression && (expression as NewExpression).arguments !== undefined;
+    const hasArguments = expression.kind === SyntaxKind.NewExpression && (expression).arguments !== undefined;
     return getOperatorAssociativity(expression.kind, operator, hasArguments);
 }
 
@@ -5263,17 +5237,17 @@ export function getOperatorAssociativity(kind: SyntaxKind, operator: SyntaxKind,
 /** @internal */
 export function getExpressionPrecedence(expression: Expression) {
     const operator = getOperator(expression);
-    const hasArguments = expression.kind === SyntaxKind.NewExpression && (expression as NewExpression).arguments !== undefined;
+    const hasArguments = expression.kind === SyntaxKind.NewExpression && (expression).arguments !== undefined;
     return getOperatorPrecedence(expression.kind, operator, hasArguments);
 }
 
 /** @internal */
 export function getOperator(expression: Expression): SyntaxKind {
     if (expression.kind === SyntaxKind.BinaryExpression) {
-        return (expression as BinaryExpression).operatorToken.kind;
+        return (expression).operatorToken.kind;
     }
     else if (expression.kind === SyntaxKind.PrefixUnaryExpression || expression.kind === SyntaxKind.PostfixUnaryExpression) {
-        return (expression as PrefixUnaryExpression | PostfixUnaryExpression).operator;
+        return (expression).operator;
     }
     else {
         return expression.kind;
@@ -6343,7 +6317,7 @@ export function parameterIsThisKeyword(parameter: ParameterDeclaration): boolean
 
 /** @internal */
 export function isThisIdentifier(node: Node | undefined): boolean {
-    return !!node && node.kind === SyntaxKind.Identifier && identifierIsThisKeyword(node as Identifier);
+    return !!node && node.kind === SyntaxKind.Identifier && identifierIsThisKeyword(node);
 }
 
 /** @internal */
@@ -7015,8 +6989,8 @@ export function isDottedName(node: Expression): boolean {
         || node.kind === SyntaxKind.ThisKeyword
         || node.kind === SyntaxKind.SuperKeyword
         || node.kind === SyntaxKind.MetaProperty
-        || node.kind === SyntaxKind.PropertyAccessExpression && isDottedName((node as PropertyAccessExpression).expression)
-        || node.kind === SyntaxKind.ParenthesizedExpression && isDottedName((node as ParenthesizedExpression).expression);
+        || node.kind === SyntaxKind.PropertyAccessExpression && isDottedName((node).expression)
+        || node.kind === SyntaxKind.ParenthesizedExpression && isDottedName((node).expression);
 }
 
 /** @internal */
@@ -7051,8 +7025,8 @@ export function isPrototypeAccess(node: Node): node is BindableStaticAccessExpre
 
 /** @internal */
 export function isRightSideOfQualifiedNameOrPropertyAccess(node: Node) {
-    return (node.parent.kind === SyntaxKind.QualifiedName && (node.parent as QualifiedName).right === node) ||
-        (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).name === node);
+    return (node.parent.kind === SyntaxKind.QualifiedName && (node.parent).right === node) ||
+        (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent).name === node);
 }
 
 /** @internal */
@@ -7071,13 +7045,13 @@ export function isRightSideOfQualifiedNameOrPropertyAccessOrJSDocMemberName(node
 /** @internal */
 export function isEmptyObjectLiteral(expression: Node): boolean {
     return expression.kind === SyntaxKind.ObjectLiteralExpression &&
-        (expression as ObjectLiteralExpression).properties.length === 0;
+        (expression).properties.length === 0;
 }
 
 /** @internal */
 export function isEmptyArrayLiteral(expression: Node): boolean {
     return expression.kind === SyntaxKind.ArrayLiteralExpression &&
-        (expression as ArrayLiteralExpression).elements.length === 0;
+        (expression).elements.length === 0;
 }
 
 /** @internal */
@@ -7560,23 +7534,23 @@ function accessKind(node: Node): AccessKind {
             return accessKind(parent);
         case SyntaxKind.PostfixUnaryExpression:
         case SyntaxKind.PrefixUnaryExpression:
-            const { operator } = parent as PrefixUnaryExpression | PostfixUnaryExpression;
+            const { operator } = parent ;
             return operator === SyntaxKind.PlusPlusToken || operator === SyntaxKind.MinusMinusToken ? AccessKind.ReadWrite : AccessKind.Read;
         case SyntaxKind.BinaryExpression:
-            const { left, operatorToken } = parent as BinaryExpression;
+            const { left, operatorToken } = parent ;
             return left === node && isAssignmentOperator(operatorToken.kind) ?
                 operatorToken.kind === SyntaxKind.EqualsToken ? AccessKind.Write : AccessKind.ReadWrite
                 : AccessKind.Read;
         case SyntaxKind.PropertyAccessExpression:
-            return (parent as PropertyAccessExpression).name !== node ? AccessKind.Read : accessKind(parent);
+            return (parent).name !== node ? AccessKind.Read : accessKind(parent);
         case SyntaxKind.PropertyAssignment: {
             const parentAccess = accessKind(parent.parent);
             // In `({ x: varname }) = { x: 1 }`, the left `x` is a read, the right `x` is a write.
-            return node === (parent as PropertyAssignment).name ? reverseAccessKind(parentAccess) : parentAccess;
+            return node === (parent).name ? reverseAccessKind(parentAccess) : parentAccess;
         }
         case SyntaxKind.ShorthandPropertyAssignment:
             // Assume it's the local variable being accessed, since we don't check public properties for --noUnusedLocals.
-            return node === (parent as ShorthandPropertyAssignment).objectAssignmentInitializer ? AccessKind.Read : accessKind(parent.parent);
+            return node === (parent).objectAssignmentInitializer ? AccessKind.Read : accessKind(parent.parent);
         case SyntaxKind.ArrayLiteralExpression:
             return accessKind(parent);
         default:
@@ -7797,7 +7771,7 @@ export function isAccessExpression(node: Node): node is AccessExpression {
 }
 
 /** @internal */
-export function getNameOfAccessExpression(node: AccessExpression) {
+export function getNameOfAccessExpression(node: AccessExpression): Expression {
     if (node.kind === SyntaxKind.PropertyAccessExpression) {
         return node.name;
     }
@@ -7870,23 +7844,23 @@ export function forEachNameInAccessChainWalkingLeft<T>(name: MemberName | String
 
 
 /** @internal */
-export function getLeftmostExpression(node: Expression, stopAtCallExpressions: boolean) {
+export function getLeftmostExpression(node: Expression, stopAtCallExpressions: boolean): Expression {
     while (true) {
         switch (node.kind) {
             case SyntaxKind.PostfixUnaryExpression:
-                node = (node as PostfixUnaryExpression).operand;
+                node = node.operand;
                 continue;
 
             case SyntaxKind.BinaryExpression:
-                node = (node as BinaryExpression).left;
+                node = node.left;
                 continue;
 
             case SyntaxKind.ConditionalExpression:
-                node = (node as ConditionalExpression).condition;
+                node = node.condition;
                 continue;
 
             case SyntaxKind.TaggedTemplateExpression:
-                node = (node as TaggedTemplateExpression).tag;
+                node = node.tag;
                 continue;
 
             case SyntaxKind.CallExpression:
@@ -7900,7 +7874,7 @@ export function getLeftmostExpression(node: Expression, stopAtCallExpressions: b
             case SyntaxKind.NonNullExpression:
             case SyntaxKind.PartiallyEmittedExpression:
             case SyntaxKind.SatisfiesExpression:
-                node = (node as CallExpression | PropertyAccessExpression | ElementAccessExpression | AsExpression | NonNullExpression | PartiallyEmittedExpression | SatisfiesExpression).expression;
+                node = node.expression;
                 continue;
         }
 
@@ -7911,7 +7885,7 @@ export function getLeftmostExpression(node: Expression, stopAtCallExpressions: b
 /** @internal */
 export interface ObjectAllocator {
     getNodeConstructor(): new (kind: SyntaxKind, pos: number, end: number) => Node;
-    getTokenConstructor(): new <TKind extends SyntaxKind>(kind: TKind, pos: number, end: number) => Token<TKind>;
+    getTokenConstructor(): new <TKind extends SyntaxKind>(kind: TKind, pos: number, end: number) => SyntaxKindToNode[TKind & keyof SyntaxKindToNode];
     getIdentifierConstructor(): new (kind: SyntaxKind.Identifier, pos: number, end: number) => Identifier;
     getPrivateIdentifierConstructor(): new (kind: SyntaxKind.PrivateIdentifier, pos: number, end: number) => PrivateIdentifier;
     getSourceFileConstructor(): new (kind: SyntaxKind.SourceFile, pos: number, end: number) => SourceFile;
@@ -7955,7 +7929,8 @@ function Signature(this: Signature, checker: TypeChecker, flags: SignatureFlags)
 function Node(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
     this.pos = pos;
     this.end = end;
-    this.kind = kind;
+    Debug.assert(kind !== SyntaxKind.Count);
+    this.kind = kind ;
     this.id = 0;
     this.flags = NodeFlags.None;
     this.modifierFlagsCache = ModifierFlags.None;
@@ -7968,6 +7943,7 @@ function Node(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
 function Token(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
     this.pos = pos;
     this.end = end;
+    Debug.assert(kind !== SyntaxKind.Count);
     this.kind = kind;
     this.id = 0;
     this.flags = NodeFlags.None;
@@ -7979,6 +7955,7 @@ function Token(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) 
 function Identifier(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
     this.pos = pos;
     this.end = end;
+    Debug.assert(kind !== SyntaxKind.Count);
     this.kind = kind;
     this.id = 0;
     this.flags = NodeFlags.None;
@@ -9876,32 +9853,32 @@ export function getContainingNodeArray(node: Node): NodeArray<Node> | undefined 
     if (!node.parent) return undefined;
     switch (node.kind) {
         case SyntaxKind.TypeParameter:
-            const { parent } = node as TypeParameterDeclaration;
-            return parent.kind === SyntaxKind.InferType ? undefined : parent.typeParameters;
+            const { parent } = node ;
+            return parent.kind === SyntaxKind.InferType || parent.kind === SyntaxKind.MappedType ? undefined : parent.typeParameters;
         case SyntaxKind.Parameter:
-            return (node as ParameterDeclaration).parent.parameters;
+            return (node).parent.parameters;
         case SyntaxKind.TemplateLiteralTypeSpan:
-            return (node as TemplateLiteralTypeSpan).parent.templateSpans;
+            return (node).parent.templateSpans;
         case SyntaxKind.TemplateSpan:
-            return (node as TemplateSpan).parent.templateSpans;
+            return (node).parent.templateSpans;
         case SyntaxKind.Decorator: {
-            const { parent } = node as Decorator;
+            const { parent } = node ;
             return canHaveDecorators(parent) ? parent.modifiers :
                 undefined;
         }
         case SyntaxKind.HeritageClause:
-            return (node as HeritageClause).parent.heritageClauses;
+            return (node).parent.heritageClauses;
     }
 
     const { parent } = node;
     if (isJSDocTag(node)) {
-        return isJSDocTypeLiteral(node.parent) ? undefined : node.parent.tags;
+        return isJSDocTypeLiteral(node.parent) || isJSDocSignature(node.parent) ? undefined : node.parent.tags;
     }
 
     switch (parent.kind) {
         case SyntaxKind.TypeLiteral:
         case SyntaxKind.InterfaceDeclaration:
-            return isTypeElement(node) ? (parent as TypeLiteralNode | InterfaceDeclaration).members : undefined;
+            return isTypeElement(node) ? (parent).members : undefined;
         case SyntaxKind.UnionType:
         case SyntaxKind.IntersectionType:
             return (parent as UnionOrIntersectionTypeNode).types;
@@ -9910,35 +9887,35 @@ export function getContainingNodeArray(node: Node): NodeArray<Node> | undefined 
         case SyntaxKind.CommaListExpression:
         case SyntaxKind.NamedImports:
         case SyntaxKind.NamedExports:
-            return (parent as TupleTypeNode | ArrayLiteralExpression | CommaListExpression | NamedImports | NamedExports).elements;
+            return (parent).elements;
         case SyntaxKind.ObjectLiteralExpression:
         case SyntaxKind.JsxAttributes:
             return (parent as ObjectLiteralExpressionBase<ObjectLiteralElement>).properties;
         case SyntaxKind.CallExpression:
         case SyntaxKind.NewExpression:
-            return isTypeNode(node) ? (parent as CallExpression | NewExpression).typeArguments :
-                (parent as CallExpression | NewExpression).expression === node ? undefined :
-                (parent as CallExpression | NewExpression).arguments;
+            return isTypeNode(node) ? (parent).typeArguments :
+                (parent).expression === node ? undefined :
+                (parent).arguments;
         case SyntaxKind.JsxElement:
         case SyntaxKind.JsxFragment:
-            return isJsxChild(node) ? (parent as JsxElement | JsxFragment).children : undefined;
+            return isJsxChild(node) ? (parent).children : undefined;
         case SyntaxKind.JsxOpeningElement:
         case SyntaxKind.JsxSelfClosingElement:
-            return isTypeNode(node) ? (parent as JsxOpeningElement | JsxSelfClosingElement).typeArguments : undefined;
+            return isTypeNode(node) ? (parent).typeArguments : undefined;
         case SyntaxKind.Block:
         case SyntaxKind.CaseClause:
         case SyntaxKind.DefaultClause:
         case SyntaxKind.ModuleBlock:
             return (parent as Block | CaseOrDefaultClause | ModuleBlock).statements;
         case SyntaxKind.CaseBlock:
-            return (parent as CaseBlock).clauses;
+            return (parent).clauses;
         case SyntaxKind.ClassDeclaration:
         case SyntaxKind.ClassExpression:
             return isClassElement(node) ? (parent as ClassLikeDeclaration).members : undefined;
         case SyntaxKind.EnumDeclaration:
-            return isEnumMember(node) ? (parent as EnumDeclaration).members : undefined;
+            return isEnumMember(node) ? (parent).members : undefined;
         case SyntaxKind.SourceFile:
-            return (parent as SourceFile).statements;
+            return (parent).statements;
     }
 }
 
@@ -10110,10 +10087,10 @@ export function isTypeDeclaration(node: Node): node is TypeParameterDeclaration 
         case SyntaxKind.JSDocEnumTag:
             return true;
         case SyntaxKind.ImportClause:
-            return (node as ImportClause).isTypeOnly;
+            return (node).isTypeOnly;
         case SyntaxKind.ImportSpecifier:
         case SyntaxKind.ExportSpecifier:
-            return (node as ImportSpecifier | ExportSpecifier).parent.parent.isTypeOnly;
+            return (node).parent.parent.isTypeOnly;
         default:
             return false;
     }
@@ -10165,9 +10142,9 @@ export function isOptionalDeclaration(declaration: Declaration): boolean {
     switch (declaration.kind) {
         case SyntaxKind.PropertyDeclaration:
         case SyntaxKind.PropertySignature:
-            return !!(declaration as PropertyDeclaration | PropertySignature).questionToken;
+            return !!(declaration).questionToken;
         case SyntaxKind.Parameter:
-            return !!(declaration as ParameterDeclaration).questionToken || isJSDocOptionalParameter(declaration as ParameterDeclaration);
+            return !!(declaration).questionToken || isJSDocOptionalParameter(declaration);
         case SyntaxKind.JSDocPropertyTag:
         case SyntaxKind.JSDocParameterTag:
             return isOptionalJSDocPropertyLikeTag(declaration);
@@ -10189,7 +10166,7 @@ export function isJSDocSatisfiesExpression(node: Node): node is JSDocSatisfiesEx
 }
 
 /** @internal */
-export function getJSDocSatisfiesExpressionType(node: JSDocSatisfiesExpression) {
+export function getJSDocSatisfiesExpressionType(node: JSDocSatisfiesExpression): TypeNode {
     return Debug.checkDefined(tryGetJSDocSatisfiesTypeNode(node));
 }
 

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -48,14 +48,11 @@ import {
     Diagnostic,
     Diagnostics,
     ElementAccessChain,
-    ElementAccessExpression,
     emptyArray,
     EntityName,
     entityNameToString,
     EnumDeclaration,
     every,
-    ExportAssignment,
-    ExportDeclaration,
     ExportSpecifier,
     Expression,
     FileReference,
@@ -91,8 +88,6 @@ import {
     hasSyntacticModifier,
     HasType,
     Identifier,
-    ImportClause,
-    ImportEqualsDeclaration,
     ImportSpecifier,
     ImportTypeNode,
     isAccessExpression,
@@ -214,8 +209,6 @@ import {
     NamedExportBindings,
     NamedImportBindings,
     NamespaceBody,
-    NamespaceExport,
-    NamespaceImport,
     NewExpression,
     Node,
     NodeArray,
@@ -820,14 +813,14 @@ function nameForNamelessJSDocTypedef(declaration: JSDocTypedefTag | JSDocEnumTag
             break;
         case SyntaxKind.ExpressionStatement:
             let expr = hostNode.expression;
-            if (expr.kind === SyntaxKind.BinaryExpression && (expr as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken) {
-                expr = (expr as BinaryExpression).left;
+            if (expr.kind === SyntaxKind.BinaryExpression && (expr).operatorToken.kind === SyntaxKind.EqualsToken) {
+                expr = (expr).left;
             }
             switch (expr.kind) {
                 case SyntaxKind.PropertyAccessExpression:
-                    return (expr as PropertyAccessExpression).name;
+                    return (expr).name;
                 case SyntaxKind.ElementAccessExpression:
-                    const arg = (expr as ElementAccessExpression).argumentExpression;
+                    const arg = (expr).argumentExpression;
                     if (isIdentifier(arg)) {
                         return arg;
                     }
@@ -874,7 +867,7 @@ export function isNamedDeclaration(node: Node): node is NamedDeclaration & { nam
 export function getNonAssignedNameOfDeclaration(declaration: Declaration | Expression): DeclarationName | undefined {
     switch (declaration.kind) {
         case SyntaxKind.Identifier:
-            return declaration as Identifier;
+            return declaration ;
         case SyntaxKind.JSDocPropertyTag:
         case SyntaxKind.JSDocParameterTag: {
             const { name } = declaration as JSDocPropertyLikeTag;
@@ -885,7 +878,7 @@ export function getNonAssignedNameOfDeclaration(declaration: Declaration | Expre
         }
         case SyntaxKind.CallExpression:
         case SyntaxKind.BinaryExpression: {
-            const expr = declaration as BinaryExpression | CallExpression;
+            const expr = declaration ;
             switch (getAssignmentDeclarationKind(expr)) {
                 case AssignmentDeclarationKind.ExportsProperty:
                 case AssignmentDeclarationKind.ThisProperty:
@@ -901,15 +894,15 @@ export function getNonAssignedNameOfDeclaration(declaration: Declaration | Expre
             }
         }
         case SyntaxKind.JSDocTypedefTag:
-            return getNameOfJSDocTypedef(declaration as JSDocTypedefTag);
+            return getNameOfJSDocTypedef(declaration);
         case SyntaxKind.JSDocEnumTag:
-            return nameForNamelessJSDocTypedef(declaration as JSDocEnumTag);
+            return nameForNamelessJSDocTypedef(declaration);
         case SyntaxKind.ExportAssignment: {
-            const { expression } = declaration as ExportAssignment;
+            const { expression } = declaration ;
             return isIdentifier(expression) ? expression : undefined;
         }
         case SyntaxKind.ElementAccessExpression:
-            const expr = declaration as ElementAccessExpression;
+            const expr = declaration ;
             if (isBindableStaticElementAccessExpression(expr)) {
                 return expr.argumentExpression;
             }
@@ -1349,7 +1342,7 @@ export function isOutermostOptionalChain(node: OptionalChain) {
 }
 
 export function isNullishCoalesce(node: Node) {
-    return node.kind === SyntaxKind.BinaryExpression && (node as BinaryExpression).operatorToken.kind === SyntaxKind.QuestionQuestionToken;
+    return node.kind === SyntaxKind.BinaryExpression && (node).operatorToken.kind === SyntaxKind.QuestionQuestionToken;
 }
 
 export function isConstTypeReference(node: Node) {
@@ -1487,12 +1480,12 @@ export function isImportOrExportSpecifier(node: Node): node is ImportSpecifier |
 export function isTypeOnlyImportDeclaration(node: Node): node is TypeOnlyImportDeclaration {
     switch (node.kind) {
         case SyntaxKind.ImportSpecifier:
-            return (node as ImportSpecifier).isTypeOnly || (node as ImportSpecifier).parent.parent.isTypeOnly;
+            return (node).isTypeOnly || (node).parent.parent.isTypeOnly;
         case SyntaxKind.NamespaceImport:
-            return (node as NamespaceImport).parent.isTypeOnly;
+            return (node).parent.isTypeOnly;
         case SyntaxKind.ImportClause:
         case SyntaxKind.ImportEqualsDeclaration:
-            return (node as ImportClause | ImportEqualsDeclaration).isTypeOnly;
+            return (node).isTypeOnly;
     }
     return false;
 }
@@ -1500,11 +1493,11 @@ export function isTypeOnlyImportDeclaration(node: Node): node is TypeOnlyImportD
 export function isTypeOnlyExportDeclaration(node: Node): node is TypeOnlyExportDeclaration {
     switch (node.kind) {
         case SyntaxKind.ExportSpecifier:
-            return (node as ExportSpecifier).isTypeOnly || (node as ExportSpecifier).parent.parent.isTypeOnly;
+            return (node).isTypeOnly || (node).parent.parent.isTypeOnly;
         case SyntaxKind.ExportDeclaration:
-            return (node as ExportDeclaration).isTypeOnly && !!(node as ExportDeclaration).moduleSpecifier && !(node as ExportDeclaration).exportClause;
+            return (node).isTypeOnly && !!(node).moduleSpecifier && !(node).exportClause;
         case SyntaxKind.NamespaceExport:
-            return (node as NamespaceExport).parent.isTypeOnly;
+            return (node).parent.isTypeOnly;
     }
     return false;
 }
@@ -1998,8 +1991,8 @@ export function isUnaryExpressionWithWrite(expr: Node): expr is PrefixUnaryExpre
         case SyntaxKind.PostfixUnaryExpression:
             return true;
         case SyntaxKind.PrefixUnaryExpression:
-            return (expr as PrefixUnaryExpression).operator === SyntaxKind.PlusPlusToken ||
-                (expr as PrefixUnaryExpression).operator === SyntaxKind.MinusMinusToken;
+            return (expr).operator === SyntaxKind.PlusPlusToken ||
+                (expr).operator === SyntaxKind.MinusMinusToken;
         default:
             return false;
     }
@@ -2067,7 +2060,7 @@ export function isIterationStatement(node: Node, lookInLabeledStatements: boolea
         case SyntaxKind.WhileStatement:
             return true;
         case SyntaxKind.LabeledStatement:
-            return lookInLabeledStatements && isIterationStatement((node as LabeledStatement).statement, lookInLabeledStatements);
+            return lookInLabeledStatements && isIterationStatement((node).statement, lookInLabeledStatements);
     }
 
     return false;
@@ -2356,7 +2349,7 @@ export function isDeclarationStatement(node: Node): node is DeclarationStatement
  *
  * @internal
  */
-export function isStatementButNotDeclaration(node: Node): node is Statement {
+export function isStatementButNotDeclaration(node: Node): boolean {
     return isStatementKindButNotDeclarationKind(node.kind);
 }
 

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -5,19 +5,11 @@ import {
     Block,
     BreakOrContinueStatement,
     canHaveDecorators,
-    CaseBlock,
     CaseOrDefaultClause,
-    CatchClause,
-    ClassDeclaration,
     createTextSpanFromBounds,
     Debug,
     DestructuringPattern,
-    DoStatement,
-    EnumDeclaration,
-    ExportAssignment,
-    ExportDeclaration,
     Expression,
-    ExpressionStatement,
     findLast,
     findNextToken,
     findPrecedingToken,
@@ -31,9 +23,6 @@ import {
     HasDecorators,
     hasOnlyExpressionInitializer,
     hasSyntacticModifier,
-    IfStatement,
-    ImportDeclaration,
-    ImportEqualsDeclaration,
     isArrayLiteralOrObjectLiteralDestructuringPattern,
     isAssignmentOperator,
     isBindingPattern,
@@ -42,10 +31,8 @@ import {
     isFunctionBlock,
     isFunctionLike,
     isVariableDeclarationList,
-    LabeledStatement,
     lastOrUndefined,
     ModifierFlags,
-    ModuleDeclaration,
     ModuleInstanceState,
     Node,
     NodeArray,
@@ -53,23 +40,13 @@ import {
     ObjectLiteralElement,
     ObjectLiteralExpression,
     ParameterDeclaration,
-    PropertyAssignment,
     PropertyDeclaration,
     PropertySignature,
-    ReturnStatement,
     skipTrivia,
     SourceFile,
-    SwitchStatement,
     SyntaxKind,
     TextSpan,
-    ThrowStatement,
-    TryStatement,
-    TypeAssertion,
     VariableDeclaration,
-    VariableDeclarationList,
-    VariableStatement,
-    WhileStatement,
-    WithStatement,
 } from "./_namespaces/ts";
 
 /**
@@ -155,15 +132,15 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
             switch (node.kind) {
                 case SyntaxKind.VariableStatement:
                     // Span on first variable declaration
-                    return spanInVariableDeclaration((node as VariableStatement).declarationList.declarations[0]);
+                    return spanInVariableDeclaration((node).declarationList.declarations[0]);
 
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.PropertySignature:
-                    return spanInVariableDeclaration(node as VariableDeclaration | PropertyDeclaration | PropertySignature);
+                    return spanInVariableDeclaration(node);
 
                 case SyntaxKind.Parameter:
-                    return spanInParameterDeclaration(node as ParameterDeclaration);
+                    return spanInParameterDeclaration(node);
 
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.MethodDeclaration:
@@ -177,30 +154,30 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
                 case SyntaxKind.Block:
                     if (isFunctionBlock(node)) {
-                        return spanInFunctionBlock(node as Block);
+                        return spanInFunctionBlock(node);
                     }
                     // falls through
                 case SyntaxKind.ModuleBlock:
                     return spanInBlock(node as Block);
 
                 case SyntaxKind.CatchClause:
-                    return spanInBlock((node as CatchClause).block);
+                    return spanInBlock((node).block);
 
                 case SyntaxKind.ExpressionStatement:
                     // span on the expression
-                    return textSpan((node as ExpressionStatement).expression);
+                    return textSpan((node).expression);
 
                 case SyntaxKind.ReturnStatement:
                     // span on return keyword and expression if present
-                    return textSpan(node.getChildAt(0), (node as ReturnStatement).expression);
+                    return textSpan(node.getChildAt(0), (node).expression);
 
                 case SyntaxKind.WhileStatement:
                     // Span on while(...)
-                    return textSpanEndingAtNextToken(node, (node as WhileStatement).expression);
+                    return textSpanEndingAtNextToken(node, (node).expression);
 
                 case SyntaxKind.DoStatement:
                     // span in statement of the do statement
-                    return spanInNode((node as DoStatement).statement);
+                    return spanInNode((node).statement);
 
                 case SyntaxKind.DebuggerStatement:
                     // span on debugger keyword
@@ -208,11 +185,11 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
                 case SyntaxKind.IfStatement:
                     // set on if(..) span
-                    return textSpanEndingAtNextToken(node, (node as IfStatement).expression);
+                    return textSpanEndingAtNextToken(node, (node).expression);
 
                 case SyntaxKind.LabeledStatement:
                     // span in statement
-                    return spanInNode((node as LabeledStatement).statement);
+                    return spanInNode((node).statement);
 
                 case SyntaxKind.BreakStatement:
                 case SyntaxKind.ContinueStatement:
@@ -220,19 +197,19 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
                     return textSpan(node.getChildAt(0), (node as BreakOrContinueStatement).label);
 
                 case SyntaxKind.ForStatement:
-                    return spanInForStatement(node as ForStatement);
+                    return spanInForStatement(node);
 
                 case SyntaxKind.ForInStatement:
                     // span of for (a in ...)
-                    return textSpanEndingAtNextToken(node, (node as ForInStatement).expression);
+                    return textSpanEndingAtNextToken(node, (node).expression);
 
                 case SyntaxKind.ForOfStatement:
                     // span in initializer
-                    return spanInInitializerOfForLike(node as ForOfStatement);
+                    return spanInInitializerOfForLike(node);
 
                 case SyntaxKind.SwitchStatement:
                     // span on switch(...)
-                    return textSpanEndingAtNextToken(node, (node as SwitchStatement).expression);
+                    return textSpanEndingAtNextToken(node, (node).expression);
 
                 case SyntaxKind.CaseClause:
                 case SyntaxKind.DefaultClause:
@@ -241,31 +218,31 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
                 case SyntaxKind.TryStatement:
                     // span in try block
-                    return spanInBlock((node as TryStatement).tryBlock);
+                    return spanInBlock((node).tryBlock);
 
                 case SyntaxKind.ThrowStatement:
                     // span in throw ...
-                    return textSpan(node, (node as ThrowStatement).expression);
+                    return textSpan(node, (node).expression);
 
                 case SyntaxKind.ExportAssignment:
                     // span on export = id
-                    return textSpan(node, (node as ExportAssignment).expression);
+                    return textSpan(node, (node).expression);
 
                 case SyntaxKind.ImportEqualsDeclaration:
                     // import statement without including semicolon
-                    return textSpan(node, (node as ImportEqualsDeclaration).moduleReference);
+                    return textSpan(node, (node).moduleReference);
 
                 case SyntaxKind.ImportDeclaration:
                     // import statement without including semicolon
-                    return textSpan(node, (node as ImportDeclaration).moduleSpecifier);
+                    return textSpan(node, (node).moduleSpecifier);
 
                 case SyntaxKind.ExportDeclaration:
                     // import statement without including semicolon
-                    return textSpan(node, (node as ExportDeclaration).moduleSpecifier);
+                    return textSpan(node, (node).moduleSpecifier);
 
                 case SyntaxKind.ModuleDeclaration:
                     // span on complete module if it is instantiated
-                    if (getModuleInstanceState(node as ModuleDeclaration) !== ModuleInstanceState.Instantiated) {
+                    if (getModuleInstanceState(node) !== ModuleInstanceState.Instantiated) {
                         return undefined;
                     }
                     // falls through
@@ -279,7 +256,7 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
                 case SyntaxKind.WithStatement:
                     // span in statement
-                    return spanInNode((node as WithStatement).statement);
+                    return spanInNode((node).statement);
 
                 case SyntaxKind.Decorator:
                     return spanInNodeArray((parent as HasDecorators).modifiers, node, isDecorator);
@@ -355,7 +332,7 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
                     }
 
                     if (node.kind === SyntaxKind.BinaryExpression) {
-                        const { left, operatorToken } = node as BinaryExpression;
+                        const { left, operatorToken } = node ;
                         // Set breakpoint in destructuring pattern if its destructuring assignment
                         // [a, b, c] or {a, b, c} of
                         // [a, b, c] = expression or
@@ -411,28 +388,28 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
                     switch (node.parent.kind) {
                         case SyntaxKind.PropertyAssignment:
                             // If this is name of property assignment, set breakpoint in the initializer
-                            if ((node.parent as PropertyAssignment).name === node &&
+                            if ((node.parent).name === node &&
                                 !isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent.parent)) {
-                                return spanInNode((node.parent as PropertyAssignment).initializer);
+                                return spanInNode((node.parent).initializer);
                             }
                             break;
                         case SyntaxKind.TypeAssertionExpression:
                             // Breakpoint in type assertion goes to its operand
-                            if ((node.parent as TypeAssertion).type === node) {
-                                return spanInNextNode((node.parent as TypeAssertion).type);
+                            if ((node.parent).type === node) {
+                                return spanInNextNode((node.parent).type);
                             }
                             break;
                         case SyntaxKind.VariableDeclaration:
                         case SyntaxKind.Parameter: {
                             // initializer of variable/parameter declaration go to previous node
-                            const { initializer, type } = node.parent as VariableDeclaration | ParameterDeclaration;
+                            const { initializer, type } = node.parent ;
                             if (initializer === node || type === node || isAssignmentOperator(node.kind)) {
                                 return spanInPreviousNode(node);
                             }
                             break;
                         }
                         case SyntaxKind.BinaryExpression: {
-                            const { left } = node.parent as BinaryExpression;
+                            const { left } = node.parent ;
                             if (isArrayLiteralOrObjectLiteralDestructuringPattern(left) && node !== left) {
                                 // If initializer of destructuring assignment move to previous token
                                 return spanInPreviousNode(node);
@@ -553,7 +530,7 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
         function spanInBlock(block: Block): TextSpan | undefined {
             switch (block.parent.kind) {
                 case SyntaxKind.ModuleDeclaration:
-                    if (getModuleInstanceState(block.parent as ModuleDeclaration) !== ModuleInstanceState.Instantiated) {
+                    if (getModuleInstanceState(block.parent) !== ModuleInstanceState.Instantiated) {
                         return undefined;
                     }
 
@@ -577,7 +554,7 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
         function spanInInitializerOfForLike(forLikeStatement: ForStatement | ForOfStatement | ForInStatement): TextSpan | undefined {
             if (forLikeStatement.initializer!.kind === SyntaxKind.VariableDeclarationList) {
                 // Declaration list - set breakpoint in first declaration
-                const variableDeclarationList = forLikeStatement.initializer as VariableDeclarationList;
+                const variableDeclarationList = forLikeStatement.initializer ;
                 if (variableDeclarationList.declarations.length > 0) {
                     return spanInNode(variableDeclarationList.declarations[0]);
                 }
@@ -641,15 +618,15 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
         function spanInOpenBraceToken(node: Node): TextSpan | undefined {
             switch (node.parent.kind) {
                 case SyntaxKind.EnumDeclaration:
-                    const enumDeclaration = node.parent as EnumDeclaration;
+                    const enumDeclaration = node.parent ;
                     return spanInNodeIfStartsOnSameLine(findPrecedingToken(node.pos, sourceFile, node.parent), enumDeclaration.members.length ? enumDeclaration.members[0] : enumDeclaration.getLastToken(sourceFile));
 
                 case SyntaxKind.ClassDeclaration:
-                    const classDeclaration = node.parent as ClassDeclaration;
+                    const classDeclaration = node.parent ;
                     return spanInNodeIfStartsOnSameLine(findPrecedingToken(node.pos, sourceFile, node.parent), classDeclaration.members.length ? classDeclaration.members[0] : classDeclaration.getLastToken(sourceFile));
 
                 case SyntaxKind.CaseBlock:
-                    return spanInNodeIfStartsOnSameLine(node.parent.parent, (node.parent as CaseBlock).clauses[0]);
+                    return spanInNodeIfStartsOnSameLine(node.parent.parent, (node.parent).clauses[0]);
             }
 
             // Default to parent node
@@ -660,7 +637,7 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
             switch (node.parent.kind) {
                 case SyntaxKind.ModuleBlock:
                     // If this is not an instantiated module block, no bp span
-                    if (getModuleInstanceState(node.parent.parent as ModuleDeclaration) !== ModuleInstanceState.Instantiated) {
+                    if (getModuleInstanceState(node.parent.parent) !== ModuleInstanceState.Instantiated) {
                         return undefined;
                     }
                     // falls through
@@ -682,7 +659,7 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
                 case SyntaxKind.CaseBlock:
                     // breakpoint in last statement of the last clause
-                    const caseBlock = node.parent as CaseBlock;
+                    const caseBlock = node.parent ;
                     const lastClause = lastOrUndefined(caseBlock.clauses);
                     if (lastClause) {
                         return spanInNode(lastOrUndefined(lastClause.statements));
@@ -787,7 +764,7 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
         function spanInWhileKeyword(node: Node): TextSpan | undefined {
             if (node.parent.kind === SyntaxKind.DoStatement) {
                 // Set span on while expression
-                return textSpanEndingAtNextToken(node, (node.parent as DoStatement).expression);
+                return textSpanEndingAtNextToken(node, (node.parent).expression);
             }
 
             // Default to parent node

--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -2,7 +2,6 @@ import {
     AccessExpression,
     append,
     ArrowFunction,
-    AsExpression,
     CallExpression,
     CallHierarchyIncomingCall,
     CallHierarchyItem,
@@ -88,10 +87,8 @@ import {
     NewExpression,
     Node,
     NodeFlags,
-    ParameterDeclaration,
     Program,
     PropertyAccessExpression,
-    SatisfiesExpression,
     SetAccessorDeclaration,
     skipTrivia,
     SourceFile,
@@ -100,7 +97,6 @@ import {
     TaggedTemplateExpression,
     TextRange,
     TextSpan,
-    TypeAssertion,
     TypeChecker,
     usingSingleLineStringWriter,
     VariableDeclaration,
@@ -522,37 +518,34 @@ function createCallSiteCollector(program: Program, callSites: CallSite[]): (node
             case SyntaxKind.TypeAliasDeclaration:
                 // do not descend into nodes that cannot contain callable nodes
                 return;
-            case SyntaxKind.ClassStaticBlockDeclaration:
-                recordCallSite(node as ClassStaticBlockDeclaration);
-                return;
             case SyntaxKind.TypeAssertionExpression:
             case SyntaxKind.AsExpression:
                 // do not descend into the type side of an assertion
-                collect((node as TypeAssertion | AsExpression).expression);
+                collect((node).expression);
                 return;
             case SyntaxKind.VariableDeclaration:
             case SyntaxKind.Parameter:
                 // do not descend into the type of a variable or parameter declaration
-                collect((node as VariableDeclaration | ParameterDeclaration).name);
-                collect((node as VariableDeclaration | ParameterDeclaration).initializer);
+                collect((node).name);
+                collect((node).initializer);
                 return;
             case SyntaxKind.CallExpression:
                 // do not descend into the type arguments of a call expression
-                recordCallSite(node as CallExpression);
-                collect((node as CallExpression).expression);
-                forEach((node as CallExpression).arguments, collect);
+                recordCallSite(node);
+                collect((node).expression);
+                forEach((node).arguments, collect);
                 return;
             case SyntaxKind.NewExpression:
                 // do not descend into the type arguments of a new expression
-                recordCallSite(node as NewExpression);
-                collect((node as NewExpression).expression);
-                forEach((node as NewExpression).arguments, collect);
+                recordCallSite(node);
+                collect((node).expression);
+                forEach((node).arguments, collect);
                 return;
             case SyntaxKind.TaggedTemplateExpression:
                 // do not descend into the type arguments of a tagged template expression
-                recordCallSite(node as TaggedTemplateExpression);
-                collect((node as TaggedTemplateExpression).tag);
-                collect((node as TaggedTemplateExpression).template);
+                recordCallSite(node);
+                collect((node).tag);
+                collect((node).template);
                 return;
             case SyntaxKind.JsxOpeningElement:
             case SyntaxKind.JsxSelfClosingElement:
@@ -562,8 +555,8 @@ function createCallSiteCollector(program: Program, callSites: CallSite[]): (node
                 collect((node as JsxOpeningLikeElement).attributes);
                 return;
             case SyntaxKind.Decorator:
-                recordCallSite(node as Decorator);
-                collect((node as Decorator).expression);
+                recordCallSite(node);
+                collect((node).expression);
                 return;
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression:
@@ -572,7 +565,7 @@ function createCallSiteCollector(program: Program, callSites: CallSite[]): (node
                 break;
             case SyntaxKind.SatisfiesExpression:
                 // do not descend into the type side of an assertion
-                collect((node as SatisfiesExpression).expression);
+                collect((node).expression);
                 return;
         }
 

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -3,7 +3,6 @@ import {
     arrayToNumericMap,
     CancellationToken,
     CharacterCodes,
-    ClassDeclaration,
     ClassificationInfo,
     ClassificationResult,
     Classifications,
@@ -18,12 +17,10 @@ import {
     Debug,
     decodedTextSpanIntersectsWith,
     EndOfLineState,
-    EnumDeclaration,
     getMeaningFromLocation,
     getModuleInstanceState,
     getTypeArgumentOrTypeParameterList,
     HasJSDoc,
-    InterfaceDeclaration,
     isAccessibilityModifier,
     isConstTypeReference,
     isIdentifier,
@@ -37,19 +34,8 @@ import {
     isToken,
     isTrivia,
     JSDoc,
-    JSDocAugmentsTag,
-    JSDocCallbackTag,
-    JSDocEnumTag,
-    JSDocImplementsTag,
     JSDocParameterTag,
-    JSDocPropertyTag,
-    JSDocReturnTag,
-    JSDocSeeTag,
     JSDocTemplateTag,
-    JSDocThisTag,
-    JSDocThrowsTag,
-    JSDocTypedefTag,
-    JSDocTypeTag,
     JsxAttribute,
     JsxClosingElement,
     JsxOpeningElement,
@@ -59,7 +45,6 @@ import {
     ModuleInstanceState,
     Node,
     nodeIsMissing,
-    ParameterDeclaration,
     parseIsolatedJSDocComment,
     Scanner,
     ScriptTarget,
@@ -74,7 +59,6 @@ import {
     textSpanIntersectsWith,
     TokenClass,
     TypeChecker,
-    TypeParameterDeclaration,
 } from "./_namespaces/ts";
 
 /** The classifier is used for syntactic highlighting in editors via the TSServer */
@@ -806,51 +790,51 @@ export function getEncodedSyntacticClassifications(cancellationToken: Cancellati
 
                 switch (tag.kind) {
                     case SyntaxKind.JSDocParameterTag:
-                        const param = tag as JSDocParameterTag;
+                        const param = tag ;
                         processJSDocParameterTag(param);
                         commentStart = param.isNameFirst && param.typeExpression?.end || param.name.end;
                         break;
                     case SyntaxKind.JSDocPropertyTag:
-                        const prop = tag as JSDocPropertyTag;
+                        const prop = tag ;
                         commentStart = prop.isNameFirst && prop.typeExpression?.end || prop.name.end;
                         break;
                     case SyntaxKind.JSDocTemplateTag:
-                        processJSDocTemplateTag(tag as JSDocTemplateTag);
+                        processJSDocTemplateTag(tag);
                         pos = tag.end;
-                        commentStart = (tag as JSDocTemplateTag).typeParameters.end;
+                        commentStart = (tag).typeParameters.end;
                         break;
                     case SyntaxKind.JSDocTypedefTag:
-                        const type = tag as JSDocTypedefTag;
+                        const type = tag ;
                         commentStart = type.typeExpression?.kind === SyntaxKind.JSDocTypeExpression && type.fullName?.end || type.typeExpression?.end || commentStart;
                         break;
                     case SyntaxKind.JSDocCallbackTag:
-                        commentStart = (tag as JSDocCallbackTag).typeExpression.end;
+                        commentStart = (tag).typeExpression.end;
                         break;
                     case SyntaxKind.JSDocTypeTag:
-                        processElement((tag as JSDocTypeTag).typeExpression);
+                        processElement((tag).typeExpression);
                         pos = tag.end;
-                        commentStart = (tag as JSDocTypeTag).typeExpression.end;
+                        commentStart = (tag).typeExpression.end;
                         break;
                     case SyntaxKind.JSDocThisTag:
                     case SyntaxKind.JSDocEnumTag:
-                        commentStart = (tag as JSDocThisTag | JSDocEnumTag).typeExpression.end;
+                        commentStart = (tag).typeExpression.end;
                         break;
                     case SyntaxKind.JSDocReturnTag:
-                        processElement((tag as JSDocReturnTag).typeExpression);
+                        processElement((tag).typeExpression);
                         pos = tag.end;
-                        commentStart = (tag as JSDocReturnTag).typeExpression?.end || commentStart;
+                        commentStart = (tag).typeExpression?.end || commentStart;
                         break;
                     case SyntaxKind.JSDocSeeTag:
-                        commentStart = (tag as JSDocSeeTag).name?.end || commentStart;
+                        commentStart = (tag).name?.end || commentStart;
                         break;
                     case SyntaxKind.JSDocAugmentsTag:
                     case SyntaxKind.JSDocImplementsTag:
-                        commentStart = (tag as JSDocImplementsTag | JSDocAugmentsTag).class.end;
+                        commentStart = (tag).class.end;
                         break;
                     case SyntaxKind.JSDocThrowsTag:
-                        processElement((tag as JSDocThrowsTag).typeExpression);
+                        processElement((tag).typeExpression);
                         pos = tag.end;
-                        commentStart = (tag as JSDocThrowsTag).typeExpression?.end || commentStart;
+                        commentStart = (tag).typeExpression?.end || commentStart;
                         break;
                 }
                 if (typeof tag.comment === "object") {
@@ -1130,22 +1114,22 @@ export function getEncodedSyntacticClassifications(cancellationToken: Cancellati
             if (token) {
                 switch (token.parent.kind) {
                     case SyntaxKind.ClassDeclaration:
-                        if ((token.parent as ClassDeclaration).name === token) {
+                        if ((token.parent).name === token) {
                             return ClassificationType.className;
                         }
                         return;
                     case SyntaxKind.TypeParameter:
-                        if ((token.parent as TypeParameterDeclaration).name === token) {
+                        if ((token.parent).name === token) {
                             return ClassificationType.typeParameterName;
                         }
                         return;
                     case SyntaxKind.InterfaceDeclaration:
-                        if ((token.parent as InterfaceDeclaration).name === token) {
+                        if ((token.parent).name === token) {
                             return ClassificationType.interfaceName;
                         }
                         return;
                     case SyntaxKind.EnumDeclaration:
-                        if ((token.parent as EnumDeclaration).name === token) {
+                        if ((token.parent).name === token) {
                             return ClassificationType.enumName;
                         }
                         return;
@@ -1155,7 +1139,7 @@ export function getEncodedSyntacticClassifications(cancellationToken: Cancellati
                         }
                         return;
                     case SyntaxKind.Parameter:
-                        if ((token.parent as ParameterDeclaration).name === token) {
+                        if ((token.parent).name === token) {
                             return isThisIdentifier(token) ? ClassificationType.keyword : ClassificationType.parameterName;
                         }
                         return;

--- a/src/services/codefixes/addOptionalPropertyUndefined.ts
+++ b/src/services/codefixes/addOptionalPropertyUndefined.ts
@@ -25,7 +25,6 @@ import {
     textChanges,
     TextSpan,
     TypeChecker,
-    UnionTypeNode,
 } from "../_namespaces/ts";
 import {
     createCodeFixActionWithoutFixAll,
@@ -118,7 +117,7 @@ function addUndefinedToOptionalProperty(changes: textChanges.ChangeTracker, toAd
         const d = add.valueDeclaration;
         if (d && (isPropertySignature(d) || isPropertyDeclaration(d)) && d.type) {
             const t = factory.createUnionTypeNode([
-                ...d.type.kind === SyntaxKind.UnionType ? (d.type as UnionTypeNode).types : [d.type],
+                ...d.type.kind === SyntaxKind.UnionType ? (d.type).types : [d.type],
                 factory.createTypeReferenceNode("undefined")
             ]);
             changes.replaceNode(d.getSourceFile(), d.type, t);

--- a/src/services/codefixes/annotateWithTypeFromJSDoc.ts
+++ b/src/services/codefixes/annotateWithTypeFromJSDoc.ts
@@ -19,7 +19,6 @@ import {
     isParameter,
     isTypeNode,
     JSDocFunctionType,
-    JSDocNonNullableType,
     JSDocNullableType,
     JSDocOptionalType,
     JSDocTypeLiteral,
@@ -129,19 +128,19 @@ function transformJSDocType(node: Node): Node {
         case SyntaxKind.JSDocUnknownType:
             return factory.createTypeReferenceNode("any", emptyArray);
         case SyntaxKind.JSDocOptionalType:
-            return transformJSDocOptionalType(node as JSDocOptionalType);
+            return transformJSDocOptionalType(node);
         case SyntaxKind.JSDocNonNullableType:
-            return transformJSDocType((node as JSDocNonNullableType).type);
+            return transformJSDocType((node).type);
         case SyntaxKind.JSDocNullableType:
-            return transformJSDocNullableType(node as JSDocNullableType);
+            return transformJSDocNullableType(node);
         case SyntaxKind.JSDocVariadicType:
-            return transformJSDocVariadicType(node as JSDocVariadicType);
+            return transformJSDocVariadicType(node);
         case SyntaxKind.JSDocFunctionType:
-            return transformJSDocFunctionType(node as JSDocFunctionType);
+            return transformJSDocFunctionType(node);
         case SyntaxKind.TypeReference:
-            return transformJSDocTypeReference(node as TypeReferenceNode);
+            return transformJSDocTypeReference(node);
         case SyntaxKind.JSDocTypeLiteral:
-            return transformJSDocTypeLiteral(node as JSDocTypeLiteral);
+            return transformJSDocTypeLiteral(node);
         default:
             const visited = visitEachChild(node, transformJSDocType, nullTransformationContext);
             setEmitFlags(visited, EmitFlags.SingleLine);

--- a/src/services/codefixes/convertFunctionToEs6Class.ts
+++ b/src/services/codefixes/convertFunctionToEs6Class.ts
@@ -267,7 +267,7 @@ function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, po
 
                 // case 1: () => { return [1,2,3] }
                 if (arrowFunctionBody.kind === SyntaxKind.Block) {
-                    bodyBlock = arrowFunctionBody as Block;
+                    bodyBlock = arrowFunctionBody ;
                 }
                 // case 2: () => [1,2,3]
                 else {

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -1,5 +1,4 @@
 import {
-    ArrowFunction,
     AwaitExpression,
     BindingName,
     BindingPattern,
@@ -22,7 +21,6 @@ import {
     forEach,
     forEachChild,
     forEachReturnStatement,
-    FunctionExpression,
     FunctionLikeDeclaration,
     GeneratedIdentifierFlags,
     getContainingFunction,
@@ -630,7 +628,7 @@ function transformCallbackArgument(func: Expression, hasContinuation: boolean, c
                 break;
             }
 
-            const synthCall = factory.createCallExpression(getSynthesizedDeepClone(func as Identifier | PropertyAccessExpression), /*typeArguments*/ undefined, isSynthIdentifier(inputArgName) ? [referenceSynthIdentifier(inputArgName)] : []);
+            const synthCall = factory.createCallExpression(getSynthesizedDeepClone(func), /*typeArguments*/ undefined, isSynthIdentifier(inputArgName) ? [referenceSynthIdentifier(inputArgName)] : []);
 
             if (shouldReturn(parent, transformer)) {
                 return maybeAnnotateAndReturn(synthCall, getExplicitPromisedTypeOfPromiseReturningCallExpression(parent, func, transformer.checker));
@@ -651,7 +649,7 @@ function transformCallbackArgument(func: Expression, hasContinuation: boolean, c
 
         case SyntaxKind.FunctionExpression:
         case SyntaxKind.ArrowFunction: {
-            const funcBody = (func as FunctionExpression | ArrowFunction).body;
+            const funcBody = (func).body;
             const returnType = getLastCallSignature(transformer.checker.getTypeAtLocation(func), transformer.checker)?.getReturnType();
 
             // Arrow functions with block bodies { } will enter this control flow

--- a/src/services/codefixes/convertToEsModule.ts
+++ b/src/services/codefixes/convertToEsModule.ts
@@ -3,7 +3,6 @@ import {
     arrayFrom,
     ArrowFunction,
     BinaryExpression,
-    BindingElement,
     BindingName,
     ClassDeclaration,
     ClassExpression,
@@ -17,7 +16,6 @@ import {
     ExportDeclaration,
     ExportSpecifier,
     Expression,
-    ExpressionStatement,
     factory,
     filter,
     findChildOfKind,
@@ -207,10 +205,10 @@ function convertStatement(
 ): ModuleExportsChanged {
     switch (statement.kind) {
         case SyntaxKind.VariableStatement:
-            convertVariableStatement(sourceFile, statement as VariableStatement, changes, checker, identifiers, target, quotePreference);
+            convertVariableStatement(sourceFile, statement , changes, checker, identifiers, target, quotePreference);
             return false;
         case SyntaxKind.ExpressionStatement: {
-            const { expression } = statement as ExpressionStatement;
+            const { expression } = statement ;
             switch (expression.kind) {
                 case SyntaxKind.CallExpression: {
                     if (isRequireCall(expression, /*requireStringLiteralLikeArgument*/ true)) {
@@ -220,8 +218,8 @@ function convertStatement(
                     return false;
                 }
                 case SyntaxKind.BinaryExpression: {
-                    const { operatorToken } = expression as BinaryExpression;
-                    return operatorToken.kind === SyntaxKind.EqualsToken && convertAssignment(sourceFile, checker, expression as BinaryExpression, changes, exports, useSitesToUnqualify);
+                    const { operatorToken } = expression ;
+                    return operatorToken.kind === SyntaxKind.EqualsToken && convertAssignment(sourceFile, checker, expression , changes, exports, useSitesToUnqualify);
                 }
             }
         }
@@ -426,7 +424,7 @@ function convertExportsDotXEquals_replaceNode(name: string | undefined, exported
     const modifiers = [factory.createToken(SyntaxKind.ExportKeyword)];
     switch (exported.kind) {
         case SyntaxKind.FunctionExpression: {
-            const { name: expressionName } = exported as FunctionExpression;
+            const { name: expressionName } = exported ;
             if (expressionName && expressionName.text !== name) {
                 // `exports.f = function g() {}` -> `export const f = function g() {}`
                 return exportConst();
@@ -436,10 +434,10 @@ function convertExportsDotXEquals_replaceNode(name: string | undefined, exported
         // falls through
         case SyntaxKind.ArrowFunction:
             // `exports.f = function() {}` --> `export function f() {}`
-            return functionExpressionToDeclaration(name, modifiers, exported as FunctionExpression | ArrowFunction, useSitesToUnqualify);
+            return functionExpressionToDeclaration(name, modifiers, exported , useSitesToUnqualify);
         case SyntaxKind.ClassExpression:
             // `exports.C = class {}` --> `export class C {}`
-            return classExpressionToDeclaration(name, modifiers, exported as ClassExpression, useSitesToUnqualify);
+            return classExpressionToDeclaration(name, modifiers, exported , useSitesToUnqualify);
         default:
             return exportConst();
     }
@@ -612,11 +610,11 @@ function isFreeIdentifier(node: Identifier): boolean {
     const { parent } = node;
     switch (parent.kind) {
         case SyntaxKind.PropertyAccessExpression:
-            return (parent as PropertyAccessExpression).name !== node;
+            return (parent).name !== node;
         case SyntaxKind.BindingElement:
-            return (parent as BindingElement).propertyName !== node;
+            return (parent).propertyName !== node;
         case SyntaxKind.ImportSpecifier:
-            return (parent as ImportSpecifier).propertyName !== node;
+            return (parent).propertyName !== node;
         default:
             return true;
     }

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -3,7 +3,6 @@ import {
     addToSeen,
     arrayFrom,
     BigIntLiteralType,
-    BinaryExpression,
     CallExpression,
     CheckFlags,
     ClassLikeDeclaration,
@@ -474,7 +473,7 @@ function createActionsForAddMissingMemberInTypeScriptFile(context: CodeFixContex
 function getTypeNode(checker: TypeChecker, node: ClassLikeDeclaration | InterfaceDeclaration | TypeLiteralNode, token: Node) {
     let typeNode: TypeNode | undefined;
     if (token.parent.parent.kind === SyntaxKind.BinaryExpression) {
-        const binaryExpression = token.parent.parent as BinaryExpression;
+        const binaryExpression = token.parent.parent ;
         const otherExpression = token.parent === binaryExpression.left ? binaryExpression.right : binaryExpression.left;
         const widenedType = checker.getWidenedType(checker.getBaseTypeOfLiteralType(checker.getTypeAtLocation(otherExpression)));
         typeNode = checker.typeToTypeNode(widenedType, node, NodeBuilderFlags.NoTruncation);

--- a/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
+++ b/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
@@ -35,7 +35,7 @@ function getImportTypeNode(sourceFile: SourceFile, pos: number): ImportTypeNode 
     const token = getTokenAtPosition(sourceFile, pos);
     Debug.assert(token.kind === SyntaxKind.ImportKeyword, "This token should be an ImportKeyword");
     Debug.assert(token.parent.kind === SyntaxKind.ImportType, "Token parent should be an ImportType");
-    return token.parent as ImportTypeNode;
+    return token.parent ;
 }
 
 function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, importType: ImportTypeNode) {

--- a/src/services/codefixes/fixIncorrectNamedTupleSyntax.ts
+++ b/src/services/codefixes/fixIncorrectNamedTupleSyntax.ts
@@ -4,9 +4,6 @@ import {
     findAncestor,
     getTokenAtPosition,
     NamedTupleMember,
-    OptionalTypeNode,
-    ParenthesizedTypeNode,
-    RestTypeNode,
     SourceFile,
     SyntaxKind,
     textChanges,
@@ -51,7 +48,7 @@ function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, na
         else if (unwrappedType.kind === SyntaxKind.RestType) {
             sawRest = true;
         }
-        unwrappedType = (unwrappedType as OptionalTypeNode | RestTypeNode | ParenthesizedTypeNode).type;
+        unwrappedType = (unwrappedType).type;
     }
     const updated = factory.updateNamedTupleMember(
         namedTupleMember,

--- a/src/services/codefixes/fixUnreachableCode.ts
+++ b/src/services/codefixes/fixUnreachableCode.ts
@@ -6,7 +6,6 @@ import {
     findAncestor,
     first,
     getTokenAtPosition,
-    IfStatement,
     isBlock,
     isStatement,
     sliceAfter,
@@ -52,7 +51,7 @@ function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, st
     if (!isBlock(statement.parent) || statement === first(statement.parent.statements)) {
         switch (container.kind) {
             case SyntaxKind.IfStatement:
-                if ((container as IfStatement).elseStatement) {
+                if ((container).elseStatement) {
                     if (isBlock(statement.parent)) {
                         break;
                     }

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -56,7 +56,6 @@ import {
     textChanges,
     tryCast,
     TypeChecker,
-    VariableDeclaration,
     VariableDeclarationList,
 } from "../_namespaces/ts";
 import {
@@ -295,7 +294,7 @@ function canPrefix(token: Identifier): boolean {
         case SyntaxKind.TypeParameter:
             return true;
         case SyntaxKind.VariableDeclaration: {
-            const varDecl = token.parent as VariableDeclaration;
+            const varDecl = token.parent ;
             switch (varDecl.parent.parent.kind) {
                 case SyntaxKind.ForOfStatement:
                 case SyntaxKind.ForInStatement:

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -713,10 +713,10 @@ function inferTypeFromReferences(program: Program, references: readonly Identifi
                 usage.isNumber = true;
                 break;
             case SyntaxKind.PrefixUnaryExpression:
-                inferTypeFromPrefixUnaryExpression(node.parent as PrefixUnaryExpression, usage);
+                inferTypeFromPrefixUnaryExpression(node.parent , usage);
                 break;
             case SyntaxKind.BinaryExpression:
-                inferTypeFromBinaryExpression(node, node.parent as BinaryExpression, usage);
+                inferTypeFromBinaryExpression(node, node.parent , usage);
                 break;
             case SyntaxKind.CaseClause:
             case SyntaxKind.DefaultClause:
@@ -724,28 +724,28 @@ function inferTypeFromReferences(program: Program, references: readonly Identifi
                 break;
             case SyntaxKind.CallExpression:
             case SyntaxKind.NewExpression:
-                if ((node.parent as CallExpression | NewExpression).expression === node) {
-                    inferTypeFromCallExpression(node.parent as CallExpression | NewExpression, usage);
+                if ((node.parent).expression === node) {
+                    inferTypeFromCallExpression(node.parent , usage);
                 }
                 else {
                     inferTypeFromContextualType(node, usage);
                 }
                 break;
             case SyntaxKind.PropertyAccessExpression:
-                inferTypeFromPropertyAccessExpression(node.parent as PropertyAccessExpression, usage);
+                inferTypeFromPropertyAccessExpression(node.parent , usage);
                 break;
             case SyntaxKind.ElementAccessExpression:
-                inferTypeFromPropertyElementExpression(node.parent as ElementAccessExpression, node, usage);
+                inferTypeFromPropertyElementExpression(node.parent , node, usage);
                 break;
             case SyntaxKind.PropertyAssignment:
             case SyntaxKind.ShorthandPropertyAssignment:
-                inferTypeFromPropertyAssignment(node.parent as PropertyAssignment | ShorthandPropertyAssignment, usage);
+                inferTypeFromPropertyAssignment(node.parent , usage);
                 break;
             case SyntaxKind.PropertyDeclaration:
-                inferTypeFromPropertyDeclaration(node.parent as PropertyDeclaration, usage);
+                inferTypeFromPropertyDeclaration(node.parent , usage);
                 break;
             case SyntaxKind.VariableDeclaration: {
-                const { name, initializer } = node.parent as VariableDeclaration;
+                const { name, initializer } = node.parent ;
                 if (node === name) {
                     if (initializer) { // This can happen for `let x = null;` which still has an implicit-any error.
                         addCandidateType(usage, checker.getTypeAtLocation(initializer));

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -185,7 +185,7 @@ export namespace DocumentHighlights {
                     : undefined;
         }
 
-        function getFromAllDeclarations<T extends Node>(nodeTest: (node: Node) => node is T, keywords: readonly SyntaxKind[]): HighlightSpan[] | undefined {
+        function getFromAllDeclarations(nodeTest: (node: Node) => node is Node, keywords: readonly SyntaxKind[]): HighlightSpan[] | undefined {
             return useParent(node.parent, nodeTest, decl => mapDefined(tryCast(decl, canHaveSymbol)?.symbol.declarations, d =>
                 nodeTest(d) ? find(d.getChildren(sourceFile), c => contains(keywords, c.kind)) : undefined));
         }
@@ -226,7 +226,7 @@ export namespace DocumentHighlights {
         let child: Node = throwStatement;
 
         while (child.parent) {
-            const parent = child.parent;
+            const parent: Node = child.parent;
 
             if (isFunctionBlock(parent) || parent.kind === SyntaxKind.SourceFile) {
                 return parent;
@@ -385,7 +385,7 @@ export namespace DocumentHighlights {
                 case SyntaxKind.WhileStatement:
                     return getLoopBreakContinueOccurrences(owner as IterationStatement);
                 case SyntaxKind.SwitchStatement:
-                    return getSwitchCaseDefaultOccurrences(owner as SwitchStatement);
+                    return getSwitchCaseDefaultOccurrences(owner);
 
             }
         }

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -2,7 +2,6 @@ import {
     Block,
     CallExpression,
     canHaveModifiers,
-    CatchClause,
     CharacterCodes,
     ClassDeclaration,
     CommentRange,
@@ -45,8 +44,6 @@ import {
     LanguageVariant,
     last,
     LineAndCharacter,
-    MethodDeclaration,
-    ModuleDeclaration,
     Node,
     NodeArray,
     nodeIsMissing,
@@ -292,14 +289,14 @@ function isListElement(parent: Node, node: Node): boolean {
         case SyntaxKind.InterfaceDeclaration:
             return rangeContainsRange((parent as InterfaceDeclaration).members, node);
         case SyntaxKind.ModuleDeclaration:
-            const body = (parent as ModuleDeclaration).body;
+            const body = (parent).body;
             return !!body && body.kind === SyntaxKind.ModuleBlock && rangeContainsRange(body.statements, node);
         case SyntaxKind.SourceFile:
         case SyntaxKind.Block:
         case SyntaxKind.ModuleBlock:
             return rangeContainsRange((parent as Block).statements, node);
         case SyntaxKind.CatchClause:
-            return rangeContainsRange((parent as CatchClause).block.statements, node);
+            return rangeContainsRange((parent).block.statements, node);
     }
 
     return false;
@@ -663,7 +660,7 @@ function formatSpanWorker(
             case SyntaxKind.GetAccessor: return SyntaxKind.GetKeyword;
             case SyntaxKind.SetAccessor: return SyntaxKind.SetKeyword;
             case SyntaxKind.MethodDeclaration:
-                if ((node as MethodDeclaration).asteriskToken) {
+                if ((node).asteriskToken) {
                     return SyntaxKind.AsteriskToken;
                 }
                 // falls through

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -1,5 +1,4 @@
 import {
-    BinaryExpression,
     contains,
     findAncestor,
     findNextToken,
@@ -19,7 +18,6 @@ import {
     SemicolonPreference,
     SyntaxKind,
     typeKeywords,
-    YieldExpression,
 } from "../_namespaces/ts";
 import {
     anyContext,
@@ -481,7 +479,7 @@ function isNotForContext(context: FormattingContext): boolean {
 function isBinaryOpContext(context: FormattingContext): boolean {
     switch (context.contextNode.kind) {
         case SyntaxKind.BinaryExpression:
-            return (context.contextNode as BinaryExpression).operatorToken.kind !== SyntaxKind.CommaToken;
+            return (context.contextNode).operatorToken.kind !== SyntaxKind.CommaToken;
         case SyntaxKind.ConditionalExpression:
         case SyntaxKind.ConditionalType:
         case SyntaxKind.AsExpression:
@@ -845,7 +843,7 @@ function isVoidOpContext(context: FormattingContext): boolean {
 }
 
 function isYieldOrYieldStarWithOperand(context: FormattingContext): boolean {
-    return context.contextNode.kind === SyntaxKind.YieldExpression && (context.contextNode as YieldExpression).expression !== undefined;
+    return context.contextNode.kind === SyntaxKind.YieldExpression && (context.contextNode).expression !== undefined;
 }
 
 function isNonNullAssertionContext(context: FormattingContext): boolean {

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -1,10 +1,6 @@
 import {
-    ArrayBindingPattern,
-    ArrayLiteralExpression,
     CallExpression,
     CharacterCodes,
-    ClassDeclaration,
-    ClassExpression,
     CommentRange,
     contains,
     Debug,
@@ -15,15 +11,12 @@ import {
     findNextToken,
     findPrecedingToken,
     FormatCodeSettings,
-    GetAccessorDeclaration,
     getLineAndCharacterOfPosition,
     getLineStartPositionForPosition,
     getStartPositionOfLine,
     getTokenAtPosition,
-    IfStatement,
     ImportClause,
     IndentStyle,
-    InterfaceDeclaration,
     isCallExpression,
     isCallOrNewExpression,
     isConditionalExpression,
@@ -32,13 +25,10 @@ import {
     isStringOrRegularExpressionOrTemplateLiteral,
     isWhiteSpaceLike,
     isWhiteSpaceSingleLine,
-    JSDocTemplateTag,
     LineAndCharacter,
     NamedImportsOrExports,
     Node,
     NodeArray,
-    ObjectBindingPattern,
-    ObjectLiteralExpression,
     positionBelongsToNode,
     rangeContainsRange,
     rangeContainsStartEnd,
@@ -48,10 +38,6 @@ import {
     SourceFileLike,
     SyntaxKind,
     TextRange,
-    TypeAliasDeclaration,
-    TypeLiteralNode,
-    TypeReferenceNode,
-    VariableDeclarationList,
 } from "../_namespaces/ts";
 import {
     getRangeOfEnclosingComment,
@@ -413,7 +399,7 @@ export namespace SmartIndenter {
     }
 
     export function childStartsOnTheSameLineWithElseInIfStatement(parent: Node, child: TextRangeWithKind, childStartLine: number, sourceFile: SourceFileLike): boolean {
-        if (parent.kind === SyntaxKind.IfStatement && (parent as IfStatement).elseStatement === child) {
+        if (parent.kind === SyntaxKind.IfStatement && (parent).elseStatement === child) {
             const elseKeyword = findChildOfKind(parent, SyntaxKind.ElseKeyword, sourceFile)!;
             Debug.assert(elseKeyword !== undefined);
 
@@ -498,13 +484,13 @@ export namespace SmartIndenter {
     function getListByRange(start: number, end: number, node: Node, sourceFile: SourceFile): NodeArray<Node> | undefined {
         switch (node.kind) {
             case SyntaxKind.TypeReference:
-                return getList((node as TypeReferenceNode).typeArguments);
+                return getList((node).typeArguments);
             case SyntaxKind.ObjectLiteralExpression:
-                return getList((node as ObjectLiteralExpression).properties);
+                return getList((node).properties);
             case SyntaxKind.ArrayLiteralExpression:
-                return getList((node as ArrayLiteralExpression).elements);
+                return getList((node).elements);
             case SyntaxKind.TypeLiteral:
-                return getList((node as TypeLiteralNode).members);
+                return getList((node).members);
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
             case SyntaxKind.ArrowFunction:
@@ -516,24 +502,24 @@ export namespace SmartIndenter {
             case SyntaxKind.ConstructSignature:
                 return getList((node as SignatureDeclaration).typeParameters) || getList((node as SignatureDeclaration).parameters);
             case SyntaxKind.GetAccessor:
-                return getList((node as GetAccessorDeclaration).parameters);
+                return getList((node).parameters);
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.ClassExpression:
             case SyntaxKind.InterfaceDeclaration:
             case SyntaxKind.TypeAliasDeclaration:
             case SyntaxKind.JSDocTemplateTag:
-                return getList((node as ClassDeclaration | ClassExpression | InterfaceDeclaration | TypeAliasDeclaration | JSDocTemplateTag).typeParameters);
+                return getList((node).typeParameters);
             case SyntaxKind.NewExpression:
             case SyntaxKind.CallExpression:
                 return getList((node as CallExpression).typeArguments) || getList((node as CallExpression).arguments);
             case SyntaxKind.VariableDeclarationList:
-                return getList((node as VariableDeclarationList).declarations);
+                return getList((node).declarations);
             case SyntaxKind.NamedImports:
             case SyntaxKind.NamedExports:
                 return getList((node as NamedImportsOrExports).elements);
             case SyntaxKind.ObjectBindingPattern:
             case SyntaxKind.ArrayBindingPattern:
-                return getList((node as ObjectBindingPattern | ArrayBindingPattern).elements);
+                return getList((node).elements);
         }
 
         function getList(list: NodeArray<Node> | undefined): NodeArray<Node> | undefined {

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -11,7 +11,6 @@ import {
     cast,
     Debug,
     ExportAssignment,
-    ExportDeclaration,
     FileReference,
     findAncestor,
     forEach,
@@ -23,11 +22,9 @@ import {
     hasSyntacticModifier,
     Identifier,
     ImportCall,
-    ImportClause,
     ImportDeclaration,
     ImportEqualsDeclaration,
     importFromModuleSpecifier,
-    ImportSpecifier,
     InternalSymbolName,
     isAccessExpression,
     isBinaryExpression,
@@ -61,7 +58,6 @@ import {
     ModuleBlock,
     ModuleDeclaration,
     NamedImportsOrExports,
-    NamespaceImport,
     Node,
     nodeIsSynthesized,
     nodeSeenTracker,
@@ -189,7 +185,7 @@ function getImportersForExport(
                         if (!isAvailableThroughGlobal) {
                             const parent = direct.parent;
                             if (exportKind === ExportKind.ExportEquals && parent.kind === SyntaxKind.VariableDeclaration) {
-                                const { name } = parent as VariableDeclaration;
+                                const { name } = parent ;
                                 if (name.kind === SyntaxKind.Identifier) {
                                     directImports.push(name);
                                     break;
@@ -469,7 +465,7 @@ export function findModuleReferences(program: Program, sourceFiles: readonly Sou
             }
             for (const ref of referencingFile.typeReferenceDirectives) {
                 const referenced = program.getResolvedTypeReferenceDirectives().get(ref.fileName, ref.resolutionMode || referencingFile.impliedNodeFormat)?.resolvedTypeReferenceDirective;
-                if (referenced !== undefined && referenced.resolvedFileName === (searchSourceFile as SourceFile).fileName) {
+                if (referenced !== undefined && referenced.resolvedFileName === (searchSourceFile).fileName) {
                     refs.push({ kind: "reference", referencingFile, ref });
                 }
             }
@@ -525,7 +521,7 @@ function forEachImport(sourceFile: SourceFile, action: (importStatement: Importe
             switch (statement.kind) {
                 case SyntaxKind.ExportDeclaration:
                 case SyntaxKind.ImportDeclaration: {
-                    const decl = statement as ImportDeclaration | ExportDeclaration;
+                    const decl = statement ;
                     if (decl.moduleSpecifier && isStringLiteral(decl.moduleSpecifier)) {
                         action(decl, decl.moduleSpecifier);
                     }
@@ -533,7 +529,7 @@ function forEachImport(sourceFile: SourceFile, action: (importStatement: Importe
                 }
 
                 case SyntaxKind.ImportEqualsDeclaration: {
-                    const decl = statement as ImportEqualsDeclaration;
+                    const decl = statement ;
                     if (isExternalModuleImportEquals(decl)) {
                         action(decl, decl.moduleReference.expression);
                     }
@@ -719,13 +715,13 @@ function isNodeImport(node: Node): boolean {
     const { parent } = node;
     switch (parent.kind) {
         case SyntaxKind.ImportEqualsDeclaration:
-            return (parent as ImportEqualsDeclaration).name === node && isExternalModuleImportEquals(parent as ImportEqualsDeclaration);
+            return (parent).name === node && isExternalModuleImportEquals(parent);
         case SyntaxKind.ImportSpecifier:
             // For a rename import `{ foo as bar }`, don't search for the imported symbol. Just find local uses of `bar`.
-            return !(parent as ImportSpecifier).propertyName;
+            return !(parent).propertyName;
         case SyntaxKind.ImportClause:
         case SyntaxKind.NamespaceImport:
-            Debug.assert((parent as ImportClause | NamespaceImport).name === node);
+            Debug.assert((parent).name === node);
             return true;
         case SyntaxKind.BindingElement:
             return isInJSFile(node) && isVariableDeclarationInitializedToBareOrAccessedRequire(parent.parent.parent);
@@ -776,14 +772,14 @@ function getSourceFileLikeForImportDeclaration(node: ImporterOrCallExpression): 
 
     const { parent } = node;
     if (parent.kind === SyntaxKind.SourceFile) {
-        return parent as SourceFile;
+        return parent ;
     }
     Debug.assert(parent.kind === SyntaxKind.ModuleBlock);
     return cast(parent.parent, isAmbientModuleDeclaration);
 }
 
 function isAmbientModuleDeclaration(node: Node): node is AmbientModuleDeclaration {
-    return node.kind === SyntaxKind.ModuleDeclaration && (node as ModuleDeclaration).name.kind === SyntaxKind.StringLiteral;
+    return node.kind === SyntaxKind.ModuleDeclaration && (node).name.kind === SyntaxKind.StringLiteral;
 }
 
 function isExternalModuleImportEquals(eq: ImportEqualsDeclaration): eq is ImportEqualsDeclaration & { moduleReference: { expression: StringLiteral } } {

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -19,7 +19,6 @@ import {
     getLanguageVariant,
     getLeadingCommentRanges,
     hasContextSensitiveParameters,
-    Identifier,
     InlayHint,
     InlayHintKind,
     InlayHintsContext,
@@ -52,7 +51,6 @@ import {
     Node,
     NodeBuilderFlags,
     ParameterDeclaration,
-    PrefixUnaryExpression,
     PropertyDeclaration,
     Signature,
     skipParentheses,
@@ -278,7 +276,7 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
     function isHintableLiteral(node: Node) {
         switch (node.kind) {
             case SyntaxKind.PrefixUnaryExpression: {
-                const operand = (node as PrefixUnaryExpression).operand;
+                const operand = (node).operand;
                 return isLiteralExpression(operand) || isIdentifier(operand) && isInfinityOrNaNString(operand.escapedText);
             }
             case SyntaxKind.TrueKeyword:
@@ -288,7 +286,7 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
             case SyntaxKind.TemplateExpression:
                 return true;
             case SyntaxKind.Identifier: {
-                const name = (node as Identifier).escapedText;
+                const name = (node).escapedText;
                 return isUndefined(name) || isInfinityOrNaNString(name);
             }
         }

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -2,9 +2,7 @@ import {
     arraysEqual,
     ArrowFunction,
     AssignmentDeclarationKind,
-    BinaryExpression,
     buildLinkParts,
-    ClassExpression,
     CompletionEntry,
     CompletionEntryDetails,
     Completions,
@@ -14,7 +12,6 @@ import {
     DocCommentTemplateOptions,
     emptyArray,
     Expression,
-    ExpressionStatement,
     find,
     findAncestor,
     flatMap,
@@ -46,20 +43,12 @@ import {
     isJSDocParameterTag,
     isWhiteSpaceSingleLine,
     JSDoc,
-    JSDocAugmentsTag,
-    JSDocCallbackTag,
     JSDocComment,
-    JSDocImplementsTag,
     JSDocParameterTag,
     JSDocPropertyTag,
-    JSDocSatisfiesTag,
-    JSDocSeeTag,
     JSDocTag,
     JSDocTagInfo,
-    JSDocTemplateTag,
-    JSDocThrowsTag,
     JSDocTypedefTag,
-    JSDocTypeTag,
     lastOrUndefined,
     length,
     lineBreakPart,
@@ -70,11 +59,7 @@ import {
     Node,
     ParameterDeclaration,
     parameterNamePart,
-    ParenthesizedExpression,
-    PropertyAssignment,
-    PropertyDeclaration,
     propertyNamePart,
-    PropertySignature,
     punctuationPart,
     ScriptElementKind,
     SourceFile,
@@ -87,7 +72,6 @@ import {
     typeAliasNamePart,
     TypeChecker,
     typeParameterNamePart,
-    VariableStatement,
 } from "./_namespaces/ts";
 
 const jsDocTagNames = [
@@ -266,15 +250,15 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
     const namePart = getTagNameDisplayPart(kind);
     switch (kind) {
         case SyntaxKind.JSDocThrowsTag:
-            const typeExpression = (tag as JSDocThrowsTag).typeExpression;
+            const typeExpression = (tag).typeExpression;
             return typeExpression ? withNode(typeExpression) :
                 comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
         case SyntaxKind.JSDocImplementsTag:
-            return withNode((tag as JSDocImplementsTag).class);
+            return withNode((tag).class);
         case SyntaxKind.JSDocAugmentsTag:
-            return withNode((tag as JSDocAugmentsTag).class);
+            return withNode((tag).class);
         case SyntaxKind.JSDocTemplateTag:
-            const templateTag = tag as JSDocTemplateTag;
+            const templateTag = tag ;
             const displayParts: SymbolDisplayPart[] = [];
             if (templateTag.constraint) {
                 displayParts.push(textPart(templateTag.constraint.getText()));
@@ -297,13 +281,13 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
             return displayParts;
         case SyntaxKind.JSDocTypeTag:
         case SyntaxKind.JSDocSatisfiesTag:
-            return withNode((tag as JSDocTypeTag | JSDocSatisfiesTag).typeExpression);
+            return withNode((tag).typeExpression);
         case SyntaxKind.JSDocTypedefTag:
         case SyntaxKind.JSDocCallbackTag:
         case SyntaxKind.JSDocPropertyTag:
         case SyntaxKind.JSDocParameterTag:
         case SyntaxKind.JSDocSeeTag:
-            const { name } = tag as JSDocTypedefTag | JSDocCallbackTag | JSDocPropertyTag | JSDocParameterTag | JSDocSeeTag;
+            const { name } = tag ;
             return name ? withNode(name)
                 : comment === undefined ? undefined
                 : getDisplayPartsFromComment(comment, checker);
@@ -400,7 +384,7 @@ export function getJSDocParameterNameCompletions(tag: JSDocParameterTag): Comple
         if (!isIdentifier(param.name)) return undefined;
 
         const name = param.name.text;
-        if (jsdoc.tags!.some(t => t !== tag && isJSDocParameterTag(t) && isIdentifier(t.name) && t.name.escapedText === name) // TODO: GH#18217
+        if (jsdoc.kind === SyntaxKind.JSDoc && jsdoc.tags!.some(t => t !== tag && isJSDocParameterTag(t) && isIdentifier(t.name) && t.name.escapedText === name) // TODO: GH#18217
             || nameThusFar !== undefined && !startsWith(name, nameThusFar)) {
             return undefined;
         }
@@ -545,7 +529,7 @@ function getCommentOwnerInfoWorker(commentOwner: Node, options: DocCommentTempla
             return { commentOwner, parameters: host.parameters, hasReturn: hasReturn(host, options) };
 
         case SyntaxKind.PropertyAssignment:
-            return getCommentOwnerInfoWorker((commentOwner as PropertyAssignment).initializer, options);
+            return getCommentOwnerInfoWorker((commentOwner).initializer, options);
 
         case SyntaxKind.ClassDeclaration:
         case SyntaxKind.InterfaceDeclaration:
@@ -555,14 +539,14 @@ function getCommentOwnerInfoWorker(commentOwner: Node, options: DocCommentTempla
             return { commentOwner };
 
         case SyntaxKind.PropertySignature: {
-            const host = commentOwner as PropertySignature;
+            const host = commentOwner ;
             return host.type && isFunctionTypeNode(host.type)
                 ? { commentOwner, parameters: host.type.parameters, hasReturn: hasReturn(host.type, options) }
                 : { commentOwner };
         }
 
         case SyntaxKind.VariableStatement: {
-            const varStatement = commentOwner as VariableStatement;
+            const varStatement = commentOwner ;
             const varDeclarations = varStatement.declarationList.declarations;
             const host = varDeclarations.length === 1 && varDeclarations[0].initializer
                 ? getRightHandSideOfAssignment(varDeclarations[0].initializer)
@@ -582,9 +566,9 @@ function getCommentOwnerInfoWorker(commentOwner: Node, options: DocCommentTempla
             return commentOwner.parent.kind === SyntaxKind.ModuleDeclaration ? undefined : { commentOwner };
 
         case SyntaxKind.ExpressionStatement:
-            return getCommentOwnerInfoWorker((commentOwner as ExpressionStatement).expression, options);
+            return getCommentOwnerInfoWorker((commentOwner).expression, options);
         case SyntaxKind.BinaryExpression: {
-            const be = commentOwner as BinaryExpression;
+            const be = commentOwner ;
             if (getAssignmentDeclarationKind(be) === AssignmentDeclarationKind.None) {
                 return "quit";
             }
@@ -593,7 +577,7 @@ function getCommentOwnerInfoWorker(commentOwner: Node, options: DocCommentTempla
                 : { commentOwner };
         }
         case SyntaxKind.PropertyDeclaration:
-            const init = (commentOwner as PropertyDeclaration).initializer;
+            const init = (commentOwner).initializer;
             if (init && (isFunctionExpression(init) || isArrowFunction(init))) {
                 return { commentOwner, parameters: init.parameters, hasReturn: hasReturn(init, options) };
             }
@@ -608,7 +592,7 @@ function hasReturn(node: Node, options: DocCommentTemplateOptions | undefined) {
 
 function getRightHandSideOfAssignment(rightHandSide: Expression): FunctionExpression | ArrowFunction | ConstructorDeclaration | undefined {
     while (rightHandSide.kind === SyntaxKind.ParenthesizedExpression) {
-        rightHandSide = (rightHandSide as ParenthesizedExpression).expression;
+        rightHandSide = (rightHandSide).expression;
     }
 
     switch (rightHandSide.kind) {
@@ -616,6 +600,6 @@ function getRightHandSideOfAssignment(rightHandSide: Expression): FunctionExpres
         case SyntaxKind.ArrowFunction:
             return (rightHandSide as FunctionExpression);
         case SyntaxKind.ClassExpression:
-            return find((rightHandSide as ClassExpression).members, isConstructorDeclaration);
+            return find((rightHandSide).members, isConstructorDeclaration);
     }
 }

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -13,9 +13,6 @@ import {
     getNodeModifiers,
     getTextOfIdentifierOrLiteral,
     Identifier,
-    ImportClause,
-    ImportEqualsDeclaration,
-    ImportSpecifier,
     isPropertyAccessExpression,
     isPropertyNameLiteral,
     NavigateToItem,
@@ -88,7 +85,7 @@ function shouldKeepItem(declaration: Declaration, checker: TypeChecker): boolean
         case SyntaxKind.ImportClause:
         case SyntaxKind.ImportSpecifier:
         case SyntaxKind.ImportEqualsDeclaration:
-            const importer = checker.getSymbolAtLocation((declaration as ImportClause | ImportSpecifier | ImportEqualsDeclaration).name!)!; // TODO: GH#18217
+            const importer = checker.getSymbolAtLocation((declaration).name!)!; // TODO: GH#18217
             const imported = checker.getAliasedSymbol(importer);
             return importer.escapedName !== imported.escapedName;
         default:

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -14,7 +14,6 @@ import {
     compareStringsCaseSensitiveUI,
     compareValues,
     concatenate,
-    ConstructorDeclaration,
     contains,
     createTextSpanFromNode,
     createTextSpanFromRange,
@@ -23,10 +22,8 @@ import {
     DeclarationName,
     declarationNameToString,
     EntityNameExpression,
-    EnumDeclaration,
     EnumMember,
     escapeString,
-    ExportAssignment,
     Expression,
     factory,
     filterMutate,
@@ -51,7 +48,6 @@ import {
     hasJSDocNodes,
     Identifier,
     idText,
-    ImportClause,
     InterfaceDeclaration,
     InternalSymbolName,
     isAmbientModule,
@@ -100,9 +96,7 @@ import {
     PropertyNameLiteral,
     removeFileExtension,
     setTextRange,
-    ShorthandPropertyAssignment,
     SourceFile,
-    SpreadAssignment,
     SyntaxKind,
     TextSpan,
     TypeElement,
@@ -332,7 +326,7 @@ function addChildrenRecursively(node: Node | undefined): void {
     switch (node.kind) {
         case SyntaxKind.Constructor:
             // Get parameter properties, and treat them as being on the *same* level as the constructor, not under it.
-            const ctr = node as ConstructorDeclaration;
+            const ctr = node ;
             addNodeWithRecursiveChild(ctr, ctr.body);
 
             // Parameter properties are children of the class, not the constructor.
@@ -354,7 +348,7 @@ function addChildrenRecursively(node: Node | undefined): void {
 
         case SyntaxKind.PropertyDeclaration:
             if (hasNavigationBarName(node as ClassElement)) {
-                addNodeWithRecursiveInitializer(node as PropertyDeclaration);
+                addNodeWithRecursiveInitializer(node);
             }
             break;
         case SyntaxKind.PropertySignature:
@@ -364,7 +358,7 @@ function addChildrenRecursively(node: Node | undefined): void {
             break;
 
         case SyntaxKind.ImportClause:
-            const importClause = node as ImportClause;
+            const importClause = node ;
             // Handle default import case e.g.:
             //    import d from "mod";
             if (importClause.name) {
@@ -388,17 +382,17 @@ function addChildrenRecursively(node: Node | undefined): void {
             break;
 
         case SyntaxKind.ShorthandPropertyAssignment:
-            addNodeWithRecursiveChild(node, (node as ShorthandPropertyAssignment).name);
+            addNodeWithRecursiveChild(node, (node).name);
             break;
         case SyntaxKind.SpreadAssignment:
-            const { expression } = node as SpreadAssignment;
+            const { expression } = node ;
             // Use the expression as the name of the SpreadAssignment, otherwise show as <unknown>.
             isIdentifier(expression) ? addLeafNode(node, expression) : addLeafNode(node);
             break;
         case SyntaxKind.BindingElement:
         case SyntaxKind.PropertyAssignment:
         case SyntaxKind.VariableDeclaration: {
-            const child = node as VariableDeclaration | PropertyAssignment | BindingElement;
+            const child = node ;
             if (isBindingPattern(child.name)) {
                 addChildrenRecursively(child.name);
             }
@@ -422,7 +416,7 @@ function addChildrenRecursively(node: Node | undefined): void {
 
         case SyntaxKind.EnumDeclaration:
             startNode(node);
-            for (const member of (node as EnumDeclaration).members) {
+            for (const member of (node).members) {
                 if (!isComputedProperty(member)) {
                     addLeafNode(member);
                 }
@@ -441,11 +435,11 @@ function addChildrenRecursively(node: Node | undefined): void {
             break;
 
         case SyntaxKind.ModuleDeclaration:
-            addNodeWithRecursiveChild(node, getInteriorModule(node as ModuleDeclaration).body);
+            addNodeWithRecursiveChild(node, getInteriorModule(node).body);
             break;
 
         case SyntaxKind.ExportAssignment: {
-            const expression = (node as ExportAssignment).expression;
+            const expression = (node).expression;
             const child = isObjectLiteralExpression(expression) || isCallExpression(expression) ? expression :
                 isArrowFunction(expression) || isFunctionExpression(expression) ? expression.body : undefined;
             if (child) {
@@ -739,8 +733,8 @@ function shouldReallyMerge(a: Node, b: Node, parent: NavigationBarNode): boolean
         case SyntaxKind.SetAccessor:
             return isStatic(a) === isStatic(b);
         case SyntaxKind.ModuleDeclaration:
-            return areSameModule(a as ModuleDeclaration, b as ModuleDeclaration)
-                && getFullyQualifiedModuleName(a as ModuleDeclaration) === getFullyQualifiedModuleName(b as ModuleDeclaration);
+            return areSameModule(a , b as ModuleDeclaration)
+                && getFullyQualifiedModuleName(a) === getFullyQualifiedModuleName(b as ModuleDeclaration);
         default:
             return true;
     }
@@ -798,7 +792,7 @@ function compareChildren(child1: NavigationBarNode, child2: NavigationBarNode) {
  */
 function tryGetName(node: Node): string | undefined {
     if (node.kind === SyntaxKind.ModuleDeclaration) {
-        return getModuleName(node as ModuleDeclaration);
+        return getModuleName(node);
     }
 
     const declName = getNameOfDeclaration(node as Declaration);
@@ -810,7 +804,7 @@ function tryGetName(node: Node): string | undefined {
         case SyntaxKind.FunctionExpression:
         case SyntaxKind.ArrowFunction:
         case SyntaxKind.ClassExpression:
-            return getFunctionOrClassName(node as FunctionExpression | ArrowFunction | ClassExpression);
+            return getFunctionOrClassName(node);
         default:
             return undefined;
     }
@@ -818,7 +812,7 @@ function tryGetName(node: Node): string | undefined {
 
 function getItemName(node: Node, name: Node | undefined): string {
     if (node.kind === SyntaxKind.ModuleDeclaration) {
-        return cleanText(getModuleName(node as ModuleDeclaration));
+        return cleanText(getModuleName(node));
     }
 
     if (name) {
@@ -832,7 +826,7 @@ function getItemName(node: Node, name: Node | undefined): string {
 
     switch (node.kind) {
         case SyntaxKind.SourceFile:
-            const sourceFile = node as SourceFile;
+            const sourceFile = node ;
             return isExternalModule(sourceFile)
                 ? `"${escapeString(getBaseFileName(removeFileExtension(normalizePath(sourceFile.fileName))))}"`
                 : "<global>";

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -4,12 +4,10 @@ import {
     Block,
     CallExpression,
     CancellationToken,
-    CaseClause,
     createTextSpanFromBounds,
     createTextSpanFromNode,
     createTextSpanFromRange,
     Debug,
-    DefaultClause,
     findChildOfKind,
     getLeadingCommentRanges,
     isAnyImportSyntax,
@@ -54,7 +52,6 @@ import {
     TextSpan,
     trimString,
     trimStringStart,
-    TryStatement,
 } from "./_namespaces/ts";
 
 /** @internal */
@@ -232,7 +229,7 @@ function getOutliningSpanForNode(n: Node, sourceFile: SourceFile): OutliningSpan
     switch (n.kind) {
         case SyntaxKind.Block:
             if (isFunctionLike(n.parent)) {
-                return functionSpan(n.parent, n as Block, sourceFile);
+                return functionSpan(n.parent, n , sourceFile);
             }
             // Check if the block is standalone, or 'attached' to some parent statement.
             // If the latter, we want to collapse the block, but consider its hint span
@@ -249,7 +246,7 @@ function getOutliningSpanForNode(n: Node, sourceFile: SourceFile): OutliningSpan
                     return spanForNode(n.parent);
                 case SyntaxKind.TryStatement:
                     // Could be the try-block, or the finally-block.
-                    const tryStatement = n.parent as TryStatement;
+                    const tryStatement = n.parent ;
                     if (tryStatement.tryBlock === n) {
                         return spanForNode(n.parent);
                     }
@@ -277,33 +274,33 @@ function getOutliningSpanForNode(n: Node, sourceFile: SourceFile): OutliningSpan
             return spanForNode(n, /*autoCollapse*/ false, /*useFullStart*/ !isTupleTypeNode(n.parent), SyntaxKind.OpenBracketToken);
         case SyntaxKind.CaseClause:
         case SyntaxKind.DefaultClause:
-            return spanForNodeArray((n as CaseClause | DefaultClause).statements);
+            return spanForNodeArray((n).statements);
         case SyntaxKind.ObjectLiteralExpression:
             return spanForObjectOrArrayLiteral(n);
         case SyntaxKind.ArrayLiteralExpression:
             return spanForObjectOrArrayLiteral(n, SyntaxKind.OpenBracketToken);
         case SyntaxKind.JsxElement:
-            return spanForJSXElement(n as JsxElement);
+            return spanForJSXElement(n);
         case SyntaxKind.JsxFragment:
-            return spanForJSXFragment(n as JsxFragment);
+            return spanForJSXFragment(n);
         case SyntaxKind.JsxSelfClosingElement:
         case SyntaxKind.JsxOpeningElement:
             return spanForJSXAttributes((n as JsxOpeningLikeElement).attributes);
         case SyntaxKind.TemplateExpression:
         case SyntaxKind.NoSubstitutionTemplateLiteral:
-            return spanForTemplateLiteral(n as TemplateExpression | NoSubstitutionTemplateLiteral);
+            return spanForTemplateLiteral(n);
         case SyntaxKind.ArrayBindingPattern:
             return spanForNode(n, /*autoCollapse*/ false, /*useFullStart*/ !isBindingElement(n.parent), SyntaxKind.OpenBracketToken);
         case SyntaxKind.ArrowFunction:
-            return spanForArrowFunction(n as ArrowFunction);
+            return spanForArrowFunction(n);
         case SyntaxKind.CallExpression:
-            return spanForCallExpression(n as CallExpression);
+            return spanForCallExpression(n);
         case SyntaxKind.ParenthesizedExpression:
-            return spanForParenthesizedExpression(n as ParenthesizedExpression);
+            return spanForParenthesizedExpression(n);
         case SyntaxKind.NamedImports:
         case SyntaxKind.NamedExports:
         case SyntaxKind.AssertClause:
-            return spanForNamedImportsOrExportsOrAssertClause(n as NamedImports | NamedExports | AssertClause);
+            return spanForNamedImportsOrExportsOrAssertClause(n);
     }
 
     function spanForNamedImportsOrExportsOrAssertClause(node: NamedImports | NamedExports | AssertClause) {

--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -19,9 +19,7 @@ import {
     getSyntacticModifierFlags,
     getTokenAtPosition,
     Identifier,
-    ImportClause,
     ImportSpecifier,
-    ImportTypeNode,
     InterfaceDeclaration,
     InternalSymbolName,
     isAmbientModule,
@@ -149,7 +147,7 @@ function getInfo(context: RefactorContext, considerPartialSpans = true): ExportI
                 || { exportNode: node, exportName: node.name, wasDefault, exportingModuleSymbol };
         }
         case SyntaxKind.VariableStatement: {
-            const vs = exportNode as VariableStatement;
+            const vs = exportNode ;
             // Must be `export const x = something;`.
             if (!(vs.declarationList.flags & NodeFlags.Const) || vs.declarationList.declarations.length !== 1) {
                 return undefined;
@@ -161,7 +159,7 @@ function getInfo(context: RefactorContext, considerPartialSpans = true): ExportI
                 || { exportNode: vs, exportName: decl.name as Identifier, wasDefault, exportingModuleSymbol };
         }
         case SyntaxKind.ExportAssignment: {
-            const node = exportNode as ExportAssignment;
+            const node = exportNode ;
             if (node.isExportEquals) return undefined;
             return noSymbolError(node.expression)
                 || { exportNode: node, exportName: node.expression as Identifier, wasDefault, exportingModuleSymbol };
@@ -241,13 +239,13 @@ function changeDefaultToNamedImport(importingSourceFile: SourceFile, ref: Identi
             break;
         case SyntaxKind.ImportSpecifier:
         case SyntaxKind.ExportSpecifier: {
-            const spec = parent as ImportSpecifier | ExportSpecifier;
+            const spec = parent ;
             // `default as foo` --> `foo`, `default as bar` --> `foo as bar`
             changes.replaceNode(importingSourceFile, spec, makeImportSpecifier(exportName, spec.name.text));
             break;
         }
         case SyntaxKind.ImportClause: {
-            const clause = parent as ImportClause;
+            const clause = parent ;
             Debug.assert(clause.name === ref, "Import clause name should match provided ref");
             const spec = makeImportSpecifier(exportName, ref.text);
             const { namedBindings } = clause;
@@ -270,7 +268,7 @@ function changeDefaultToNamedImport(importingSourceFile: SourceFile, ref: Identi
             break;
         }
         case SyntaxKind.ImportType:
-            const importTypeNode = parent as ImportTypeNode;
+            const importTypeNode = parent ;
             changes.replaceNode(importingSourceFile, parent, factory.createImportTypeNode(importTypeNode.argument, importTypeNode.assertions, factory.createIdentifier(exportName), importTypeNode.typeArguments, importTypeNode.isTypeOf));
             break;
         default:

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -1,7 +1,7 @@
 import {
     ApplicableRefactorInfo,
     BinaryExpression,
-    BinaryOperator,
+    BinaryOperatorToken,
     copyTrailingAsLeadingComments,
     copyTrailingComments,
     Debug,
@@ -34,7 +34,6 @@ import {
     TemplateSpan,
     TemplateTail,
     textChanges,
-    Token,
 } from "../_namespaces/ts";
 import { registerRefactor } from "../_namespaces/ts.refactor";
 
@@ -143,7 +142,7 @@ function getParentBinaryExpression(expr: Node) {
 }
 
 function treeToArray(current: Expression) {
-    const loop = (current: Node): { nodes: Expression[], operators: Token<BinaryOperator>[], hasString: boolean, validOperators: boolean} => {
+    const loop = (current: Node): { nodes: Expression[], operators: BinaryOperatorToken[], hasString: boolean, validOperators: boolean} => {
         if (!isBinaryExpression(current)) {
             return { nodes: [current as Expression], operators: [], validOperators: true,
                      hasString: isStringLiteral(current) || isNoSubstitutionTemplateLiteral(current) };
@@ -168,7 +167,7 @@ function treeToArray(current: Expression) {
 
 // to copy comments following the operator
 // "foo" + /* comment */ "bar"
-const copyTrailingOperatorComments = (operators: Token<BinaryOperator>[], file: SourceFile) => (index: number, targetNode: Node) => {
+const copyTrailingOperatorComments = (operators: BinaryOperatorToken[], file: SourceFile) => (index: number, targetNode: Node) => {
     if (index < operators.length) {
          copyTrailingComments(operators[index], targetNode, file, SyntaxKind.MultiLineCommentTrivia, /*hasTrailingNewLine*/ false);
     }
@@ -224,7 +223,7 @@ function concatConsecutiveString(index: number, nodes: readonly Expression[]): [
     return [index, text, rawText, indexes];
 }
 
-function nodesToTemplate({ nodes, operators }: { nodes: readonly Expression[], operators: Token<BinaryOperator>[] }, file: SourceFile) {
+function nodesToTemplate({ nodes, operators }: { nodes: readonly Expression[], operators: BinaryOperatorToken[] }, file: SourceFile) {
     const copyOperatorComments = copyTrailingOperatorComments(operators, file);
     const copyCommentFromStringLiterals = copyCommentFromMultiNode(nodes, file, copyOperatorComments);
     const [begin, headText, rawHeadText, headIndexes] = concatConsecutiveString(0, nodes);

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -7,7 +7,6 @@ import {
     BindingElement,
     Block,
     BlockLike,
-    BreakStatement,
     CancellationToken,
     canHaveModifiers,
     CharacterCodes,
@@ -18,7 +17,6 @@ import {
     compareStringsCaseSensitive,
     compareValues,
     contains,
-    ContinueStatement,
     createDiagnosticForNode,
     createFileDiagnostic,
     Debug,
@@ -108,7 +106,6 @@ import {
     isVariableDeclaration,
     isVariableDeclarationList,
     isVariableStatement,
-    LabeledStatement,
     last,
     map,
     mapDefined,
@@ -145,7 +142,6 @@ import {
     TextRange,
     TextSpan,
     textSpanEnd,
-    TryStatement,
     Type,
     TypeChecker,
     TypeElement,
@@ -729,7 +725,7 @@ export function getRangeToExtract(sourceFile: SourceFile, span: TextSpan, invoke
                     permittedJumps = PermittedJumps.None;
                     break;
                 case SyntaxKind.Block:
-                    if (node.parent && node.parent.kind === SyntaxKind.TryStatement && (node.parent as TryStatement).finallyBlock === node) {
+                    if (node.parent && node.parent.kind === SyntaxKind.TryStatement && (node.parent).finallyBlock === node) {
                         // allow unconditional returns from finally blocks
                         permittedJumps = PermittedJumps.Return;
                     }
@@ -754,7 +750,7 @@ export function getRangeToExtract(sourceFile: SourceFile, span: TextSpan, invoke
                     thisNode = node;
                     break;
                 case SyntaxKind.LabeledStatement: {
-                    const label = (node as LabeledStatement).label;
+                    const label = (node).label;
                     (seenLabels || (seenLabels = [])).push(label.escapedText);
                     forEachChild(node, visit);
                     seenLabels.pop();
@@ -762,7 +758,7 @@ export function getRangeToExtract(sourceFile: SourceFile, span: TextSpan, invoke
                 }
                 case SyntaxKind.BreakStatement:
                 case SyntaxKind.ContinueStatement: {
-                    const label = (node as BreakStatement | ContinueStatement).label;
+                    const label = (node).label;
                     if (label) {
                         if (!contains(seenLabels, label.escapedText)) {
                             // attempts to jump to label that is not in range to be extracted

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -924,7 +924,7 @@ function isPureImport(node: Node): boolean {
         case SyntaxKind.ImportEqualsDeclaration:
             return !hasSyntacticModifier(node, ModifierFlags.Export);
         case SyntaxKind.VariableStatement:
-            return (node as VariableStatement).declarationList.declarations.every(d => !!d.initializer && isRequireCall(d.initializer, /*requireStringLiteralLikeArgument*/ true));
+            return (node).declarationList.declarations.every(d => !!d.initializer && isRequireCall(d.initializer, /*requireStringLiteralLikeArgument*/ true));
         default:
             return false;
     }
@@ -1033,13 +1033,13 @@ function forEachTopLevelDeclaration<T>(statement: Statement, cb: (node: TopLevel
         case SyntaxKind.TypeAliasDeclaration:
         case SyntaxKind.InterfaceDeclaration:
         case SyntaxKind.ImportEqualsDeclaration:
-            return cb(statement as FunctionDeclaration | ClassDeclaration | EnumDeclaration | ModuleDeclaration | TypeAliasDeclaration | InterfaceDeclaration | ImportEqualsDeclaration);
+            return cb(statement);
 
         case SyntaxKind.VariableStatement:
-            return firstDefined((statement as VariableStatement).declarationList.declarations, decl => forEachTopLevelDeclarationInBindingName(decl.name, cb));
+            return firstDefined((statement).declarationList.declarations, decl => forEachTopLevelDeclarationInBindingName(decl.name, cb));
 
         case SyntaxKind.ExpressionStatement: {
-            const { expression } = statement as ExpressionStatement;
+            const { expression } = statement ;
             return isBinaryExpression(expression) && getAssignmentDeclarationKind(expression) === AssignmentDeclarationKind.ExportsProperty
                 ? cb(statement as TopLevelExpressionStatement)
                 : undefined;
@@ -1055,7 +1055,7 @@ function isInImport(decl: Declaration) {
         case SyntaxKind.NamespaceImport:
             return true;
         case SyntaxKind.VariableDeclaration:
-            return isVariableDeclarationInImport(decl as VariableDeclaration);
+            return isVariableDeclarationInImport(decl);
         case SyntaxKind.BindingElement:
             return isVariableDeclaration(decl.parent.parent) && isVariableDeclarationInImport(decl.parent.parent);
         default:

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -28,7 +28,6 @@ import {
     isStringLiteralLike,
     isStringOrNumericLiteralLike,
     Node,
-    NumericLiteral,
     Path,
     Program,
     removeFileExtension,
@@ -235,7 +234,7 @@ export function nodeIsEligibleForRename(node: Node): boolean {
         case SyntaxKind.ThisKeyword:
             return true;
         case SyntaxKind.NumericLiteral:
-            return isLiteralNameOfPropertyDeclarationOrIndexAccess(node as NumericLiteral);
+            return isLiteralNameOfPropertyDeclarationOrIndexAccess(node);
         default:
             return false;
     }

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -1,5 +1,4 @@
 import {
-    ArrowFunction,
     BinaryExpression,
     CallLikeExpression,
     CancellationToken,
@@ -24,7 +23,6 @@ import {
     first,
     firstDefined,
     flatMapToMutable,
-    FunctionExpression,
     getInvokedExpression,
     getPossibleGenericSignatures,
     getPossibleTypeArgumentsInfo,
@@ -63,7 +61,6 @@ import {
     Node,
     NodeBuilderFlags,
     ParameterDeclaration,
-    ParenthesizedExpression,
     Printer,
     Program,
     punctuationPart,
@@ -434,12 +431,12 @@ function getContextualSignatureLocationInfo(node: Node, sourceFile: SourceFile, 
             const info = getArgumentOrParameterListInfo(node, position, sourceFile);
             if (!info) return undefined;
             const { argumentIndex, argumentCount, argumentsSpan } = info;
-            const contextualType = isMethodDeclaration(parent) ? checker.getContextualTypeForObjectLiteralElement(parent) : checker.getContextualType(parent as ParenthesizedExpression | FunctionExpression | ArrowFunction);
+            const contextualType = isMethodDeclaration(parent) ? checker.getContextualTypeForObjectLiteralElement(parent) : checker.getContextualType(parent);
             return contextualType && { contextualType, argumentIndex, argumentCount, argumentsSpan };
         case SyntaxKind.BinaryExpression: {
-            const highestBinary = getHighestBinary(parent as BinaryExpression);
+            const highestBinary = getHighestBinary(parent);
             const contextualType = checker.getContextualType(highestBinary);
-            const argumentIndex = node.kind === SyntaxKind.OpenParenToken ? 0 : countBinaryExpressionParameters(parent as BinaryExpression) - 1;
+            const argumentIndex = node.kind === SyntaxKind.OpenParenToken ? 0 : countBinaryExpressionParameters(parent) - 1;
             const argumentCount = countBinaryExpressionParameters(highestBinary);
             return contextualType && { contextualType, argumentIndex, argumentCount, argumentsSpan: createTextSpanFromNode(parent) };
         }

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -4,7 +4,6 @@ import {
     arrayFrom,
     CallLikeExpression,
     CancellationToken,
-    CaseClause,
     changeExtension,
     CharacterCodes,
     combinePaths,
@@ -26,7 +25,6 @@ import {
     Debug,
     deduplicate,
     directorySeparator,
-    ElementAccessExpression,
     emptyArray,
     endsWith,
     ensureTrailingDirectorySeparator,
@@ -65,7 +63,6 @@ import {
     hasProperty,
     hasTrailingDirectorySeparator,
     hostGetCanonicalFileName,
-    IndexedAccessTypeNode,
     isApplicableVersionedTypesKey,
     isArray,
     isCallExpression,
@@ -103,7 +100,6 @@ import {
     ObjectLiteralExpression,
     Path,
     Program,
-    PropertyAssignment,
     rangeContainsPosition,
     readJson,
     removeFileExtension,
@@ -348,7 +344,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
             return fromUnionableLiteralType(grandParent);
         }
         case SyntaxKind.PropertyAssignment:
-            if (isObjectLiteralExpression(parent.parent) && (parent as PropertyAssignment).name === node) {
+            if (isObjectLiteralExpression(parent.parent) && (parent).name === node) {
                 // Get quoted name of properties of the object literal expression
                 // i.e. interface ConfigFiles {
                 //          'jspm:dev': string
@@ -366,7 +362,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
             return fromContextualType() || fromContextualType(ContextFlags.None);
 
         case SyntaxKind.ElementAccessExpression: {
-            const { expression, argumentExpression } = parent as ElementAccessExpression;
+            const { expression, argumentExpression } = parent ;
             if (node === skipParentheses(argumentExpression)) {
                 // Get all names of properties on the expression
                 // i.e. interface A {
@@ -402,7 +398,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
             //      export * from "/*completion position*/";
             return { kind: StringLiteralCompletionKind.Paths, paths: getStringLiteralCompletionsFromModuleNames(sourceFile, node, compilerOptions, host, typeChecker, preferences) };
         case SyntaxKind.CaseClause:
-            const tracker = newCaseClauseTracker(typeChecker, (parent as CaseClause).parent.clauses);
+            const tracker = newCaseClauseTracker(typeChecker, (parent).parent.clauses);
             const contextualTypes = fromContextualType();
             if (!contextualTypes) {
                 return;
@@ -430,7 +426,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
                 //          bar: string;
                 //      }
                 //      let x: Foo["/*completion position*/"]
-                const { indexType, objectType } = grandParent as IndexedAccessTypeNode;
+                const { indexType, objectType } = grandParent ;
                 if (!rangeContainsPosition(indexType, position)) {
                     return undefined;
                 }
@@ -440,7 +436,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
                 if (!result) {
                     return undefined;
                 }
-                const alreadyUsedTypes = getAlreadyUsedTypesInStringLiteralUnion(grandParent as UnionTypeNode, parent as LiteralTypeNode);
+                const alreadyUsedTypes = getAlreadyUsedTypesInStringLiteralUnion(grandParent , parent as LiteralTypeNode);
                 if (result.kind === StringLiteralCompletionKind.Properties) {
                     return { kind: StringLiteralCompletionKind.Properties, symbols: result.symbols.filter(sym => !contains(alreadyUsedTypes, sym.name)), hasIndexSignature: result.hasIndexSignature };
                 }

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -12,7 +12,6 @@ import {
     Diagnostics,
     DiagnosticWithLocation,
     Expression,
-    ExpressionStatement,
     Extension,
     fileExtensionIsOneOf,
     forEachReturnStatement,
@@ -58,7 +57,6 @@ import {
     SourceFile,
     SyntaxKind,
     TypeChecker,
-    VariableStatement,
 } from "./_namespaces/ts";
 
 const visitedNestedConvertibleFunctions = new Map<string, true>();
@@ -138,10 +136,10 @@ function containsTopLevelCommonjs(sourceFile: SourceFile): boolean {
     return sourceFile.statements.some(statement => {
         switch (statement.kind) {
             case SyntaxKind.VariableStatement:
-                return (statement as VariableStatement).declarationList.declarations.some(decl =>
+                return (statement).declarationList.declarations.some(decl =>
                     !!decl.initializer && isRequireCall(propertyAccessLeftHandSide(decl.initializer), /*requireStringLiteralLikeArgument*/ true));
             case SyntaxKind.ExpressionStatement: {
-                const { expression } = statement as ExpressionStatement;
+                const { expression } = statement ;
                 if (!isBinaryExpression(expression)) return isRequireCall(expression, /*requireStringLiteralLikeArgument*/ true);
                 const kind = getAssignmentDeclarationKind(expression);
                 return kind === AssignmentDeclarationKind.ExportsProperty || kind === AssignmentDeclarationKind.ModuleExports;
@@ -249,17 +247,17 @@ function hasSupportedNumberOfArguments(node: CallExpression & { readonly express
 }
 
 // should be kept up to date with getTransformationBody in convertToAsyncFunction.ts
-function isFixablePromiseArgument(arg: Expression, checker: TypeChecker): boolean {
+function isFixablePromiseArgument(arg: Expression | FunctionDeclaration, checker: TypeChecker): boolean {
     switch (arg.kind) {
         case SyntaxKind.FunctionDeclaration:
         case SyntaxKind.FunctionExpression:
-            const functionFlags = getFunctionFlags(arg as FunctionDeclaration | FunctionExpression);
+            const functionFlags = getFunctionFlags(arg);
             if (functionFlags & FunctionFlags.Generator) {
                 return false;
             }
             // falls through
         case SyntaxKind.ArrowFunction:
-            visitedNestedConvertibleFunctions.set(getKeyFromNode(arg as FunctionLikeDeclaration), true);
+            visitedNestedConvertibleFunctions.set(getKeyFromNode(arg), true);
             // falls through
         case SyntaxKind.NullKeyword:
             return true;

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -1,7 +1,6 @@
 import {
     addRange,
     arrayFrom,
-    BinaryExpression,
     CallExpression,
     CheckFlags,
     contains,
@@ -10,8 +9,6 @@ import {
     displayPart,
     EmitHint,
     emptyArray,
-    EnumMember,
-    ExportAssignment,
     find,
     first,
     firstDefined,
@@ -31,7 +28,6 @@ import {
     getTextOfNode,
     hasSyntacticModifier,
     idText,
-    ImportEqualsDeclaration,
     isArrowFunction,
     isBindingElement,
     isCallExpression,
@@ -75,7 +71,6 @@ import {
     NodeBuilderFlags,
     ObjectFlags,
     operatorPart,
-    PropertyAccessExpression,
     PropertyDeclaration,
     punctuationPart,
     ScriptElementKind,
@@ -295,7 +290,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
         type = isThisExpression ? typeChecker.getTypeAtLocation(location) : typeChecker.getTypeOfSymbolAtLocation(symbol, location);
 
         if (location.parent && location.parent.kind === SyntaxKind.PropertyAccessExpression) {
-            const right = (location.parent as PropertyAccessExpression).name;
+            const right = (location.parent).name;
             // Either the location is on the right of a property access, or on the left and the right is missing
             if (right === location || (right && right.getFullWidth() === 0)) {
                 location = location.parent;
@@ -522,7 +517,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
         addPrefixForAnyFunctionOrVar(symbol, "enum member");
         const declaration = symbol.declarations?.[0];
         if (declaration?.kind === SyntaxKind.EnumMember) {
-            const constantValue = typeChecker.getConstantValue(declaration as EnumMember);
+            const constantValue = typeChecker.getConstantValue(declaration);
             if (constantValue !== undefined) {
                 displayParts.push(spacePart());
                 displayParts.push(operatorPart(SyntaxKind.EqualsToken));
@@ -575,7 +570,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
                 case SyntaxKind.ExportAssignment:
                     displayParts.push(keywordPart(SyntaxKind.ExportKeyword));
                     displayParts.push(spacePart());
-                    displayParts.push(keywordPart((symbol.declarations[0] as ExportAssignment).isExportEquals ? SyntaxKind.EqualsToken : SyntaxKind.DefaultKeyword));
+                    displayParts.push(keywordPart((symbol.declarations[0]).isExportEquals ? SyntaxKind.EqualsToken : SyntaxKind.DefaultKeyword));
                     break;
                 case SyntaxKind.ExportSpecifier:
                     displayParts.push(keywordPart(SyntaxKind.ExportKeyword));
@@ -588,7 +583,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
         addFullSymbolName(symbol);
         forEach(symbol.declarations, declaration => {
             if (declaration.kind === SyntaxKind.ImportEqualsDeclaration) {
-                const importEqualsDeclaration = declaration as ImportEqualsDeclaration;
+                const importEqualsDeclaration = declaration ;
                 if (isExternalModuleImportEqualsDeclaration(importEqualsDeclaration)) {
                     displayParts.push(spacePart());
                     displayParts.push(operatorPart(SyntaxKind.EqualsToken));
@@ -686,7 +681,7 @@ export function getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker: Typ
                     continue;
                 }
 
-                const rhsSymbol = typeChecker.getSymbolAtLocation((declaration.parent as BinaryExpression).right);
+                const rhsSymbol = typeChecker.getSymbolAtLocation((declaration.parent).right);
                 if (!rhsSymbol) {
                     continue;
                 }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -1,7 +1,6 @@
 import {
     addToSeen,
     ArrowFunction,
-    BindingElement,
     CharacterCodes,
     ClassElement,
     ClassExpression,
@@ -120,7 +119,6 @@ import {
     MultiMap,
     NamedImportBindings,
     NamedImports,
-    NamespaceImport,
     Node,
     NodeArray,
     NodeFactoryFlags,
@@ -1172,7 +1170,7 @@ function tryMergeJsdocTags(oldTag: JSDocTag, newTag: JSDocTag): JSDocTag | undef
     }
     switch (oldTag.kind) {
         case SyntaxKind.JSDocParameterTag: {
-            const oldParam = oldTag as JSDocParameterTag;
+            const oldParam = oldTag ;
             const newParam = newTag as JSDocParameterTag;
             return isIdentifier(oldParam.name) && isIdentifier(newParam.name) && oldParam.name.escapedText === newParam.name.escapedText
                 ? factory.createJSDocParameterTag(/*tagName*/ undefined, newParam.name, /*isBracketed*/ false, newParam.typeExpression, newParam.isNameFirst, oldParam.comment)
@@ -1660,7 +1658,7 @@ namespace deleteDeclaration {
                 break;
 
             case SyntaxKind.BindingElement:
-                const pattern = (node as BindingElement).parent;
+                const pattern = (node).parent;
                 const preserveComma = pattern.kind === SyntaxKind.ArrayBindingPattern && node !== last(pattern.elements);
                 if (preserveComma) {
                     deleteNode(changes, sourceFile, node);
@@ -1671,7 +1669,7 @@ namespace deleteDeclaration {
                 break;
 
             case SyntaxKind.VariableDeclaration:
-                deleteVariableDeclaration(changes, deletedNodesInLists, sourceFile, node as VariableDeclaration);
+                deleteVariableDeclaration(changes, deletedNodesInLists, sourceFile, node);
                 break;
 
             case SyntaxKind.TypeParameter:
@@ -1679,7 +1677,7 @@ namespace deleteDeclaration {
                 break;
 
             case SyntaxKind.ImportSpecifier:
-                const namedImports = (node as ImportSpecifier).parent;
+                const namedImports = (node).parent;
                 if (namedImports.elements.length === 1) {
                     deleteImportBinding(changes, sourceFile, namedImports);
                 }
@@ -1689,7 +1687,7 @@ namespace deleteDeclaration {
                 break;
 
             case SyntaxKind.NamespaceImport:
-                deleteImportBinding(changes, sourceFile, node as NamespaceImport);
+                deleteImportBinding(changes, sourceFile, node);
                 break;
 
             case SyntaxKind.SemicolonToken:

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -43,7 +43,7 @@ import {
 
 declare module "../compiler/types" {
     // Module transform: converted from interface augmentation
-    export interface Node {
+    export interface NodeBase {
         getSourceFile(): SourceFile;
         getChildCount(sourceFile?: SourceFile): number;
         getChildAt(index: number, sourceFile?: SourceFile): Node;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -6,7 +6,6 @@ import {
     AnyImportOrRequireStatement,
     assertType,
     AssignmentDeclarationKind,
-    BinaryExpression,
     binarySearchKey,
     BindingElement,
     BreakOrContinueStatement,
@@ -14,7 +13,6 @@ import {
     canHaveModifiers,
     CaseClause,
     cast,
-    CatchClause,
     CharacterCodes,
     ClassDeclaration,
     ClassExpression,
@@ -27,7 +25,6 @@ import {
     compareValues,
     Comparison,
     CompilerOptions,
-    ConditionalExpression,
     contains,
     ContextFlags,
     createPrinterWithRemoveCommentsOmitTrailingSemicolon,
@@ -40,7 +37,6 @@ import {
     Decorator,
     DefaultClause,
     defaultMaximumTruncationLength,
-    DeleteExpression,
     Diagnostic,
     DiagnosticAndArguments,
     DiagnosticArguments,
@@ -50,21 +46,16 @@ import {
     DisplayPartsSymbolWriter,
     DocumentPosition,
     DocumentSpan,
-    DoStatement,
-    ElementAccessExpression,
     EmitFlags,
     EmitHint,
     emitModuleKindIsNonNodeESM,
     emptyArray,
-    EndOfFileToken,
     endsWith,
     ensureScriptKind,
     EqualityOperator,
     escapeString,
-    ExportAssignment,
     ExportDeclaration,
     Expression,
-    ExpressionStatement,
     factory,
     FileTextChanges,
     filter,
@@ -82,7 +73,6 @@ import {
     formatStringFromArgs,
     formatting,
     FormattingHost,
-    ForOfStatement,
     FunctionDeclaration,
     FunctionExpression,
     FunctionLikeDeclaration,
@@ -119,13 +109,10 @@ import {
     identifierIsThisKeyword,
     identity,
     idText,
-    IfStatement,
     ImportClause,
     ImportDeclaration,
     ImportSpecifier,
-    ImportTypeNode,
     indexOfNode,
-    IndexSignatureDeclaration,
     InternalSymbolName,
     isAmbientModule,
     isAnyImportSyntax,
@@ -257,11 +244,9 @@ import {
     JSDocLinkCode,
     JSDocLinkDisplayPart,
     JSDocLinkPlain,
-    JSDocTypedefTag,
     JsTyping,
     JsxEmit,
     JsxOpeningLikeElement,
-    LabeledStatement,
     LanguageServiceHost,
     last,
     lastOrUndefined,
@@ -270,7 +255,6 @@ import {
     maybeBind,
     Modifier,
     ModifierFlags,
-    ModuleDeclaration,
     ModuleInstanceState,
     ModuleKind,
     ModuleResolutionKind,
@@ -296,11 +280,9 @@ import {
     PackageJsonDependencyGroup,
     parseBigInt,
     pathIsRelative,
-    PrefixUnaryExpression,
     Program,
     ProjectPackageJsonInfo,
     PropertyAccessExpression,
-    PropertyAssignment,
     PropertyName,
     PseudoBigInt,
     pseudoBigIntToString,
@@ -326,7 +308,6 @@ import {
     SourceFile,
     SourceFileLike,
     SourceMapper,
-    SpreadElement,
     stableSort,
     startsWith,
     stringContains,
@@ -346,7 +327,6 @@ import {
     TaggedTemplateExpression,
     TemplateExpression,
     TemplateLiteralToken,
-    TemplateSpan,
     TextChange,
     textChanges,
     TextRange,
@@ -363,15 +343,11 @@ import {
     TypeFlags,
     TypeFormatFlags,
     TypeNode,
-    TypeOfExpression,
-    TypeQueryNode,
     unescapeLeadingUnderscores,
     UserPreferences,
     VariableDeclaration,
     visitEachChild,
-    VoidExpression,
     walkUpParenthesizedExpressions,
-    YieldExpression,
 } from "./_namespaces/ts";
 
 // These utilities are common to multiple language service features.
@@ -420,17 +396,17 @@ export function getMeaningFromDeclaration(node: Node): SemanticMeaning {
 
         case SyntaxKind.JSDocTypedefTag:
             // If it has no name node, it shares the name with the value declaration below it.
-            return (node as JSDocTypedefTag).name === undefined ? SemanticMeaning.Value | SemanticMeaning.Type : SemanticMeaning.Type;
+            return (node).name === undefined ? SemanticMeaning.Value | SemanticMeaning.Type : SemanticMeaning.Type;
 
         case SyntaxKind.EnumMember:
         case SyntaxKind.ClassDeclaration:
             return SemanticMeaning.Value | SemanticMeaning.Type;
 
         case SyntaxKind.ModuleDeclaration:
-            if (isAmbientModule(node as ModuleDeclaration)) {
+            if (isAmbientModule(node)) {
                 return SemanticMeaning.Namespace | SemanticMeaning.Value;
             }
-            else if (getModuleInstanceState(node as ModuleDeclaration) === ModuleInstanceState.Instantiated) {
+            else if (getModuleInstanceState(node) === ModuleInstanceState.Instantiated) {
                 return SemanticMeaning.Namespace | SemanticMeaning.Value;
             }
             else {
@@ -544,8 +520,8 @@ function isPropertyAccessNamespaceReference(node: Node): boolean {
 
     if (!isLastClause && root.parent.kind === SyntaxKind.ExpressionWithTypeArguments && root.parent.parent.kind === SyntaxKind.HeritageClause) {
         const decl = root.parent.parent.parent;
-        return (decl.kind === SyntaxKind.ClassDeclaration && (root.parent.parent as HeritageClause).token === SyntaxKind.ImplementsKeyword) ||
-            (decl.kind === SyntaxKind.InterfaceDeclaration && (root.parent.parent as HeritageClause).token === SyntaxKind.ExtendsKeyword);
+        return (decl.kind === SyntaxKind.ClassDeclaration && (root.parent.parent).token === SyntaxKind.ImplementsKeyword) ||
+            (decl.kind === SyntaxKind.InterfaceDeclaration && (root.parent.parent).token === SyntaxKind.ExtendsKeyword);
     }
 
     return false;
@@ -567,7 +543,7 @@ function isTypeReference(node: Node): boolean {
         case SyntaxKind.TypeReference:
             return true;
         case SyntaxKind.ImportType:
-            return !(node.parent as ImportTypeNode).isTypeOf;
+            return !(node.parent).isTypeOf;
         case SyntaxKind.ExpressionWithTypeArguments:
             return isPartOfTypeNode(node.parent);
     }
@@ -638,8 +614,8 @@ export function climbPastPropertyOrElementAccess(node: Node) {
 /** @internal */
 export function getTargetLabel(referenceNode: Node, labelName: string): Identifier | undefined {
     while (referenceNode) {
-        if (referenceNode.kind === SyntaxKind.LabeledStatement && (referenceNode as LabeledStatement).label.escapedText === labelName) {
-            return (referenceNode as LabeledStatement).label;
+        if (referenceNode.kind === SyntaxKind.LabeledStatement && (referenceNode).label.escapedText === labelName) {
+            return (referenceNode).label;
         }
         referenceNode = referenceNode.parent;
     }
@@ -714,7 +690,7 @@ export function isLiteralNameOfPropertyDeclarationOrIndexAccess(node: StringLite
         case SyntaxKind.ModuleDeclaration:
             return getNameOfDeclaration(node.parent as Declaration) === node;
         case SyntaxKind.ElementAccessExpression:
-            return (node.parent as ElementAccessExpression).argumentExpression === node;
+            return (node.parent).argumentExpression === node;
         case SyntaxKind.ComputedPropertyName:
             return true;
         case SyntaxKind.LiteralType:
@@ -765,7 +741,7 @@ export function getContainerNode(node: Node): Declaration | undefined {
 export function getNodeKind(node: Node): ScriptElementKind {
     switch (node.kind) {
         case SyntaxKind.SourceFile:
-            return isExternalModule(node as SourceFile) ? ScriptElementKind.moduleElement : ScriptElementKind.scriptElement;
+            return isExternalModule(node) ? ScriptElementKind.moduleElement : ScriptElementKind.scriptElement;
         case SyntaxKind.ModuleDeclaration:
             return ScriptElementKind.moduleElement;
         case SyntaxKind.ClassDeclaration:
@@ -778,7 +754,7 @@ export function getNodeKind(node: Node): ScriptElementKind {
             return ScriptElementKind.typeElement;
         case SyntaxKind.EnumDeclaration: return ScriptElementKind.enumElement;
         case SyntaxKind.VariableDeclaration:
-            return getKindOfVariableDeclaration(node as VariableDeclaration);
+            return getKindOfVariableDeclaration(node);
         case SyntaxKind.BindingElement:
             return getKindOfVariableDeclaration(getRootDeclaration(node) as VariableDeclaration);
         case SyntaxKind.ArrowFunction:
@@ -791,7 +767,7 @@ export function getNodeKind(node: Node): ScriptElementKind {
         case SyntaxKind.MethodSignature:
             return ScriptElementKind.memberFunctionElement;
         case SyntaxKind.PropertyAssignment:
-            const { initializer } = node as PropertyAssignment;
+            const { initializer } = node ;
             return isFunctionLike(initializer) ? ScriptElementKind.memberFunctionElement : ScriptElementKind.memberVariableElement;
         case SyntaxKind.PropertyDeclaration:
         case SyntaxKind.PropertySignature:
@@ -814,8 +790,8 @@ export function getNodeKind(node: Node): ScriptElementKind {
         case SyntaxKind.NamespaceExport:
             return ScriptElementKind.alias;
         case SyntaxKind.BinaryExpression:
-            const kind = getAssignmentDeclarationKind(node as BinaryExpression);
-            const { right } = node as BinaryExpression;
+            const kind = getAssignmentDeclarationKind(node);
+            const { right } = node ;
             switch (kind) {
                 case AssignmentDeclarationKind.ObjectDefinePropertyValue:
                 case AssignmentDeclarationKind.ObjectDefinePropertyExports:
@@ -843,7 +819,7 @@ export function getNodeKind(node: Node): ScriptElementKind {
         case SyntaxKind.Identifier:
             return isImportClause(node.parent) ? ScriptElementKind.alias : ScriptElementKind.unknown;
         case SyntaxKind.ExportAssignment:
-            const scriptKind = getNodeKind((node as ExportAssignment).expression);
+            const scriptKind = getNodeKind((node).expression);
             // If the expression didn't come back with something (like it does for an identifiers)
             return scriptKind === ScriptElementKind.unknown ? ScriptElementKind.constElement : scriptKind;
         default:
@@ -867,7 +843,7 @@ export function isThis(node: Node): boolean {
             return true;
         case SyntaxKind.Identifier:
             // 'this' as a parameter
-            return identifierIsThisKeyword(node as Identifier) && node.parent.kind === SyntaxKind.Parameter;
+            return identifierIsThisKeyword(node) && node.parent.kind === SyntaxKind.Parameter;
         default:
             return false;
     }
@@ -965,9 +941,9 @@ function isCompletedNode(n: Node | undefined, sourceFile: SourceFile): boolean {
         case SyntaxKind.NamedExports:
             return nodeEndsWith(n, SyntaxKind.CloseBraceToken, sourceFile);
         case SyntaxKind.CatchClause:
-            return isCompletedNode((n as CatchClause).block, sourceFile);
+            return isCompletedNode((n).block, sourceFile);
         case SyntaxKind.NewExpression:
-            if (!(n as NewExpression).arguments) {
+            if (!(n).arguments) {
                 return true;
             }
         // falls through
@@ -1004,16 +980,16 @@ function isCompletedNode(n: Node | undefined, sourceFile: SourceFile): boolean {
             return hasChildOfKind(n, SyntaxKind.CloseParenToken, sourceFile);
 
         case SyntaxKind.ModuleDeclaration:
-            return !!(n as ModuleDeclaration).body && isCompletedNode((n as ModuleDeclaration).body, sourceFile);
+            return !!(n).body && isCompletedNode((n).body, sourceFile);
 
         case SyntaxKind.IfStatement:
-            if ((n as IfStatement).elseStatement) {
-                return isCompletedNode((n as IfStatement).elseStatement, sourceFile);
+            if ((n).elseStatement) {
+                return isCompletedNode((n).elseStatement, sourceFile);
             }
-            return isCompletedNode((n as IfStatement).thenStatement, sourceFile);
+            return isCompletedNode((n).thenStatement, sourceFile);
 
         case SyntaxKind.ExpressionStatement:
-            return isCompletedNode((n as ExpressionStatement).expression, sourceFile) ||
+            return isCompletedNode((n).expression, sourceFile) ||
                 hasChildOfKind(n, SyntaxKind.SemicolonToken, sourceFile);
 
         case SyntaxKind.ArrayLiteralExpression:
@@ -1024,8 +1000,8 @@ function isCompletedNode(n: Node | undefined, sourceFile: SourceFile): boolean {
             return nodeEndsWith(n, SyntaxKind.CloseBracketToken, sourceFile);
 
         case SyntaxKind.IndexSignature:
-            if ((n as IndexSignatureDeclaration).type) {
-                return isCompletedNode((n as IndexSignatureDeclaration).type, sourceFile);
+            if ((n).type) {
+                return isCompletedNode((n).type, sourceFile);
             }
 
             return hasChildOfKind(n, SyntaxKind.CloseBracketToken, sourceFile);
@@ -1044,37 +1020,37 @@ function isCompletedNode(n: Node | undefined, sourceFile: SourceFile): boolean {
             // rough approximation: if DoStatement has While keyword - then if node is completed is checking the presence of ')';
             return hasChildOfKind(n, SyntaxKind.WhileKeyword, sourceFile)
                 ? nodeEndsWith(n, SyntaxKind.CloseParenToken, sourceFile)
-                : isCompletedNode((n as DoStatement).statement, sourceFile);
+                : isCompletedNode((n).statement, sourceFile);
 
         case SyntaxKind.TypeQuery:
-            return isCompletedNode((n as TypeQueryNode).exprName, sourceFile);
+            return isCompletedNode((n).exprName, sourceFile);
 
         case SyntaxKind.TypeOfExpression:
         case SyntaxKind.DeleteExpression:
         case SyntaxKind.VoidExpression:
         case SyntaxKind.YieldExpression:
         case SyntaxKind.SpreadElement:
-            const unaryWordExpression = n as (TypeOfExpression | DeleteExpression | VoidExpression | YieldExpression | SpreadElement);
+            const unaryWordExpression = n ;
             return isCompletedNode(unaryWordExpression.expression, sourceFile);
 
         case SyntaxKind.TaggedTemplateExpression:
-            return isCompletedNode((n as TaggedTemplateExpression).template, sourceFile);
+            return isCompletedNode((n).template, sourceFile);
         case SyntaxKind.TemplateExpression:
-            const lastSpan = lastOrUndefined((n as TemplateExpression).templateSpans);
+            const lastSpan = lastOrUndefined((n).templateSpans);
             return isCompletedNode(lastSpan, sourceFile);
         case SyntaxKind.TemplateSpan:
-            return nodeIsPresent((n as TemplateSpan).literal);
+            return nodeIsPresent((n).literal);
 
         case SyntaxKind.ExportDeclaration:
         case SyntaxKind.ImportDeclaration:
-            return nodeIsPresent((n as ExportDeclaration | ImportDeclaration).moduleSpecifier);
+            return nodeIsPresent((n).moduleSpecifier);
 
         case SyntaxKind.PrefixUnaryExpression:
-            return isCompletedNode((n as PrefixUnaryExpression).operand, sourceFile);
+            return isCompletedNode((n).operand, sourceFile);
         case SyntaxKind.BinaryExpression:
-            return isCompletedNode((n as BinaryExpression).right, sourceFile);
+            return isCompletedNode((n).right, sourceFile);
         case SyntaxKind.ConditionalExpression:
-            return isCompletedNode((n as ConditionalExpression).whenFalse, sourceFile);
+            return isCompletedNode((n).whenFalse, sourceFile);
 
         default:
             return true;
@@ -1126,7 +1102,7 @@ export function hasChildOfKind(n: Node, kind: SyntaxKind, sourceFile: SourceFile
 }
 
 /** @internal */
-export function findChildOfKind<T extends Node>(n: Node, kind: T["kind"], sourceFile: SourceFileLike): T | undefined {
+export function findChildOfKind<T extends Node>(n: Node, kind: T["kind"] | SyntaxKind.Count, sourceFile: SourceFileLike): T | undefined {
     return find(n.getChildren(sourceFile), (c): c is T => c.kind === kind);
 }
 
@@ -1215,10 +1191,10 @@ function getAdjustedLocationForDeclaration(node: Node, forRename: boolean) {
         switch (node.kind) {
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.ClassExpression:
-                return getAdjustedLocationForClass(node as ClassDeclaration | ClassExpression);
+                return getAdjustedLocationForClass(node);
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
-                return getAdjustedLocationForFunction(node as FunctionDeclaration | FunctionExpression);
+                return getAdjustedLocationForFunction(node);
             case SyntaxKind.Constructor:
                 return node;
         }
@@ -1548,7 +1524,7 @@ function getTokenAtPositionWorker(sourceFile: SourceFile, position: number, allo
     outer: while (true) {
         // find the child that contains 'position'
 
-        const children = current.getChildren(sourceFile);
+        const children: Node[] = current.getChildren(sourceFile);
         const i = binarySearchKey(children, position, (_, i) => i, (middle, _) => {
             // This last callback is more of a selector than a comparator -
             // `EqualTo` causes the `middle` result to be returned
@@ -2130,7 +2106,7 @@ export function hasDocComment(sourceFile: SourceFile, position: number): boolean
 function nodeHasTokens(n: Node, sourceFile: SourceFileLike): boolean {
     // If we have a token or node that has a non-zero width, it must have tokens.
     // Note: getWidth() does not take trivia into account.
-    return n.kind === SyntaxKind.EndOfFileToken ? !!(n as EndOfFileToken).jsDoc : n.getWidth(sourceFile) !== 0;
+    return n.kind === SyntaxKind.EndOfFileToken ? !!(n).jsDoc : n.getWidth(sourceFile) !== 0;
 }
 
 /** @internal */
@@ -2228,15 +2204,15 @@ export function isArrayLiteralOrObjectLiteralDestructuringPattern(node: Node) {
         // [a,b,c] from:
         // [a, b, c] = someExpression;
         if (node.parent.kind === SyntaxKind.BinaryExpression &&
-            (node.parent as BinaryExpression).left === node &&
-            (node.parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken) {
+            (node.parent).left === node &&
+            (node.parent).operatorToken.kind === SyntaxKind.EqualsToken) {
             return true;
         }
 
         // [a, b, c] from:
         // for([a, b, c] of expression)
         if (node.parent.kind === SyntaxKind.ForOfStatement &&
-            (node.parent as ForOfStatement).initializer === node) {
+            (node.parent).initializer === node) {
             return true;
         }
 
@@ -3105,7 +3081,7 @@ export function getSynthesizedDeepCloneWithReplacements<T extends Node>(
         setOriginalNode(clone, node);
     }
     else {
-        clone = getSynthesizedDeepCloneWorker(node as NonNullable<T>, replaceNode);
+        clone = getSynthesizedDeepCloneWorker(node, replaceNode);
     }
 
     if (clone && !includeTrivia) suppressLeadingAndTrailingTrivia(clone);
@@ -3324,15 +3300,15 @@ export function getContextualTypeFromParent(node: Expression, checker: TypeCheck
     const parent = walkUpParenthesizedExpressions(node.parent);
     switch (parent.kind) {
         case SyntaxKind.NewExpression:
-            return checker.getContextualType(parent as NewExpression, contextFlags);
+            return checker.getContextualType(parent , contextFlags);
         case SyntaxKind.BinaryExpression: {
-            const { left, operatorToken, right } = parent as BinaryExpression;
+            const { left, operatorToken, right } = parent ;
             return isEqualityOperatorKind(operatorToken.kind)
                 ? checker.getTypeAtLocation(node === right ? left : right)
                 : checker.getContextualType(node, contextFlags);
         }
         case SyntaxKind.CaseClause:
-            return getSwitchedType(parent as CaseClause, checker);
+            return getSwitchedType(parent , checker);
         default:
             return checker.getContextualType(node, contextFlags);
     }

--- a/src/testRunner/unittests/customTransforms.ts
+++ b/src/testRunner/unittests/customTransforms.ts
@@ -48,7 +48,7 @@ describe("unittests:: customTransforms", () => {
         function visit(node: ts.Node): ts.VisitResult<ts.Node> {
             switch (node.kind) {
                 case ts.SyntaxKind.FunctionDeclaration:
-                    return visitFunction(node as ts.FunctionDeclaration);
+                    return visitFunction(node);
                 default:
                     return ts.visitEachChild(node, visit, context);
             }
@@ -64,7 +64,7 @@ describe("unittests:: customTransforms", () => {
         function visit(node: ts.Node): ts.VisitResult<ts.Node> {
             switch (node.kind) {
                 case ts.SyntaxKind.VariableStatement:
-                    return visitVariableStatement(node as ts.VariableStatement);
+                    return visitVariableStatement(node);
                 default:
                     return ts.visitEachChild(node, visit, context);
             }

--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -1071,52 +1071,52 @@ export * from "lib";
 
         switch (node1.kind) {
             case ts.SyntaxKind.ImportDeclaration:
-                const decl1 = node1 as ts.ImportDeclaration;
+                const decl1 = node1 ;
                 const decl2 = node2 as ts.ImportDeclaration;
                 assertEqual(decl1.importClause, decl2.importClause);
                 assertEqual(decl1.moduleSpecifier, decl2.moduleSpecifier);
                 break;
             case ts.SyntaxKind.ImportClause:
-                const clause1 = node1 as ts.ImportClause;
+                const clause1 = node1 ;
                 const clause2 = node2 as ts.ImportClause;
                 assertEqual(clause1.name, clause2.name);
                 assertEqual(clause1.namedBindings, clause2.namedBindings);
                 break;
             case ts.SyntaxKind.NamespaceImport:
-                const nsi1 = node1 as ts.NamespaceImport;
+                const nsi1 = node1 ;
                 const nsi2 = node2 as ts.NamespaceImport;
                 assertEqual(nsi1.name, nsi2.name);
                 break;
             case ts.SyntaxKind.NamedImports:
-                const ni1 = node1 as ts.NamedImports;
+                const ni1 = node1 ;
                 const ni2 = node2 as ts.NamedImports;
                 assertListEqual(ni1.elements, ni2.elements);
                 break;
             case ts.SyntaxKind.ImportSpecifier:
-                const is1 = node1 as ts.ImportSpecifier;
+                const is1 = node1 ;
                 const is2 = node2 as ts.ImportSpecifier;
                 assertEqual(is1.name, is2.name);
                 assertEqual(is1.propertyName, is2.propertyName);
                 break;
             case ts.SyntaxKind.ExportDeclaration:
-                const ed1 = node1 as ts.ExportDeclaration;
+                const ed1 = node1 ;
                 const ed2 = node2 as ts.ExportDeclaration;
                 assertEqual(ed1.exportClause, ed2.exportClause);
                 assertEqual(ed1.moduleSpecifier, ed2.moduleSpecifier);
                 break;
             case ts.SyntaxKind.NamedExports:
-                const ne1 = node1 as ts.NamedExports;
+                const ne1 = node1 ;
                 const ne2 = node2 as ts.NamedExports;
                 assertListEqual(ne1.elements, ne2.elements);
                 break;
             case ts.SyntaxKind.ExportSpecifier:
-                const es1 = node1 as ts.ExportSpecifier;
+                const es1 = node1 ;
                 const es2 = node2 as ts.ExportSpecifier;
                 assertEqual(es1.name, es2.name);
                 assertEqual(es1.propertyName, es2.propertyName);
                 break;
             case ts.SyntaxKind.Identifier:
-                const id1 = node1 as ts.Identifier;
+                const id1 = node1 ;
                 const id2 = node2 as ts.Identifier;
                 assert.equal(id1.text, id2.text);
                 break;

--- a/src/testRunner/unittests/tsbuild/publicApi.ts
+++ b/src/testRunner/unittests/tsbuild/publicApi.ts
@@ -98,7 +98,7 @@ ${patch ? vfs.formatPatch(patch) : ""}`
                 function visit(node: ts.Node): ts.VisitResult<ts.Node> {
                     switch (node.kind) {
                         case ts.SyntaxKind.FunctionDeclaration:
-                            return visitFunction(node as ts.FunctionDeclaration);
+                            return visitFunction(node);
                         default:
                             return ts.visitEachChild(node, visit, context);
                     }
@@ -114,7 +114,7 @@ ${patch ? vfs.formatPatch(patch) : ""}`
                 function visit(node: ts.Node): ts.VisitResult<ts.Node> {
                     switch (node.kind) {
                         case ts.SyntaxKind.VariableStatement:
-                            return visitVariableStatement(node as ts.VariableStatement);
+                            return visitVariableStatement(node);
                         default:
                             return ts.visitEachChild(node, visit, context);
                     }

--- a/src/testRunner/unittests/tsbuildWatch/publicApi.ts
+++ b/src/testRunner/unittests/tsbuildWatch/publicApi.ts
@@ -83,7 +83,7 @@ export function f22() { } // trailing`
             function visit(node: ts.Node): ts.VisitResult<ts.Node> {
                 switch (node.kind) {
                     case ts.SyntaxKind.FunctionDeclaration:
-                        return visitFunction(node as ts.FunctionDeclaration);
+                        return visitFunction(node);
                     default:
                         return ts.visitEachChild(node, visit, context);
                 }
@@ -99,7 +99,7 @@ export function f22() { } // trailing`
             function visit(node: ts.Node): ts.VisitResult<ts.Node> {
                 switch (node.kind) {
                     case ts.SyntaxKind.VariableStatement:
-                        return visitVariableStatement(node as ts.VariableStatement);
+                        return visitVariableStatement(node);
                     default:
                         return ts.visitEachChild(node, visit, context);
                 }

--- a/tests/baselines/reference/APILibCheck.js
+++ b/tests/baselines/reference/APILibCheck.js
@@ -6,29 +6,8 @@
     "types": "/.ts/typescript.d.ts"
 }
 
-//// [package.json]
-{
-    "name": "typescript-internal",
-    "types": "/.ts/typescript.internal.d.ts"
-}
-
-//// [package.json]
-{
-    "name": "tsserverlibrary",
-    "types": "/.ts/tsserverlibrary.d.ts"
-}
-
-//// [package.json]
-{
-    "name": "tsserverlibrary-internal",
-    "types": "/.ts/tsserverlibrary.internal.d.ts"
-}
-
 //// [index.ts]
 import ts = require("typescript");
-import tsInternal = require("typescript-internal");
-import tsserverlibrary = require("tsserverlibrary");
-import tsserverlibraryInternal = require("tsserverlibrary-internal");
 
 
 //// [index.js]

--- a/tests/baselines/reference/APILibCheck.symbols
+++ b/tests/baselines/reference/APILibCheck.symbols
@@ -2,12 +2,3 @@
 import ts = require("typescript");
 >ts : Symbol(ts, Decl(index.ts, 0, 0))
 
-import tsInternal = require("typescript-internal");
->tsInternal : Symbol(tsInternal, Decl(index.ts, 0, 34))
-
-import tsserverlibrary = require("tsserverlibrary");
->tsserverlibrary : Symbol(tsserverlibrary, Decl(index.ts, 1, 51))
-
-import tsserverlibraryInternal = require("tsserverlibrary-internal");
->tsserverlibraryInternal : Symbol(tsserverlibraryInternal, Decl(index.ts, 2, 52))
-

--- a/tests/baselines/reference/APILibCheck.types
+++ b/tests/baselines/reference/APILibCheck.types
@@ -2,12 +2,3 @@
 import ts = require("typescript");
 >ts : typeof ts
 
-import tsInternal = require("typescript-internal");
->tsInternal : typeof tsInternal
-
-import tsserverlibrary = require("tsserverlibrary");
->tsserverlibrary : typeof tsserverlibrary
-
-import tsserverlibraryInternal = require("tsserverlibrary-internal");
->tsserverlibraryInternal : typeof tsserverlibraryInternal
-

--- a/tests/baselines/reference/APILibCheck2.js
+++ b/tests/baselines/reference/APILibCheck2.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/APILibCheck2.ts] ////
+
+//// [package.json]
+{
+    "name": "typescript-internal",
+    "types": "/.ts/typescript.internal.d.ts"
+}
+
+//// [index.ts]
+import tsInternal = require("typescript-internal");
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/APILibCheck2.symbols
+++ b/tests/baselines/reference/APILibCheck2.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/index.ts ===
+import tsInternal = require("typescript-internal");
+>tsInternal : Symbol(tsInternal, Decl(index.ts, 0, 0))
+

--- a/tests/baselines/reference/APILibCheck2.types
+++ b/tests/baselines/reference/APILibCheck2.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/index.ts ===
+import tsInternal = require("typescript-internal");
+>tsInternal : typeof tsInternal
+

--- a/tests/baselines/reference/APILibCheck3.js
+++ b/tests/baselines/reference/APILibCheck3.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/APILibCheck3.ts] ////
+
+//// [package.json]
+{
+    "name": "tsserverlibrary",
+    "types": "/.ts/tsserverlibrary.d.ts"
+}
+
+//// [index.ts]
+import tsserverlibrary = require("tsserverlibrary");
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/APILibCheck3.symbols
+++ b/tests/baselines/reference/APILibCheck3.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/index.ts ===
+import tsserverlibrary = require("tsserverlibrary");
+>tsserverlibrary : Symbol(tsserverlibrary, Decl(index.ts, 0, 0))
+

--- a/tests/baselines/reference/APILibCheck3.types
+++ b/tests/baselines/reference/APILibCheck3.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/index.ts ===
+import tsserverlibrary = require("tsserverlibrary");
+>tsserverlibrary : typeof tsserverlibrary
+

--- a/tests/baselines/reference/APILibCheck4.js
+++ b/tests/baselines/reference/APILibCheck4.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/APILibCheck4.ts] ////
+
+//// [package.json]
+{
+    "name": "tsserverlibrary-internal",
+    "types": "/.ts/tsserverlibrary.internal.d.ts"
+}
+
+//// [index.ts]
+import tsserverlibraryInternal = require("tsserverlibrary-internal");
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/APILibCheck4.symbols
+++ b/tests/baselines/reference/APILibCheck4.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/index.ts ===
+import tsserverlibraryInternal = require("tsserverlibrary-internal");
+>tsserverlibraryInternal : Symbol(tsserverlibraryInternal, Decl(index.ts, 0, 0))
+

--- a/tests/baselines/reference/APILibCheck4.types
+++ b/tests/baselines/reference/APILibCheck4.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/index.ts ===
+import tsserverlibraryInternal = require("tsserverlibrary-internal");
+>tsserverlibraryInternal : typeof tsserverlibraryInternal
+

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4498,6 +4498,392 @@ declare namespace ts {
     type TokenSyntaxKind = SyntaxKind.Unknown | SyntaxKind.EndOfFileToken | TriviaSyntaxKind | LiteralSyntaxKind | PseudoLiteralSyntaxKind | PunctuationSyntaxKind | SyntaxKind.Identifier | KeywordSyntaxKind;
     type JsxTokenSyntaxKind = SyntaxKind.LessThanSlashToken | SyntaxKind.EndOfFileToken | SyntaxKind.ConflictMarkerTrivia | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.OpenBraceToken | SyntaxKind.LessThanToken;
     type JSDocSyntaxKind = SyntaxKind.EndOfFileToken | SyntaxKind.WhitespaceTrivia | SyntaxKind.AtToken | SyntaxKind.NewLineTrivia | SyntaxKind.AsteriskToken | SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.LessThanToken | SyntaxKind.GreaterThanToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.EqualsToken | SyntaxKind.CommaToken | SyntaxKind.DotToken | SyntaxKind.Identifier | SyntaxKind.BacktickToken | SyntaxKind.HashToken | SyntaxKind.Unknown | KeywordSyntaxKind;
+    interface SyntaxKindToNode {
+        [SyntaxKind.Unknown]: Token<SyntaxKind.Unknown>;
+        [SyntaxKind.EndOfFileToken]: EndOfFileToken;
+        [SyntaxKind.SingleLineCommentTrivia]: Token<SyntaxKind.SingleLineCommentTrivia>;
+        [SyntaxKind.MultiLineCommentTrivia]: Token<SyntaxKind.MultiLineCommentTrivia>;
+        [SyntaxKind.NewLineTrivia]: Token<SyntaxKind.NewLineTrivia>;
+        [SyntaxKind.WhitespaceTrivia]: Token<SyntaxKind.WhitespaceTrivia>;
+        [SyntaxKind.ShebangTrivia]: Token<SyntaxKind.ShebangTrivia>;
+        [SyntaxKind.ConflictMarkerTrivia]: Token<SyntaxKind.ConflictMarkerTrivia>;
+        [SyntaxKind.NonTextFileMarkerTrivia]: Token<SyntaxKind.NonTextFileMarkerTrivia>;
+        [SyntaxKind.NumericLiteral]: NumericLiteral;
+        [SyntaxKind.BigIntLiteral]: BigIntLiteral;
+        [SyntaxKind.StringLiteral]: StringLiteral;
+        [SyntaxKind.JsxText]: JsxText;
+        [SyntaxKind.JsxTextAllWhiteSpaces]: Token<SyntaxKind.JsxTextAllWhiteSpaces>;
+        [SyntaxKind.RegularExpressionLiteral]: RegularExpressionLiteral;
+        [SyntaxKind.NoSubstitutionTemplateLiteral]: NoSubstitutionTemplateLiteral;
+        [SyntaxKind.TemplateHead]: TemplateHead;
+        [SyntaxKind.TemplateMiddle]: TemplateMiddle;
+        [SyntaxKind.TemplateTail]: TemplateTail;
+        [SyntaxKind.OpenBraceToken]: Token<SyntaxKind.OpenBraceToken>;
+        [SyntaxKind.CloseBraceToken]: Token<SyntaxKind.CloseBraceToken>;
+        [SyntaxKind.OpenParenToken]: Token<SyntaxKind.OpenParenToken>;
+        [SyntaxKind.CloseParenToken]: Token<SyntaxKind.CloseParenToken>;
+        [SyntaxKind.OpenBracketToken]: Token<SyntaxKind.OpenBracketToken>;
+        [SyntaxKind.CloseBracketToken]: Token<SyntaxKind.CloseBracketToken>;
+        [SyntaxKind.DotToken]: DotToken;
+        [SyntaxKind.DotDotDotToken]: DotDotDotToken;
+        [SyntaxKind.SemicolonToken]: Token<SyntaxKind.SemicolonToken>;
+        [SyntaxKind.CommaToken]: Token<SyntaxKind.CommaToken>;
+        [SyntaxKind.QuestionDotToken]: QuestionDotToken;
+        [SyntaxKind.LessThanToken]: Token<SyntaxKind.LessThanToken>;
+        [SyntaxKind.LessThanSlashToken]: Token<SyntaxKind.LessThanSlashToken>;
+        [SyntaxKind.GreaterThanToken]: Token<SyntaxKind.GreaterThanToken>;
+        [SyntaxKind.LessThanEqualsToken]: Token<SyntaxKind.LessThanEqualsToken>;
+        [SyntaxKind.GreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanEqualsToken>;
+        [SyntaxKind.EqualsEqualsToken]: Token<SyntaxKind.EqualsEqualsToken>;
+        [SyntaxKind.ExclamationEqualsToken]: Token<SyntaxKind.ExclamationEqualsToken>;
+        [SyntaxKind.EqualsEqualsEqualsToken]: Token<SyntaxKind.EqualsEqualsEqualsToken>;
+        [SyntaxKind.ExclamationEqualsEqualsToken]: Token<SyntaxKind.ExclamationEqualsEqualsToken>;
+        [SyntaxKind.EqualsGreaterThanToken]: Token<SyntaxKind.EqualsGreaterThanToken>;
+        [SyntaxKind.PlusToken]: PlusToken;
+        [SyntaxKind.MinusToken]: MinusToken;
+        [SyntaxKind.AsteriskToken]: AsteriskToken;
+        [SyntaxKind.AsteriskAsteriskToken]: Token<SyntaxKind.AsteriskAsteriskToken>;
+        [SyntaxKind.SlashToken]: Token<SyntaxKind.SlashToken>;
+        [SyntaxKind.PercentToken]: Token<SyntaxKind.PercentToken>;
+        [SyntaxKind.PlusPlusToken]: Token<SyntaxKind.PlusPlusToken>;
+        [SyntaxKind.MinusMinusToken]: Token<SyntaxKind.MinusMinusToken>;
+        [SyntaxKind.LessThanLessThanToken]: Token<SyntaxKind.LessThanLessThanToken>;
+        [SyntaxKind.GreaterThanGreaterThanToken]: Token<SyntaxKind.GreaterThanGreaterThanToken>;
+        [SyntaxKind.GreaterThanGreaterThanGreaterThanToken]: Token<SyntaxKind.GreaterThanGreaterThanGreaterThanToken>;
+        [SyntaxKind.AmpersandToken]: Token<SyntaxKind.AmpersandToken>;
+        [SyntaxKind.BarToken]: Token<SyntaxKind.BarToken>;
+        [SyntaxKind.CaretToken]: Token<SyntaxKind.CaretToken>;
+        [SyntaxKind.ExclamationToken]: Token<SyntaxKind.ExclamationToken>;
+        [SyntaxKind.TildeToken]: Token<SyntaxKind.TildeToken>;
+        [SyntaxKind.AmpersandAmpersandToken]: Token<SyntaxKind.AmpersandAmpersandToken>;
+        [SyntaxKind.BarBarToken]: Token<SyntaxKind.BarBarToken>;
+        [SyntaxKind.QuestionToken]: QuestionToken;
+        [SyntaxKind.ColonToken]: ColonToken;
+        [SyntaxKind.AtToken]: Token<SyntaxKind.AtToken>;
+        [SyntaxKind.QuestionQuestionToken]: Token<SyntaxKind.QuestionQuestionToken>;
+        [SyntaxKind.BacktickToken]: Token<SyntaxKind.BacktickToken>;
+        [SyntaxKind.HashToken]: Token<SyntaxKind.HashToken>;
+        [SyntaxKind.EqualsToken]: EqualsToken;
+        [SyntaxKind.PlusEqualsToken]: Token<SyntaxKind.PlusEqualsToken>;
+        [SyntaxKind.MinusEqualsToken]: Token<SyntaxKind.MinusEqualsToken>;
+        [SyntaxKind.AsteriskEqualsToken]: Token<SyntaxKind.AsteriskEqualsToken>;
+        [SyntaxKind.AsteriskAsteriskEqualsToken]: Token<SyntaxKind.AsteriskAsteriskEqualsToken>;
+        [SyntaxKind.SlashEqualsToken]: Token<SyntaxKind.SlashEqualsToken>;
+        [SyntaxKind.PercentEqualsToken]: Token<SyntaxKind.PercentEqualsToken>;
+        [SyntaxKind.LessThanLessThanEqualsToken]: Token<SyntaxKind.LessThanLessThanEqualsToken>;
+        [SyntaxKind.GreaterThanGreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanGreaterThanEqualsToken>;
+        [SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken>;
+        [SyntaxKind.AmpersandEqualsToken]: Token<SyntaxKind.AmpersandEqualsToken>;
+        [SyntaxKind.BarEqualsToken]: Token<SyntaxKind.BarEqualsToken>;
+        [SyntaxKind.BarBarEqualsToken]: BarBarEqualsToken;
+        [SyntaxKind.AmpersandAmpersandEqualsToken]: AmpersandAmpersandEqualsToken;
+        [SyntaxKind.QuestionQuestionEqualsToken]: QuestionQuestionEqualsToken;
+        [SyntaxKind.CaretEqualsToken]: Token<SyntaxKind.CaretEqualsToken>;
+        [SyntaxKind.Identifier]: Identifier;
+        [SyntaxKind.PrivateIdentifier]: PrivateIdentifier;
+        [SyntaxKind.BreakKeyword]: KeywordToken<SyntaxKind.BreakKeyword>;
+        [SyntaxKind.CaseKeyword]: KeywordToken<SyntaxKind.CaseKeyword>;
+        [SyntaxKind.CatchKeyword]: KeywordToken<SyntaxKind.CatchKeyword>;
+        [SyntaxKind.ClassKeyword]: KeywordToken<SyntaxKind.ClassKeyword>;
+        [SyntaxKind.ConstKeyword]: KeywordToken<SyntaxKind.ConstKeyword>;
+        [SyntaxKind.ContinueKeyword]: KeywordToken<SyntaxKind.ContinueKeyword>;
+        [SyntaxKind.DebuggerKeyword]: KeywordToken<SyntaxKind.DebuggerKeyword>;
+        [SyntaxKind.DefaultKeyword]: KeywordToken<SyntaxKind.DefaultKeyword>;
+        [SyntaxKind.DeleteKeyword]: KeywordToken<SyntaxKind.DeleteKeyword>;
+        [SyntaxKind.DoKeyword]: KeywordToken<SyntaxKind.DoKeyword>;
+        [SyntaxKind.ElseKeyword]: KeywordToken<SyntaxKind.ElseKeyword>;
+        [SyntaxKind.EnumKeyword]: KeywordToken<SyntaxKind.EnumKeyword>;
+        [SyntaxKind.ExportKeyword]: KeywordToken<SyntaxKind.ExportKeyword>;
+        [SyntaxKind.ExtendsKeyword]: KeywordToken<SyntaxKind.ExtendsKeyword>;
+        [SyntaxKind.FalseKeyword]: KeywordToken<SyntaxKind.FalseKeyword>;
+        [SyntaxKind.FinallyKeyword]: KeywordToken<SyntaxKind.FinallyKeyword>;
+        [SyntaxKind.ForKeyword]: KeywordToken<SyntaxKind.ForKeyword>;
+        [SyntaxKind.FunctionKeyword]: KeywordToken<SyntaxKind.FunctionKeyword>;
+        [SyntaxKind.IfKeyword]: KeywordToken<SyntaxKind.IfKeyword>;
+        [SyntaxKind.ImportKeyword]: KeywordToken<SyntaxKind.ImportKeyword>;
+        [SyntaxKind.InKeyword]: KeywordToken<SyntaxKind.InKeyword>;
+        [SyntaxKind.InstanceOfKeyword]: KeywordToken<SyntaxKind.InstanceOfKeyword>;
+        [SyntaxKind.NewKeyword]: KeywordToken<SyntaxKind.NewKeyword>;
+        [SyntaxKind.NullKeyword]: KeywordToken<SyntaxKind.NullKeyword>;
+        [SyntaxKind.ReturnKeyword]: KeywordToken<SyntaxKind.ReturnKeyword>;
+        [SyntaxKind.SuperKeyword]: KeywordToken<SyntaxKind.SuperKeyword>;
+        [SyntaxKind.SwitchKeyword]: KeywordToken<SyntaxKind.SwitchKeyword>;
+        [SyntaxKind.ThisKeyword]: KeywordToken<SyntaxKind.ThisKeyword>;
+        [SyntaxKind.ThrowKeyword]: KeywordToken<SyntaxKind.ThrowKeyword>;
+        [SyntaxKind.TrueKeyword]: KeywordToken<SyntaxKind.TrueKeyword>;
+        [SyntaxKind.TryKeyword]: KeywordToken<SyntaxKind.TryKeyword>;
+        [SyntaxKind.TypeOfKeyword]: KeywordToken<SyntaxKind.TypeOfKeyword>;
+        [SyntaxKind.VarKeyword]: KeywordToken<SyntaxKind.VarKeyword>;
+        [SyntaxKind.VoidKeyword]: KeywordToken<SyntaxKind.VoidKeyword>;
+        [SyntaxKind.WhileKeyword]: KeywordToken<SyntaxKind.WhileKeyword>;
+        [SyntaxKind.WithKeyword]: KeywordToken<SyntaxKind.WithKeyword>;
+        [SyntaxKind.ImplementsKeyword]: KeywordToken<SyntaxKind.ImplementsKeyword>;
+        [SyntaxKind.InterfaceKeyword]: KeywordToken<SyntaxKind.InterfaceKeyword>;
+        [SyntaxKind.LetKeyword]: KeywordToken<SyntaxKind.LetKeyword>;
+        [SyntaxKind.PackageKeyword]: KeywordToken<SyntaxKind.PackageKeyword>;
+        [SyntaxKind.PrivateKeyword]: KeywordToken<SyntaxKind.PrivateKeyword>;
+        [SyntaxKind.ProtectedKeyword]: KeywordToken<SyntaxKind.ProtectedKeyword>;
+        [SyntaxKind.PublicKeyword]: KeywordToken<SyntaxKind.PublicKeyword>;
+        [SyntaxKind.StaticKeyword]: KeywordToken<SyntaxKind.StaticKeyword>;
+        [SyntaxKind.YieldKeyword]: KeywordToken<SyntaxKind.YieldKeyword>;
+        [SyntaxKind.AbstractKeyword]: KeywordToken<SyntaxKind.AbstractKeyword>;
+        [SyntaxKind.AccessorKeyword]: KeywordToken<SyntaxKind.AccessorKeyword>;
+        [SyntaxKind.AsKeyword]: KeywordToken<SyntaxKind.AsKeyword>;
+        [SyntaxKind.AssertsKeyword]: KeywordToken<SyntaxKind.AssertsKeyword>;
+        [SyntaxKind.AssertKeyword]: KeywordToken<SyntaxKind.AssertKeyword>;
+        [SyntaxKind.AnyKeyword]: KeywordToken<SyntaxKind.AnyKeyword>;
+        [SyntaxKind.AsyncKeyword]: KeywordToken<SyntaxKind.AsyncKeyword>;
+        [SyntaxKind.AwaitKeyword]: KeywordToken<SyntaxKind.AwaitKeyword>;
+        [SyntaxKind.BooleanKeyword]: KeywordToken<SyntaxKind.BooleanKeyword>;
+        [SyntaxKind.ConstructorKeyword]: KeywordToken<SyntaxKind.ConstructorKeyword>;
+        [SyntaxKind.DeclareKeyword]: KeywordToken<SyntaxKind.DeclareKeyword>;
+        [SyntaxKind.GetKeyword]: KeywordToken<SyntaxKind.GetKeyword>;
+        [SyntaxKind.InferKeyword]: KeywordToken<SyntaxKind.InferKeyword>;
+        [SyntaxKind.IntrinsicKeyword]: KeywordToken<SyntaxKind.IntrinsicKeyword>;
+        [SyntaxKind.IsKeyword]: KeywordToken<SyntaxKind.IsKeyword>;
+        [SyntaxKind.KeyOfKeyword]: KeywordToken<SyntaxKind.KeyOfKeyword>;
+        [SyntaxKind.ModuleKeyword]: KeywordToken<SyntaxKind.ModuleKeyword>;
+        [SyntaxKind.NamespaceKeyword]: KeywordToken<SyntaxKind.NamespaceKeyword>;
+        [SyntaxKind.NeverKeyword]: KeywordToken<SyntaxKind.NeverKeyword>;
+        [SyntaxKind.OutKeyword]: KeywordToken<SyntaxKind.OutKeyword>;
+        [SyntaxKind.ReadonlyKeyword]: KeywordToken<SyntaxKind.ReadonlyKeyword>;
+        [SyntaxKind.RequireKeyword]: KeywordToken<SyntaxKind.RequireKeyword>;
+        [SyntaxKind.NumberKeyword]: KeywordToken<SyntaxKind.NumberKeyword>;
+        [SyntaxKind.ObjectKeyword]: KeywordToken<SyntaxKind.ObjectKeyword>;
+        [SyntaxKind.SatisfiesKeyword]: KeywordToken<SyntaxKind.SatisfiesKeyword>;
+        [SyntaxKind.SetKeyword]: KeywordToken<SyntaxKind.SetKeyword>;
+        [SyntaxKind.StringKeyword]: KeywordToken<SyntaxKind.StringKeyword>;
+        [SyntaxKind.SymbolKeyword]: KeywordToken<SyntaxKind.SymbolKeyword>;
+        [SyntaxKind.TypeKeyword]: KeywordToken<SyntaxKind.TypeKeyword>;
+        [SyntaxKind.UndefinedKeyword]: KeywordToken<SyntaxKind.UndefinedKeyword>;
+        [SyntaxKind.UniqueKeyword]: KeywordToken<SyntaxKind.UniqueKeyword>;
+        [SyntaxKind.UnknownKeyword]: KeywordToken<SyntaxKind.UnknownKeyword>;
+        [SyntaxKind.FromKeyword]: KeywordToken<SyntaxKind.FromKeyword>;
+        [SyntaxKind.GlobalKeyword]: KeywordToken<SyntaxKind.GlobalKeyword>;
+        [SyntaxKind.BigIntKeyword]: KeywordToken<SyntaxKind.BigIntKeyword>;
+        [SyntaxKind.OverrideKeyword]: KeywordToken<SyntaxKind.OverrideKeyword>;
+        [SyntaxKind.OfKeyword]: KeywordToken<SyntaxKind.OfKeyword>;
+        [SyntaxKind.QualifiedName]: QualifiedName;
+        [SyntaxKind.ComputedPropertyName]: ComputedPropertyName;
+        [SyntaxKind.TypeParameter]: TypeParameterDeclaration;
+        [SyntaxKind.Parameter]: ParameterDeclaration;
+        [SyntaxKind.Decorator]: Decorator;
+        [SyntaxKind.PropertySignature]: PropertySignature;
+        [SyntaxKind.PropertyDeclaration]: PropertyDeclaration;
+        [SyntaxKind.MethodSignature]: MethodSignature;
+        [SyntaxKind.MethodDeclaration]: MethodDeclaration;
+        [SyntaxKind.ClassStaticBlockDeclaration]: ClassStaticBlockDeclaration;
+        [SyntaxKind.Constructor]: ConstructorDeclaration;
+        [SyntaxKind.GetAccessor]: GetAccessorDeclaration;
+        [SyntaxKind.SetAccessor]: SetAccessorDeclaration;
+        [SyntaxKind.CallSignature]: CallSignatureDeclaration;
+        [SyntaxKind.ConstructSignature]: ConstructSignatureDeclaration;
+        [SyntaxKind.IndexSignature]: IndexSignatureDeclaration;
+        [SyntaxKind.TypePredicate]: TypePredicateNode;
+        [SyntaxKind.TypeReference]: TypeReferenceNode;
+        [SyntaxKind.FunctionType]: FunctionTypeNode;
+        [SyntaxKind.ConstructorType]: ConstructorTypeNode;
+        [SyntaxKind.TypeQuery]: TypeQueryNode;
+        [SyntaxKind.TypeLiteral]: TypeLiteralNode;
+        [SyntaxKind.ArrayType]: ArrayTypeNode;
+        [SyntaxKind.TupleType]: TupleTypeNode;
+        [SyntaxKind.OptionalType]: OptionalTypeNode;
+        [SyntaxKind.RestType]: RestTypeNode;
+        [SyntaxKind.UnionType]: UnionTypeNode;
+        [SyntaxKind.IntersectionType]: IntersectionTypeNode;
+        [SyntaxKind.ConditionalType]: ConditionalTypeNode;
+        [SyntaxKind.InferType]: InferTypeNode;
+        [SyntaxKind.ParenthesizedType]: ParenthesizedTypeNode;
+        [SyntaxKind.ThisType]: ThisTypeNode;
+        [SyntaxKind.TypeOperator]: TypeOperatorNode;
+        [SyntaxKind.IndexedAccessType]: IndexedAccessTypeNode;
+        [SyntaxKind.MappedType]: MappedTypeNode;
+        [SyntaxKind.LiteralType]: LiteralTypeNode;
+        [SyntaxKind.NamedTupleMember]: NamedTupleMember;
+        [SyntaxKind.TemplateLiteralType]: TemplateLiteralTypeNode;
+        [SyntaxKind.TemplateLiteralTypeSpan]: TemplateLiteralTypeSpan;
+        [SyntaxKind.ImportType]: ImportTypeNode;
+        [SyntaxKind.ObjectBindingPattern]: ObjectBindingPattern;
+        [SyntaxKind.ArrayBindingPattern]: ArrayBindingPattern;
+        [SyntaxKind.BindingElement]: BindingElement;
+        [SyntaxKind.ArrayLiteralExpression]: ArrayLiteralExpression;
+        [SyntaxKind.ObjectLiteralExpression]: ObjectLiteralExpression;
+        [SyntaxKind.PropertyAccessExpression]: PropertyAccessExpression;
+        [SyntaxKind.ElementAccessExpression]: ElementAccessExpression;
+        [SyntaxKind.CallExpression]: CallExpression;
+        [SyntaxKind.NewExpression]: NewExpression;
+        [SyntaxKind.TaggedTemplateExpression]: TaggedTemplateExpression;
+        [SyntaxKind.TypeAssertionExpression]: TypeAssertion;
+        [SyntaxKind.ParenthesizedExpression]: ParenthesizedExpression;
+        [SyntaxKind.FunctionExpression]: FunctionExpression;
+        [SyntaxKind.ArrowFunction]: ArrowFunction;
+        [SyntaxKind.DeleteExpression]: DeleteExpression;
+        [SyntaxKind.TypeOfExpression]: TypeOfExpression;
+        [SyntaxKind.VoidExpression]: VoidExpression;
+        [SyntaxKind.AwaitExpression]: AwaitExpression;
+        [SyntaxKind.PrefixUnaryExpression]: PrefixUnaryExpression;
+        [SyntaxKind.PostfixUnaryExpression]: PostfixUnaryExpression;
+        [SyntaxKind.BinaryExpression]: BinaryExpression;
+        [SyntaxKind.ConditionalExpression]: ConditionalExpression;
+        [SyntaxKind.TemplateExpression]: TemplateExpression;
+        [SyntaxKind.YieldExpression]: YieldExpression;
+        [SyntaxKind.SpreadElement]: SpreadElement;
+        [SyntaxKind.ClassExpression]: ClassExpression;
+        [SyntaxKind.OmittedExpression]: OmittedExpression;
+        [SyntaxKind.ExpressionWithTypeArguments]: ExpressionWithTypeArguments;
+        [SyntaxKind.AsExpression]: AsExpression;
+        [SyntaxKind.NonNullExpression]: NonNullExpression;
+        [SyntaxKind.MetaProperty]: MetaProperty;
+        [SyntaxKind.SyntheticExpression]: SyntheticExpression;
+        [SyntaxKind.SatisfiesExpression]: SatisfiesExpression;
+        [SyntaxKind.TemplateSpan]: TemplateSpan;
+        [SyntaxKind.SemicolonClassElement]: SemicolonClassElement;
+        [SyntaxKind.Block]: Block;
+        [SyntaxKind.EmptyStatement]: EmptyStatement;
+        [SyntaxKind.VariableStatement]: VariableStatement;
+        [SyntaxKind.ExpressionStatement]: ExpressionStatement;
+        [SyntaxKind.IfStatement]: IfStatement;
+        [SyntaxKind.DoStatement]: DoStatement;
+        [SyntaxKind.WhileStatement]: WhileStatement;
+        [SyntaxKind.ForStatement]: ForStatement;
+        [SyntaxKind.ForInStatement]: ForInStatement;
+        [SyntaxKind.ForOfStatement]: ForOfStatement;
+        [SyntaxKind.ContinueStatement]: ContinueStatement;
+        [SyntaxKind.BreakStatement]: BreakStatement;
+        [SyntaxKind.ReturnStatement]: ReturnStatement;
+        [SyntaxKind.WithStatement]: WithStatement;
+        [SyntaxKind.SwitchStatement]: SwitchStatement;
+        [SyntaxKind.LabeledStatement]: LabeledStatement;
+        [SyntaxKind.ThrowStatement]: ThrowStatement;
+        [SyntaxKind.TryStatement]: TryStatement;
+        [SyntaxKind.DebuggerStatement]: DebuggerStatement;
+        [SyntaxKind.VariableDeclaration]: VariableDeclaration;
+        [SyntaxKind.VariableDeclarationList]: VariableDeclarationList;
+        [SyntaxKind.FunctionDeclaration]: FunctionDeclaration;
+        [SyntaxKind.ClassDeclaration]: ClassDeclaration;
+        [SyntaxKind.InterfaceDeclaration]: InterfaceDeclaration;
+        [SyntaxKind.TypeAliasDeclaration]: TypeAliasDeclaration;
+        [SyntaxKind.EnumDeclaration]: EnumDeclaration;
+        [SyntaxKind.ModuleDeclaration]: ModuleDeclaration;
+        [SyntaxKind.ModuleBlock]: ModuleBlock;
+        [SyntaxKind.CaseBlock]: CaseBlock;
+        [SyntaxKind.NamespaceExportDeclaration]: NamespaceExportDeclaration;
+        [SyntaxKind.ImportEqualsDeclaration]: ImportEqualsDeclaration;
+        [SyntaxKind.ImportDeclaration]: ImportDeclaration;
+        [SyntaxKind.ImportClause]: ImportClause;
+        [SyntaxKind.NamespaceImport]: NamespaceImport;
+        [SyntaxKind.NamedImports]: NamedImports;
+        [SyntaxKind.ImportSpecifier]: ImportSpecifier;
+        [SyntaxKind.ExportAssignment]: ExportAssignment;
+        [SyntaxKind.ExportDeclaration]: ExportDeclaration;
+        [SyntaxKind.NamedExports]: NamedExports;
+        [SyntaxKind.NamespaceExport]: NamespaceExport;
+        [SyntaxKind.ExportSpecifier]: ExportSpecifier;
+        [SyntaxKind.MissingDeclaration]: MissingDeclaration;
+        [SyntaxKind.ExternalModuleReference]: ExternalModuleReference;
+        [SyntaxKind.JsxElement]: JsxElement;
+        [SyntaxKind.JsxSelfClosingElement]: JsxSelfClosingElement;
+        [SyntaxKind.JsxOpeningElement]: JsxOpeningElement;
+        [SyntaxKind.JsxClosingElement]: JsxClosingElement;
+        [SyntaxKind.JsxFragment]: JsxFragment;
+        [SyntaxKind.JsxOpeningFragment]: JsxOpeningFragment;
+        [SyntaxKind.JsxClosingFragment]: JsxClosingFragment;
+        [SyntaxKind.JsxAttribute]: JsxAttribute;
+        [SyntaxKind.JsxAttributes]: JsxAttributes;
+        [SyntaxKind.JsxSpreadAttribute]: JsxSpreadAttribute;
+        [SyntaxKind.JsxExpression]: JsxExpression;
+        [SyntaxKind.JsxNamespacedName]: JsxNamespacedName;
+        [SyntaxKind.CaseClause]: CaseClause;
+        [SyntaxKind.DefaultClause]: DefaultClause;
+        [SyntaxKind.HeritageClause]: HeritageClause;
+        [SyntaxKind.CatchClause]: CatchClause;
+        [SyntaxKind.AssertClause]: AssertClause;
+        [SyntaxKind.AssertEntry]: AssertEntry;
+        [SyntaxKind.ImportTypeAssertionContainer]: ImportTypeAssertionContainer;
+        [SyntaxKind.PropertyAssignment]: PropertyAssignment;
+        [SyntaxKind.ShorthandPropertyAssignment]: ShorthandPropertyAssignment;
+        [SyntaxKind.SpreadAssignment]: SpreadAssignment;
+        [SyntaxKind.EnumMember]: EnumMember;
+        /** @deprecated */ [SyntaxKind.UnparsedPrologue]: UnparsedPrologue;
+        /** @deprecated */ [SyntaxKind.UnparsedPrepend]: UnparsedPrepend;
+        /** @deprecated */ [SyntaxKind.UnparsedText]: UnparsedTextLike;
+        /** @deprecated */ [SyntaxKind.UnparsedInternalText]: UnparsedTextLike;
+        /** @deprecated */ [SyntaxKind.UnparsedSyntheticReference]: UnparsedSyntheticReference;
+        [SyntaxKind.SourceFile]: SourceFile;
+        [SyntaxKind.Bundle]: Bundle;
+        /** @deprecated */ [SyntaxKind.UnparsedSource]: UnparsedSource;
+        /** @deprecated */ [SyntaxKind.InputFiles]: InputFiles;
+        [SyntaxKind.JSDocTypeExpression]: JSDocTypeExpression;
+        [SyntaxKind.JSDocNameReference]: JSDocNameReference;
+        [SyntaxKind.JSDocMemberName]: JSDocMemberName;
+        [SyntaxKind.JSDocAllType]: JSDocAllType;
+        [SyntaxKind.JSDocUnknownType]: JSDocUnknownType;
+        [SyntaxKind.JSDocNullableType]: JSDocNullableType;
+        [SyntaxKind.JSDocNonNullableType]: JSDocNonNullableType;
+        [SyntaxKind.JSDocOptionalType]: JSDocOptionalType;
+        [SyntaxKind.JSDocFunctionType]: JSDocFunctionType;
+        [SyntaxKind.JSDocVariadicType]: JSDocVariadicType;
+        [SyntaxKind.JSDocNamepathType]: JSDocNamepathType;
+        [SyntaxKind.JSDoc]: JSDoc;
+        [SyntaxKind.JSDocText]: JSDocText;
+        [SyntaxKind.JSDocTypeLiteral]: JSDocTypeLiteral;
+        [SyntaxKind.JSDocSignature]: JSDocSignature;
+        [SyntaxKind.JSDocLink]: JSDocLink;
+        [SyntaxKind.JSDocLinkCode]: JSDocLinkCode;
+        [SyntaxKind.JSDocLinkPlain]: JSDocLinkPlain;
+        [SyntaxKind.JSDocTag]: JSDocUnknownTag;
+        [SyntaxKind.JSDocAugmentsTag]: JSDocAugmentsTag;
+        [SyntaxKind.JSDocImplementsTag]: JSDocImplementsTag;
+        [SyntaxKind.JSDocAuthorTag]: JSDocAuthorTag;
+        [SyntaxKind.JSDocDeprecatedTag]: JSDocDeprecatedTag;
+        [SyntaxKind.JSDocClassTag]: JSDocClassTag;
+        [SyntaxKind.JSDocPublicTag]: JSDocPublicTag;
+        [SyntaxKind.JSDocPrivateTag]: JSDocPrivateTag;
+        [SyntaxKind.JSDocProtectedTag]: JSDocProtectedTag;
+        [SyntaxKind.JSDocReadonlyTag]: JSDocReadonlyTag;
+        [SyntaxKind.JSDocOverrideTag]: JSDocOverrideTag;
+        [SyntaxKind.JSDocCallbackTag]: JSDocCallbackTag;
+        [SyntaxKind.JSDocOverloadTag]: JSDocOverloadTag;
+        [SyntaxKind.JSDocEnumTag]: JSDocEnumTag;
+        [SyntaxKind.JSDocParameterTag]: JSDocParameterTag;
+        [SyntaxKind.JSDocReturnTag]: JSDocReturnTag;
+        [SyntaxKind.JSDocThisTag]: JSDocThisTag;
+        [SyntaxKind.JSDocTypeTag]: JSDocTypeTag;
+        [SyntaxKind.JSDocTemplateTag]: JSDocTemplateTag;
+        [SyntaxKind.JSDocTypedefTag]: JSDocTypedefTag;
+        [SyntaxKind.JSDocSeeTag]: JSDocSeeTag;
+        [SyntaxKind.JSDocPropertyTag]: JSDocPropertyTag;
+        [SyntaxKind.JSDocThrowsTag]: JSDocThrowsTag;
+        [SyntaxKind.JSDocSatisfiesTag]: JSDocSatisfiesTag;
+        [SyntaxKind.SyntaxList]: SyntaxList;
+        [SyntaxKind.NotEmittedStatement]: NotEmittedStatement;
+        [SyntaxKind.PartiallyEmittedExpression]: PartiallyEmittedExpression;
+        [SyntaxKind.CommaListExpression]: CommaListExpression;
+        [SyntaxKind.SyntheticReferenceExpression]: SyntheticReferenceExpression;
+    }
+    type Node = SyntaxKindToNode[keyof SyntaxKindToNode];
+    type Declaration = Identifier | NamedDeclaration | TypeLiteralNode | NamedTupleMember | MappedTypeNode | StringLiteral | BinaryExpression | NoSubstitutionTemplateLiteral | NumericLiteral | ObjectLiteralExpression | ElementAccessExpression | CallExpression | NewExpression | JsxAttributes | JsxAttribute | JSDocEnumTag | JSDocSignature | JSDocPropertyLikeTag | JSDocTypeLiteral | SourceFile;
+    type NamedDeclaration = DeclarationStatement | TypeParameterDeclaration | SignatureDeclaration | VariableDeclaration | ParameterDeclaration | BindingElement | ObjectLiteralElement | PropertyAccessExpression | ClassDeclaration | ClassExpression | ClassElement | TypeElement | EnumMember | ImportClause | NamespaceImport | NamespaceExport | ImportSpecifier | ExportSpecifier | JSDocTypedefTag | JSDocCallbackTag;
+    type DeclarationStatement = FunctionDeclaration | MissingDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | EnumDeclaration | ModuleDeclaration | ImportEqualsDeclaration | NamespaceExportDeclaration | ExportDeclaration | ExportAssignment;
+    type Statement = DeclarationStatement | NotEmittedStatement | EmptyStatement | DebuggerStatement | Block | VariableStatement | ExpressionStatement | IfStatement | IterationStatement | BreakStatement | ContinueStatement | ReturnStatement | WithStatement | SwitchStatement | LabeledStatement | ThrowStatement | TryStatement | ModuleBlock | ImportDeclaration;
+    type IterationStatement = DoStatement | WhileStatement | ForStatement | ForInStatement | ForOfStatement;
+    type TypeElement = CallSignatureDeclaration | ConstructSignatureDeclaration | PropertySignature | MethodSignature | GetAccessorDeclaration | SetAccessorDeclaration | IndexSignatureDeclaration;
+    type ClassElement = PropertyDeclaration | MethodDeclaration | ConstructorDeclaration | SemicolonClassElement | GetAccessorDeclaration | SetAccessorDeclaration | IndexSignatureDeclaration | ClassStaticBlockDeclaration;
+    type ObjectLiteralElement = PropertyAssignment | ShorthandPropertyAssignment | SpreadAssignment | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | JsxSpreadAttribute;
+    type TypeNode = KeywordTypeNode | ThisTypeNode | FunctionTypeNode | ConstructorTypeNode | NodeWithTypeArguments | TypePredicateNode | TypeLiteralNode | ArrayTypeNode | TupleTypeNode | NamedTupleMember | OptionalTypeNode | RestTypeNode | UnionTypeNode | IntersectionTypeNode | ConditionalTypeNode | InferTypeNode | ParenthesizedTypeNode | TypeOperatorNode | IndexedAccessTypeNode | MappedTypeNode | LiteralTypeNode | TemplateLiteralTypeNode | TemplateLiteralTypeSpan | JSDocTypeExpression | JSDocType;
+    type JSDocType = JSDocAllType | JSDocUnknownType | JSDocNonNullableType | JSDocNullableType | JSDocOptionalType | JSDocFunctionType | JSDocVariadicType | JSDocNamepathType | JSDocSignature | JSDocTypeLiteral;
+    type NodeWithTypeArguments = ImportTypeNode | TypeReferenceNode | TypeQueryNode | ExpressionWithTypeArguments;
+    type JSDocTag = JSDocUnknownTag | JSDocAugmentsTag | JSDocImplementsTag | JSDocAuthorTag | JSDocDeprecatedTag | JSDocClassTag | JSDocPublicTag | JSDocPrivateTag | JSDocProtectedTag | JSDocReadonlyTag | JSDocOverrideTag | JSDocOverloadTag | JSDocEnumTag | JSDocThisTag | JSDocTemplateTag | JSDocSeeTag | JSDocReturnTag | JSDocTypeTag | JSDocTypedefTag | JSDocCallbackTag | JSDocThrowsTag | JSDocPropertyLikeTag | JSDocSatisfiesTag;
+    type Expression = OmittedExpression | UnaryExpression | YieldExpression | SyntheticExpression | BinaryExpression | ConditionalExpression | ArrowFunction | SpreadElement | AsExpression | SatisfiesExpression | JsxOpeningElement | JsxOpeningFragment | JsxClosingFragment | JsxExpression | CommaListExpression;
+    type UnaryExpression = UpdateExpression | DeleteExpression | TypeOfExpression | VoidExpression | AwaitExpression | TypeAssertion;
+    type UpdateExpression = PrefixUnaryExpression | PostfixUnaryExpression | LeftHandSideExpression;
+    type LeftHandSideExpression = PartiallyEmittedExpression | MemberExpression | CallExpression | NonNullExpression | SyntheticReferenceExpression;
+    type MemberExpression = PrimaryExpression | PropertyAccessExpression | ElementAccessExpression | ExpressionWithTypeArguments | TaggedTemplateExpression;
+    type PrimaryExpression = Identifier | PrivateIdentifier | NullLiteral | TrueLiteral | FalseLiteral | ThisExpression | SuperExpression | ImportExpression | FunctionExpression | LiteralExpression | TemplateExpression | ParenthesizedExpression | ArrayLiteralExpression | ObjectLiteralExpression | NewExpression | MetaProperty | JsxElement | JsxAttributes | JsxNamespacedName | JsxSelfClosingElement | JsxFragment | MissingDeclaration | ClassExpression;
+    type LiteralExpression = StringLiteral | RegularExpressionLiteral | NoSubstitutionTemplateLiteral | NumericLiteral | BigIntLiteral;
+    type JSDocPropertyLikeTag = JSDocPropertyTag | JSDocParameterTag;
+    type LiteralLikeNode = TemplateLiteralLikeNode | LiteralExpression | JsxText;
+    type TemplateLiteralLikeNode = NoSubstitutionTemplateLiteral | TemplateHead | TemplateMiddle | TemplateTail;
     enum NodeFlags {
         None = 0,
         Let = 1,
@@ -4566,12 +4952,12 @@ declare namespace ts {
         IntrinsicIndexedElement = 2,
         IntrinsicElement = 3
     }
-    interface Node extends ReadonlyTextRange {
+    interface NodeBase extends ReadonlyTextRange {
         readonly kind: SyntaxKind;
         readonly flags: NodeFlags;
         readonly parent: Node;
     }
-    interface Node {
+    interface NodeBase {
         getSourceFile(): SourceFile;
         getChildCount(sourceFile?: SourceFile): number;
         getChildAt(index: number, sourceFile?: SourceFile): Node;
@@ -4588,13 +4974,13 @@ declare namespace ts {
         getLastToken(sourceFile?: SourceFile): Node | undefined;
         forEachChild<T>(cbNode: (node: Node) => T | undefined, cbNodeArray?: (nodes: NodeArray<Node>) => T | undefined): T | undefined;
     }
-    interface JSDocContainer extends Node {
+    interface JSDocContainer extends NodeBase {
         _jsdocContainerBrand: any;
     }
-    interface LocalsContainer extends Node {
+    interface LocalsContainer extends NodeBase {
         _localsContainerBrand: any;
     }
-    interface FlowContainer extends Node {
+    interface FlowContainer extends NodeBase {
         _flowContainerBrand: any;
     }
     type HasJSDoc = AccessorDeclaration | ArrowFunction | BinaryExpression | Block | BreakStatement | CallSignatureDeclaration | CaseClause | ClassLikeDeclaration | ClassStaticBlockDeclaration | ConstructorDeclaration | ConstructorTypeNode | ConstructSignatureDeclaration | ContinueStatement | DebuggerStatement | DoStatement | ElementAccessExpression | EmptyStatement | EndOfFileToken | EnumDeclaration | EnumMember | ExportAssignment | ExportDeclaration | ExportSpecifier | ExpressionStatement | ForInStatement | ForOfStatement | ForStatement | FunctionDeclaration | FunctionExpression | FunctionTypeNode | Identifier | IfStatement | ImportDeclaration | ImportEqualsDeclaration | IndexSignatureDeclaration | InterfaceDeclaration | JSDocFunctionType | JSDocSignature | LabeledStatement | MethodDeclaration | MethodSignature | ModuleDeclaration | NamedTupleMember | NamespaceExportDeclaration | ObjectLiteralExpression | ParameterDeclaration | ParenthesizedExpression | PropertyAccessExpression | PropertyAssignment | PropertyDeclaration | PropertySignature | ReturnStatement | SemicolonClassElement | ShorthandPropertyAssignment | SpreadAssignment | SwitchStatement | ThrowStatement | TryStatement | TypeAliasDeclaration | TypeParameterDeclaration | VariableDeclaration | VariableStatement | WhileStatement | WithStatement;
@@ -4607,7 +4993,7 @@ declare namespace ts {
     interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
         readonly hasTrailingComma: boolean;
     }
-    interface Token<TKind extends SyntaxKind> extends Node {
+    interface Token<TKind extends SyntaxKind> extends NodeBase {
         readonly kind: TKind;
     }
     type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & JSDocContainer;
@@ -4663,7 +5049,7 @@ declare namespace ts {
         FileLevel = 32,
         AllowNameSubstitution = 64
     }
-    interface Identifier extends PrimaryExpression, Declaration, JSDocContainer, FlowContainer {
+    interface Identifier extends PrimaryExpressionBase, DeclarationBase, JSDocContainer, FlowContainer {
         readonly kind: SyntaxKind.Identifier;
         /**
          * Prefer to use `id.unescapedText`. (Note: This is available only in services, not internally to the TypeScript compiler.)
@@ -4683,7 +5069,7 @@ declare namespace ts {
     interface TransientIdentifier extends Identifier {
         resolvedSymbol: Symbol;
     }
-    interface QualifiedName extends Node, FlowContainer {
+    interface QualifiedName extends NodeBase, FlowContainer {
         readonly kind: SyntaxKind.QualifiedName;
         readonly left: EntityName;
         readonly right: Identifier;
@@ -4692,35 +5078,35 @@ declare namespace ts {
     type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
     type MemberName = Identifier | PrivateIdentifier;
     type DeclarationName = Identifier | PrivateIdentifier | StringLiteralLike | NumericLiteral | ComputedPropertyName | ElementAccessExpression | BindingPattern | EntityNameExpression;
-    interface Declaration extends Node {
+    interface DeclarationBase extends NodeBase {
         _declarationBrand: any;
     }
-    interface NamedDeclaration extends Declaration {
+    interface NamedDeclarationBase extends DeclarationBase {
         readonly name?: DeclarationName;
     }
-    interface DeclarationStatement extends NamedDeclaration, Statement {
+    interface DeclarationStatementBase extends NamedDeclarationBase, StatementBase {
         readonly name?: Identifier | StringLiteral | NumericLiteral;
     }
-    interface ComputedPropertyName extends Node {
+    interface ComputedPropertyName extends NodeBase {
         readonly kind: SyntaxKind.ComputedPropertyName;
         readonly parent: Declaration;
         readonly expression: Expression;
     }
-    interface PrivateIdentifier extends PrimaryExpression {
+    interface PrivateIdentifier extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.PrivateIdentifier;
         readonly escapedText: __String;
     }
     interface PrivateIdentifier {
         readonly text: string;
     }
-    interface Decorator extends Node {
+    interface Decorator extends NodeBase {
         readonly kind: SyntaxKind.Decorator;
         readonly parent: NamedDeclaration;
         readonly expression: LeftHandSideExpression;
     }
-    interface TypeParameterDeclaration extends NamedDeclaration, JSDocContainer {
+    interface TypeParameterDeclaration extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.TypeParameter;
-        readonly parent: DeclarationWithTypeParameterChildren | InferTypeNode;
+        readonly parent: DeclarationWithTypeParameterChildren | InferTypeNode | MappedTypeNode;
         readonly modifiers?: NodeArray<Modifier>;
         readonly name: Identifier;
         /** Note: Consider calling `getEffectiveConstraintOfTypeParameter` */
@@ -4728,7 +5114,7 @@ declare namespace ts {
         readonly default?: TypeNode;
         expression?: Expression;
     }
-    interface SignatureDeclarationBase extends NamedDeclaration, JSDocContainer {
+    interface SignatureDeclarationBase extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SignatureDeclaration["kind"];
         readonly name?: PropertyName;
         readonly typeParameters?: NodeArray<TypeParameterDeclaration> | undefined;
@@ -4736,14 +5122,14 @@ declare namespace ts {
         readonly type?: TypeNode | undefined;
     }
     type SignatureDeclaration = CallSignatureDeclaration | ConstructSignatureDeclaration | MethodSignature | IndexSignatureDeclaration | FunctionTypeNode | ConstructorTypeNode | JSDocFunctionType | FunctionDeclaration | MethodDeclaration | ConstructorDeclaration | AccessorDeclaration | FunctionExpression | ArrowFunction;
-    interface CallSignatureDeclaration extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+    interface CallSignatureDeclaration extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.CallSignature;
     }
-    interface ConstructSignatureDeclaration extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+    interface ConstructSignatureDeclaration extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.ConstructSignature;
     }
     type BindingName = Identifier | BindingPattern;
-    interface VariableDeclaration extends NamedDeclaration, JSDocContainer {
+    interface VariableDeclaration extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.VariableDeclaration;
         readonly parent: VariableDeclarationList | CatchClause;
         readonly name: BindingName;
@@ -4751,12 +5137,12 @@ declare namespace ts {
         readonly type?: TypeNode;
         readonly initializer?: Expression;
     }
-    interface VariableDeclarationList extends Node {
+    interface VariableDeclarationList extends NodeBase {
         readonly kind: SyntaxKind.VariableDeclarationList;
         readonly parent: VariableStatement | ForStatement | ForOfStatement | ForInStatement;
         readonly declarations: NodeArray<VariableDeclaration>;
     }
-    interface ParameterDeclaration extends NamedDeclaration, JSDocContainer {
+    interface ParameterDeclaration extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.Parameter;
         readonly parent: SignatureDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -4766,7 +5152,7 @@ declare namespace ts {
         readonly type?: TypeNode;
         readonly initializer?: Expression;
     }
-    interface BindingElement extends NamedDeclaration, FlowContainer {
+    interface BindingElement extends NamedDeclarationBase, FlowContainer {
         readonly kind: SyntaxKind.BindingElement;
         readonly parent: BindingPattern;
         readonly propertyName?: PropertyName;
@@ -4774,7 +5160,7 @@ declare namespace ts {
         readonly name: BindingName;
         readonly initializer?: Expression;
     }
-    interface PropertySignature extends TypeElement, JSDocContainer {
+    interface PropertySignature extends TypeElementBase, JSDocContainer {
         readonly kind: SyntaxKind.PropertySignature;
         readonly parent: TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<Modifier>;
@@ -4782,7 +5168,7 @@ declare namespace ts {
         readonly questionToken?: QuestionToken;
         readonly type?: TypeNode;
     }
-    interface PropertyDeclaration extends ClassElement, JSDocContainer {
+    interface PropertyDeclaration extends ClassElementBase, JSDocContainer {
         readonly kind: SyntaxKind.PropertyDeclaration;
         readonly parent: ClassLikeDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -4795,37 +5181,37 @@ declare namespace ts {
     interface AutoAccessorPropertyDeclaration extends PropertyDeclaration {
         _autoAccessorBrand: any;
     }
-    interface ObjectLiteralElement extends NamedDeclaration {
+    interface ObjectLiteralElementBase extends NamedDeclarationBase {
         _objectLiteralBrand: any;
         readonly name?: PropertyName;
     }
     /** Unlike ObjectLiteralElement, excludes JSXAttribute and JSXSpreadAttribute. */
     type ObjectLiteralElementLike = PropertyAssignment | ShorthandPropertyAssignment | SpreadAssignment | MethodDeclaration | AccessorDeclaration;
-    interface PropertyAssignment extends ObjectLiteralElement, JSDocContainer {
+    interface PropertyAssignment extends ObjectLiteralElementBase, JSDocContainer {
         readonly kind: SyntaxKind.PropertyAssignment;
         readonly parent: ObjectLiteralExpression;
         readonly name: PropertyName;
         readonly initializer: Expression;
     }
-    interface ShorthandPropertyAssignment extends ObjectLiteralElement, JSDocContainer {
+    interface ShorthandPropertyAssignment extends ObjectLiteralElementBase, JSDocContainer {
         readonly kind: SyntaxKind.ShorthandPropertyAssignment;
         readonly parent: ObjectLiteralExpression;
         readonly name: Identifier;
         readonly equalsToken?: EqualsToken;
         readonly objectAssignmentInitializer?: Expression;
     }
-    interface SpreadAssignment extends ObjectLiteralElement, JSDocContainer {
+    interface SpreadAssignment extends ObjectLiteralElementBase, JSDocContainer {
         readonly kind: SyntaxKind.SpreadAssignment;
         readonly parent: ObjectLiteralExpression;
         readonly expression: Expression;
     }
     type VariableLikeDeclaration = VariableDeclaration | ParameterDeclaration | BindingElement | PropertyDeclaration | PropertyAssignment | PropertySignature | JsxAttribute | ShorthandPropertyAssignment | EnumMember | JSDocPropertyTag | JSDocParameterTag;
-    interface ObjectBindingPattern extends Node {
+    interface ObjectBindingPattern extends NodeBase {
         readonly kind: SyntaxKind.ObjectBindingPattern;
         readonly parent: VariableDeclaration | ParameterDeclaration | BindingElement;
         readonly elements: NodeArray<BindingElement>;
     }
-    interface ArrayBindingPattern extends Node {
+    interface ArrayBindingPattern extends NodeBase {
         readonly kind: SyntaxKind.ArrayBindingPattern;
         readonly parent: VariableDeclaration | ParameterDeclaration | BindingElement;
         readonly elements: NodeArray<ArrayBindingElement>;
@@ -4850,44 +5236,44 @@ declare namespace ts {
     type FunctionLikeDeclaration = FunctionDeclaration | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | ConstructorDeclaration | FunctionExpression | ArrowFunction;
     /** @deprecated Use SignatureDeclaration */
     type FunctionLike = SignatureDeclaration;
-    interface FunctionDeclaration extends FunctionLikeDeclarationBase, DeclarationStatement, LocalsContainer {
+    interface FunctionDeclaration extends FunctionLikeDeclarationBase, DeclarationStatementBase, LocalsContainer {
         readonly kind: SyntaxKind.FunctionDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name?: Identifier;
         readonly body?: FunctionBody;
     }
-    interface MethodSignature extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+    interface MethodSignature extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.MethodSignature;
         readonly parent: TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<Modifier>;
         readonly name: PropertyName;
     }
-    interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+    interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.MethodDeclaration;
         readonly parent: ClassLikeDeclaration | ObjectLiteralExpression;
         readonly modifiers?: NodeArray<ModifierLike> | undefined;
         readonly name: PropertyName;
         readonly body?: FunctionBody | undefined;
     }
-    interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElement, JSDocContainer, LocalsContainer {
+    interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.Constructor;
         readonly parent: ClassLikeDeclaration;
         readonly modifiers?: NodeArray<ModifierLike> | undefined;
         readonly body?: FunctionBody | undefined;
     }
     /** For when we encounter a semicolon in a class declaration. ES6 allows these as class elements. */
-    interface SemicolonClassElement extends ClassElement, JSDocContainer {
+    interface SemicolonClassElement extends ClassElementBase, JSDocContainer {
         readonly kind: SyntaxKind.SemicolonClassElement;
         readonly parent: ClassLikeDeclaration;
     }
-    interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, TypeElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+    interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, TypeElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.GetAccessor;
         readonly parent: ClassLikeDeclaration | ObjectLiteralExpression | TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: PropertyName;
         readonly body?: FunctionBody;
     }
-    interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, TypeElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+    interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, TypeElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.SetAccessor;
         readonly parent: ClassLikeDeclaration | ObjectLiteralExpression | TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -4895,41 +5281,41 @@ declare namespace ts {
         readonly body?: FunctionBody;
     }
     type AccessorDeclaration = GetAccessorDeclaration | SetAccessorDeclaration;
-    interface IndexSignatureDeclaration extends SignatureDeclarationBase, ClassElement, TypeElement, LocalsContainer {
+    interface IndexSignatureDeclaration extends SignatureDeclarationBase, ClassElementBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.IndexSignature;
         readonly parent: ObjectTypeDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly type: TypeNode;
     }
-    interface ClassStaticBlockDeclaration extends ClassElement, JSDocContainer, LocalsContainer {
+    interface ClassStaticBlockDeclaration extends ClassElementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.ClassStaticBlockDeclaration;
         readonly parent: ClassDeclaration | ClassExpression;
         readonly body: Block;
     }
-    interface TypeNode extends Node {
+    interface TypeNodeBase extends NodeBase {
         _typeNodeBrand: any;
     }
-    interface KeywordTypeNode<TKind extends KeywordTypeSyntaxKind = KeywordTypeSyntaxKind> extends KeywordToken<TKind>, TypeNode {
+    interface KeywordTypeNode<TKind extends KeywordTypeSyntaxKind = KeywordTypeSyntaxKind> extends KeywordToken<TKind>, TypeNodeBase {
         readonly kind: TKind;
     }
-    interface ImportTypeAssertionContainer extends Node {
+    interface ImportTypeAssertionContainer extends NodeBase {
         readonly kind: SyntaxKind.ImportTypeAssertionContainer;
         readonly parent: ImportTypeNode;
         readonly assertClause: AssertClause;
         readonly multiLine?: boolean;
     }
-    interface ImportTypeNode extends NodeWithTypeArguments {
+    interface ImportTypeNode extends NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.ImportType;
         readonly isTypeOf: boolean;
         readonly argument: TypeNode;
         readonly assertions?: ImportTypeAssertionContainer;
         readonly qualifier?: EntityName;
     }
-    interface ThisTypeNode extends TypeNode {
+    interface ThisTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.ThisType;
     }
     type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode;
-    interface FunctionOrConstructorTypeNodeBase extends TypeNode, SignatureDeclarationBase {
+    interface FunctionOrConstructorTypeNodeBase extends TypeNodeBase, SignatureDeclarationBase {
         readonly kind: SyntaxKind.FunctionType | SyntaxKind.ConstructorType;
         readonly type: TypeNode;
     }
@@ -4940,87 +5326,87 @@ declare namespace ts {
         readonly kind: SyntaxKind.ConstructorType;
         readonly modifiers?: NodeArray<Modifier>;
     }
-    interface NodeWithTypeArguments extends TypeNode {
+    interface NodeWithTypeArgumentsBase extends TypeNodeBase {
         readonly typeArguments?: NodeArray<TypeNode>;
     }
     type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
-    interface TypeReferenceNode extends NodeWithTypeArguments {
+    interface TypeReferenceNode extends NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.TypeReference;
         readonly typeName: EntityName;
     }
-    interface TypePredicateNode extends TypeNode {
+    interface TypePredicateNode extends TypeNodeBase {
         readonly kind: SyntaxKind.TypePredicate;
         readonly parent: SignatureDeclaration | JSDocTypeExpression;
         readonly assertsModifier?: AssertsKeyword;
         readonly parameterName: Identifier | ThisTypeNode;
         readonly type?: TypeNode;
     }
-    interface TypeQueryNode extends NodeWithTypeArguments {
+    interface TypeQueryNode extends NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.TypeQuery;
         readonly exprName: EntityName;
     }
-    interface TypeLiteralNode extends TypeNode, Declaration {
+    interface TypeLiteralNode extends TypeNodeBase, DeclarationBase {
         readonly kind: SyntaxKind.TypeLiteral;
         readonly members: NodeArray<TypeElement>;
     }
-    interface ArrayTypeNode extends TypeNode {
+    interface ArrayTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.ArrayType;
         readonly elementType: TypeNode;
     }
-    interface TupleTypeNode extends TypeNode {
+    interface TupleTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.TupleType;
         readonly elements: NodeArray<TypeNode | NamedTupleMember>;
     }
-    interface NamedTupleMember extends TypeNode, Declaration, JSDocContainer {
+    interface NamedTupleMember extends TypeNodeBase, DeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.NamedTupleMember;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
         readonly name: Identifier;
         readonly questionToken?: Token<SyntaxKind.QuestionToken>;
         readonly type: TypeNode;
     }
-    interface OptionalTypeNode extends TypeNode {
+    interface OptionalTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.OptionalType;
         readonly type: TypeNode;
     }
-    interface RestTypeNode extends TypeNode {
+    interface RestTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.RestType;
         readonly type: TypeNode;
     }
     type UnionOrIntersectionTypeNode = UnionTypeNode | IntersectionTypeNode;
-    interface UnionTypeNode extends TypeNode {
+    interface UnionTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.UnionType;
         readonly types: NodeArray<TypeNode>;
     }
-    interface IntersectionTypeNode extends TypeNode {
+    interface IntersectionTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.IntersectionType;
         readonly types: NodeArray<TypeNode>;
     }
-    interface ConditionalTypeNode extends TypeNode, LocalsContainer {
+    interface ConditionalTypeNode extends TypeNodeBase, LocalsContainer {
         readonly kind: SyntaxKind.ConditionalType;
         readonly checkType: TypeNode;
         readonly extendsType: TypeNode;
         readonly trueType: TypeNode;
         readonly falseType: TypeNode;
     }
-    interface InferTypeNode extends TypeNode {
+    interface InferTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.InferType;
         readonly typeParameter: TypeParameterDeclaration;
     }
-    interface ParenthesizedTypeNode extends TypeNode {
+    interface ParenthesizedTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.ParenthesizedType;
         readonly type: TypeNode;
     }
-    interface TypeOperatorNode extends TypeNode {
+    interface TypeOperatorNode extends TypeNodeBase {
         readonly kind: SyntaxKind.TypeOperator;
         readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword;
         readonly type: TypeNode;
     }
-    interface IndexedAccessTypeNode extends TypeNode {
+    interface IndexedAccessTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.IndexedAccessType;
         readonly objectType: TypeNode;
         readonly indexType: TypeNode;
     }
-    interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer {
+    interface MappedTypeNode extends TypeNodeBase, DeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.MappedType;
         readonly readonlyToken?: ReadonlyKeyword | PlusToken | MinusToken;
         readonly typeParameter: TypeParameterDeclaration;
@@ -5030,106 +5416,106 @@ declare namespace ts {
         /** Used only to produce grammar errors */
         readonly members?: NodeArray<TypeElement>;
     }
-    interface LiteralTypeNode extends TypeNode {
+    interface LiteralTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.LiteralType;
         readonly literal: NullLiteral | BooleanLiteral | LiteralExpression | PrefixUnaryExpression;
     }
-    interface StringLiteral extends LiteralExpression, Declaration {
+    interface StringLiteral extends LiteralExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.StringLiteral;
     }
     type StringLiteralLike = StringLiteral | NoSubstitutionTemplateLiteral;
     type PropertyNameLiteral = Identifier | StringLiteralLike | NumericLiteral;
-    interface TemplateLiteralTypeNode extends TypeNode {
+    interface TemplateLiteralTypeNode extends TypeNodeBase {
         kind: SyntaxKind.TemplateLiteralType;
         readonly head: TemplateHead;
         readonly templateSpans: NodeArray<TemplateLiteralTypeSpan>;
     }
-    interface TemplateLiteralTypeSpan extends TypeNode {
+    interface TemplateLiteralTypeSpan extends TypeNodeBase {
         readonly kind: SyntaxKind.TemplateLiteralTypeSpan;
         readonly parent: TemplateLiteralTypeNode;
         readonly type: TypeNode;
         readonly literal: TemplateMiddle | TemplateTail;
     }
-    interface Expression extends Node {
+    interface ExpressionBase extends NodeBase {
         _expressionBrand: any;
     }
-    interface OmittedExpression extends Expression {
+    interface OmittedExpression extends ExpressionBase {
         readonly kind: SyntaxKind.OmittedExpression;
     }
-    interface PartiallyEmittedExpression extends LeftHandSideExpression {
+    interface PartiallyEmittedExpression extends LeftHandSideExpressionBase {
         readonly kind: SyntaxKind.PartiallyEmittedExpression;
         readonly expression: Expression;
     }
-    interface UnaryExpression extends Expression {
+    interface UnaryExpressionBase extends ExpressionBase {
         _unaryExpressionBrand: any;
     }
     /** Deprecated, please use UpdateExpression */
     type IncrementExpression = UpdateExpression;
-    interface UpdateExpression extends UnaryExpression {
+    interface UpdateExpressionBase extends UnaryExpressionBase {
         _updateExpressionBrand: any;
     }
     type PrefixUnaryOperator = SyntaxKind.PlusPlusToken | SyntaxKind.MinusMinusToken | SyntaxKind.PlusToken | SyntaxKind.MinusToken | SyntaxKind.TildeToken | SyntaxKind.ExclamationToken;
-    interface PrefixUnaryExpression extends UpdateExpression {
+    interface PrefixUnaryExpression extends UpdateExpressionBase {
         readonly kind: SyntaxKind.PrefixUnaryExpression;
         readonly operator: PrefixUnaryOperator;
         readonly operand: UnaryExpression;
     }
     type PostfixUnaryOperator = SyntaxKind.PlusPlusToken | SyntaxKind.MinusMinusToken;
-    interface PostfixUnaryExpression extends UpdateExpression {
+    interface PostfixUnaryExpression extends UpdateExpressionBase {
         readonly kind: SyntaxKind.PostfixUnaryExpression;
         readonly operand: LeftHandSideExpression;
         readonly operator: PostfixUnaryOperator;
     }
-    interface LeftHandSideExpression extends UpdateExpression {
+    interface LeftHandSideExpressionBase extends UpdateExpressionBase {
         _leftHandSideExpressionBrand: any;
     }
-    interface MemberExpression extends LeftHandSideExpression {
+    interface MemberExpressionBase extends LeftHandSideExpressionBase {
         _memberExpressionBrand: any;
     }
-    interface PrimaryExpression extends MemberExpression {
+    interface PrimaryExpressionBase extends MemberExpressionBase {
         _primaryExpressionBrand: any;
     }
-    interface NullLiteral extends PrimaryExpression {
+    interface NullLiteral extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.NullKeyword;
     }
-    interface TrueLiteral extends PrimaryExpression {
+    interface TrueLiteral extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.TrueKeyword;
     }
-    interface FalseLiteral extends PrimaryExpression {
+    interface FalseLiteral extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.FalseKeyword;
     }
     type BooleanLiteral = TrueLiteral | FalseLiteral;
-    interface ThisExpression extends PrimaryExpression, FlowContainer {
+    interface ThisExpression extends PrimaryExpressionBase, FlowContainer {
         readonly kind: SyntaxKind.ThisKeyword;
     }
-    interface SuperExpression extends PrimaryExpression, FlowContainer {
+    interface SuperExpression extends PrimaryExpressionBase, FlowContainer {
         readonly kind: SyntaxKind.SuperKeyword;
     }
-    interface ImportExpression extends PrimaryExpression {
+    interface ImportExpression extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.ImportKeyword;
     }
-    interface DeleteExpression extends UnaryExpression {
+    interface DeleteExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.DeleteExpression;
         readonly expression: UnaryExpression;
     }
-    interface TypeOfExpression extends UnaryExpression {
+    interface TypeOfExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.TypeOfExpression;
         readonly expression: UnaryExpression;
     }
-    interface VoidExpression extends UnaryExpression {
+    interface VoidExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.VoidExpression;
         readonly expression: UnaryExpression;
     }
-    interface AwaitExpression extends UnaryExpression {
+    interface AwaitExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.AwaitExpression;
         readonly expression: UnaryExpression;
     }
-    interface YieldExpression extends Expression {
+    interface YieldExpression extends ExpressionBase {
         readonly kind: SyntaxKind.YieldExpression;
         readonly asteriskToken?: AsteriskToken;
         readonly expression?: Expression;
     }
-    interface SyntheticExpression extends Expression {
+    interface SyntheticExpression extends ExpressionBase {
         readonly kind: SyntaxKind.SyntheticExpression;
         readonly isSpread: boolean;
         readonly type: Type;
@@ -5155,8 +5541,8 @@ declare namespace ts {
     type AssignmentOperatorOrHigher = SyntaxKind.QuestionQuestionToken | LogicalOperatorOrHigher | AssignmentOperator;
     type BinaryOperator = AssignmentOperatorOrHigher | SyntaxKind.CommaToken;
     type LogicalOrCoalescingAssignmentOperator = SyntaxKind.AmpersandAmpersandEqualsToken | SyntaxKind.BarBarEqualsToken | SyntaxKind.QuestionQuestionEqualsToken;
-    type BinaryOperatorToken = Token<BinaryOperator>;
-    interface BinaryExpression extends Expression, Declaration, JSDocContainer {
+    type BinaryOperatorToken<TOperator extends BinaryOperator = BinaryOperator> = TOperator extends SyntaxKind ? Token<TOperator> : never;
+    interface BinaryExpression extends ExpressionBase, DeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.BinaryExpression;
         readonly left: Expression;
         readonly operatorToken: BinaryOperatorToken;
@@ -5183,7 +5569,7 @@ declare namespace ts {
     type ArrayBindingOrAssignmentPattern = ArrayBindingPattern | ArrayLiteralExpression;
     type AssignmentPattern = ObjectLiteralExpression | ArrayLiteralExpression;
     type BindingOrAssignmentPattern = ObjectBindingOrAssignmentPattern | ArrayBindingOrAssignmentPattern;
-    interface ConditionalExpression extends Expression {
+    interface ConditionalExpression extends ExpressionBase {
         readonly kind: SyntaxKind.ConditionalExpression;
         readonly condition: Expression;
         readonly questionToken: QuestionToken;
@@ -5193,34 +5579,34 @@ declare namespace ts {
     }
     type FunctionBody = Block;
     type ConciseBody = FunctionBody | Expression;
-    interface FunctionExpression extends PrimaryExpression, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
+    interface FunctionExpression extends PrimaryExpressionBase, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.FunctionExpression;
         readonly modifiers?: NodeArray<Modifier>;
         readonly name?: Identifier;
         readonly body: FunctionBody;
     }
-    interface ArrowFunction extends Expression, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
+    interface ArrowFunction extends ExpressionBase, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ArrowFunction;
         readonly modifiers?: NodeArray<Modifier>;
         readonly equalsGreaterThanToken: EqualsGreaterThanToken;
         readonly body: ConciseBody;
         readonly name: never;
     }
-    interface LiteralLikeNode extends Node {
+    interface LiteralLikeNodeBase extends NodeBase {
         text: string;
         isUnterminated?: boolean;
         hasExtendedUnicodeEscape?: boolean;
     }
-    interface TemplateLiteralLikeNode extends LiteralLikeNode {
+    interface TemplateLiteralLikeNodeBase extends LiteralLikeNodeBase {
         rawText?: string;
     }
-    interface LiteralExpression extends LiteralLikeNode, PrimaryExpression {
+    interface LiteralExpressionBase extends LiteralLikeNodeBase, PrimaryExpressionBase {
         _literalExpressionBrand: any;
     }
-    interface RegularExpressionLiteral extends LiteralExpression {
+    interface RegularExpressionLiteral extends LiteralExpressionBase {
         readonly kind: SyntaxKind.RegularExpressionLiteral;
     }
-    interface NoSubstitutionTemplateLiteral extends LiteralExpression, TemplateLiteralLikeNode, Declaration {
+    interface NoSubstitutionTemplateLiteral extends LiteralExpressionBase, TemplateLiteralLikeNodeBase, DeclarationBase {
         readonly kind: SyntaxKind.NoSubstitutionTemplateLiteral;
     }
     enum TokenFlags {
@@ -5231,48 +5617,48 @@ declare namespace ts {
         BinarySpecifier = 128,
         OctalSpecifier = 256
     }
-    interface NumericLiteral extends LiteralExpression, Declaration {
+    interface NumericLiteral extends LiteralExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.NumericLiteral;
     }
-    interface BigIntLiteral extends LiteralExpression {
+    interface BigIntLiteral extends LiteralExpressionBase {
         readonly kind: SyntaxKind.BigIntLiteral;
     }
     type LiteralToken = NumericLiteral | BigIntLiteral | StringLiteral | JsxText | RegularExpressionLiteral | NoSubstitutionTemplateLiteral;
-    interface TemplateHead extends TemplateLiteralLikeNode {
+    interface TemplateHead extends TemplateLiteralLikeNodeBase {
         readonly kind: SyntaxKind.TemplateHead;
         readonly parent: TemplateExpression | TemplateLiteralTypeNode;
     }
-    interface TemplateMiddle extends TemplateLiteralLikeNode {
+    interface TemplateMiddle extends TemplateLiteralLikeNodeBase {
         readonly kind: SyntaxKind.TemplateMiddle;
         readonly parent: TemplateSpan | TemplateLiteralTypeSpan;
     }
-    interface TemplateTail extends TemplateLiteralLikeNode {
+    interface TemplateTail extends TemplateLiteralLikeNodeBase {
         readonly kind: SyntaxKind.TemplateTail;
         readonly parent: TemplateSpan | TemplateLiteralTypeSpan;
     }
     type PseudoLiteralToken = TemplateHead | TemplateMiddle | TemplateTail;
     type TemplateLiteralToken = NoSubstitutionTemplateLiteral | PseudoLiteralToken;
-    interface TemplateExpression extends PrimaryExpression {
+    interface TemplateExpression extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.TemplateExpression;
         readonly head: TemplateHead;
         readonly templateSpans: NodeArray<TemplateSpan>;
     }
     type TemplateLiteral = TemplateExpression | NoSubstitutionTemplateLiteral;
-    interface TemplateSpan extends Node {
+    interface TemplateSpan extends NodeBase {
         readonly kind: SyntaxKind.TemplateSpan;
         readonly parent: TemplateExpression;
         readonly expression: Expression;
         readonly literal: TemplateMiddle | TemplateTail;
     }
-    interface ParenthesizedExpression extends PrimaryExpression, JSDocContainer {
+    interface ParenthesizedExpression extends PrimaryExpressionBase, JSDocContainer {
         readonly kind: SyntaxKind.ParenthesizedExpression;
         readonly expression: Expression;
     }
-    interface ArrayLiteralExpression extends PrimaryExpression {
+    interface ArrayLiteralExpression extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.ArrayLiteralExpression;
         readonly elements: NodeArray<Expression>;
     }
-    interface SpreadElement extends Expression {
+    interface SpreadElement extends ExpressionBase {
         readonly kind: SyntaxKind.SpreadElement;
         readonly parent: ArrayLiteralExpression | CallExpression | NewExpression;
         readonly expression: Expression;
@@ -5283,7 +5669,7 @@ declare namespace ts {
      * JSXAttribute or JSXSpreadAttribute. ObjectLiteralExpression, on the other hand, can only have properties of type
      * ObjectLiteralElement (e.g. PropertyAssignment, ShorthandPropertyAssignment etc.)
      */
-    interface ObjectLiteralExpressionBase<T extends ObjectLiteralElement> extends PrimaryExpression, Declaration {
+    interface ObjectLiteralExpressionBase<T extends ObjectLiteralElement> extends PrimaryExpressionBase, DeclarationBase {
         readonly properties: NodeArray<T>;
     }
     interface ObjectLiteralExpression extends ObjectLiteralExpressionBase<ObjectLiteralElementLike>, JSDocContainer {
@@ -5292,7 +5678,7 @@ declare namespace ts {
     type EntityNameExpression = Identifier | PropertyAccessEntityNameExpression;
     type EntityNameOrEntityNameExpression = EntityName | EntityNameExpression;
     type AccessExpression = PropertyAccessExpression | ElementAccessExpression;
-    interface PropertyAccessExpression extends MemberExpression, NamedDeclaration, JSDocContainer, FlowContainer {
+    interface PropertyAccessExpression extends MemberExpressionBase, NamedDeclarationBase, JSDocContainer, FlowContainer {
         readonly kind: SyntaxKind.PropertyAccessExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
@@ -5311,7 +5697,7 @@ declare namespace ts {
         readonly expression: EntityNameExpression;
         readonly name: Identifier;
     }
-    interface ElementAccessExpression extends MemberExpression, Declaration, JSDocContainer, FlowContainer {
+    interface ElementAccessExpression extends MemberExpressionBase, DeclarationBase, JSDocContainer, FlowContainer {
         readonly kind: SyntaxKind.ElementAccessExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
@@ -5324,7 +5710,7 @@ declare namespace ts {
         readonly expression: SuperExpression;
     }
     type SuperProperty = SuperPropertyAccessExpression | SuperElementAccessExpression;
-    interface CallExpression extends LeftHandSideExpression, Declaration {
+    interface CallExpression extends LeftHandSideExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.CallExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
@@ -5341,52 +5727,52 @@ declare namespace ts {
     interface ImportCall extends CallExpression {
         readonly expression: ImportExpression;
     }
-    interface ExpressionWithTypeArguments extends MemberExpression, NodeWithTypeArguments {
+    interface ExpressionWithTypeArguments extends MemberExpressionBase, NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.ExpressionWithTypeArguments;
         readonly expression: LeftHandSideExpression;
     }
-    interface NewExpression extends PrimaryExpression, Declaration {
+    interface NewExpression extends PrimaryExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.NewExpression;
         readonly expression: LeftHandSideExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly arguments?: NodeArray<Expression>;
     }
-    interface TaggedTemplateExpression extends MemberExpression {
+    interface TaggedTemplateExpression extends MemberExpressionBase {
         readonly kind: SyntaxKind.TaggedTemplateExpression;
         readonly tag: LeftHandSideExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly template: TemplateLiteral;
     }
     type CallLikeExpression = CallExpression | NewExpression | TaggedTemplateExpression | Decorator | JsxOpeningLikeElement;
-    interface AsExpression extends Expression {
+    interface AsExpression extends ExpressionBase {
         readonly kind: SyntaxKind.AsExpression;
         readonly expression: Expression;
         readonly type: TypeNode;
     }
-    interface TypeAssertion extends UnaryExpression {
+    interface TypeAssertion extends UnaryExpressionBase {
         readonly kind: SyntaxKind.TypeAssertionExpression;
         readonly type: TypeNode;
         readonly expression: UnaryExpression;
     }
-    interface SatisfiesExpression extends Expression {
+    interface SatisfiesExpression extends ExpressionBase {
         readonly kind: SyntaxKind.SatisfiesExpression;
         readonly expression: Expression;
         readonly type: TypeNode;
     }
     type AssertionExpression = TypeAssertion | AsExpression;
-    interface NonNullExpression extends LeftHandSideExpression {
+    interface NonNullExpression extends LeftHandSideExpressionBase {
         readonly kind: SyntaxKind.NonNullExpression;
         readonly expression: Expression;
     }
     interface NonNullChain extends NonNullExpression {
         _optionalChainBrand: any;
     }
-    interface MetaProperty extends PrimaryExpression, FlowContainer {
+    interface MetaProperty extends PrimaryExpressionBase, FlowContainer {
         readonly kind: SyntaxKind.MetaProperty;
         readonly keywordToken: SyntaxKind.NewKeyword | SyntaxKind.ImportKeyword;
         readonly name: Identifier;
     }
-    interface JsxElement extends PrimaryExpression {
+    interface JsxElement extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxElement;
         readonly openingElement: JsxOpeningElement;
         readonly children: NodeArray<JsxChild>;
@@ -5399,203 +5785,206 @@ declare namespace ts {
     interface JsxTagNamePropertyAccess extends PropertyAccessExpression {
         readonly expression: JsxTagNameExpression;
     }
-    interface JsxAttributes extends PrimaryExpression, Declaration {
+    interface JsxAttributes extends PrimaryExpressionBase, DeclarationBase {
         readonly properties: NodeArray<JsxAttributeLike>;
         readonly kind: SyntaxKind.JsxAttributes;
         readonly parent: JsxOpeningLikeElement;
     }
-    interface JsxNamespacedName extends PrimaryExpression {
+    interface JsxNamespacedName extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxNamespacedName;
         readonly name: Identifier;
         readonly namespace: Identifier;
     }
-    interface JsxOpeningElement extends Expression {
+    interface JsxOpeningElement extends ExpressionBase {
         readonly kind: SyntaxKind.JsxOpeningElement;
         readonly parent: JsxElement;
         readonly tagName: JsxTagNameExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly attributes: JsxAttributes;
     }
-    interface JsxSelfClosingElement extends PrimaryExpression {
+    interface JsxSelfClosingElement extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxSelfClosingElement;
         readonly tagName: JsxTagNameExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly attributes: JsxAttributes;
     }
-    interface JsxFragment extends PrimaryExpression {
+    interface JsxFragment extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxFragment;
         readonly openingFragment: JsxOpeningFragment;
         readonly children: NodeArray<JsxChild>;
         readonly closingFragment: JsxClosingFragment;
     }
-    interface JsxOpeningFragment extends Expression {
+    interface JsxOpeningFragment extends ExpressionBase {
         readonly kind: SyntaxKind.JsxOpeningFragment;
         readonly parent: JsxFragment;
     }
-    interface JsxClosingFragment extends Expression {
+    interface JsxClosingFragment extends ExpressionBase {
         readonly kind: SyntaxKind.JsxClosingFragment;
         readonly parent: JsxFragment;
     }
-    interface JsxAttribute extends Declaration {
+    interface JsxAttribute extends DeclarationBase {
         readonly kind: SyntaxKind.JsxAttribute;
         readonly parent: JsxAttributes;
         readonly name: JsxAttributeName;
         readonly initializer?: JsxAttributeValue;
     }
     type JsxAttributeValue = StringLiteral | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
-    interface JsxSpreadAttribute extends ObjectLiteralElement {
+    interface JsxSpreadAttribute extends ObjectLiteralElementBase {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
         readonly name: PropertyName;
         readonly parent: JsxAttributes;
         readonly expression: Expression;
     }
-    interface JsxClosingElement extends Node {
+    interface JsxClosingElement extends NodeBase {
         readonly kind: SyntaxKind.JsxClosingElement;
         readonly parent: JsxElement;
         readonly tagName: JsxTagNameExpression;
     }
-    interface JsxExpression extends Expression {
+    interface JsxExpression extends ExpressionBase {
         readonly kind: SyntaxKind.JsxExpression;
         readonly parent: JsxElement | JsxFragment | JsxAttributeLike;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
         readonly expression?: Expression;
     }
-    interface JsxText extends LiteralLikeNode {
+    interface JsxText extends LiteralLikeNodeBase {
         readonly kind: SyntaxKind.JsxText;
         readonly parent: JsxElement | JsxFragment;
         readonly containsOnlyTriviaWhiteSpaces: boolean;
     }
     type JsxChild = JsxText | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
-    interface Statement extends Node, JSDocContainer {
+    interface StatementBase extends NodeBase, JSDocContainer {
         _statementBrand: any;
     }
-    interface NotEmittedStatement extends Statement {
+    interface NotEmittedStatement extends StatementBase {
         readonly kind: SyntaxKind.NotEmittedStatement;
     }
     /**
      * A list of comma-separated expressions. This node is only created by transformations.
      */
-    interface CommaListExpression extends Expression {
+    interface CommaListExpression extends ExpressionBase {
         readonly kind: SyntaxKind.CommaListExpression;
         readonly elements: NodeArray<Expression>;
     }
-    interface EmptyStatement extends Statement {
+    interface SyntheticReferenceExpression extends LeftHandSideExpressionBase {
+        readonly kind: SyntaxKind.SyntheticReferenceExpression;
+    }
+    interface EmptyStatement extends StatementBase {
         readonly kind: SyntaxKind.EmptyStatement;
     }
-    interface DebuggerStatement extends Statement, FlowContainer {
+    interface DebuggerStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.DebuggerStatement;
     }
-    interface MissingDeclaration extends DeclarationStatement, PrimaryExpression {
+    interface MissingDeclaration extends DeclarationStatementBase, PrimaryExpressionBase {
         readonly kind: SyntaxKind.MissingDeclaration;
         readonly name?: Identifier;
     }
     type BlockLike = SourceFile | Block | ModuleBlock | CaseOrDefaultClause;
-    interface Block extends Statement, LocalsContainer {
+    interface Block extends StatementBase, LocalsContainer {
         readonly kind: SyntaxKind.Block;
         readonly statements: NodeArray<Statement>;
     }
-    interface VariableStatement extends Statement, FlowContainer {
+    interface VariableStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.VariableStatement;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly declarationList: VariableDeclarationList;
     }
-    interface ExpressionStatement extends Statement, FlowContainer {
+    interface ExpressionStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ExpressionStatement;
         readonly expression: Expression;
     }
-    interface IfStatement extends Statement, FlowContainer {
+    interface IfStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.IfStatement;
         readonly expression: Expression;
         readonly thenStatement: Statement;
         readonly elseStatement?: Statement;
     }
-    interface IterationStatement extends Statement {
+    interface IterationStatementBase extends StatementBase {
         readonly statement: Statement;
     }
-    interface DoStatement extends IterationStatement, FlowContainer {
+    interface DoStatement extends IterationStatementBase, FlowContainer {
         readonly kind: SyntaxKind.DoStatement;
         readonly expression: Expression;
     }
-    interface WhileStatement extends IterationStatement, FlowContainer {
+    interface WhileStatement extends IterationStatementBase, FlowContainer {
         readonly kind: SyntaxKind.WhileStatement;
         readonly expression: Expression;
     }
     type ForInitializer = VariableDeclarationList | Expression;
-    interface ForStatement extends IterationStatement, LocalsContainer, FlowContainer {
+    interface ForStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ForStatement;
         readonly initializer?: ForInitializer;
         readonly condition?: Expression;
         readonly incrementor?: Expression;
     }
     type ForInOrOfStatement = ForInStatement | ForOfStatement;
-    interface ForInStatement extends IterationStatement, LocalsContainer, FlowContainer {
+    interface ForInStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ForInStatement;
         readonly initializer: ForInitializer;
         readonly expression: Expression;
     }
-    interface ForOfStatement extends IterationStatement, LocalsContainer, FlowContainer {
+    interface ForOfStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ForOfStatement;
         readonly awaitModifier?: AwaitKeyword;
         readonly initializer: ForInitializer;
         readonly expression: Expression;
     }
-    interface BreakStatement extends Statement, FlowContainer {
+    interface BreakStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.BreakStatement;
         readonly label?: Identifier;
     }
-    interface ContinueStatement extends Statement, FlowContainer {
+    interface ContinueStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ContinueStatement;
         readonly label?: Identifier;
     }
     type BreakOrContinueStatement = BreakStatement | ContinueStatement;
-    interface ReturnStatement extends Statement, FlowContainer {
+    interface ReturnStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ReturnStatement;
         readonly expression?: Expression;
     }
-    interface WithStatement extends Statement, FlowContainer {
+    interface WithStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.WithStatement;
         readonly expression: Expression;
         readonly statement: Statement;
     }
-    interface SwitchStatement extends Statement, FlowContainer {
+    interface SwitchStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.SwitchStatement;
         readonly expression: Expression;
         readonly caseBlock: CaseBlock;
         possiblyExhaustive?: boolean;
     }
-    interface CaseBlock extends Node, LocalsContainer {
+    interface CaseBlock extends NodeBase, LocalsContainer {
         readonly kind: SyntaxKind.CaseBlock;
         readonly parent: SwitchStatement;
         readonly clauses: NodeArray<CaseOrDefaultClause>;
     }
-    interface CaseClause extends Node, JSDocContainer {
+    interface CaseClause extends NodeBase, JSDocContainer {
         readonly kind: SyntaxKind.CaseClause;
         readonly parent: CaseBlock;
         readonly expression: Expression;
         readonly statements: NodeArray<Statement>;
     }
-    interface DefaultClause extends Node {
+    interface DefaultClause extends NodeBase {
         readonly kind: SyntaxKind.DefaultClause;
         readonly parent: CaseBlock;
         readonly statements: NodeArray<Statement>;
     }
     type CaseOrDefaultClause = CaseClause | DefaultClause;
-    interface LabeledStatement extends Statement, FlowContainer {
+    interface LabeledStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.LabeledStatement;
         readonly label: Identifier;
         readonly statement: Statement;
     }
-    interface ThrowStatement extends Statement, FlowContainer {
+    interface ThrowStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ThrowStatement;
         readonly expression: Expression;
     }
-    interface TryStatement extends Statement, FlowContainer {
+    interface TryStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.TryStatement;
         readonly tryBlock: Block;
         readonly catchClause?: CatchClause;
         readonly finallyBlock?: Block;
     }
-    interface CatchClause extends Node, LocalsContainer {
+    interface CatchClause extends NodeBase, LocalsContainer {
         readonly kind: SyntaxKind.CatchClause;
         readonly parent: TryStatement;
         readonly variableDeclaration?: VariableDeclaration;
@@ -5604,34 +5993,34 @@ declare namespace ts {
     type ObjectTypeDeclaration = ClassLikeDeclaration | InterfaceDeclaration | TypeLiteralNode;
     type DeclarationWithTypeParameters = DeclarationWithTypeParameterChildren | JSDocTypedefTag | JSDocCallbackTag | JSDocSignature;
     type DeclarationWithTypeParameterChildren = SignatureDeclaration | ClassLikeDeclaration | InterfaceDeclaration | TypeAliasDeclaration | JSDocTemplateTag;
-    interface ClassLikeDeclarationBase extends NamedDeclaration, JSDocContainer {
+    interface ClassLikeDeclarationBase extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.ClassDeclaration | SyntaxKind.ClassExpression;
         readonly name?: Identifier;
         readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
         readonly heritageClauses?: NodeArray<HeritageClause>;
         readonly members: NodeArray<ClassElement>;
     }
-    interface ClassDeclaration extends ClassLikeDeclarationBase, DeclarationStatement {
+    interface ClassDeclaration extends ClassLikeDeclarationBase, DeclarationStatementBase {
         readonly kind: SyntaxKind.ClassDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         /** May be undefined in `export default class { ... }`. */
         readonly name?: Identifier;
     }
-    interface ClassExpression extends ClassLikeDeclarationBase, PrimaryExpression {
+    interface ClassExpression extends ClassLikeDeclarationBase, PrimaryExpressionBase {
         readonly kind: SyntaxKind.ClassExpression;
         readonly modifiers?: NodeArray<ModifierLike>;
     }
     type ClassLikeDeclaration = ClassDeclaration | ClassExpression;
-    interface ClassElement extends NamedDeclaration {
+    interface ClassElementBase extends NamedDeclarationBase {
         _classElementBrand: any;
         readonly name?: PropertyName;
     }
-    interface TypeElement extends NamedDeclaration {
+    interface TypeElementBase extends NamedDeclarationBase {
         _typeElementBrand: any;
         readonly name?: PropertyName;
         readonly questionToken?: QuestionToken | undefined;
     }
-    interface InterfaceDeclaration extends DeclarationStatement, JSDocContainer {
+    interface InterfaceDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.InterfaceDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: Identifier;
@@ -5639,26 +6028,26 @@ declare namespace ts {
         readonly heritageClauses?: NodeArray<HeritageClause>;
         readonly members: NodeArray<TypeElement>;
     }
-    interface HeritageClause extends Node {
+    interface HeritageClause extends NodeBase {
         readonly kind: SyntaxKind.HeritageClause;
         readonly parent: InterfaceDeclaration | ClassLikeDeclaration;
         readonly token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword;
         readonly types: NodeArray<ExpressionWithTypeArguments>;
     }
-    interface TypeAliasDeclaration extends DeclarationStatement, JSDocContainer, LocalsContainer {
+    interface TypeAliasDeclaration extends DeclarationStatementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.TypeAliasDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: Identifier;
         readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
         readonly type: TypeNode;
     }
-    interface EnumMember extends NamedDeclaration, JSDocContainer {
+    interface EnumMember extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.EnumMember;
         readonly parent: EnumDeclaration;
         readonly name: PropertyName;
         readonly initializer?: Expression;
     }
-    interface EnumDeclaration extends DeclarationStatement, JSDocContainer {
+    interface EnumDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.EnumDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: Identifier;
@@ -5666,7 +6055,7 @@ declare namespace ts {
     }
     type ModuleName = Identifier | StringLiteral;
     type ModuleBody = NamespaceBody | JSDocNamespaceBody;
-    interface ModuleDeclaration extends DeclarationStatement, JSDocContainer, LocalsContainer {
+    interface ModuleDeclaration extends DeclarationStatementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.ModuleDeclaration;
         readonly parent: ModuleBody | SourceFile;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -5683,7 +6072,7 @@ declare namespace ts {
         readonly name: Identifier;
         readonly body?: JSDocNamespaceBody;
     }
-    interface ModuleBlock extends Node, Statement {
+    interface ModuleBlock extends NodeBase, StatementBase {
         readonly kind: SyntaxKind.ModuleBlock;
         readonly parent: ModuleDeclaration;
         readonly statements: NodeArray<Statement>;
@@ -5694,7 +6083,7 @@ declare namespace ts {
      * - import x = require("mod");
      * - import x = M.x;
      */
-    interface ImportEqualsDeclaration extends DeclarationStatement, JSDocContainer {
+    interface ImportEqualsDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.ImportEqualsDeclaration;
         readonly parent: SourceFile | ModuleBlock;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -5702,12 +6091,12 @@ declare namespace ts {
         readonly isTypeOnly: boolean;
         readonly moduleReference: ModuleReference;
     }
-    interface ExternalModuleReference extends Node {
+    interface ExternalModuleReference extends NodeBase {
         readonly kind: SyntaxKind.ExternalModuleReference;
         readonly parent: ImportEqualsDeclaration;
         readonly expression: Expression;
     }
-    interface ImportDeclaration extends Statement {
+    interface ImportDeclaration extends StatementBase {
         readonly kind: SyntaxKind.ImportDeclaration;
         readonly parent: SourceFile | ModuleBlock;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -5718,7 +6107,7 @@ declare namespace ts {
     }
     type NamedImportBindings = NamespaceImport | NamedImports;
     type NamedExportBindings = NamespaceExport | NamedExports;
-    interface ImportClause extends NamedDeclaration {
+    interface ImportClause extends NamedDeclarationBase {
         readonly kind: SyntaxKind.ImportClause;
         readonly parent: ImportDeclaration;
         readonly isTypeOnly: boolean;
@@ -5726,33 +6115,33 @@ declare namespace ts {
         readonly namedBindings?: NamedImportBindings;
     }
     type AssertionKey = Identifier | StringLiteral;
-    interface AssertEntry extends Node {
+    interface AssertEntry extends NodeBase {
         readonly kind: SyntaxKind.AssertEntry;
         readonly parent: AssertClause;
         readonly name: AssertionKey;
         readonly value: Expression;
     }
-    interface AssertClause extends Node {
+    interface AssertClause extends NodeBase {
         readonly kind: SyntaxKind.AssertClause;
         readonly parent: ImportDeclaration | ExportDeclaration;
         readonly elements: NodeArray<AssertEntry>;
         readonly multiLine?: boolean;
     }
-    interface NamespaceImport extends NamedDeclaration {
+    interface NamespaceImport extends NamedDeclarationBase {
         readonly kind: SyntaxKind.NamespaceImport;
         readonly parent: ImportClause;
         readonly name: Identifier;
     }
-    interface NamespaceExport extends NamedDeclaration {
+    interface NamespaceExport extends NamedDeclarationBase {
         readonly kind: SyntaxKind.NamespaceExport;
         readonly parent: ExportDeclaration;
         readonly name: Identifier;
     }
-    interface NamespaceExportDeclaration extends DeclarationStatement, JSDocContainer {
+    interface NamespaceExportDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.NamespaceExportDeclaration;
         readonly name: Identifier;
     }
-    interface ExportDeclaration extends DeclarationStatement, JSDocContainer {
+    interface ExportDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.ExportDeclaration;
         readonly parent: SourceFile | ModuleBlock;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -5763,25 +6152,25 @@ declare namespace ts {
         readonly moduleSpecifier?: Expression;
         readonly assertClause?: AssertClause;
     }
-    interface NamedImports extends Node {
+    interface NamedImports extends NodeBase {
         readonly kind: SyntaxKind.NamedImports;
         readonly parent: ImportClause;
         readonly elements: NodeArray<ImportSpecifier>;
     }
-    interface NamedExports extends Node {
+    interface NamedExports extends NodeBase {
         readonly kind: SyntaxKind.NamedExports;
         readonly parent: ExportDeclaration;
         readonly elements: NodeArray<ExportSpecifier>;
     }
     type NamedImportsOrExports = NamedImports | NamedExports;
-    interface ImportSpecifier extends NamedDeclaration {
+    interface ImportSpecifier extends NamedDeclarationBase {
         readonly kind: SyntaxKind.ImportSpecifier;
         readonly parent: NamedImports;
         readonly propertyName?: Identifier;
         readonly name: Identifier;
         readonly isTypeOnly: boolean;
     }
-    interface ExportSpecifier extends NamedDeclaration, JSDocContainer {
+    interface ExportSpecifier extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.ExportSpecifier;
         readonly parent: NamedExports;
         readonly isTypeOnly: boolean;
@@ -5828,7 +6217,7 @@ declare namespace ts {
      * This is either an `export =` or an `export default` declaration.
      * Unless `isExportEquals` is set, this node was parsed as an `export default`.
      */
-    interface ExportAssignment extends DeclarationStatement, JSDocContainer {
+    interface ExportAssignment extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.ExportAssignment;
         readonly parent: SourceFile;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -5853,205 +6242,207 @@ declare namespace ts {
         end: -1;
         hasLeadingNewline?: boolean;
     }
-    interface JSDocTypeExpression extends TypeNode {
+    interface JSDocTypeExpression extends TypeNodeBase {
         readonly kind: SyntaxKind.JSDocTypeExpression;
         readonly type: TypeNode;
     }
-    interface JSDocNameReference extends Node {
+    interface JSDocNameReference extends NodeBase {
         readonly kind: SyntaxKind.JSDocNameReference;
         readonly name: EntityName | JSDocMemberName;
     }
     /** Class#method reference in JSDoc */
-    interface JSDocMemberName extends Node {
+    interface JSDocMemberName extends NodeBase {
         readonly kind: SyntaxKind.JSDocMemberName;
         readonly left: EntityName | JSDocMemberName;
         readonly right: Identifier;
     }
-    interface JSDocType extends TypeNode {
+    interface JSDocTypeBase extends TypeNodeBase {
         _jsDocTypeBrand: any;
     }
-    interface JSDocAllType extends JSDocType {
+    interface JSDocAllType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocAllType;
     }
-    interface JSDocUnknownType extends JSDocType {
+    interface JSDocUnknownType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocUnknownType;
     }
-    interface JSDocNonNullableType extends JSDocType {
+    interface JSDocNonNullableType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocNonNullableType;
         readonly type: TypeNode;
         readonly postfix: boolean;
     }
-    interface JSDocNullableType extends JSDocType {
+    interface JSDocNullableType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocNullableType;
         readonly type: TypeNode;
         readonly postfix: boolean;
     }
-    interface JSDocOptionalType extends JSDocType {
+    interface JSDocOptionalType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocOptionalType;
         readonly type: TypeNode;
     }
-    interface JSDocFunctionType extends JSDocType, SignatureDeclarationBase, LocalsContainer {
+    interface JSDocFunctionType extends JSDocTypeBase, SignatureDeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocFunctionType;
     }
-    interface JSDocVariadicType extends JSDocType {
+    interface JSDocVariadicType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocVariadicType;
         readonly type: TypeNode;
     }
-    interface JSDocNamepathType extends JSDocType {
+    interface JSDocNamepathType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocNamepathType;
         readonly type: TypeNode;
     }
     type JSDocTypeReferencingNode = JSDocVariadicType | JSDocOptionalType | JSDocNullableType | JSDocNonNullableType;
-    interface JSDoc extends Node {
+    interface JSDoc extends NodeBase {
         readonly kind: SyntaxKind.JSDoc;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
         readonly comment?: string | NodeArray<JSDocComment>;
     }
-    interface JSDocTag extends Node {
-        readonly parent: JSDoc | JSDocTypeLiteral;
+    interface JSDocTagBase extends NodeBase {
+        readonly parent: JSDoc | JSDocSignature | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment?: string | NodeArray<JSDocComment>;
     }
-    interface JSDocLink extends Node {
+    interface JSDocLink extends NodeBase {
         readonly kind: SyntaxKind.JSDocLink;
         readonly name?: EntityName | JSDocMemberName;
         text: string;
     }
-    interface JSDocLinkCode extends Node {
+    interface JSDocLinkCode extends NodeBase {
         readonly kind: SyntaxKind.JSDocLinkCode;
         readonly name?: EntityName | JSDocMemberName;
         text: string;
     }
-    interface JSDocLinkPlain extends Node {
+    interface JSDocLinkPlain extends NodeBase {
         readonly kind: SyntaxKind.JSDocLinkPlain;
         readonly name?: EntityName | JSDocMemberName;
         text: string;
     }
     type JSDocComment = JSDocText | JSDocLink | JSDocLinkCode | JSDocLinkPlain;
-    interface JSDocText extends Node {
+    interface JSDocText extends NodeBase {
         readonly kind: SyntaxKind.JSDocText;
         text: string;
     }
-    interface JSDocUnknownTag extends JSDocTag {
+    interface JSDocUnknownTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocTag;
     }
     /**
      * Note that `@extends` is a synonym of `@augments`.
      * Both tags are represented by this interface.
      */
-    interface JSDocAugmentsTag extends JSDocTag {
+    interface JSDocAugmentsTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocAugmentsTag;
         readonly class: ExpressionWithTypeArguments & {
             readonly expression: Identifier | PropertyAccessEntityNameExpression;
         };
     }
-    interface JSDocImplementsTag extends JSDocTag {
+    interface JSDocImplementsTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocImplementsTag;
         readonly class: ExpressionWithTypeArguments & {
             readonly expression: Identifier | PropertyAccessEntityNameExpression;
         };
     }
-    interface JSDocAuthorTag extends JSDocTag {
+    interface JSDocAuthorTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocAuthorTag;
     }
-    interface JSDocDeprecatedTag extends JSDocTag {
+    interface JSDocDeprecatedTag extends JSDocTagBase {
         kind: SyntaxKind.JSDocDeprecatedTag;
     }
-    interface JSDocClassTag extends JSDocTag {
+    interface JSDocClassTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocClassTag;
     }
-    interface JSDocPublicTag extends JSDocTag {
+    interface JSDocPublicTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocPublicTag;
     }
-    interface JSDocPrivateTag extends JSDocTag {
+    interface JSDocPrivateTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocPrivateTag;
     }
-    interface JSDocProtectedTag extends JSDocTag {
+    interface JSDocProtectedTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocProtectedTag;
     }
-    interface JSDocReadonlyTag extends JSDocTag {
+    interface JSDocReadonlyTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocReadonlyTag;
     }
-    interface JSDocOverrideTag extends JSDocTag {
+    interface JSDocOverrideTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocOverrideTag;
     }
-    interface JSDocEnumTag extends JSDocTag, Declaration, LocalsContainer {
+    interface JSDocEnumTag extends JSDocTagBase, DeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocEnumTag;
         readonly parent: JSDoc;
         readonly typeExpression: JSDocTypeExpression;
     }
-    interface JSDocThisTag extends JSDocTag {
+    interface JSDocThisTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocThisTag;
         readonly typeExpression: JSDocTypeExpression;
     }
-    interface JSDocTemplateTag extends JSDocTag {
+    interface JSDocTemplateTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocTemplateTag;
         readonly constraint: JSDocTypeExpression | undefined;
         readonly typeParameters: NodeArray<TypeParameterDeclaration>;
     }
-    interface JSDocSeeTag extends JSDocTag {
+    interface JSDocSeeTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocSeeTag;
         readonly name?: JSDocNameReference;
     }
-    interface JSDocReturnTag extends JSDocTag {
+    interface JSDocReturnTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocReturnTag;
         readonly typeExpression?: JSDocTypeExpression;
     }
-    interface JSDocTypeTag extends JSDocTag {
+    interface JSDocTypeTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocTypeTag;
         readonly typeExpression: JSDocTypeExpression;
     }
-    interface JSDocTypedefTag extends JSDocTag, NamedDeclaration, LocalsContainer {
+    interface JSDocTypedefTag extends JSDocTagBase, NamedDeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocTypedefTag;
         readonly parent: JSDoc;
         readonly fullName?: JSDocNamespaceDeclaration | Identifier;
         readonly name?: Identifier;
         readonly typeExpression?: JSDocTypeExpression | JSDocTypeLiteral;
     }
-    interface JSDocCallbackTag extends JSDocTag, NamedDeclaration, LocalsContainer {
+    interface JSDocCallbackTag extends JSDocTagBase, NamedDeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocCallbackTag;
         readonly parent: JSDoc;
         readonly fullName?: JSDocNamespaceDeclaration | Identifier;
         readonly name?: Identifier;
         readonly typeExpression: JSDocSignature;
     }
-    interface JSDocOverloadTag extends JSDocTag {
+    interface JSDocOverloadTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocOverloadTag;
         readonly parent: JSDoc;
         readonly typeExpression: JSDocSignature;
     }
-    interface JSDocThrowsTag extends JSDocTag {
+    interface JSDocThrowsTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocThrowsTag;
         readonly typeExpression?: JSDocTypeExpression;
     }
-    interface JSDocSignature extends JSDocType, Declaration, JSDocContainer, LocalsContainer {
+    interface JSDocSignature extends JSDocTypeBase, DeclarationBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.JSDocSignature;
         readonly typeParameters?: readonly JSDocTemplateTag[];
         readonly parameters: readonly JSDocParameterTag[];
         readonly type: JSDocReturnTag | undefined;
     }
-    interface JSDocPropertyLikeTag extends JSDocTag, Declaration {
-        readonly parent: JSDoc;
+    interface JSDocPropertyLikeTagBase extends JSDocTagBase, DeclarationBase {
+        readonly parent: JSDoc | JSDocSignature | JSDocTypeLiteral;
         readonly name: EntityName;
         readonly typeExpression?: JSDocTypeExpression;
         /** Whether the property name came before the type -- non-standard for JSDoc, but Typescript-like */
         readonly isNameFirst: boolean;
         readonly isBracketed: boolean;
     }
-    interface JSDocPropertyTag extends JSDocPropertyLikeTag {
+    interface JSDocPropertyTag extends JSDocPropertyLikeTagBase {
+        readonly parent: JSDocTypeLiteral;
         readonly kind: SyntaxKind.JSDocPropertyTag;
     }
-    interface JSDocParameterTag extends JSDocPropertyLikeTag {
+    interface JSDocParameterTag extends JSDocPropertyLikeTagBase {
+        readonly parent: JSDocSignature | JSDoc | JSDocTypeLiteral;
         readonly kind: SyntaxKind.JSDocParameterTag;
     }
-    interface JSDocTypeLiteral extends JSDocType, Declaration {
+    interface JSDocTypeLiteral extends JSDocTypeBase, DeclarationBase {
         readonly kind: SyntaxKind.JSDocTypeLiteral;
-        readonly jsDocPropertyTags?: readonly JSDocPropertyLikeTag[];
+        readonly jsDocPropertyTags?: readonly JSDocPropertyTag[];
         /** If true, then this type literal represents an *array* of its type. */
         readonly isArrayType: boolean;
     }
-    interface JSDocSatisfiesTag extends JSDocTag {
+    interface JSDocSatisfiesTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocSatisfiesTag;
         readonly typeExpression: JSDocTypeExpression;
     }
@@ -6129,10 +6520,10 @@ declare namespace ts {
         getLineAndCharacterOfPosition(pos: number): LineAndCharacter;
     }
     type ResolutionMode = ModuleKind.ESNext | ModuleKind.CommonJS | undefined;
-    interface SourceFile extends Declaration, LocalsContainer {
+    interface SourceFile extends DeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.SourceFile;
         readonly statements: NodeArray<Statement>;
-        readonly endOfFileToken: Token<SyntaxKind.EndOfFileToken>;
+        readonly endOfFileToken: EndOfFileToken;
         fileName: string;
         text: string;
         amdDependencies: readonly AmdDependency[];
@@ -6178,13 +6569,13 @@ declare namespace ts {
         getPositionOfLineAndCharacter(line: number, character: number): number;
         update(newText: string, textChangeRange: TextChangeRange): SourceFile;
     }
-    interface Bundle extends Node {
+    interface Bundle extends NodeBase {
         readonly kind: SyntaxKind.Bundle;
         /** @deprecated */ readonly prepends: readonly (InputFiles | UnparsedSource)[];
         readonly sourceFiles: readonly SourceFile[];
     }
     /** @deprecated */
-    interface InputFiles extends Node {
+    interface InputFiles extends NodeBase {
         readonly kind: SyntaxKind.InputFiles;
         javascriptPath?: string;
         javascriptText: string;
@@ -6196,7 +6587,7 @@ declare namespace ts {
         declarationMapText?: string;
     }
     /** @deprecated */
-    interface UnparsedSource extends Node {
+    interface UnparsedSource extends NodeBase {
         readonly kind: SyntaxKind.UnparsedSource;
         fileName: string;
         text: string;
@@ -6216,7 +6607,7 @@ declare namespace ts {
     /** @deprecated */
     type UnparsedNode = UnparsedPrologue | UnparsedSourceText | UnparsedSyntheticReference;
     /** @deprecated */
-    interface UnparsedSection extends Node {
+    interface UnparsedSection extends NodeBase {
         readonly kind: SyntaxKind;
         readonly parent: UnparsedSource;
         readonly data?: string;
@@ -8282,7 +8673,7 @@ declare namespace ts {
         span: TextSpan;
         newLength: number;
     }
-    interface SyntaxList extends Node {
+    interface SyntaxList extends NodeBase {
         kind: SyntaxKind.SyntaxList;
         _children: Node[];
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -451,6 +451,392 @@ declare namespace ts {
     type TokenSyntaxKind = SyntaxKind.Unknown | SyntaxKind.EndOfFileToken | TriviaSyntaxKind | LiteralSyntaxKind | PseudoLiteralSyntaxKind | PunctuationSyntaxKind | SyntaxKind.Identifier | KeywordSyntaxKind;
     type JsxTokenSyntaxKind = SyntaxKind.LessThanSlashToken | SyntaxKind.EndOfFileToken | SyntaxKind.ConflictMarkerTrivia | SyntaxKind.JsxText | SyntaxKind.JsxTextAllWhiteSpaces | SyntaxKind.OpenBraceToken | SyntaxKind.LessThanToken;
     type JSDocSyntaxKind = SyntaxKind.EndOfFileToken | SyntaxKind.WhitespaceTrivia | SyntaxKind.AtToken | SyntaxKind.NewLineTrivia | SyntaxKind.AsteriskToken | SyntaxKind.OpenBraceToken | SyntaxKind.CloseBraceToken | SyntaxKind.LessThanToken | SyntaxKind.GreaterThanToken | SyntaxKind.OpenBracketToken | SyntaxKind.CloseBracketToken | SyntaxKind.EqualsToken | SyntaxKind.CommaToken | SyntaxKind.DotToken | SyntaxKind.Identifier | SyntaxKind.BacktickToken | SyntaxKind.HashToken | SyntaxKind.Unknown | KeywordSyntaxKind;
+    interface SyntaxKindToNode {
+        [SyntaxKind.Unknown]: Token<SyntaxKind.Unknown>;
+        [SyntaxKind.EndOfFileToken]: EndOfFileToken;
+        [SyntaxKind.SingleLineCommentTrivia]: Token<SyntaxKind.SingleLineCommentTrivia>;
+        [SyntaxKind.MultiLineCommentTrivia]: Token<SyntaxKind.MultiLineCommentTrivia>;
+        [SyntaxKind.NewLineTrivia]: Token<SyntaxKind.NewLineTrivia>;
+        [SyntaxKind.WhitespaceTrivia]: Token<SyntaxKind.WhitespaceTrivia>;
+        [SyntaxKind.ShebangTrivia]: Token<SyntaxKind.ShebangTrivia>;
+        [SyntaxKind.ConflictMarkerTrivia]: Token<SyntaxKind.ConflictMarkerTrivia>;
+        [SyntaxKind.NonTextFileMarkerTrivia]: Token<SyntaxKind.NonTextFileMarkerTrivia>;
+        [SyntaxKind.NumericLiteral]: NumericLiteral;
+        [SyntaxKind.BigIntLiteral]: BigIntLiteral;
+        [SyntaxKind.StringLiteral]: StringLiteral;
+        [SyntaxKind.JsxText]: JsxText;
+        [SyntaxKind.JsxTextAllWhiteSpaces]: Token<SyntaxKind.JsxTextAllWhiteSpaces>;
+        [SyntaxKind.RegularExpressionLiteral]: RegularExpressionLiteral;
+        [SyntaxKind.NoSubstitutionTemplateLiteral]: NoSubstitutionTemplateLiteral;
+        [SyntaxKind.TemplateHead]: TemplateHead;
+        [SyntaxKind.TemplateMiddle]: TemplateMiddle;
+        [SyntaxKind.TemplateTail]: TemplateTail;
+        [SyntaxKind.OpenBraceToken]: Token<SyntaxKind.OpenBraceToken>;
+        [SyntaxKind.CloseBraceToken]: Token<SyntaxKind.CloseBraceToken>;
+        [SyntaxKind.OpenParenToken]: Token<SyntaxKind.OpenParenToken>;
+        [SyntaxKind.CloseParenToken]: Token<SyntaxKind.CloseParenToken>;
+        [SyntaxKind.OpenBracketToken]: Token<SyntaxKind.OpenBracketToken>;
+        [SyntaxKind.CloseBracketToken]: Token<SyntaxKind.CloseBracketToken>;
+        [SyntaxKind.DotToken]: DotToken;
+        [SyntaxKind.DotDotDotToken]: DotDotDotToken;
+        [SyntaxKind.SemicolonToken]: Token<SyntaxKind.SemicolonToken>;
+        [SyntaxKind.CommaToken]: Token<SyntaxKind.CommaToken>;
+        [SyntaxKind.QuestionDotToken]: QuestionDotToken;
+        [SyntaxKind.LessThanToken]: Token<SyntaxKind.LessThanToken>;
+        [SyntaxKind.LessThanSlashToken]: Token<SyntaxKind.LessThanSlashToken>;
+        [SyntaxKind.GreaterThanToken]: Token<SyntaxKind.GreaterThanToken>;
+        [SyntaxKind.LessThanEqualsToken]: Token<SyntaxKind.LessThanEqualsToken>;
+        [SyntaxKind.GreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanEqualsToken>;
+        [SyntaxKind.EqualsEqualsToken]: Token<SyntaxKind.EqualsEqualsToken>;
+        [SyntaxKind.ExclamationEqualsToken]: Token<SyntaxKind.ExclamationEqualsToken>;
+        [SyntaxKind.EqualsEqualsEqualsToken]: Token<SyntaxKind.EqualsEqualsEqualsToken>;
+        [SyntaxKind.ExclamationEqualsEqualsToken]: Token<SyntaxKind.ExclamationEqualsEqualsToken>;
+        [SyntaxKind.EqualsGreaterThanToken]: Token<SyntaxKind.EqualsGreaterThanToken>;
+        [SyntaxKind.PlusToken]: PlusToken;
+        [SyntaxKind.MinusToken]: MinusToken;
+        [SyntaxKind.AsteriskToken]: AsteriskToken;
+        [SyntaxKind.AsteriskAsteriskToken]: Token<SyntaxKind.AsteriskAsteriskToken>;
+        [SyntaxKind.SlashToken]: Token<SyntaxKind.SlashToken>;
+        [SyntaxKind.PercentToken]: Token<SyntaxKind.PercentToken>;
+        [SyntaxKind.PlusPlusToken]: Token<SyntaxKind.PlusPlusToken>;
+        [SyntaxKind.MinusMinusToken]: Token<SyntaxKind.MinusMinusToken>;
+        [SyntaxKind.LessThanLessThanToken]: Token<SyntaxKind.LessThanLessThanToken>;
+        [SyntaxKind.GreaterThanGreaterThanToken]: Token<SyntaxKind.GreaterThanGreaterThanToken>;
+        [SyntaxKind.GreaterThanGreaterThanGreaterThanToken]: Token<SyntaxKind.GreaterThanGreaterThanGreaterThanToken>;
+        [SyntaxKind.AmpersandToken]: Token<SyntaxKind.AmpersandToken>;
+        [SyntaxKind.BarToken]: Token<SyntaxKind.BarToken>;
+        [SyntaxKind.CaretToken]: Token<SyntaxKind.CaretToken>;
+        [SyntaxKind.ExclamationToken]: Token<SyntaxKind.ExclamationToken>;
+        [SyntaxKind.TildeToken]: Token<SyntaxKind.TildeToken>;
+        [SyntaxKind.AmpersandAmpersandToken]: Token<SyntaxKind.AmpersandAmpersandToken>;
+        [SyntaxKind.BarBarToken]: Token<SyntaxKind.BarBarToken>;
+        [SyntaxKind.QuestionToken]: QuestionToken;
+        [SyntaxKind.ColonToken]: ColonToken;
+        [SyntaxKind.AtToken]: Token<SyntaxKind.AtToken>;
+        [SyntaxKind.QuestionQuestionToken]: Token<SyntaxKind.QuestionQuestionToken>;
+        [SyntaxKind.BacktickToken]: Token<SyntaxKind.BacktickToken>;
+        [SyntaxKind.HashToken]: Token<SyntaxKind.HashToken>;
+        [SyntaxKind.EqualsToken]: EqualsToken;
+        [SyntaxKind.PlusEqualsToken]: Token<SyntaxKind.PlusEqualsToken>;
+        [SyntaxKind.MinusEqualsToken]: Token<SyntaxKind.MinusEqualsToken>;
+        [SyntaxKind.AsteriskEqualsToken]: Token<SyntaxKind.AsteriskEqualsToken>;
+        [SyntaxKind.AsteriskAsteriskEqualsToken]: Token<SyntaxKind.AsteriskAsteriskEqualsToken>;
+        [SyntaxKind.SlashEqualsToken]: Token<SyntaxKind.SlashEqualsToken>;
+        [SyntaxKind.PercentEqualsToken]: Token<SyntaxKind.PercentEqualsToken>;
+        [SyntaxKind.LessThanLessThanEqualsToken]: Token<SyntaxKind.LessThanLessThanEqualsToken>;
+        [SyntaxKind.GreaterThanGreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanGreaterThanEqualsToken>;
+        [SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken]: Token<SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken>;
+        [SyntaxKind.AmpersandEqualsToken]: Token<SyntaxKind.AmpersandEqualsToken>;
+        [SyntaxKind.BarEqualsToken]: Token<SyntaxKind.BarEqualsToken>;
+        [SyntaxKind.BarBarEqualsToken]: BarBarEqualsToken;
+        [SyntaxKind.AmpersandAmpersandEqualsToken]: AmpersandAmpersandEqualsToken;
+        [SyntaxKind.QuestionQuestionEqualsToken]: QuestionQuestionEqualsToken;
+        [SyntaxKind.CaretEqualsToken]: Token<SyntaxKind.CaretEqualsToken>;
+        [SyntaxKind.Identifier]: Identifier;
+        [SyntaxKind.PrivateIdentifier]: PrivateIdentifier;
+        [SyntaxKind.BreakKeyword]: KeywordToken<SyntaxKind.BreakKeyword>;
+        [SyntaxKind.CaseKeyword]: KeywordToken<SyntaxKind.CaseKeyword>;
+        [SyntaxKind.CatchKeyword]: KeywordToken<SyntaxKind.CatchKeyword>;
+        [SyntaxKind.ClassKeyword]: KeywordToken<SyntaxKind.ClassKeyword>;
+        [SyntaxKind.ConstKeyword]: KeywordToken<SyntaxKind.ConstKeyword>;
+        [SyntaxKind.ContinueKeyword]: KeywordToken<SyntaxKind.ContinueKeyword>;
+        [SyntaxKind.DebuggerKeyword]: KeywordToken<SyntaxKind.DebuggerKeyword>;
+        [SyntaxKind.DefaultKeyword]: KeywordToken<SyntaxKind.DefaultKeyword>;
+        [SyntaxKind.DeleteKeyword]: KeywordToken<SyntaxKind.DeleteKeyword>;
+        [SyntaxKind.DoKeyword]: KeywordToken<SyntaxKind.DoKeyword>;
+        [SyntaxKind.ElseKeyword]: KeywordToken<SyntaxKind.ElseKeyword>;
+        [SyntaxKind.EnumKeyword]: KeywordToken<SyntaxKind.EnumKeyword>;
+        [SyntaxKind.ExportKeyword]: KeywordToken<SyntaxKind.ExportKeyword>;
+        [SyntaxKind.ExtendsKeyword]: KeywordToken<SyntaxKind.ExtendsKeyword>;
+        [SyntaxKind.FalseKeyword]: KeywordToken<SyntaxKind.FalseKeyword>;
+        [SyntaxKind.FinallyKeyword]: KeywordToken<SyntaxKind.FinallyKeyword>;
+        [SyntaxKind.ForKeyword]: KeywordToken<SyntaxKind.ForKeyword>;
+        [SyntaxKind.FunctionKeyword]: KeywordToken<SyntaxKind.FunctionKeyword>;
+        [SyntaxKind.IfKeyword]: KeywordToken<SyntaxKind.IfKeyword>;
+        [SyntaxKind.ImportKeyword]: KeywordToken<SyntaxKind.ImportKeyword>;
+        [SyntaxKind.InKeyword]: KeywordToken<SyntaxKind.InKeyword>;
+        [SyntaxKind.InstanceOfKeyword]: KeywordToken<SyntaxKind.InstanceOfKeyword>;
+        [SyntaxKind.NewKeyword]: KeywordToken<SyntaxKind.NewKeyword>;
+        [SyntaxKind.NullKeyword]: KeywordToken<SyntaxKind.NullKeyword>;
+        [SyntaxKind.ReturnKeyword]: KeywordToken<SyntaxKind.ReturnKeyword>;
+        [SyntaxKind.SuperKeyword]: KeywordToken<SyntaxKind.SuperKeyword>;
+        [SyntaxKind.SwitchKeyword]: KeywordToken<SyntaxKind.SwitchKeyword>;
+        [SyntaxKind.ThisKeyword]: KeywordToken<SyntaxKind.ThisKeyword>;
+        [SyntaxKind.ThrowKeyword]: KeywordToken<SyntaxKind.ThrowKeyword>;
+        [SyntaxKind.TrueKeyword]: KeywordToken<SyntaxKind.TrueKeyword>;
+        [SyntaxKind.TryKeyword]: KeywordToken<SyntaxKind.TryKeyword>;
+        [SyntaxKind.TypeOfKeyword]: KeywordToken<SyntaxKind.TypeOfKeyword>;
+        [SyntaxKind.VarKeyword]: KeywordToken<SyntaxKind.VarKeyword>;
+        [SyntaxKind.VoidKeyword]: KeywordToken<SyntaxKind.VoidKeyword>;
+        [SyntaxKind.WhileKeyword]: KeywordToken<SyntaxKind.WhileKeyword>;
+        [SyntaxKind.WithKeyword]: KeywordToken<SyntaxKind.WithKeyword>;
+        [SyntaxKind.ImplementsKeyword]: KeywordToken<SyntaxKind.ImplementsKeyword>;
+        [SyntaxKind.InterfaceKeyword]: KeywordToken<SyntaxKind.InterfaceKeyword>;
+        [SyntaxKind.LetKeyword]: KeywordToken<SyntaxKind.LetKeyword>;
+        [SyntaxKind.PackageKeyword]: KeywordToken<SyntaxKind.PackageKeyword>;
+        [SyntaxKind.PrivateKeyword]: KeywordToken<SyntaxKind.PrivateKeyword>;
+        [SyntaxKind.ProtectedKeyword]: KeywordToken<SyntaxKind.ProtectedKeyword>;
+        [SyntaxKind.PublicKeyword]: KeywordToken<SyntaxKind.PublicKeyword>;
+        [SyntaxKind.StaticKeyword]: KeywordToken<SyntaxKind.StaticKeyword>;
+        [SyntaxKind.YieldKeyword]: KeywordToken<SyntaxKind.YieldKeyword>;
+        [SyntaxKind.AbstractKeyword]: KeywordToken<SyntaxKind.AbstractKeyword>;
+        [SyntaxKind.AccessorKeyword]: KeywordToken<SyntaxKind.AccessorKeyword>;
+        [SyntaxKind.AsKeyword]: KeywordToken<SyntaxKind.AsKeyword>;
+        [SyntaxKind.AssertsKeyword]: KeywordToken<SyntaxKind.AssertsKeyword>;
+        [SyntaxKind.AssertKeyword]: KeywordToken<SyntaxKind.AssertKeyword>;
+        [SyntaxKind.AnyKeyword]: KeywordToken<SyntaxKind.AnyKeyword>;
+        [SyntaxKind.AsyncKeyword]: KeywordToken<SyntaxKind.AsyncKeyword>;
+        [SyntaxKind.AwaitKeyword]: KeywordToken<SyntaxKind.AwaitKeyword>;
+        [SyntaxKind.BooleanKeyword]: KeywordToken<SyntaxKind.BooleanKeyword>;
+        [SyntaxKind.ConstructorKeyword]: KeywordToken<SyntaxKind.ConstructorKeyword>;
+        [SyntaxKind.DeclareKeyword]: KeywordToken<SyntaxKind.DeclareKeyword>;
+        [SyntaxKind.GetKeyword]: KeywordToken<SyntaxKind.GetKeyword>;
+        [SyntaxKind.InferKeyword]: KeywordToken<SyntaxKind.InferKeyword>;
+        [SyntaxKind.IntrinsicKeyword]: KeywordToken<SyntaxKind.IntrinsicKeyword>;
+        [SyntaxKind.IsKeyword]: KeywordToken<SyntaxKind.IsKeyword>;
+        [SyntaxKind.KeyOfKeyword]: KeywordToken<SyntaxKind.KeyOfKeyword>;
+        [SyntaxKind.ModuleKeyword]: KeywordToken<SyntaxKind.ModuleKeyword>;
+        [SyntaxKind.NamespaceKeyword]: KeywordToken<SyntaxKind.NamespaceKeyword>;
+        [SyntaxKind.NeverKeyword]: KeywordToken<SyntaxKind.NeverKeyword>;
+        [SyntaxKind.OutKeyword]: KeywordToken<SyntaxKind.OutKeyword>;
+        [SyntaxKind.ReadonlyKeyword]: KeywordToken<SyntaxKind.ReadonlyKeyword>;
+        [SyntaxKind.RequireKeyword]: KeywordToken<SyntaxKind.RequireKeyword>;
+        [SyntaxKind.NumberKeyword]: KeywordToken<SyntaxKind.NumberKeyword>;
+        [SyntaxKind.ObjectKeyword]: KeywordToken<SyntaxKind.ObjectKeyword>;
+        [SyntaxKind.SatisfiesKeyword]: KeywordToken<SyntaxKind.SatisfiesKeyword>;
+        [SyntaxKind.SetKeyword]: KeywordToken<SyntaxKind.SetKeyword>;
+        [SyntaxKind.StringKeyword]: KeywordToken<SyntaxKind.StringKeyword>;
+        [SyntaxKind.SymbolKeyword]: KeywordToken<SyntaxKind.SymbolKeyword>;
+        [SyntaxKind.TypeKeyword]: KeywordToken<SyntaxKind.TypeKeyword>;
+        [SyntaxKind.UndefinedKeyword]: KeywordToken<SyntaxKind.UndefinedKeyword>;
+        [SyntaxKind.UniqueKeyword]: KeywordToken<SyntaxKind.UniqueKeyword>;
+        [SyntaxKind.UnknownKeyword]: KeywordToken<SyntaxKind.UnknownKeyword>;
+        [SyntaxKind.FromKeyword]: KeywordToken<SyntaxKind.FromKeyword>;
+        [SyntaxKind.GlobalKeyword]: KeywordToken<SyntaxKind.GlobalKeyword>;
+        [SyntaxKind.BigIntKeyword]: KeywordToken<SyntaxKind.BigIntKeyword>;
+        [SyntaxKind.OverrideKeyword]: KeywordToken<SyntaxKind.OverrideKeyword>;
+        [SyntaxKind.OfKeyword]: KeywordToken<SyntaxKind.OfKeyword>;
+        [SyntaxKind.QualifiedName]: QualifiedName;
+        [SyntaxKind.ComputedPropertyName]: ComputedPropertyName;
+        [SyntaxKind.TypeParameter]: TypeParameterDeclaration;
+        [SyntaxKind.Parameter]: ParameterDeclaration;
+        [SyntaxKind.Decorator]: Decorator;
+        [SyntaxKind.PropertySignature]: PropertySignature;
+        [SyntaxKind.PropertyDeclaration]: PropertyDeclaration;
+        [SyntaxKind.MethodSignature]: MethodSignature;
+        [SyntaxKind.MethodDeclaration]: MethodDeclaration;
+        [SyntaxKind.ClassStaticBlockDeclaration]: ClassStaticBlockDeclaration;
+        [SyntaxKind.Constructor]: ConstructorDeclaration;
+        [SyntaxKind.GetAccessor]: GetAccessorDeclaration;
+        [SyntaxKind.SetAccessor]: SetAccessorDeclaration;
+        [SyntaxKind.CallSignature]: CallSignatureDeclaration;
+        [SyntaxKind.ConstructSignature]: ConstructSignatureDeclaration;
+        [SyntaxKind.IndexSignature]: IndexSignatureDeclaration;
+        [SyntaxKind.TypePredicate]: TypePredicateNode;
+        [SyntaxKind.TypeReference]: TypeReferenceNode;
+        [SyntaxKind.FunctionType]: FunctionTypeNode;
+        [SyntaxKind.ConstructorType]: ConstructorTypeNode;
+        [SyntaxKind.TypeQuery]: TypeQueryNode;
+        [SyntaxKind.TypeLiteral]: TypeLiteralNode;
+        [SyntaxKind.ArrayType]: ArrayTypeNode;
+        [SyntaxKind.TupleType]: TupleTypeNode;
+        [SyntaxKind.OptionalType]: OptionalTypeNode;
+        [SyntaxKind.RestType]: RestTypeNode;
+        [SyntaxKind.UnionType]: UnionTypeNode;
+        [SyntaxKind.IntersectionType]: IntersectionTypeNode;
+        [SyntaxKind.ConditionalType]: ConditionalTypeNode;
+        [SyntaxKind.InferType]: InferTypeNode;
+        [SyntaxKind.ParenthesizedType]: ParenthesizedTypeNode;
+        [SyntaxKind.ThisType]: ThisTypeNode;
+        [SyntaxKind.TypeOperator]: TypeOperatorNode;
+        [SyntaxKind.IndexedAccessType]: IndexedAccessTypeNode;
+        [SyntaxKind.MappedType]: MappedTypeNode;
+        [SyntaxKind.LiteralType]: LiteralTypeNode;
+        [SyntaxKind.NamedTupleMember]: NamedTupleMember;
+        [SyntaxKind.TemplateLiteralType]: TemplateLiteralTypeNode;
+        [SyntaxKind.TemplateLiteralTypeSpan]: TemplateLiteralTypeSpan;
+        [SyntaxKind.ImportType]: ImportTypeNode;
+        [SyntaxKind.ObjectBindingPattern]: ObjectBindingPattern;
+        [SyntaxKind.ArrayBindingPattern]: ArrayBindingPattern;
+        [SyntaxKind.BindingElement]: BindingElement;
+        [SyntaxKind.ArrayLiteralExpression]: ArrayLiteralExpression;
+        [SyntaxKind.ObjectLiteralExpression]: ObjectLiteralExpression;
+        [SyntaxKind.PropertyAccessExpression]: PropertyAccessExpression;
+        [SyntaxKind.ElementAccessExpression]: ElementAccessExpression;
+        [SyntaxKind.CallExpression]: CallExpression;
+        [SyntaxKind.NewExpression]: NewExpression;
+        [SyntaxKind.TaggedTemplateExpression]: TaggedTemplateExpression;
+        [SyntaxKind.TypeAssertionExpression]: TypeAssertion;
+        [SyntaxKind.ParenthesizedExpression]: ParenthesizedExpression;
+        [SyntaxKind.FunctionExpression]: FunctionExpression;
+        [SyntaxKind.ArrowFunction]: ArrowFunction;
+        [SyntaxKind.DeleteExpression]: DeleteExpression;
+        [SyntaxKind.TypeOfExpression]: TypeOfExpression;
+        [SyntaxKind.VoidExpression]: VoidExpression;
+        [SyntaxKind.AwaitExpression]: AwaitExpression;
+        [SyntaxKind.PrefixUnaryExpression]: PrefixUnaryExpression;
+        [SyntaxKind.PostfixUnaryExpression]: PostfixUnaryExpression;
+        [SyntaxKind.BinaryExpression]: BinaryExpression;
+        [SyntaxKind.ConditionalExpression]: ConditionalExpression;
+        [SyntaxKind.TemplateExpression]: TemplateExpression;
+        [SyntaxKind.YieldExpression]: YieldExpression;
+        [SyntaxKind.SpreadElement]: SpreadElement;
+        [SyntaxKind.ClassExpression]: ClassExpression;
+        [SyntaxKind.OmittedExpression]: OmittedExpression;
+        [SyntaxKind.ExpressionWithTypeArguments]: ExpressionWithTypeArguments;
+        [SyntaxKind.AsExpression]: AsExpression;
+        [SyntaxKind.NonNullExpression]: NonNullExpression;
+        [SyntaxKind.MetaProperty]: MetaProperty;
+        [SyntaxKind.SyntheticExpression]: SyntheticExpression;
+        [SyntaxKind.SatisfiesExpression]: SatisfiesExpression;
+        [SyntaxKind.TemplateSpan]: TemplateSpan;
+        [SyntaxKind.SemicolonClassElement]: SemicolonClassElement;
+        [SyntaxKind.Block]: Block;
+        [SyntaxKind.EmptyStatement]: EmptyStatement;
+        [SyntaxKind.VariableStatement]: VariableStatement;
+        [SyntaxKind.ExpressionStatement]: ExpressionStatement;
+        [SyntaxKind.IfStatement]: IfStatement;
+        [SyntaxKind.DoStatement]: DoStatement;
+        [SyntaxKind.WhileStatement]: WhileStatement;
+        [SyntaxKind.ForStatement]: ForStatement;
+        [SyntaxKind.ForInStatement]: ForInStatement;
+        [SyntaxKind.ForOfStatement]: ForOfStatement;
+        [SyntaxKind.ContinueStatement]: ContinueStatement;
+        [SyntaxKind.BreakStatement]: BreakStatement;
+        [SyntaxKind.ReturnStatement]: ReturnStatement;
+        [SyntaxKind.WithStatement]: WithStatement;
+        [SyntaxKind.SwitchStatement]: SwitchStatement;
+        [SyntaxKind.LabeledStatement]: LabeledStatement;
+        [SyntaxKind.ThrowStatement]: ThrowStatement;
+        [SyntaxKind.TryStatement]: TryStatement;
+        [SyntaxKind.DebuggerStatement]: DebuggerStatement;
+        [SyntaxKind.VariableDeclaration]: VariableDeclaration;
+        [SyntaxKind.VariableDeclarationList]: VariableDeclarationList;
+        [SyntaxKind.FunctionDeclaration]: FunctionDeclaration;
+        [SyntaxKind.ClassDeclaration]: ClassDeclaration;
+        [SyntaxKind.InterfaceDeclaration]: InterfaceDeclaration;
+        [SyntaxKind.TypeAliasDeclaration]: TypeAliasDeclaration;
+        [SyntaxKind.EnumDeclaration]: EnumDeclaration;
+        [SyntaxKind.ModuleDeclaration]: ModuleDeclaration;
+        [SyntaxKind.ModuleBlock]: ModuleBlock;
+        [SyntaxKind.CaseBlock]: CaseBlock;
+        [SyntaxKind.NamespaceExportDeclaration]: NamespaceExportDeclaration;
+        [SyntaxKind.ImportEqualsDeclaration]: ImportEqualsDeclaration;
+        [SyntaxKind.ImportDeclaration]: ImportDeclaration;
+        [SyntaxKind.ImportClause]: ImportClause;
+        [SyntaxKind.NamespaceImport]: NamespaceImport;
+        [SyntaxKind.NamedImports]: NamedImports;
+        [SyntaxKind.ImportSpecifier]: ImportSpecifier;
+        [SyntaxKind.ExportAssignment]: ExportAssignment;
+        [SyntaxKind.ExportDeclaration]: ExportDeclaration;
+        [SyntaxKind.NamedExports]: NamedExports;
+        [SyntaxKind.NamespaceExport]: NamespaceExport;
+        [SyntaxKind.ExportSpecifier]: ExportSpecifier;
+        [SyntaxKind.MissingDeclaration]: MissingDeclaration;
+        [SyntaxKind.ExternalModuleReference]: ExternalModuleReference;
+        [SyntaxKind.JsxElement]: JsxElement;
+        [SyntaxKind.JsxSelfClosingElement]: JsxSelfClosingElement;
+        [SyntaxKind.JsxOpeningElement]: JsxOpeningElement;
+        [SyntaxKind.JsxClosingElement]: JsxClosingElement;
+        [SyntaxKind.JsxFragment]: JsxFragment;
+        [SyntaxKind.JsxOpeningFragment]: JsxOpeningFragment;
+        [SyntaxKind.JsxClosingFragment]: JsxClosingFragment;
+        [SyntaxKind.JsxAttribute]: JsxAttribute;
+        [SyntaxKind.JsxAttributes]: JsxAttributes;
+        [SyntaxKind.JsxSpreadAttribute]: JsxSpreadAttribute;
+        [SyntaxKind.JsxExpression]: JsxExpression;
+        [SyntaxKind.JsxNamespacedName]: JsxNamespacedName;
+        [SyntaxKind.CaseClause]: CaseClause;
+        [SyntaxKind.DefaultClause]: DefaultClause;
+        [SyntaxKind.HeritageClause]: HeritageClause;
+        [SyntaxKind.CatchClause]: CatchClause;
+        [SyntaxKind.AssertClause]: AssertClause;
+        [SyntaxKind.AssertEntry]: AssertEntry;
+        [SyntaxKind.ImportTypeAssertionContainer]: ImportTypeAssertionContainer;
+        [SyntaxKind.PropertyAssignment]: PropertyAssignment;
+        [SyntaxKind.ShorthandPropertyAssignment]: ShorthandPropertyAssignment;
+        [SyntaxKind.SpreadAssignment]: SpreadAssignment;
+        [SyntaxKind.EnumMember]: EnumMember;
+        /** @deprecated */ [SyntaxKind.UnparsedPrologue]: UnparsedPrologue;
+        /** @deprecated */ [SyntaxKind.UnparsedPrepend]: UnparsedPrepend;
+        /** @deprecated */ [SyntaxKind.UnparsedText]: UnparsedTextLike;
+        /** @deprecated */ [SyntaxKind.UnparsedInternalText]: UnparsedTextLike;
+        /** @deprecated */ [SyntaxKind.UnparsedSyntheticReference]: UnparsedSyntheticReference;
+        [SyntaxKind.SourceFile]: SourceFile;
+        [SyntaxKind.Bundle]: Bundle;
+        /** @deprecated */ [SyntaxKind.UnparsedSource]: UnparsedSource;
+        /** @deprecated */ [SyntaxKind.InputFiles]: InputFiles;
+        [SyntaxKind.JSDocTypeExpression]: JSDocTypeExpression;
+        [SyntaxKind.JSDocNameReference]: JSDocNameReference;
+        [SyntaxKind.JSDocMemberName]: JSDocMemberName;
+        [SyntaxKind.JSDocAllType]: JSDocAllType;
+        [SyntaxKind.JSDocUnknownType]: JSDocUnknownType;
+        [SyntaxKind.JSDocNullableType]: JSDocNullableType;
+        [SyntaxKind.JSDocNonNullableType]: JSDocNonNullableType;
+        [SyntaxKind.JSDocOptionalType]: JSDocOptionalType;
+        [SyntaxKind.JSDocFunctionType]: JSDocFunctionType;
+        [SyntaxKind.JSDocVariadicType]: JSDocVariadicType;
+        [SyntaxKind.JSDocNamepathType]: JSDocNamepathType;
+        [SyntaxKind.JSDoc]: JSDoc;
+        [SyntaxKind.JSDocText]: JSDocText;
+        [SyntaxKind.JSDocTypeLiteral]: JSDocTypeLiteral;
+        [SyntaxKind.JSDocSignature]: JSDocSignature;
+        [SyntaxKind.JSDocLink]: JSDocLink;
+        [SyntaxKind.JSDocLinkCode]: JSDocLinkCode;
+        [SyntaxKind.JSDocLinkPlain]: JSDocLinkPlain;
+        [SyntaxKind.JSDocTag]: JSDocUnknownTag;
+        [SyntaxKind.JSDocAugmentsTag]: JSDocAugmentsTag;
+        [SyntaxKind.JSDocImplementsTag]: JSDocImplementsTag;
+        [SyntaxKind.JSDocAuthorTag]: JSDocAuthorTag;
+        [SyntaxKind.JSDocDeprecatedTag]: JSDocDeprecatedTag;
+        [SyntaxKind.JSDocClassTag]: JSDocClassTag;
+        [SyntaxKind.JSDocPublicTag]: JSDocPublicTag;
+        [SyntaxKind.JSDocPrivateTag]: JSDocPrivateTag;
+        [SyntaxKind.JSDocProtectedTag]: JSDocProtectedTag;
+        [SyntaxKind.JSDocReadonlyTag]: JSDocReadonlyTag;
+        [SyntaxKind.JSDocOverrideTag]: JSDocOverrideTag;
+        [SyntaxKind.JSDocCallbackTag]: JSDocCallbackTag;
+        [SyntaxKind.JSDocOverloadTag]: JSDocOverloadTag;
+        [SyntaxKind.JSDocEnumTag]: JSDocEnumTag;
+        [SyntaxKind.JSDocParameterTag]: JSDocParameterTag;
+        [SyntaxKind.JSDocReturnTag]: JSDocReturnTag;
+        [SyntaxKind.JSDocThisTag]: JSDocThisTag;
+        [SyntaxKind.JSDocTypeTag]: JSDocTypeTag;
+        [SyntaxKind.JSDocTemplateTag]: JSDocTemplateTag;
+        [SyntaxKind.JSDocTypedefTag]: JSDocTypedefTag;
+        [SyntaxKind.JSDocSeeTag]: JSDocSeeTag;
+        [SyntaxKind.JSDocPropertyTag]: JSDocPropertyTag;
+        [SyntaxKind.JSDocThrowsTag]: JSDocThrowsTag;
+        [SyntaxKind.JSDocSatisfiesTag]: JSDocSatisfiesTag;
+        [SyntaxKind.SyntaxList]: SyntaxList;
+        [SyntaxKind.NotEmittedStatement]: NotEmittedStatement;
+        [SyntaxKind.PartiallyEmittedExpression]: PartiallyEmittedExpression;
+        [SyntaxKind.CommaListExpression]: CommaListExpression;
+        [SyntaxKind.SyntheticReferenceExpression]: SyntheticReferenceExpression;
+    }
+    type Node = SyntaxKindToNode[keyof SyntaxKindToNode];
+    type Declaration = Identifier | NamedDeclaration | TypeLiteralNode | NamedTupleMember | MappedTypeNode | StringLiteral | BinaryExpression | NoSubstitutionTemplateLiteral | NumericLiteral | ObjectLiteralExpression | ElementAccessExpression | CallExpression | NewExpression | JsxAttributes | JsxAttribute | JSDocEnumTag | JSDocSignature | JSDocPropertyLikeTag | JSDocTypeLiteral | SourceFile;
+    type NamedDeclaration = DeclarationStatement | TypeParameterDeclaration | SignatureDeclaration | VariableDeclaration | ParameterDeclaration | BindingElement | ObjectLiteralElement | PropertyAccessExpression | ClassDeclaration | ClassExpression | ClassElement | TypeElement | EnumMember | ImportClause | NamespaceImport | NamespaceExport | ImportSpecifier | ExportSpecifier | JSDocTypedefTag | JSDocCallbackTag;
+    type DeclarationStatement = FunctionDeclaration | MissingDeclaration | ClassDeclaration | InterfaceDeclaration | TypeAliasDeclaration | EnumDeclaration | ModuleDeclaration | ImportEqualsDeclaration | NamespaceExportDeclaration | ExportDeclaration | ExportAssignment;
+    type Statement = DeclarationStatement | NotEmittedStatement | EmptyStatement | DebuggerStatement | Block | VariableStatement | ExpressionStatement | IfStatement | IterationStatement | BreakStatement | ContinueStatement | ReturnStatement | WithStatement | SwitchStatement | LabeledStatement | ThrowStatement | TryStatement | ModuleBlock | ImportDeclaration;
+    type IterationStatement = DoStatement | WhileStatement | ForStatement | ForInStatement | ForOfStatement;
+    type TypeElement = CallSignatureDeclaration | ConstructSignatureDeclaration | PropertySignature | MethodSignature | GetAccessorDeclaration | SetAccessorDeclaration | IndexSignatureDeclaration;
+    type ClassElement = PropertyDeclaration | MethodDeclaration | ConstructorDeclaration | SemicolonClassElement | GetAccessorDeclaration | SetAccessorDeclaration | IndexSignatureDeclaration | ClassStaticBlockDeclaration;
+    type ObjectLiteralElement = PropertyAssignment | ShorthandPropertyAssignment | SpreadAssignment | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | JsxSpreadAttribute;
+    type TypeNode = KeywordTypeNode | ThisTypeNode | FunctionTypeNode | ConstructorTypeNode | NodeWithTypeArguments | TypePredicateNode | TypeLiteralNode | ArrayTypeNode | TupleTypeNode | NamedTupleMember | OptionalTypeNode | RestTypeNode | UnionTypeNode | IntersectionTypeNode | ConditionalTypeNode | InferTypeNode | ParenthesizedTypeNode | TypeOperatorNode | IndexedAccessTypeNode | MappedTypeNode | LiteralTypeNode | TemplateLiteralTypeNode | TemplateLiteralTypeSpan | JSDocTypeExpression | JSDocType;
+    type JSDocType = JSDocAllType | JSDocUnknownType | JSDocNonNullableType | JSDocNullableType | JSDocOptionalType | JSDocFunctionType | JSDocVariadicType | JSDocNamepathType | JSDocSignature | JSDocTypeLiteral;
+    type NodeWithTypeArguments = ImportTypeNode | TypeReferenceNode | TypeQueryNode | ExpressionWithTypeArguments;
+    type JSDocTag = JSDocUnknownTag | JSDocAugmentsTag | JSDocImplementsTag | JSDocAuthorTag | JSDocDeprecatedTag | JSDocClassTag | JSDocPublicTag | JSDocPrivateTag | JSDocProtectedTag | JSDocReadonlyTag | JSDocOverrideTag | JSDocOverloadTag | JSDocEnumTag | JSDocThisTag | JSDocTemplateTag | JSDocSeeTag | JSDocReturnTag | JSDocTypeTag | JSDocTypedefTag | JSDocCallbackTag | JSDocThrowsTag | JSDocPropertyLikeTag | JSDocSatisfiesTag;
+    type Expression = OmittedExpression | UnaryExpression | YieldExpression | SyntheticExpression | BinaryExpression | ConditionalExpression | ArrowFunction | SpreadElement | AsExpression | SatisfiesExpression | JsxOpeningElement | JsxOpeningFragment | JsxClosingFragment | JsxExpression | CommaListExpression;
+    type UnaryExpression = UpdateExpression | DeleteExpression | TypeOfExpression | VoidExpression | AwaitExpression | TypeAssertion;
+    type UpdateExpression = PrefixUnaryExpression | PostfixUnaryExpression | LeftHandSideExpression;
+    type LeftHandSideExpression = PartiallyEmittedExpression | MemberExpression | CallExpression | NonNullExpression | SyntheticReferenceExpression;
+    type MemberExpression = PrimaryExpression | PropertyAccessExpression | ElementAccessExpression | ExpressionWithTypeArguments | TaggedTemplateExpression;
+    type PrimaryExpression = Identifier | PrivateIdentifier | NullLiteral | TrueLiteral | FalseLiteral | ThisExpression | SuperExpression | ImportExpression | FunctionExpression | LiteralExpression | TemplateExpression | ParenthesizedExpression | ArrayLiteralExpression | ObjectLiteralExpression | NewExpression | MetaProperty | JsxElement | JsxAttributes | JsxNamespacedName | JsxSelfClosingElement | JsxFragment | MissingDeclaration | ClassExpression;
+    type LiteralExpression = StringLiteral | RegularExpressionLiteral | NoSubstitutionTemplateLiteral | NumericLiteral | BigIntLiteral;
+    type JSDocPropertyLikeTag = JSDocPropertyTag | JSDocParameterTag;
+    type LiteralLikeNode = TemplateLiteralLikeNode | LiteralExpression | JsxText;
+    type TemplateLiteralLikeNode = NoSubstitutionTemplateLiteral | TemplateHead | TemplateMiddle | TemplateTail;
     enum NodeFlags {
         None = 0,
         Let = 1,
@@ -519,12 +905,12 @@ declare namespace ts {
         IntrinsicIndexedElement = 2,
         IntrinsicElement = 3
     }
-    interface Node extends ReadonlyTextRange {
+    interface NodeBase extends ReadonlyTextRange {
         readonly kind: SyntaxKind;
         readonly flags: NodeFlags;
         readonly parent: Node;
     }
-    interface Node {
+    interface NodeBase {
         getSourceFile(): SourceFile;
         getChildCount(sourceFile?: SourceFile): number;
         getChildAt(index: number, sourceFile?: SourceFile): Node;
@@ -541,13 +927,13 @@ declare namespace ts {
         getLastToken(sourceFile?: SourceFile): Node | undefined;
         forEachChild<T>(cbNode: (node: Node) => T | undefined, cbNodeArray?: (nodes: NodeArray<Node>) => T | undefined): T | undefined;
     }
-    interface JSDocContainer extends Node {
+    interface JSDocContainer extends NodeBase {
         _jsdocContainerBrand: any;
     }
-    interface LocalsContainer extends Node {
+    interface LocalsContainer extends NodeBase {
         _localsContainerBrand: any;
     }
-    interface FlowContainer extends Node {
+    interface FlowContainer extends NodeBase {
         _flowContainerBrand: any;
     }
     type HasJSDoc = AccessorDeclaration | ArrowFunction | BinaryExpression | Block | BreakStatement | CallSignatureDeclaration | CaseClause | ClassLikeDeclaration | ClassStaticBlockDeclaration | ConstructorDeclaration | ConstructorTypeNode | ConstructSignatureDeclaration | ContinueStatement | DebuggerStatement | DoStatement | ElementAccessExpression | EmptyStatement | EndOfFileToken | EnumDeclaration | EnumMember | ExportAssignment | ExportDeclaration | ExportSpecifier | ExpressionStatement | ForInStatement | ForOfStatement | ForStatement | FunctionDeclaration | FunctionExpression | FunctionTypeNode | Identifier | IfStatement | ImportDeclaration | ImportEqualsDeclaration | IndexSignatureDeclaration | InterfaceDeclaration | JSDocFunctionType | JSDocSignature | LabeledStatement | MethodDeclaration | MethodSignature | ModuleDeclaration | NamedTupleMember | NamespaceExportDeclaration | ObjectLiteralExpression | ParameterDeclaration | ParenthesizedExpression | PropertyAccessExpression | PropertyAssignment | PropertyDeclaration | PropertySignature | ReturnStatement | SemicolonClassElement | ShorthandPropertyAssignment | SpreadAssignment | SwitchStatement | ThrowStatement | TryStatement | TypeAliasDeclaration | TypeParameterDeclaration | VariableDeclaration | VariableStatement | WhileStatement | WithStatement;
@@ -560,7 +946,7 @@ declare namespace ts {
     interface NodeArray<T extends Node> extends ReadonlyArray<T>, ReadonlyTextRange {
         readonly hasTrailingComma: boolean;
     }
-    interface Token<TKind extends SyntaxKind> extends Node {
+    interface Token<TKind extends SyntaxKind> extends NodeBase {
         readonly kind: TKind;
     }
     type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & JSDocContainer;
@@ -616,7 +1002,7 @@ declare namespace ts {
         FileLevel = 32,
         AllowNameSubstitution = 64
     }
-    interface Identifier extends PrimaryExpression, Declaration, JSDocContainer, FlowContainer {
+    interface Identifier extends PrimaryExpressionBase, DeclarationBase, JSDocContainer, FlowContainer {
         readonly kind: SyntaxKind.Identifier;
         /**
          * Prefer to use `id.unescapedText`. (Note: This is available only in services, not internally to the TypeScript compiler.)
@@ -636,7 +1022,7 @@ declare namespace ts {
     interface TransientIdentifier extends Identifier {
         resolvedSymbol: Symbol;
     }
-    interface QualifiedName extends Node, FlowContainer {
+    interface QualifiedName extends NodeBase, FlowContainer {
         readonly kind: SyntaxKind.QualifiedName;
         readonly left: EntityName;
         readonly right: Identifier;
@@ -645,35 +1031,35 @@ declare namespace ts {
     type PropertyName = Identifier | StringLiteral | NumericLiteral | ComputedPropertyName | PrivateIdentifier;
     type MemberName = Identifier | PrivateIdentifier;
     type DeclarationName = Identifier | PrivateIdentifier | StringLiteralLike | NumericLiteral | ComputedPropertyName | ElementAccessExpression | BindingPattern | EntityNameExpression;
-    interface Declaration extends Node {
+    interface DeclarationBase extends NodeBase {
         _declarationBrand: any;
     }
-    interface NamedDeclaration extends Declaration {
+    interface NamedDeclarationBase extends DeclarationBase {
         readonly name?: DeclarationName;
     }
-    interface DeclarationStatement extends NamedDeclaration, Statement {
+    interface DeclarationStatementBase extends NamedDeclarationBase, StatementBase {
         readonly name?: Identifier | StringLiteral | NumericLiteral;
     }
-    interface ComputedPropertyName extends Node {
+    interface ComputedPropertyName extends NodeBase {
         readonly kind: SyntaxKind.ComputedPropertyName;
         readonly parent: Declaration;
         readonly expression: Expression;
     }
-    interface PrivateIdentifier extends PrimaryExpression {
+    interface PrivateIdentifier extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.PrivateIdentifier;
         readonly escapedText: __String;
     }
     interface PrivateIdentifier {
         readonly text: string;
     }
-    interface Decorator extends Node {
+    interface Decorator extends NodeBase {
         readonly kind: SyntaxKind.Decorator;
         readonly parent: NamedDeclaration;
         readonly expression: LeftHandSideExpression;
     }
-    interface TypeParameterDeclaration extends NamedDeclaration, JSDocContainer {
+    interface TypeParameterDeclaration extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.TypeParameter;
-        readonly parent: DeclarationWithTypeParameterChildren | InferTypeNode;
+        readonly parent: DeclarationWithTypeParameterChildren | InferTypeNode | MappedTypeNode;
         readonly modifiers?: NodeArray<Modifier>;
         readonly name: Identifier;
         /** Note: Consider calling `getEffectiveConstraintOfTypeParameter` */
@@ -681,7 +1067,7 @@ declare namespace ts {
         readonly default?: TypeNode;
         expression?: Expression;
     }
-    interface SignatureDeclarationBase extends NamedDeclaration, JSDocContainer {
+    interface SignatureDeclarationBase extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SignatureDeclaration["kind"];
         readonly name?: PropertyName;
         readonly typeParameters?: NodeArray<TypeParameterDeclaration> | undefined;
@@ -689,14 +1075,14 @@ declare namespace ts {
         readonly type?: TypeNode | undefined;
     }
     type SignatureDeclaration = CallSignatureDeclaration | ConstructSignatureDeclaration | MethodSignature | IndexSignatureDeclaration | FunctionTypeNode | ConstructorTypeNode | JSDocFunctionType | FunctionDeclaration | MethodDeclaration | ConstructorDeclaration | AccessorDeclaration | FunctionExpression | ArrowFunction;
-    interface CallSignatureDeclaration extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+    interface CallSignatureDeclaration extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.CallSignature;
     }
-    interface ConstructSignatureDeclaration extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+    interface ConstructSignatureDeclaration extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.ConstructSignature;
     }
     type BindingName = Identifier | BindingPattern;
-    interface VariableDeclaration extends NamedDeclaration, JSDocContainer {
+    interface VariableDeclaration extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.VariableDeclaration;
         readonly parent: VariableDeclarationList | CatchClause;
         readonly name: BindingName;
@@ -704,12 +1090,12 @@ declare namespace ts {
         readonly type?: TypeNode;
         readonly initializer?: Expression;
     }
-    interface VariableDeclarationList extends Node {
+    interface VariableDeclarationList extends NodeBase {
         readonly kind: SyntaxKind.VariableDeclarationList;
         readonly parent: VariableStatement | ForStatement | ForOfStatement | ForInStatement;
         readonly declarations: NodeArray<VariableDeclaration>;
     }
-    interface ParameterDeclaration extends NamedDeclaration, JSDocContainer {
+    interface ParameterDeclaration extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.Parameter;
         readonly parent: SignatureDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -719,7 +1105,7 @@ declare namespace ts {
         readonly type?: TypeNode;
         readonly initializer?: Expression;
     }
-    interface BindingElement extends NamedDeclaration, FlowContainer {
+    interface BindingElement extends NamedDeclarationBase, FlowContainer {
         readonly kind: SyntaxKind.BindingElement;
         readonly parent: BindingPattern;
         readonly propertyName?: PropertyName;
@@ -727,7 +1113,7 @@ declare namespace ts {
         readonly name: BindingName;
         readonly initializer?: Expression;
     }
-    interface PropertySignature extends TypeElement, JSDocContainer {
+    interface PropertySignature extends TypeElementBase, JSDocContainer {
         readonly kind: SyntaxKind.PropertySignature;
         readonly parent: TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<Modifier>;
@@ -735,7 +1121,7 @@ declare namespace ts {
         readonly questionToken?: QuestionToken;
         readonly type?: TypeNode;
     }
-    interface PropertyDeclaration extends ClassElement, JSDocContainer {
+    interface PropertyDeclaration extends ClassElementBase, JSDocContainer {
         readonly kind: SyntaxKind.PropertyDeclaration;
         readonly parent: ClassLikeDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -748,37 +1134,37 @@ declare namespace ts {
     interface AutoAccessorPropertyDeclaration extends PropertyDeclaration {
         _autoAccessorBrand: any;
     }
-    interface ObjectLiteralElement extends NamedDeclaration {
+    interface ObjectLiteralElementBase extends NamedDeclarationBase {
         _objectLiteralBrand: any;
         readonly name?: PropertyName;
     }
     /** Unlike ObjectLiteralElement, excludes JSXAttribute and JSXSpreadAttribute. */
     type ObjectLiteralElementLike = PropertyAssignment | ShorthandPropertyAssignment | SpreadAssignment | MethodDeclaration | AccessorDeclaration;
-    interface PropertyAssignment extends ObjectLiteralElement, JSDocContainer {
+    interface PropertyAssignment extends ObjectLiteralElementBase, JSDocContainer {
         readonly kind: SyntaxKind.PropertyAssignment;
         readonly parent: ObjectLiteralExpression;
         readonly name: PropertyName;
         readonly initializer: Expression;
     }
-    interface ShorthandPropertyAssignment extends ObjectLiteralElement, JSDocContainer {
+    interface ShorthandPropertyAssignment extends ObjectLiteralElementBase, JSDocContainer {
         readonly kind: SyntaxKind.ShorthandPropertyAssignment;
         readonly parent: ObjectLiteralExpression;
         readonly name: Identifier;
         readonly equalsToken?: EqualsToken;
         readonly objectAssignmentInitializer?: Expression;
     }
-    interface SpreadAssignment extends ObjectLiteralElement, JSDocContainer {
+    interface SpreadAssignment extends ObjectLiteralElementBase, JSDocContainer {
         readonly kind: SyntaxKind.SpreadAssignment;
         readonly parent: ObjectLiteralExpression;
         readonly expression: Expression;
     }
     type VariableLikeDeclaration = VariableDeclaration | ParameterDeclaration | BindingElement | PropertyDeclaration | PropertyAssignment | PropertySignature | JsxAttribute | ShorthandPropertyAssignment | EnumMember | JSDocPropertyTag | JSDocParameterTag;
-    interface ObjectBindingPattern extends Node {
+    interface ObjectBindingPattern extends NodeBase {
         readonly kind: SyntaxKind.ObjectBindingPattern;
         readonly parent: VariableDeclaration | ParameterDeclaration | BindingElement;
         readonly elements: NodeArray<BindingElement>;
     }
-    interface ArrayBindingPattern extends Node {
+    interface ArrayBindingPattern extends NodeBase {
         readonly kind: SyntaxKind.ArrayBindingPattern;
         readonly parent: VariableDeclaration | ParameterDeclaration | BindingElement;
         readonly elements: NodeArray<ArrayBindingElement>;
@@ -803,44 +1189,44 @@ declare namespace ts {
     type FunctionLikeDeclaration = FunctionDeclaration | MethodDeclaration | GetAccessorDeclaration | SetAccessorDeclaration | ConstructorDeclaration | FunctionExpression | ArrowFunction;
     /** @deprecated Use SignatureDeclaration */
     type FunctionLike = SignatureDeclaration;
-    interface FunctionDeclaration extends FunctionLikeDeclarationBase, DeclarationStatement, LocalsContainer {
+    interface FunctionDeclaration extends FunctionLikeDeclarationBase, DeclarationStatementBase, LocalsContainer {
         readonly kind: SyntaxKind.FunctionDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name?: Identifier;
         readonly body?: FunctionBody;
     }
-    interface MethodSignature extends SignatureDeclarationBase, TypeElement, LocalsContainer {
+    interface MethodSignature extends SignatureDeclarationBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.MethodSignature;
         readonly parent: TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<Modifier>;
         readonly name: PropertyName;
     }
-    interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+    interface MethodDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.MethodDeclaration;
         readonly parent: ClassLikeDeclaration | ObjectLiteralExpression;
         readonly modifiers?: NodeArray<ModifierLike> | undefined;
         readonly name: PropertyName;
         readonly body?: FunctionBody | undefined;
     }
-    interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElement, JSDocContainer, LocalsContainer {
+    interface ConstructorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.Constructor;
         readonly parent: ClassLikeDeclaration;
         readonly modifiers?: NodeArray<ModifierLike> | undefined;
         readonly body?: FunctionBody | undefined;
     }
     /** For when we encounter a semicolon in a class declaration. ES6 allows these as class elements. */
-    interface SemicolonClassElement extends ClassElement, JSDocContainer {
+    interface SemicolonClassElement extends ClassElementBase, JSDocContainer {
         readonly kind: SyntaxKind.SemicolonClassElement;
         readonly parent: ClassLikeDeclaration;
     }
-    interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, TypeElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+    interface GetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, TypeElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.GetAccessor;
         readonly parent: ClassLikeDeclaration | ObjectLiteralExpression | TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: PropertyName;
         readonly body?: FunctionBody;
     }
-    interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElement, TypeElement, ObjectLiteralElement, JSDocContainer, LocalsContainer, FlowContainer {
+    interface SetAccessorDeclaration extends FunctionLikeDeclarationBase, ClassElementBase, TypeElementBase, ObjectLiteralElementBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.SetAccessor;
         readonly parent: ClassLikeDeclaration | ObjectLiteralExpression | TypeLiteralNode | InterfaceDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -848,41 +1234,41 @@ declare namespace ts {
         readonly body?: FunctionBody;
     }
     type AccessorDeclaration = GetAccessorDeclaration | SetAccessorDeclaration;
-    interface IndexSignatureDeclaration extends SignatureDeclarationBase, ClassElement, TypeElement, LocalsContainer {
+    interface IndexSignatureDeclaration extends SignatureDeclarationBase, ClassElementBase, TypeElementBase, LocalsContainer {
         readonly kind: SyntaxKind.IndexSignature;
         readonly parent: ObjectTypeDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly type: TypeNode;
     }
-    interface ClassStaticBlockDeclaration extends ClassElement, JSDocContainer, LocalsContainer {
+    interface ClassStaticBlockDeclaration extends ClassElementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.ClassStaticBlockDeclaration;
         readonly parent: ClassDeclaration | ClassExpression;
         readonly body: Block;
     }
-    interface TypeNode extends Node {
+    interface TypeNodeBase extends NodeBase {
         _typeNodeBrand: any;
     }
-    interface KeywordTypeNode<TKind extends KeywordTypeSyntaxKind = KeywordTypeSyntaxKind> extends KeywordToken<TKind>, TypeNode {
+    interface KeywordTypeNode<TKind extends KeywordTypeSyntaxKind = KeywordTypeSyntaxKind> extends KeywordToken<TKind>, TypeNodeBase {
         readonly kind: TKind;
     }
-    interface ImportTypeAssertionContainer extends Node {
+    interface ImportTypeAssertionContainer extends NodeBase {
         readonly kind: SyntaxKind.ImportTypeAssertionContainer;
         readonly parent: ImportTypeNode;
         readonly assertClause: AssertClause;
         readonly multiLine?: boolean;
     }
-    interface ImportTypeNode extends NodeWithTypeArguments {
+    interface ImportTypeNode extends NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.ImportType;
         readonly isTypeOf: boolean;
         readonly argument: TypeNode;
         readonly assertions?: ImportTypeAssertionContainer;
         readonly qualifier?: EntityName;
     }
-    interface ThisTypeNode extends TypeNode {
+    interface ThisTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.ThisType;
     }
     type FunctionOrConstructorTypeNode = FunctionTypeNode | ConstructorTypeNode;
-    interface FunctionOrConstructorTypeNodeBase extends TypeNode, SignatureDeclarationBase {
+    interface FunctionOrConstructorTypeNodeBase extends TypeNodeBase, SignatureDeclarationBase {
         readonly kind: SyntaxKind.FunctionType | SyntaxKind.ConstructorType;
         readonly type: TypeNode;
     }
@@ -893,87 +1279,87 @@ declare namespace ts {
         readonly kind: SyntaxKind.ConstructorType;
         readonly modifiers?: NodeArray<Modifier>;
     }
-    interface NodeWithTypeArguments extends TypeNode {
+    interface NodeWithTypeArgumentsBase extends TypeNodeBase {
         readonly typeArguments?: NodeArray<TypeNode>;
     }
     type TypeReferenceType = TypeReferenceNode | ExpressionWithTypeArguments;
-    interface TypeReferenceNode extends NodeWithTypeArguments {
+    interface TypeReferenceNode extends NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.TypeReference;
         readonly typeName: EntityName;
     }
-    interface TypePredicateNode extends TypeNode {
+    interface TypePredicateNode extends TypeNodeBase {
         readonly kind: SyntaxKind.TypePredicate;
         readonly parent: SignatureDeclaration | JSDocTypeExpression;
         readonly assertsModifier?: AssertsKeyword;
         readonly parameterName: Identifier | ThisTypeNode;
         readonly type?: TypeNode;
     }
-    interface TypeQueryNode extends NodeWithTypeArguments {
+    interface TypeQueryNode extends NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.TypeQuery;
         readonly exprName: EntityName;
     }
-    interface TypeLiteralNode extends TypeNode, Declaration {
+    interface TypeLiteralNode extends TypeNodeBase, DeclarationBase {
         readonly kind: SyntaxKind.TypeLiteral;
         readonly members: NodeArray<TypeElement>;
     }
-    interface ArrayTypeNode extends TypeNode {
+    interface ArrayTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.ArrayType;
         readonly elementType: TypeNode;
     }
-    interface TupleTypeNode extends TypeNode {
+    interface TupleTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.TupleType;
         readonly elements: NodeArray<TypeNode | NamedTupleMember>;
     }
-    interface NamedTupleMember extends TypeNode, Declaration, JSDocContainer {
+    interface NamedTupleMember extends TypeNodeBase, DeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.NamedTupleMember;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
         readonly name: Identifier;
         readonly questionToken?: Token<SyntaxKind.QuestionToken>;
         readonly type: TypeNode;
     }
-    interface OptionalTypeNode extends TypeNode {
+    interface OptionalTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.OptionalType;
         readonly type: TypeNode;
     }
-    interface RestTypeNode extends TypeNode {
+    interface RestTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.RestType;
         readonly type: TypeNode;
     }
     type UnionOrIntersectionTypeNode = UnionTypeNode | IntersectionTypeNode;
-    interface UnionTypeNode extends TypeNode {
+    interface UnionTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.UnionType;
         readonly types: NodeArray<TypeNode>;
     }
-    interface IntersectionTypeNode extends TypeNode {
+    interface IntersectionTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.IntersectionType;
         readonly types: NodeArray<TypeNode>;
     }
-    interface ConditionalTypeNode extends TypeNode, LocalsContainer {
+    interface ConditionalTypeNode extends TypeNodeBase, LocalsContainer {
         readonly kind: SyntaxKind.ConditionalType;
         readonly checkType: TypeNode;
         readonly extendsType: TypeNode;
         readonly trueType: TypeNode;
         readonly falseType: TypeNode;
     }
-    interface InferTypeNode extends TypeNode {
+    interface InferTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.InferType;
         readonly typeParameter: TypeParameterDeclaration;
     }
-    interface ParenthesizedTypeNode extends TypeNode {
+    interface ParenthesizedTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.ParenthesizedType;
         readonly type: TypeNode;
     }
-    interface TypeOperatorNode extends TypeNode {
+    interface TypeOperatorNode extends TypeNodeBase {
         readonly kind: SyntaxKind.TypeOperator;
         readonly operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword;
         readonly type: TypeNode;
     }
-    interface IndexedAccessTypeNode extends TypeNode {
+    interface IndexedAccessTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.IndexedAccessType;
         readonly objectType: TypeNode;
         readonly indexType: TypeNode;
     }
-    interface MappedTypeNode extends TypeNode, Declaration, LocalsContainer {
+    interface MappedTypeNode extends TypeNodeBase, DeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.MappedType;
         readonly readonlyToken?: ReadonlyKeyword | PlusToken | MinusToken;
         readonly typeParameter: TypeParameterDeclaration;
@@ -983,106 +1369,106 @@ declare namespace ts {
         /** Used only to produce grammar errors */
         readonly members?: NodeArray<TypeElement>;
     }
-    interface LiteralTypeNode extends TypeNode {
+    interface LiteralTypeNode extends TypeNodeBase {
         readonly kind: SyntaxKind.LiteralType;
         readonly literal: NullLiteral | BooleanLiteral | LiteralExpression | PrefixUnaryExpression;
     }
-    interface StringLiteral extends LiteralExpression, Declaration {
+    interface StringLiteral extends LiteralExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.StringLiteral;
     }
     type StringLiteralLike = StringLiteral | NoSubstitutionTemplateLiteral;
     type PropertyNameLiteral = Identifier | StringLiteralLike | NumericLiteral;
-    interface TemplateLiteralTypeNode extends TypeNode {
+    interface TemplateLiteralTypeNode extends TypeNodeBase {
         kind: SyntaxKind.TemplateLiteralType;
         readonly head: TemplateHead;
         readonly templateSpans: NodeArray<TemplateLiteralTypeSpan>;
     }
-    interface TemplateLiteralTypeSpan extends TypeNode {
+    interface TemplateLiteralTypeSpan extends TypeNodeBase {
         readonly kind: SyntaxKind.TemplateLiteralTypeSpan;
         readonly parent: TemplateLiteralTypeNode;
         readonly type: TypeNode;
         readonly literal: TemplateMiddle | TemplateTail;
     }
-    interface Expression extends Node {
+    interface ExpressionBase extends NodeBase {
         _expressionBrand: any;
     }
-    interface OmittedExpression extends Expression {
+    interface OmittedExpression extends ExpressionBase {
         readonly kind: SyntaxKind.OmittedExpression;
     }
-    interface PartiallyEmittedExpression extends LeftHandSideExpression {
+    interface PartiallyEmittedExpression extends LeftHandSideExpressionBase {
         readonly kind: SyntaxKind.PartiallyEmittedExpression;
         readonly expression: Expression;
     }
-    interface UnaryExpression extends Expression {
+    interface UnaryExpressionBase extends ExpressionBase {
         _unaryExpressionBrand: any;
     }
     /** Deprecated, please use UpdateExpression */
     type IncrementExpression = UpdateExpression;
-    interface UpdateExpression extends UnaryExpression {
+    interface UpdateExpressionBase extends UnaryExpressionBase {
         _updateExpressionBrand: any;
     }
     type PrefixUnaryOperator = SyntaxKind.PlusPlusToken | SyntaxKind.MinusMinusToken | SyntaxKind.PlusToken | SyntaxKind.MinusToken | SyntaxKind.TildeToken | SyntaxKind.ExclamationToken;
-    interface PrefixUnaryExpression extends UpdateExpression {
+    interface PrefixUnaryExpression extends UpdateExpressionBase {
         readonly kind: SyntaxKind.PrefixUnaryExpression;
         readonly operator: PrefixUnaryOperator;
         readonly operand: UnaryExpression;
     }
     type PostfixUnaryOperator = SyntaxKind.PlusPlusToken | SyntaxKind.MinusMinusToken;
-    interface PostfixUnaryExpression extends UpdateExpression {
+    interface PostfixUnaryExpression extends UpdateExpressionBase {
         readonly kind: SyntaxKind.PostfixUnaryExpression;
         readonly operand: LeftHandSideExpression;
         readonly operator: PostfixUnaryOperator;
     }
-    interface LeftHandSideExpression extends UpdateExpression {
+    interface LeftHandSideExpressionBase extends UpdateExpressionBase {
         _leftHandSideExpressionBrand: any;
     }
-    interface MemberExpression extends LeftHandSideExpression {
+    interface MemberExpressionBase extends LeftHandSideExpressionBase {
         _memberExpressionBrand: any;
     }
-    interface PrimaryExpression extends MemberExpression {
+    interface PrimaryExpressionBase extends MemberExpressionBase {
         _primaryExpressionBrand: any;
     }
-    interface NullLiteral extends PrimaryExpression {
+    interface NullLiteral extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.NullKeyword;
     }
-    interface TrueLiteral extends PrimaryExpression {
+    interface TrueLiteral extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.TrueKeyword;
     }
-    interface FalseLiteral extends PrimaryExpression {
+    interface FalseLiteral extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.FalseKeyword;
     }
     type BooleanLiteral = TrueLiteral | FalseLiteral;
-    interface ThisExpression extends PrimaryExpression, FlowContainer {
+    interface ThisExpression extends PrimaryExpressionBase, FlowContainer {
         readonly kind: SyntaxKind.ThisKeyword;
     }
-    interface SuperExpression extends PrimaryExpression, FlowContainer {
+    interface SuperExpression extends PrimaryExpressionBase, FlowContainer {
         readonly kind: SyntaxKind.SuperKeyword;
     }
-    interface ImportExpression extends PrimaryExpression {
+    interface ImportExpression extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.ImportKeyword;
     }
-    interface DeleteExpression extends UnaryExpression {
+    interface DeleteExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.DeleteExpression;
         readonly expression: UnaryExpression;
     }
-    interface TypeOfExpression extends UnaryExpression {
+    interface TypeOfExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.TypeOfExpression;
         readonly expression: UnaryExpression;
     }
-    interface VoidExpression extends UnaryExpression {
+    interface VoidExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.VoidExpression;
         readonly expression: UnaryExpression;
     }
-    interface AwaitExpression extends UnaryExpression {
+    interface AwaitExpression extends UnaryExpressionBase {
         readonly kind: SyntaxKind.AwaitExpression;
         readonly expression: UnaryExpression;
     }
-    interface YieldExpression extends Expression {
+    interface YieldExpression extends ExpressionBase {
         readonly kind: SyntaxKind.YieldExpression;
         readonly asteriskToken?: AsteriskToken;
         readonly expression?: Expression;
     }
-    interface SyntheticExpression extends Expression {
+    interface SyntheticExpression extends ExpressionBase {
         readonly kind: SyntaxKind.SyntheticExpression;
         readonly isSpread: boolean;
         readonly type: Type;
@@ -1108,8 +1494,8 @@ declare namespace ts {
     type AssignmentOperatorOrHigher = SyntaxKind.QuestionQuestionToken | LogicalOperatorOrHigher | AssignmentOperator;
     type BinaryOperator = AssignmentOperatorOrHigher | SyntaxKind.CommaToken;
     type LogicalOrCoalescingAssignmentOperator = SyntaxKind.AmpersandAmpersandEqualsToken | SyntaxKind.BarBarEqualsToken | SyntaxKind.QuestionQuestionEqualsToken;
-    type BinaryOperatorToken = Token<BinaryOperator>;
-    interface BinaryExpression extends Expression, Declaration, JSDocContainer {
+    type BinaryOperatorToken<TOperator extends BinaryOperator = BinaryOperator> = TOperator extends SyntaxKind ? Token<TOperator> : never;
+    interface BinaryExpression extends ExpressionBase, DeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.BinaryExpression;
         readonly left: Expression;
         readonly operatorToken: BinaryOperatorToken;
@@ -1136,7 +1522,7 @@ declare namespace ts {
     type ArrayBindingOrAssignmentPattern = ArrayBindingPattern | ArrayLiteralExpression;
     type AssignmentPattern = ObjectLiteralExpression | ArrayLiteralExpression;
     type BindingOrAssignmentPattern = ObjectBindingOrAssignmentPattern | ArrayBindingOrAssignmentPattern;
-    interface ConditionalExpression extends Expression {
+    interface ConditionalExpression extends ExpressionBase {
         readonly kind: SyntaxKind.ConditionalExpression;
         readonly condition: Expression;
         readonly questionToken: QuestionToken;
@@ -1146,34 +1532,34 @@ declare namespace ts {
     }
     type FunctionBody = Block;
     type ConciseBody = FunctionBody | Expression;
-    interface FunctionExpression extends PrimaryExpression, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
+    interface FunctionExpression extends PrimaryExpressionBase, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.FunctionExpression;
         readonly modifiers?: NodeArray<Modifier>;
         readonly name?: Identifier;
         readonly body: FunctionBody;
     }
-    interface ArrowFunction extends Expression, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
+    interface ArrowFunction extends ExpressionBase, FunctionLikeDeclarationBase, JSDocContainer, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ArrowFunction;
         readonly modifiers?: NodeArray<Modifier>;
         readonly equalsGreaterThanToken: EqualsGreaterThanToken;
         readonly body: ConciseBody;
         readonly name: never;
     }
-    interface LiteralLikeNode extends Node {
+    interface LiteralLikeNodeBase extends NodeBase {
         text: string;
         isUnterminated?: boolean;
         hasExtendedUnicodeEscape?: boolean;
     }
-    interface TemplateLiteralLikeNode extends LiteralLikeNode {
+    interface TemplateLiteralLikeNodeBase extends LiteralLikeNodeBase {
         rawText?: string;
     }
-    interface LiteralExpression extends LiteralLikeNode, PrimaryExpression {
+    interface LiteralExpressionBase extends LiteralLikeNodeBase, PrimaryExpressionBase {
         _literalExpressionBrand: any;
     }
-    interface RegularExpressionLiteral extends LiteralExpression {
+    interface RegularExpressionLiteral extends LiteralExpressionBase {
         readonly kind: SyntaxKind.RegularExpressionLiteral;
     }
-    interface NoSubstitutionTemplateLiteral extends LiteralExpression, TemplateLiteralLikeNode, Declaration {
+    interface NoSubstitutionTemplateLiteral extends LiteralExpressionBase, TemplateLiteralLikeNodeBase, DeclarationBase {
         readonly kind: SyntaxKind.NoSubstitutionTemplateLiteral;
     }
     enum TokenFlags {
@@ -1184,48 +1570,48 @@ declare namespace ts {
         BinarySpecifier = 128,
         OctalSpecifier = 256
     }
-    interface NumericLiteral extends LiteralExpression, Declaration {
+    interface NumericLiteral extends LiteralExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.NumericLiteral;
     }
-    interface BigIntLiteral extends LiteralExpression {
+    interface BigIntLiteral extends LiteralExpressionBase {
         readonly kind: SyntaxKind.BigIntLiteral;
     }
     type LiteralToken = NumericLiteral | BigIntLiteral | StringLiteral | JsxText | RegularExpressionLiteral | NoSubstitutionTemplateLiteral;
-    interface TemplateHead extends TemplateLiteralLikeNode {
+    interface TemplateHead extends TemplateLiteralLikeNodeBase {
         readonly kind: SyntaxKind.TemplateHead;
         readonly parent: TemplateExpression | TemplateLiteralTypeNode;
     }
-    interface TemplateMiddle extends TemplateLiteralLikeNode {
+    interface TemplateMiddle extends TemplateLiteralLikeNodeBase {
         readonly kind: SyntaxKind.TemplateMiddle;
         readonly parent: TemplateSpan | TemplateLiteralTypeSpan;
     }
-    interface TemplateTail extends TemplateLiteralLikeNode {
+    interface TemplateTail extends TemplateLiteralLikeNodeBase {
         readonly kind: SyntaxKind.TemplateTail;
         readonly parent: TemplateSpan | TemplateLiteralTypeSpan;
     }
     type PseudoLiteralToken = TemplateHead | TemplateMiddle | TemplateTail;
     type TemplateLiteralToken = NoSubstitutionTemplateLiteral | PseudoLiteralToken;
-    interface TemplateExpression extends PrimaryExpression {
+    interface TemplateExpression extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.TemplateExpression;
         readonly head: TemplateHead;
         readonly templateSpans: NodeArray<TemplateSpan>;
     }
     type TemplateLiteral = TemplateExpression | NoSubstitutionTemplateLiteral;
-    interface TemplateSpan extends Node {
+    interface TemplateSpan extends NodeBase {
         readonly kind: SyntaxKind.TemplateSpan;
         readonly parent: TemplateExpression;
         readonly expression: Expression;
         readonly literal: TemplateMiddle | TemplateTail;
     }
-    interface ParenthesizedExpression extends PrimaryExpression, JSDocContainer {
+    interface ParenthesizedExpression extends PrimaryExpressionBase, JSDocContainer {
         readonly kind: SyntaxKind.ParenthesizedExpression;
         readonly expression: Expression;
     }
-    interface ArrayLiteralExpression extends PrimaryExpression {
+    interface ArrayLiteralExpression extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.ArrayLiteralExpression;
         readonly elements: NodeArray<Expression>;
     }
-    interface SpreadElement extends Expression {
+    interface SpreadElement extends ExpressionBase {
         readonly kind: SyntaxKind.SpreadElement;
         readonly parent: ArrayLiteralExpression | CallExpression | NewExpression;
         readonly expression: Expression;
@@ -1236,7 +1622,7 @@ declare namespace ts {
      * JSXAttribute or JSXSpreadAttribute. ObjectLiteralExpression, on the other hand, can only have properties of type
      * ObjectLiteralElement (e.g. PropertyAssignment, ShorthandPropertyAssignment etc.)
      */
-    interface ObjectLiteralExpressionBase<T extends ObjectLiteralElement> extends PrimaryExpression, Declaration {
+    interface ObjectLiteralExpressionBase<T extends ObjectLiteralElement> extends PrimaryExpressionBase, DeclarationBase {
         readonly properties: NodeArray<T>;
     }
     interface ObjectLiteralExpression extends ObjectLiteralExpressionBase<ObjectLiteralElementLike>, JSDocContainer {
@@ -1245,7 +1631,7 @@ declare namespace ts {
     type EntityNameExpression = Identifier | PropertyAccessEntityNameExpression;
     type EntityNameOrEntityNameExpression = EntityName | EntityNameExpression;
     type AccessExpression = PropertyAccessExpression | ElementAccessExpression;
-    interface PropertyAccessExpression extends MemberExpression, NamedDeclaration, JSDocContainer, FlowContainer {
+    interface PropertyAccessExpression extends MemberExpressionBase, NamedDeclarationBase, JSDocContainer, FlowContainer {
         readonly kind: SyntaxKind.PropertyAccessExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
@@ -1264,7 +1650,7 @@ declare namespace ts {
         readonly expression: EntityNameExpression;
         readonly name: Identifier;
     }
-    interface ElementAccessExpression extends MemberExpression, Declaration, JSDocContainer, FlowContainer {
+    interface ElementAccessExpression extends MemberExpressionBase, DeclarationBase, JSDocContainer, FlowContainer {
         readonly kind: SyntaxKind.ElementAccessExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
@@ -1277,7 +1663,7 @@ declare namespace ts {
         readonly expression: SuperExpression;
     }
     type SuperProperty = SuperPropertyAccessExpression | SuperElementAccessExpression;
-    interface CallExpression extends LeftHandSideExpression, Declaration {
+    interface CallExpression extends LeftHandSideExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.CallExpression;
         readonly expression: LeftHandSideExpression;
         readonly questionDotToken?: QuestionDotToken;
@@ -1294,52 +1680,52 @@ declare namespace ts {
     interface ImportCall extends CallExpression {
         readonly expression: ImportExpression;
     }
-    interface ExpressionWithTypeArguments extends MemberExpression, NodeWithTypeArguments {
+    interface ExpressionWithTypeArguments extends MemberExpressionBase, NodeWithTypeArgumentsBase {
         readonly kind: SyntaxKind.ExpressionWithTypeArguments;
         readonly expression: LeftHandSideExpression;
     }
-    interface NewExpression extends PrimaryExpression, Declaration {
+    interface NewExpression extends PrimaryExpressionBase, DeclarationBase {
         readonly kind: SyntaxKind.NewExpression;
         readonly expression: LeftHandSideExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly arguments?: NodeArray<Expression>;
     }
-    interface TaggedTemplateExpression extends MemberExpression {
+    interface TaggedTemplateExpression extends MemberExpressionBase {
         readonly kind: SyntaxKind.TaggedTemplateExpression;
         readonly tag: LeftHandSideExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly template: TemplateLiteral;
     }
     type CallLikeExpression = CallExpression | NewExpression | TaggedTemplateExpression | Decorator | JsxOpeningLikeElement;
-    interface AsExpression extends Expression {
+    interface AsExpression extends ExpressionBase {
         readonly kind: SyntaxKind.AsExpression;
         readonly expression: Expression;
         readonly type: TypeNode;
     }
-    interface TypeAssertion extends UnaryExpression {
+    interface TypeAssertion extends UnaryExpressionBase {
         readonly kind: SyntaxKind.TypeAssertionExpression;
         readonly type: TypeNode;
         readonly expression: UnaryExpression;
     }
-    interface SatisfiesExpression extends Expression {
+    interface SatisfiesExpression extends ExpressionBase {
         readonly kind: SyntaxKind.SatisfiesExpression;
         readonly expression: Expression;
         readonly type: TypeNode;
     }
     type AssertionExpression = TypeAssertion | AsExpression;
-    interface NonNullExpression extends LeftHandSideExpression {
+    interface NonNullExpression extends LeftHandSideExpressionBase {
         readonly kind: SyntaxKind.NonNullExpression;
         readonly expression: Expression;
     }
     interface NonNullChain extends NonNullExpression {
         _optionalChainBrand: any;
     }
-    interface MetaProperty extends PrimaryExpression, FlowContainer {
+    interface MetaProperty extends PrimaryExpressionBase, FlowContainer {
         readonly kind: SyntaxKind.MetaProperty;
         readonly keywordToken: SyntaxKind.NewKeyword | SyntaxKind.ImportKeyword;
         readonly name: Identifier;
     }
-    interface JsxElement extends PrimaryExpression {
+    interface JsxElement extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxElement;
         readonly openingElement: JsxOpeningElement;
         readonly children: NodeArray<JsxChild>;
@@ -1352,203 +1738,206 @@ declare namespace ts {
     interface JsxTagNamePropertyAccess extends PropertyAccessExpression {
         readonly expression: JsxTagNameExpression;
     }
-    interface JsxAttributes extends PrimaryExpression, Declaration {
+    interface JsxAttributes extends PrimaryExpressionBase, DeclarationBase {
         readonly properties: NodeArray<JsxAttributeLike>;
         readonly kind: SyntaxKind.JsxAttributes;
         readonly parent: JsxOpeningLikeElement;
     }
-    interface JsxNamespacedName extends PrimaryExpression {
+    interface JsxNamespacedName extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxNamespacedName;
         readonly name: Identifier;
         readonly namespace: Identifier;
     }
-    interface JsxOpeningElement extends Expression {
+    interface JsxOpeningElement extends ExpressionBase {
         readonly kind: SyntaxKind.JsxOpeningElement;
         readonly parent: JsxElement;
         readonly tagName: JsxTagNameExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly attributes: JsxAttributes;
     }
-    interface JsxSelfClosingElement extends PrimaryExpression {
+    interface JsxSelfClosingElement extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxSelfClosingElement;
         readonly tagName: JsxTagNameExpression;
         readonly typeArguments?: NodeArray<TypeNode>;
         readonly attributes: JsxAttributes;
     }
-    interface JsxFragment extends PrimaryExpression {
+    interface JsxFragment extends PrimaryExpressionBase {
         readonly kind: SyntaxKind.JsxFragment;
         readonly openingFragment: JsxOpeningFragment;
         readonly children: NodeArray<JsxChild>;
         readonly closingFragment: JsxClosingFragment;
     }
-    interface JsxOpeningFragment extends Expression {
+    interface JsxOpeningFragment extends ExpressionBase {
         readonly kind: SyntaxKind.JsxOpeningFragment;
         readonly parent: JsxFragment;
     }
-    interface JsxClosingFragment extends Expression {
+    interface JsxClosingFragment extends ExpressionBase {
         readonly kind: SyntaxKind.JsxClosingFragment;
         readonly parent: JsxFragment;
     }
-    interface JsxAttribute extends Declaration {
+    interface JsxAttribute extends DeclarationBase {
         readonly kind: SyntaxKind.JsxAttribute;
         readonly parent: JsxAttributes;
         readonly name: JsxAttributeName;
         readonly initializer?: JsxAttributeValue;
     }
     type JsxAttributeValue = StringLiteral | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
-    interface JsxSpreadAttribute extends ObjectLiteralElement {
+    interface JsxSpreadAttribute extends ObjectLiteralElementBase {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
         readonly name: PropertyName;
         readonly parent: JsxAttributes;
         readonly expression: Expression;
     }
-    interface JsxClosingElement extends Node {
+    interface JsxClosingElement extends NodeBase {
         readonly kind: SyntaxKind.JsxClosingElement;
         readonly parent: JsxElement;
         readonly tagName: JsxTagNameExpression;
     }
-    interface JsxExpression extends Expression {
+    interface JsxExpression extends ExpressionBase {
         readonly kind: SyntaxKind.JsxExpression;
         readonly parent: JsxElement | JsxFragment | JsxAttributeLike;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
         readonly expression?: Expression;
     }
-    interface JsxText extends LiteralLikeNode {
+    interface JsxText extends LiteralLikeNodeBase {
         readonly kind: SyntaxKind.JsxText;
         readonly parent: JsxElement | JsxFragment;
         readonly containsOnlyTriviaWhiteSpaces: boolean;
     }
     type JsxChild = JsxText | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
-    interface Statement extends Node, JSDocContainer {
+    interface StatementBase extends NodeBase, JSDocContainer {
         _statementBrand: any;
     }
-    interface NotEmittedStatement extends Statement {
+    interface NotEmittedStatement extends StatementBase {
         readonly kind: SyntaxKind.NotEmittedStatement;
     }
     /**
      * A list of comma-separated expressions. This node is only created by transformations.
      */
-    interface CommaListExpression extends Expression {
+    interface CommaListExpression extends ExpressionBase {
         readonly kind: SyntaxKind.CommaListExpression;
         readonly elements: NodeArray<Expression>;
     }
-    interface EmptyStatement extends Statement {
+    interface SyntheticReferenceExpression extends LeftHandSideExpressionBase {
+        readonly kind: SyntaxKind.SyntheticReferenceExpression;
+    }
+    interface EmptyStatement extends StatementBase {
         readonly kind: SyntaxKind.EmptyStatement;
     }
-    interface DebuggerStatement extends Statement, FlowContainer {
+    interface DebuggerStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.DebuggerStatement;
     }
-    interface MissingDeclaration extends DeclarationStatement, PrimaryExpression {
+    interface MissingDeclaration extends DeclarationStatementBase, PrimaryExpressionBase {
         readonly kind: SyntaxKind.MissingDeclaration;
         readonly name?: Identifier;
     }
     type BlockLike = SourceFile | Block | ModuleBlock | CaseOrDefaultClause;
-    interface Block extends Statement, LocalsContainer {
+    interface Block extends StatementBase, LocalsContainer {
         readonly kind: SyntaxKind.Block;
         readonly statements: NodeArray<Statement>;
     }
-    interface VariableStatement extends Statement, FlowContainer {
+    interface VariableStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.VariableStatement;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly declarationList: VariableDeclarationList;
     }
-    interface ExpressionStatement extends Statement, FlowContainer {
+    interface ExpressionStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ExpressionStatement;
         readonly expression: Expression;
     }
-    interface IfStatement extends Statement, FlowContainer {
+    interface IfStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.IfStatement;
         readonly expression: Expression;
         readonly thenStatement: Statement;
         readonly elseStatement?: Statement;
     }
-    interface IterationStatement extends Statement {
+    interface IterationStatementBase extends StatementBase {
         readonly statement: Statement;
     }
-    interface DoStatement extends IterationStatement, FlowContainer {
+    interface DoStatement extends IterationStatementBase, FlowContainer {
         readonly kind: SyntaxKind.DoStatement;
         readonly expression: Expression;
     }
-    interface WhileStatement extends IterationStatement, FlowContainer {
+    interface WhileStatement extends IterationStatementBase, FlowContainer {
         readonly kind: SyntaxKind.WhileStatement;
         readonly expression: Expression;
     }
     type ForInitializer = VariableDeclarationList | Expression;
-    interface ForStatement extends IterationStatement, LocalsContainer, FlowContainer {
+    interface ForStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ForStatement;
         readonly initializer?: ForInitializer;
         readonly condition?: Expression;
         readonly incrementor?: Expression;
     }
     type ForInOrOfStatement = ForInStatement | ForOfStatement;
-    interface ForInStatement extends IterationStatement, LocalsContainer, FlowContainer {
+    interface ForInStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ForInStatement;
         readonly initializer: ForInitializer;
         readonly expression: Expression;
     }
-    interface ForOfStatement extends IterationStatement, LocalsContainer, FlowContainer {
+    interface ForOfStatement extends IterationStatementBase, LocalsContainer, FlowContainer {
         readonly kind: SyntaxKind.ForOfStatement;
         readonly awaitModifier?: AwaitKeyword;
         readonly initializer: ForInitializer;
         readonly expression: Expression;
     }
-    interface BreakStatement extends Statement, FlowContainer {
+    interface BreakStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.BreakStatement;
         readonly label?: Identifier;
     }
-    interface ContinueStatement extends Statement, FlowContainer {
+    interface ContinueStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ContinueStatement;
         readonly label?: Identifier;
     }
     type BreakOrContinueStatement = BreakStatement | ContinueStatement;
-    interface ReturnStatement extends Statement, FlowContainer {
+    interface ReturnStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ReturnStatement;
         readonly expression?: Expression;
     }
-    interface WithStatement extends Statement, FlowContainer {
+    interface WithStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.WithStatement;
         readonly expression: Expression;
         readonly statement: Statement;
     }
-    interface SwitchStatement extends Statement, FlowContainer {
+    interface SwitchStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.SwitchStatement;
         readonly expression: Expression;
         readonly caseBlock: CaseBlock;
         possiblyExhaustive?: boolean;
     }
-    interface CaseBlock extends Node, LocalsContainer {
+    interface CaseBlock extends NodeBase, LocalsContainer {
         readonly kind: SyntaxKind.CaseBlock;
         readonly parent: SwitchStatement;
         readonly clauses: NodeArray<CaseOrDefaultClause>;
     }
-    interface CaseClause extends Node, JSDocContainer {
+    interface CaseClause extends NodeBase, JSDocContainer {
         readonly kind: SyntaxKind.CaseClause;
         readonly parent: CaseBlock;
         readonly expression: Expression;
         readonly statements: NodeArray<Statement>;
     }
-    interface DefaultClause extends Node {
+    interface DefaultClause extends NodeBase {
         readonly kind: SyntaxKind.DefaultClause;
         readonly parent: CaseBlock;
         readonly statements: NodeArray<Statement>;
     }
     type CaseOrDefaultClause = CaseClause | DefaultClause;
-    interface LabeledStatement extends Statement, FlowContainer {
+    interface LabeledStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.LabeledStatement;
         readonly label: Identifier;
         readonly statement: Statement;
     }
-    interface ThrowStatement extends Statement, FlowContainer {
+    interface ThrowStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.ThrowStatement;
         readonly expression: Expression;
     }
-    interface TryStatement extends Statement, FlowContainer {
+    interface TryStatement extends StatementBase, FlowContainer {
         readonly kind: SyntaxKind.TryStatement;
         readonly tryBlock: Block;
         readonly catchClause?: CatchClause;
         readonly finallyBlock?: Block;
     }
-    interface CatchClause extends Node, LocalsContainer {
+    interface CatchClause extends NodeBase, LocalsContainer {
         readonly kind: SyntaxKind.CatchClause;
         readonly parent: TryStatement;
         readonly variableDeclaration?: VariableDeclaration;
@@ -1557,34 +1946,34 @@ declare namespace ts {
     type ObjectTypeDeclaration = ClassLikeDeclaration | InterfaceDeclaration | TypeLiteralNode;
     type DeclarationWithTypeParameters = DeclarationWithTypeParameterChildren | JSDocTypedefTag | JSDocCallbackTag | JSDocSignature;
     type DeclarationWithTypeParameterChildren = SignatureDeclaration | ClassLikeDeclaration | InterfaceDeclaration | TypeAliasDeclaration | JSDocTemplateTag;
-    interface ClassLikeDeclarationBase extends NamedDeclaration, JSDocContainer {
+    interface ClassLikeDeclarationBase extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.ClassDeclaration | SyntaxKind.ClassExpression;
         readonly name?: Identifier;
         readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
         readonly heritageClauses?: NodeArray<HeritageClause>;
         readonly members: NodeArray<ClassElement>;
     }
-    interface ClassDeclaration extends ClassLikeDeclarationBase, DeclarationStatement {
+    interface ClassDeclaration extends ClassLikeDeclarationBase, DeclarationStatementBase {
         readonly kind: SyntaxKind.ClassDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         /** May be undefined in `export default class { ... }`. */
         readonly name?: Identifier;
     }
-    interface ClassExpression extends ClassLikeDeclarationBase, PrimaryExpression {
+    interface ClassExpression extends ClassLikeDeclarationBase, PrimaryExpressionBase {
         readonly kind: SyntaxKind.ClassExpression;
         readonly modifiers?: NodeArray<ModifierLike>;
     }
     type ClassLikeDeclaration = ClassDeclaration | ClassExpression;
-    interface ClassElement extends NamedDeclaration {
+    interface ClassElementBase extends NamedDeclarationBase {
         _classElementBrand: any;
         readonly name?: PropertyName;
     }
-    interface TypeElement extends NamedDeclaration {
+    interface TypeElementBase extends NamedDeclarationBase {
         _typeElementBrand: any;
         readonly name?: PropertyName;
         readonly questionToken?: QuestionToken | undefined;
     }
-    interface InterfaceDeclaration extends DeclarationStatement, JSDocContainer {
+    interface InterfaceDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.InterfaceDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: Identifier;
@@ -1592,26 +1981,26 @@ declare namespace ts {
         readonly heritageClauses?: NodeArray<HeritageClause>;
         readonly members: NodeArray<TypeElement>;
     }
-    interface HeritageClause extends Node {
+    interface HeritageClause extends NodeBase {
         readonly kind: SyntaxKind.HeritageClause;
         readonly parent: InterfaceDeclaration | ClassLikeDeclaration;
         readonly token: SyntaxKind.ExtendsKeyword | SyntaxKind.ImplementsKeyword;
         readonly types: NodeArray<ExpressionWithTypeArguments>;
     }
-    interface TypeAliasDeclaration extends DeclarationStatement, JSDocContainer, LocalsContainer {
+    interface TypeAliasDeclaration extends DeclarationStatementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.TypeAliasDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: Identifier;
         readonly typeParameters?: NodeArray<TypeParameterDeclaration>;
         readonly type: TypeNode;
     }
-    interface EnumMember extends NamedDeclaration, JSDocContainer {
+    interface EnumMember extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.EnumMember;
         readonly parent: EnumDeclaration;
         readonly name: PropertyName;
         readonly initializer?: Expression;
     }
-    interface EnumDeclaration extends DeclarationStatement, JSDocContainer {
+    interface EnumDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.EnumDeclaration;
         readonly modifiers?: NodeArray<ModifierLike>;
         readonly name: Identifier;
@@ -1619,7 +2008,7 @@ declare namespace ts {
     }
     type ModuleName = Identifier | StringLiteral;
     type ModuleBody = NamespaceBody | JSDocNamespaceBody;
-    interface ModuleDeclaration extends DeclarationStatement, JSDocContainer, LocalsContainer {
+    interface ModuleDeclaration extends DeclarationStatementBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.ModuleDeclaration;
         readonly parent: ModuleBody | SourceFile;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -1636,7 +2025,7 @@ declare namespace ts {
         readonly name: Identifier;
         readonly body?: JSDocNamespaceBody;
     }
-    interface ModuleBlock extends Node, Statement {
+    interface ModuleBlock extends NodeBase, StatementBase {
         readonly kind: SyntaxKind.ModuleBlock;
         readonly parent: ModuleDeclaration;
         readonly statements: NodeArray<Statement>;
@@ -1647,7 +2036,7 @@ declare namespace ts {
      * - import x = require("mod");
      * - import x = M.x;
      */
-    interface ImportEqualsDeclaration extends DeclarationStatement, JSDocContainer {
+    interface ImportEqualsDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.ImportEqualsDeclaration;
         readonly parent: SourceFile | ModuleBlock;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -1655,12 +2044,12 @@ declare namespace ts {
         readonly isTypeOnly: boolean;
         readonly moduleReference: ModuleReference;
     }
-    interface ExternalModuleReference extends Node {
+    interface ExternalModuleReference extends NodeBase {
         readonly kind: SyntaxKind.ExternalModuleReference;
         readonly parent: ImportEqualsDeclaration;
         readonly expression: Expression;
     }
-    interface ImportDeclaration extends Statement {
+    interface ImportDeclaration extends StatementBase {
         readonly kind: SyntaxKind.ImportDeclaration;
         readonly parent: SourceFile | ModuleBlock;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -1671,7 +2060,7 @@ declare namespace ts {
     }
     type NamedImportBindings = NamespaceImport | NamedImports;
     type NamedExportBindings = NamespaceExport | NamedExports;
-    interface ImportClause extends NamedDeclaration {
+    interface ImportClause extends NamedDeclarationBase {
         readonly kind: SyntaxKind.ImportClause;
         readonly parent: ImportDeclaration;
         readonly isTypeOnly: boolean;
@@ -1679,33 +2068,33 @@ declare namespace ts {
         readonly namedBindings?: NamedImportBindings;
     }
     type AssertionKey = Identifier | StringLiteral;
-    interface AssertEntry extends Node {
+    interface AssertEntry extends NodeBase {
         readonly kind: SyntaxKind.AssertEntry;
         readonly parent: AssertClause;
         readonly name: AssertionKey;
         readonly value: Expression;
     }
-    interface AssertClause extends Node {
+    interface AssertClause extends NodeBase {
         readonly kind: SyntaxKind.AssertClause;
         readonly parent: ImportDeclaration | ExportDeclaration;
         readonly elements: NodeArray<AssertEntry>;
         readonly multiLine?: boolean;
     }
-    interface NamespaceImport extends NamedDeclaration {
+    interface NamespaceImport extends NamedDeclarationBase {
         readonly kind: SyntaxKind.NamespaceImport;
         readonly parent: ImportClause;
         readonly name: Identifier;
     }
-    interface NamespaceExport extends NamedDeclaration {
+    interface NamespaceExport extends NamedDeclarationBase {
         readonly kind: SyntaxKind.NamespaceExport;
         readonly parent: ExportDeclaration;
         readonly name: Identifier;
     }
-    interface NamespaceExportDeclaration extends DeclarationStatement, JSDocContainer {
+    interface NamespaceExportDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.NamespaceExportDeclaration;
         readonly name: Identifier;
     }
-    interface ExportDeclaration extends DeclarationStatement, JSDocContainer {
+    interface ExportDeclaration extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.ExportDeclaration;
         readonly parent: SourceFile | ModuleBlock;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -1716,25 +2105,25 @@ declare namespace ts {
         readonly moduleSpecifier?: Expression;
         readonly assertClause?: AssertClause;
     }
-    interface NamedImports extends Node {
+    interface NamedImports extends NodeBase {
         readonly kind: SyntaxKind.NamedImports;
         readonly parent: ImportClause;
         readonly elements: NodeArray<ImportSpecifier>;
     }
-    interface NamedExports extends Node {
+    interface NamedExports extends NodeBase {
         readonly kind: SyntaxKind.NamedExports;
         readonly parent: ExportDeclaration;
         readonly elements: NodeArray<ExportSpecifier>;
     }
     type NamedImportsOrExports = NamedImports | NamedExports;
-    interface ImportSpecifier extends NamedDeclaration {
+    interface ImportSpecifier extends NamedDeclarationBase {
         readonly kind: SyntaxKind.ImportSpecifier;
         readonly parent: NamedImports;
         readonly propertyName?: Identifier;
         readonly name: Identifier;
         readonly isTypeOnly: boolean;
     }
-    interface ExportSpecifier extends NamedDeclaration, JSDocContainer {
+    interface ExportSpecifier extends NamedDeclarationBase, JSDocContainer {
         readonly kind: SyntaxKind.ExportSpecifier;
         readonly parent: NamedExports;
         readonly isTypeOnly: boolean;
@@ -1781,7 +2170,7 @@ declare namespace ts {
      * This is either an `export =` or an `export default` declaration.
      * Unless `isExportEquals` is set, this node was parsed as an `export default`.
      */
-    interface ExportAssignment extends DeclarationStatement, JSDocContainer {
+    interface ExportAssignment extends DeclarationStatementBase, JSDocContainer {
         readonly kind: SyntaxKind.ExportAssignment;
         readonly parent: SourceFile;
         readonly modifiers?: NodeArray<ModifierLike>;
@@ -1806,205 +2195,207 @@ declare namespace ts {
         end: -1;
         hasLeadingNewline?: boolean;
     }
-    interface JSDocTypeExpression extends TypeNode {
+    interface JSDocTypeExpression extends TypeNodeBase {
         readonly kind: SyntaxKind.JSDocTypeExpression;
         readonly type: TypeNode;
     }
-    interface JSDocNameReference extends Node {
+    interface JSDocNameReference extends NodeBase {
         readonly kind: SyntaxKind.JSDocNameReference;
         readonly name: EntityName | JSDocMemberName;
     }
     /** Class#method reference in JSDoc */
-    interface JSDocMemberName extends Node {
+    interface JSDocMemberName extends NodeBase {
         readonly kind: SyntaxKind.JSDocMemberName;
         readonly left: EntityName | JSDocMemberName;
         readonly right: Identifier;
     }
-    interface JSDocType extends TypeNode {
+    interface JSDocTypeBase extends TypeNodeBase {
         _jsDocTypeBrand: any;
     }
-    interface JSDocAllType extends JSDocType {
+    interface JSDocAllType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocAllType;
     }
-    interface JSDocUnknownType extends JSDocType {
+    interface JSDocUnknownType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocUnknownType;
     }
-    interface JSDocNonNullableType extends JSDocType {
+    interface JSDocNonNullableType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocNonNullableType;
         readonly type: TypeNode;
         readonly postfix: boolean;
     }
-    interface JSDocNullableType extends JSDocType {
+    interface JSDocNullableType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocNullableType;
         readonly type: TypeNode;
         readonly postfix: boolean;
     }
-    interface JSDocOptionalType extends JSDocType {
+    interface JSDocOptionalType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocOptionalType;
         readonly type: TypeNode;
     }
-    interface JSDocFunctionType extends JSDocType, SignatureDeclarationBase, LocalsContainer {
+    interface JSDocFunctionType extends JSDocTypeBase, SignatureDeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocFunctionType;
     }
-    interface JSDocVariadicType extends JSDocType {
+    interface JSDocVariadicType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocVariadicType;
         readonly type: TypeNode;
     }
-    interface JSDocNamepathType extends JSDocType {
+    interface JSDocNamepathType extends JSDocTypeBase {
         readonly kind: SyntaxKind.JSDocNamepathType;
         readonly type: TypeNode;
     }
     type JSDocTypeReferencingNode = JSDocVariadicType | JSDocOptionalType | JSDocNullableType | JSDocNonNullableType;
-    interface JSDoc extends Node {
+    interface JSDoc extends NodeBase {
         readonly kind: SyntaxKind.JSDoc;
         readonly parent: HasJSDoc;
         readonly tags?: NodeArray<JSDocTag>;
         readonly comment?: string | NodeArray<JSDocComment>;
     }
-    interface JSDocTag extends Node {
-        readonly parent: JSDoc | JSDocTypeLiteral;
+    interface JSDocTagBase extends NodeBase {
+        readonly parent: JSDoc | JSDocSignature | JSDocTypeLiteral;
         readonly tagName: Identifier;
         readonly comment?: string | NodeArray<JSDocComment>;
     }
-    interface JSDocLink extends Node {
+    interface JSDocLink extends NodeBase {
         readonly kind: SyntaxKind.JSDocLink;
         readonly name?: EntityName | JSDocMemberName;
         text: string;
     }
-    interface JSDocLinkCode extends Node {
+    interface JSDocLinkCode extends NodeBase {
         readonly kind: SyntaxKind.JSDocLinkCode;
         readonly name?: EntityName | JSDocMemberName;
         text: string;
     }
-    interface JSDocLinkPlain extends Node {
+    interface JSDocLinkPlain extends NodeBase {
         readonly kind: SyntaxKind.JSDocLinkPlain;
         readonly name?: EntityName | JSDocMemberName;
         text: string;
     }
     type JSDocComment = JSDocText | JSDocLink | JSDocLinkCode | JSDocLinkPlain;
-    interface JSDocText extends Node {
+    interface JSDocText extends NodeBase {
         readonly kind: SyntaxKind.JSDocText;
         text: string;
     }
-    interface JSDocUnknownTag extends JSDocTag {
+    interface JSDocUnknownTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocTag;
     }
     /**
      * Note that `@extends` is a synonym of `@augments`.
      * Both tags are represented by this interface.
      */
-    interface JSDocAugmentsTag extends JSDocTag {
+    interface JSDocAugmentsTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocAugmentsTag;
         readonly class: ExpressionWithTypeArguments & {
             readonly expression: Identifier | PropertyAccessEntityNameExpression;
         };
     }
-    interface JSDocImplementsTag extends JSDocTag {
+    interface JSDocImplementsTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocImplementsTag;
         readonly class: ExpressionWithTypeArguments & {
             readonly expression: Identifier | PropertyAccessEntityNameExpression;
         };
     }
-    interface JSDocAuthorTag extends JSDocTag {
+    interface JSDocAuthorTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocAuthorTag;
     }
-    interface JSDocDeprecatedTag extends JSDocTag {
+    interface JSDocDeprecatedTag extends JSDocTagBase {
         kind: SyntaxKind.JSDocDeprecatedTag;
     }
-    interface JSDocClassTag extends JSDocTag {
+    interface JSDocClassTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocClassTag;
     }
-    interface JSDocPublicTag extends JSDocTag {
+    interface JSDocPublicTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocPublicTag;
     }
-    interface JSDocPrivateTag extends JSDocTag {
+    interface JSDocPrivateTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocPrivateTag;
     }
-    interface JSDocProtectedTag extends JSDocTag {
+    interface JSDocProtectedTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocProtectedTag;
     }
-    interface JSDocReadonlyTag extends JSDocTag {
+    interface JSDocReadonlyTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocReadonlyTag;
     }
-    interface JSDocOverrideTag extends JSDocTag {
+    interface JSDocOverrideTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocOverrideTag;
     }
-    interface JSDocEnumTag extends JSDocTag, Declaration, LocalsContainer {
+    interface JSDocEnumTag extends JSDocTagBase, DeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocEnumTag;
         readonly parent: JSDoc;
         readonly typeExpression: JSDocTypeExpression;
     }
-    interface JSDocThisTag extends JSDocTag {
+    interface JSDocThisTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocThisTag;
         readonly typeExpression: JSDocTypeExpression;
     }
-    interface JSDocTemplateTag extends JSDocTag {
+    interface JSDocTemplateTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocTemplateTag;
         readonly constraint: JSDocTypeExpression | undefined;
         readonly typeParameters: NodeArray<TypeParameterDeclaration>;
     }
-    interface JSDocSeeTag extends JSDocTag {
+    interface JSDocSeeTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocSeeTag;
         readonly name?: JSDocNameReference;
     }
-    interface JSDocReturnTag extends JSDocTag {
+    interface JSDocReturnTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocReturnTag;
         readonly typeExpression?: JSDocTypeExpression;
     }
-    interface JSDocTypeTag extends JSDocTag {
+    interface JSDocTypeTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocTypeTag;
         readonly typeExpression: JSDocTypeExpression;
     }
-    interface JSDocTypedefTag extends JSDocTag, NamedDeclaration, LocalsContainer {
+    interface JSDocTypedefTag extends JSDocTagBase, NamedDeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocTypedefTag;
         readonly parent: JSDoc;
         readonly fullName?: JSDocNamespaceDeclaration | Identifier;
         readonly name?: Identifier;
         readonly typeExpression?: JSDocTypeExpression | JSDocTypeLiteral;
     }
-    interface JSDocCallbackTag extends JSDocTag, NamedDeclaration, LocalsContainer {
+    interface JSDocCallbackTag extends JSDocTagBase, NamedDeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.JSDocCallbackTag;
         readonly parent: JSDoc;
         readonly fullName?: JSDocNamespaceDeclaration | Identifier;
         readonly name?: Identifier;
         readonly typeExpression: JSDocSignature;
     }
-    interface JSDocOverloadTag extends JSDocTag {
+    interface JSDocOverloadTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocOverloadTag;
         readonly parent: JSDoc;
         readonly typeExpression: JSDocSignature;
     }
-    interface JSDocThrowsTag extends JSDocTag {
+    interface JSDocThrowsTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocThrowsTag;
         readonly typeExpression?: JSDocTypeExpression;
     }
-    interface JSDocSignature extends JSDocType, Declaration, JSDocContainer, LocalsContainer {
+    interface JSDocSignature extends JSDocTypeBase, DeclarationBase, JSDocContainer, LocalsContainer {
         readonly kind: SyntaxKind.JSDocSignature;
         readonly typeParameters?: readonly JSDocTemplateTag[];
         readonly parameters: readonly JSDocParameterTag[];
         readonly type: JSDocReturnTag | undefined;
     }
-    interface JSDocPropertyLikeTag extends JSDocTag, Declaration {
-        readonly parent: JSDoc;
+    interface JSDocPropertyLikeTagBase extends JSDocTagBase, DeclarationBase {
+        readonly parent: JSDoc | JSDocSignature | JSDocTypeLiteral;
         readonly name: EntityName;
         readonly typeExpression?: JSDocTypeExpression;
         /** Whether the property name came before the type -- non-standard for JSDoc, but Typescript-like */
         readonly isNameFirst: boolean;
         readonly isBracketed: boolean;
     }
-    interface JSDocPropertyTag extends JSDocPropertyLikeTag {
+    interface JSDocPropertyTag extends JSDocPropertyLikeTagBase {
+        readonly parent: JSDocTypeLiteral;
         readonly kind: SyntaxKind.JSDocPropertyTag;
     }
-    interface JSDocParameterTag extends JSDocPropertyLikeTag {
+    interface JSDocParameterTag extends JSDocPropertyLikeTagBase {
+        readonly parent: JSDocSignature | JSDoc | JSDocTypeLiteral;
         readonly kind: SyntaxKind.JSDocParameterTag;
     }
-    interface JSDocTypeLiteral extends JSDocType, Declaration {
+    interface JSDocTypeLiteral extends JSDocTypeBase, DeclarationBase {
         readonly kind: SyntaxKind.JSDocTypeLiteral;
-        readonly jsDocPropertyTags?: readonly JSDocPropertyLikeTag[];
+        readonly jsDocPropertyTags?: readonly JSDocPropertyTag[];
         /** If true, then this type literal represents an *array* of its type. */
         readonly isArrayType: boolean;
     }
-    interface JSDocSatisfiesTag extends JSDocTag {
+    interface JSDocSatisfiesTag extends JSDocTagBase {
         readonly kind: SyntaxKind.JSDocSatisfiesTag;
         readonly typeExpression: JSDocTypeExpression;
     }
@@ -2082,10 +2473,10 @@ declare namespace ts {
         getLineAndCharacterOfPosition(pos: number): LineAndCharacter;
     }
     type ResolutionMode = ModuleKind.ESNext | ModuleKind.CommonJS | undefined;
-    interface SourceFile extends Declaration, LocalsContainer {
+    interface SourceFile extends DeclarationBase, LocalsContainer {
         readonly kind: SyntaxKind.SourceFile;
         readonly statements: NodeArray<Statement>;
-        readonly endOfFileToken: Token<SyntaxKind.EndOfFileToken>;
+        readonly endOfFileToken: EndOfFileToken;
         fileName: string;
         text: string;
         amdDependencies: readonly AmdDependency[];
@@ -2131,13 +2522,13 @@ declare namespace ts {
         getPositionOfLineAndCharacter(line: number, character: number): number;
         update(newText: string, textChangeRange: TextChangeRange): SourceFile;
     }
-    interface Bundle extends Node {
+    interface Bundle extends NodeBase {
         readonly kind: SyntaxKind.Bundle;
         /** @deprecated */ readonly prepends: readonly (InputFiles | UnparsedSource)[];
         readonly sourceFiles: readonly SourceFile[];
     }
     /** @deprecated */
-    interface InputFiles extends Node {
+    interface InputFiles extends NodeBase {
         readonly kind: SyntaxKind.InputFiles;
         javascriptPath?: string;
         javascriptText: string;
@@ -2149,7 +2540,7 @@ declare namespace ts {
         declarationMapText?: string;
     }
     /** @deprecated */
-    interface UnparsedSource extends Node {
+    interface UnparsedSource extends NodeBase {
         readonly kind: SyntaxKind.UnparsedSource;
         fileName: string;
         text: string;
@@ -2169,7 +2560,7 @@ declare namespace ts {
     /** @deprecated */
     type UnparsedNode = UnparsedPrologue | UnparsedSourceText | UnparsedSyntheticReference;
     /** @deprecated */
-    interface UnparsedSection extends Node {
+    interface UnparsedSection extends NodeBase {
         readonly kind: SyntaxKind;
         readonly parent: UnparsedSource;
         readonly data?: string;
@@ -4235,7 +4626,7 @@ declare namespace ts {
         span: TextSpan;
         newLength: number;
     }
-    interface SyntaxList extends Node {
+    interface SyntaxList extends NodeBase {
         kind: SyntaxKind.SyntaxList;
         _children: Node[];
     }

--- a/tests/cases/compiler/APILibCheck.ts
+++ b/tests/cases/compiler/APILibCheck.ts
@@ -9,26 +9,5 @@
     "types": "/.ts/typescript.d.ts"
 }
 
-// @filename: node_modules/typescript-internal/package.json
-{
-    "name": "typescript-internal",
-    "types": "/.ts/typescript.internal.d.ts"
-}
-
-// @filename: node_modules/tsserverlibrary/package.json
-{
-    "name": "tsserverlibrary",
-    "types": "/.ts/tsserverlibrary.d.ts"
-}
-
-// @filename: node_modules/tsserverlibrary-internal/package.json
-{
-    "name": "tsserverlibrary-internal",
-    "types": "/.ts/tsserverlibrary.internal.d.ts"
-}
-
 // @filename: index.ts
 import ts = require("typescript");
-import tsInternal = require("typescript-internal");
-import tsserverlibrary = require("tsserverlibrary");
-import tsserverlibraryInternal = require("tsserverlibrary-internal");

--- a/tests/cases/compiler/APILibCheck2.ts
+++ b/tests/cases/compiler/APILibCheck2.ts
@@ -1,0 +1,13 @@
+// @module: commonjs
+// @noImplicitAny: true
+// @strictNullChecks: true
+// @lib: es2018
+
+// @filename: node_modules/typescript-internal/package.json
+{
+    "name": "typescript-internal",
+    "types": "/.ts/typescript.internal.d.ts"
+}
+
+// @filename: index.ts
+import tsInternal = require("typescript-internal");

--- a/tests/cases/compiler/APILibCheck3.ts
+++ b/tests/cases/compiler/APILibCheck3.ts
@@ -1,0 +1,13 @@
+// @module: commonjs
+// @noImplicitAny: true
+// @strictNullChecks: true
+// @lib: es2018
+
+// @filename: node_modules/tsserverlibrary/package.json
+{
+    "name": "tsserverlibrary",
+    "types": "/.ts/tsserverlibrary.d.ts"
+}
+
+// @filename: index.ts
+import tsserverlibrary = require("tsserverlibrary");

--- a/tests/cases/compiler/APILibCheck4.ts
+++ b/tests/cases/compiler/APILibCheck4.ts
@@ -1,0 +1,13 @@
+// @module: commonjs
+// @noImplicitAny: true
+// @strictNullChecks: true
+// @lib: es2018
+
+// @filename: node_modules/tsserverlibrary-internal/package.json
+{
+    "name": "tsserverlibrary-internal",
+    "types": "/.ts/tsserverlibrary.internal.d.ts"
+}
+
+// @filename: index.ts
+import tsserverlibraryInternal = require("tsserverlibrary-internal");


### PR DESCRIPTION
Like `Node`, `Expression`, `TypeNode`, and the like.

This allows us to make many more `switch` statements in our codebase exhaustive (a change not included in this PR, which just swaps over to unions and fixes resulting errors/lints).

This is like the `Compiler-Unions` perf test, except:
1. Totally complete, rather than just the `compiler` folder.
2. Totally up-to-date (this comment will age well 😂).

Incremental rebuilds are a rebuild-accelerating thing now, so I think this is more palatable nowadays (because a fresh build does _still_ take about 2.7x longer than `main` today does). Especially since using unions for all these types has tangible style and safety advantages (no more casts everywhere!). Immediately, this found some dead code (which is now gone) and some incorrect types (which are now fixed). In addition to the ergonomic niceties of using unions like this, I do think using them more like this would help us dogfood our own typesystem more in scenarios we consider more "extreme", since we have 363 different node kinds now (and usually growing), so the `Node` type is what we should consider a "reasonable" but large type.

There are a handful of places where I had to introduce some new casts to work around some bogus complexity errors (opened #54146 to track the issue causing it, and flagged the offending locations), but other than that this actually works pretty well without significant refactoring (other than automatically removing a ton of useless casts). The big question is really just if we, as a team, think the tradeoffs are worth it at this point or not.