### PR TITLE
Bump volta to v20 and packageManager to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,9 +110,9 @@
         "source-map-support": false,
         "inspector": false
     },
-    "packageManager": "npm@8.19.3",
+    "packageManager": "npm@8.19.4",
     "volta": {
-        "node": "14.21.1",
-        "npm": "8.19.3"
+        "node": "20.1.0",
+        "npm": "8.19.4"
     }
 }


### PR DESCRIPTION
Given we only kept v14 around for stack restarting, and v19+ have brought the feature back, this should be safe to do now. @andrewbranch noted that Node 14 has no macOS ARM builds, so newer would be good.

Or, we can just drop this config. I'm not sure who all is still using volta anymore (maybe just @DanielRosenwasser).

It's a shame volta doesn't offer any configuration mechanism that _isn't_ package.json.