### PR TITLE
fix(54152): Cannot use const enum to define an interface key in isolatedModules mode

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37819,7 +37819,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (getIsolatedModules(compilerOptions)) {
             Debug.assert(!!(type.symbol.flags & SymbolFlags.ConstEnum));
             const constEnumDeclaration = type.symbol.valueDeclaration as EnumDeclaration;
-            if (constEnumDeclaration.flags & NodeFlags.Ambient) {
+            if (constEnumDeclaration.flags & NodeFlags.Ambient && !(node.flags & NodeFlags.Ambient)) {
                 error(node, Diagnostics.Cannot_access_ambient_const_enums_when_0_is_enabled, isolatedModulesLikeFlagName);
             }
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37819,7 +37819,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (getIsolatedModules(compilerOptions)) {
             Debug.assert(!!(type.symbol.flags & SymbolFlags.ConstEnum));
             const constEnumDeclaration = type.symbol.valueDeclaration as EnumDeclaration;
-            if (constEnumDeclaration.flags & NodeFlags.Ambient && !(node.flags & NodeFlags.Ambient)) {
+            if (constEnumDeclaration.flags & NodeFlags.Ambient && !isValidTypeOnlyAliasUseSite(node)) {
                 error(node, Diagnostics.Cannot_access_ambient_const_enums_when_0_is_enabled, isolatedModulesLikeFlagName);
             }
         }

--- a/tests/baselines/reference/isolatedModulesConstEnum.js
+++ b/tests/baselines/reference/isolatedModulesConstEnum.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/isolatedModulesConstEnum.ts] ////
+
+//// [foo.d.ts]
+declare const enum EventName {
+    FOO = 1,
+    BAR = 2
+}
+
+type E1 = {
+    [EventName.FOO]: number;
+    [EventName.BAR]: string;
+};
+
+//// [bar.ts]
+type E2 = {
+    [EventName.FOO]: number;
+    [EventName.BAR]: string;
+};
+
+
+//// [bar.js]

--- a/tests/baselines/reference/isolatedModulesConstEnum.symbols
+++ b/tests/baselines/reference/isolatedModulesConstEnum.symbols
@@ -9,17 +9,35 @@ declare const enum EventName {
 >BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))
 }
 
-type EventMap = {
->EventMap : Symbol(EventMap, Decl(foo.d.ts, 3, 1))
+type E1 = {
+>E1 : Symbol(E1, Decl(foo.d.ts, 3, 1))
 
     [EventName.FOO]: number;
->[EventName.FOO] : Symbol([EventName.FOO], Decl(foo.d.ts, 5, 17))
+>[EventName.FOO] : Symbol([EventName.FOO], Decl(foo.d.ts, 5, 11))
 >EventName.FOO : Symbol(EventName.FOO, Decl(foo.d.ts, 0, 30))
 >EventName : Symbol(EventName, Decl(foo.d.ts, 0, 0))
 >FOO : Symbol(EventName.FOO, Decl(foo.d.ts, 0, 30))
 
     [EventName.BAR]: string;
 >[EventName.BAR] : Symbol([EventName.BAR], Decl(foo.d.ts, 6, 28))
+>EventName.BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))
+>EventName : Symbol(EventName, Decl(foo.d.ts, 0, 0))
+>BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))
+
+};
+
+=== /bar.ts ===
+type E2 = {
+>E2 : Symbol(E2, Decl(bar.ts, 0, 0))
+
+    [EventName.FOO]: number;
+>[EventName.FOO] : Symbol([EventName.FOO], Decl(bar.ts, 0, 11))
+>EventName.FOO : Symbol(EventName.FOO, Decl(foo.d.ts, 0, 30))
+>EventName : Symbol(EventName, Decl(foo.d.ts, 0, 0))
+>FOO : Symbol(EventName.FOO, Decl(foo.d.ts, 0, 30))
+
+    [EventName.BAR]: string;
+>[EventName.BAR] : Symbol([EventName.BAR], Decl(bar.ts, 1, 28))
 >EventName.BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))
 >EventName : Symbol(EventName, Decl(foo.d.ts, 0, 0))
 >BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))

--- a/tests/baselines/reference/isolatedModulesConstEnum.symbols
+++ b/tests/baselines/reference/isolatedModulesConstEnum.symbols
@@ -1,0 +1,28 @@
+=== /foo.d.ts ===
+declare const enum EventName {
+>EventName : Symbol(EventName, Decl(foo.d.ts, 0, 0))
+
+    FOO = 1,
+>FOO : Symbol(EventName.FOO, Decl(foo.d.ts, 0, 30))
+
+    BAR = 2
+>BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))
+}
+
+type EventMap = {
+>EventMap : Symbol(EventMap, Decl(foo.d.ts, 3, 1))
+
+    [EventName.FOO]: number;
+>[EventName.FOO] : Symbol([EventName.FOO], Decl(foo.d.ts, 5, 17))
+>EventName.FOO : Symbol(EventName.FOO, Decl(foo.d.ts, 0, 30))
+>EventName : Symbol(EventName, Decl(foo.d.ts, 0, 0))
+>FOO : Symbol(EventName.FOO, Decl(foo.d.ts, 0, 30))
+
+    [EventName.BAR]: string;
+>[EventName.BAR] : Symbol([EventName.BAR], Decl(foo.d.ts, 6, 28))
+>EventName.BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))
+>EventName : Symbol(EventName, Decl(foo.d.ts, 0, 0))
+>BAR : Symbol(EventName.BAR, Decl(foo.d.ts, 1, 12))
+
+};
+

--- a/tests/baselines/reference/isolatedModulesConstEnum.types
+++ b/tests/baselines/reference/isolatedModulesConstEnum.types
@@ -1,0 +1,30 @@
+=== /foo.d.ts ===
+declare const enum EventName {
+>EventName : EventName
+
+    FOO = 1,
+>FOO : EventName.FOO
+>1 : 1
+
+    BAR = 2
+>BAR : EventName.BAR
+>2 : 2
+}
+
+type EventMap = {
+>EventMap : { 1: number; 2: string; }
+
+    [EventName.FOO]: number;
+>[EventName.FOO] : number
+>EventName.FOO : EventName.FOO
+>EventName : typeof EventName
+>FOO : EventName.FOO
+
+    [EventName.BAR]: string;
+>[EventName.BAR] : string
+>EventName.BAR : EventName.BAR
+>EventName : typeof EventName
+>BAR : EventName.BAR
+
+};
+

--- a/tests/baselines/reference/isolatedModulesConstEnum.types
+++ b/tests/baselines/reference/isolatedModulesConstEnum.types
@@ -11,8 +11,26 @@ declare const enum EventName {
 >2 : 2
 }
 
-type EventMap = {
->EventMap : { 1: number; 2: string; }
+type E1 = {
+>E1 : { 1: number; 2: string; }
+
+    [EventName.FOO]: number;
+>[EventName.FOO] : number
+>EventName.FOO : EventName.FOO
+>EventName : typeof EventName
+>FOO : EventName.FOO
+
+    [EventName.BAR]: string;
+>[EventName.BAR] : string
+>EventName.BAR : EventName.BAR
+>EventName : typeof EventName
+>BAR : EventName.BAR
+
+};
+
+=== /bar.ts ===
+type E2 = {
+>E2 : { 1: number; 2: string; }
 
     [EventName.FOO]: number;
 >[EventName.FOO] : number

--- a/tests/cases/compiler/isolatedModulesConstEnum.ts
+++ b/tests/cases/compiler/isolatedModulesConstEnum.ts
@@ -1,0 +1,11 @@
+// @isolatedModules: true
+// @filename: /foo.d.ts
+declare const enum EventName {
+    FOO = 1,
+    BAR = 2
+}
+
+type EventMap = {
+    [EventName.FOO]: number;
+    [EventName.BAR]: string;
+};

--- a/tests/cases/compiler/isolatedModulesConstEnum.ts
+++ b/tests/cases/compiler/isolatedModulesConstEnum.ts
@@ -5,7 +5,13 @@ declare const enum EventName {
     BAR = 2
 }
 
-type EventMap = {
+type E1 = {
+    [EventName.FOO]: number;
+    [EventName.BAR]: string;
+};
+
+// @filename: /bar.ts
+type E2 = {
     [EventName.FOO]: number;
     [EventName.BAR]: string;
 };


### PR DESCRIPTION
Fixes #54152