### PR TITLE
fix(54155): "Move to file" does not carry all function overload and implementation signatures

### DIFF
--- a/tests/cases/fourslash/moveToFile_overloads1.ts
+++ b/tests/cases/fourslash/moveToFile_overloads1.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /add.ts
+////
+
+// @Filename: /a.ts
+////[|function add(x: number, y: number): number;|]
+////function add(x: string, y: string): string;
+////function add(x: any, y: any) {
+////    return x + y;
+////}
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+    interactiveRefactorArguments: { targetFile: "/add.ts" }
+});

--- a/tests/cases/fourslash/moveToFile_overloads2.ts
+++ b/tests/cases/fourslash/moveToFile_overloads2.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /add.ts
+////
+
+// @Filename: /a.ts
+////function add(x: number, y: number): number;
+////function add(x: string, y: string): string;
+////[|function add(x: any, y: any) {
+////    return x + y;
+////}|]
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+    interactiveRefactorArguments: { targetFile: "/add.ts" }
+});

--- a/tests/cases/fourslash/moveToFile_overloads3.ts
+++ b/tests/cases/fourslash/moveToFile_overloads3.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /add.ts
+////
+
+// @Filename: /a.ts
+////function add(x: number, y: number): number;
+////[|function add(x: string, y: string): string;
+////function add(x: any, y: any) {
+////    return x + y;
+////}|]
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+    interactiveRefactorArguments: { targetFile: "/add.ts" },
+});

--- a/tests/cases/fourslash/moveToFile_overloads4.ts
+++ b/tests/cases/fourslash/moveToFile_overloads4.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /add.ts
+////
+
+// @Filename: /a.ts
+////function add(x: number, y: number): number;
+////[|function add(x: string, y: string): string;
+////function add(x: any, y: any) {
+////    return x + y;
+////}|]
+////function remove() {}
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts": "function remove() {}",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+    interactiveRefactorArguments: { targetFile: "/add.ts" },
+});

--- a/tests/cases/fourslash/moveToFile_overloads5.ts
+++ b/tests/cases/fourslash/moveToFile_overloads5.ts
@@ -1,0 +1,29 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /add.ts
+////
+
+// @Filename: /a.ts
+////function add(x: number, y: number): number;
+////[|function add(x: string, y: string): string;
+////function add(x: any, y: any) {
+////    return x + y;
+////}|]
+////export const a = add();
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts":
+`import { add } from "./add";
+
+export const a = add();`,
+        "/add.ts":
+`export function add(x: number, y: number): number;
+export function add(x: string, y: string): string;
+export function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+    interactiveRefactorArguments: { targetFile: "/add.ts" },
+});

--- a/tests/cases/fourslash/moveToNewFile_overloads1.ts
+++ b/tests/cases/fourslash/moveToNewFile_overloads1.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////[|function add(x: number, y: number): number;|]
+////function add(x: string, y: string): string;
+////function add(x: any, y: any) {
+////    return x + y;
+////}
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+});

--- a/tests/cases/fourslash/moveToNewFile_overloads2.ts
+++ b/tests/cases/fourslash/moveToNewFile_overloads2.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////function add(x: number, y: number): number;
+////function add(x: string, y: string): string;
+////[|function add(x: any, y: any) {
+////    return x + y;
+////}|]
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+});

--- a/tests/cases/fourslash/moveToNewFile_overloads3.ts
+++ b/tests/cases/fourslash/moveToNewFile_overloads3.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////function add(x: number, y: number): number;
+////[|function add(x: string, y: string): string;
+////function add(x: any, y: any) {
+////    return x + y;
+////}|]
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+});

--- a/tests/cases/fourslash/moveToNewFile_overloads4.ts
+++ b/tests/cases/fourslash/moveToNewFile_overloads4.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////function add(x: number, y: number): number;
+////[|function add(x: string, y: string): string;
+////function add(x: any, y: any) {
+////    return x + y;
+////}|]
+////function remove() {}
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts": "function remove() {}",
+        "/add.ts":
+`function add(x: number, y: number): number;
+function add(x: string, y: string): string;
+function add(x: any, y: any) {
+    return x + y;
+}
+`
+    },
+});


### PR DESCRIPTION
Fixes #54155