### PR TITLE
Fix for formatter crash for Move to file

### DIFF
--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -1240,12 +1240,12 @@ namespace changesToText {
 
             const textChanges = mapDefined(normalized, c => {
                 const span = createTextSpanFromRange(c.range);
-                const sourceFile = c.kind === ChangeKind.ReplaceWithSingleNode ? getSourceFileOfNode(getOriginalNode(c.node)) ?? c.sourceFile :
+                const targetSourceFile = c.kind === ChangeKind.ReplaceWithSingleNode ? getSourceFileOfNode(getOriginalNode(c.node)) ?? c.sourceFile :
                     c.kind === ChangeKind.ReplaceWithMultipleNodes ? getSourceFileOfNode(getOriginalNode(c.nodes[0])) ?? c.sourceFile :
                     c.sourceFile;
-                const newText = computeNewText(c, sourceFile, newLineCharacter, formatContext, validate);
+                const newText = computeNewText(c, targetSourceFile, sourceFile, newLineCharacter, formatContext, validate);
                 // Filter out redundant changes.
-                if (span.length === newText.length && stringContainsAt(sourceFile.text, newText, span.start)) {
+                if (span.length === newText.length && stringContainsAt(targetSourceFile.text, newText, span.start)) {
                     return undefined;
                 }
 
@@ -1269,7 +1269,7 @@ namespace changesToText {
         return applyChanges(nonFormattedText, changes) + newLineCharacter;
     }
 
-    function computeNewText(change: Change, sourceFile: SourceFile, newLineCharacter: string, formatContext: formatting.FormatContext, validate: ValidateNonFormattedText | undefined): string {
+    function computeNewText(change: Change, targetSourceFile: SourceFile, sourceFile: SourceFile, newLineCharacter: string, formatContext: formatting.FormatContext, validate: ValidateNonFormattedText | undefined): string {
         if (change.kind === ChangeKind.Remove) {
             return "";
         }
@@ -1278,26 +1278,26 @@ namespace changesToText {
         }
 
         const { options = {}, range: { pos } } = change;
-        const format = (n: Node) => getFormattedTextOfNode(n, sourceFile, pos, options, newLineCharacter, formatContext, validate);
+        const format = (n: Node) => getFormattedTextOfNode(n, targetSourceFile, sourceFile, pos, options, newLineCharacter, formatContext, validate);
         const text = change.kind === ChangeKind.ReplaceWithMultipleNodes
             ? change.nodes.map(n => removeSuffix(format(n), newLineCharacter)).join(change.options?.joiner || newLineCharacter)
             : format(change.node);
         // strip initial indentation (spaces or tabs) if text will be inserted in the middle of the line
-        const noIndent = (options.indentation !== undefined || getLineStartPositionForPosition(pos, sourceFile) === pos) ? text : text.replace(/^\s+/, "");
+        const noIndent = (options.indentation !== undefined || getLineStartPositionForPosition(pos, targetSourceFile) === pos) ? text : text.replace(/^\s+/, "");
         return (options.prefix || "") + noIndent
              + ((!options.suffix || endsWith(noIndent, options.suffix))
                 ? "" : options.suffix);
     }
 
     /** Note: this may mutate `nodeIn`. */
-    function getFormattedTextOfNode(nodeIn: Node, sourceFile: SourceFile, pos: number, { indentation, prefix, delta }: InsertNodeOptions, newLineCharacter: string, formatContext: formatting.FormatContext, validate: ValidateNonFormattedText | undefined): string {
-        const { node, text } = getNonformattedText(nodeIn, sourceFile, newLineCharacter);
+    function getFormattedTextOfNode(nodeIn: Node, targetSourceFile: SourceFile, sourceFile: SourceFile, pos: number, { indentation, prefix, delta }: InsertNodeOptions, newLineCharacter: string, formatContext: formatting.FormatContext, validate: ValidateNonFormattedText | undefined): string {
+        const { node, text } = getNonformattedText(nodeIn, targetSourceFile, newLineCharacter);
         if (validate) validate(node, text);
-        const formatOptions = getFormatCodeSettingsForWriting(formatContext, sourceFile);
+        const formatOptions = getFormatCodeSettingsForWriting(formatContext, targetSourceFile);
         const initialIndentation =
             indentation !== undefined
                 ? indentation
-                : formatting.SmartIndenter.getIndentation(pos, sourceFile, formatOptions, prefix === newLineCharacter || getLineStartPositionForPosition(pos, sourceFile) === pos);
+                : formatting.SmartIndenter.getIndentation(pos, sourceFile, formatOptions, prefix === newLineCharacter || getLineStartPositionForPosition(pos, targetSourceFile) === pos);
         if (delta === undefined) {
             delta = formatting.SmartIndenter.shouldIndentChildNode(formatOptions, nodeIn) ? (formatOptions.indentSize || 0) : 0;
         }
@@ -1308,7 +1308,7 @@ namespace changesToText {
                 return getLineAndCharacterOfPosition(this, pos);
             }
         };
-        const changes = formatting.formatNodeGivenIndentation(node, file, sourceFile.languageVariant, initialIndentation, delta, { ...formatContext, options: formatOptions });
+        const changes = formatting.formatNodeGivenIndentation(node, file, targetSourceFile.languageVariant, initialIndentation, delta, { ...formatContext, options: formatOptions });
         return applyChanges(text, changes);
     }
 

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -52,9 +52,11 @@ import {
     getNewLineKind,
     getNewLineOrDefaultFromHost,
     getNodeId,
+    getOriginalNode,
     getPrecedingNonSpaceCharacterPosition,
     getScriptKindFromFileName,
     getShebang,
+    getSourceFileOfNode,
     getStartPositionOfLine,
     getTokenAtPosition,
     getTouchingToken,
@@ -1238,6 +1240,9 @@ namespace changesToText {
 
             const textChanges = mapDefined(normalized, c => {
                 const span = createTextSpanFromRange(c.range);
+                const sourceFile = c.kind === ChangeKind.ReplaceWithSingleNode ? getSourceFileOfNode(getOriginalNode(c.node)) ?? c.sourceFile :
+                    c.kind === ChangeKind.ReplaceWithMultipleNodes ? getSourceFileOfNode(getOriginalNode(c.nodes[0])) ?? c.sourceFile :
+                    c.sourceFile;
                 const newText = computeNewText(c, sourceFile, newLineCharacter, formatContext, validate);
                 // Filter out redundant changes.
                 if (span.length === newText.length && stringContainsAt(sourceFile.text, newText, span.start)) {

--- a/tests/cases/fourslash/moveToFile_multipleStatements2.ts
+++ b/tests/cases/fourslash/moveToFile_multipleStatements2.ts
@@ -1,0 +1,69 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: /bar.ts
+////import { } from './somefile';
+////const a = 12;
+
+//@Filename: /a.ts
+//// [|export type ProblemKind =
+////   | "NoResolution"
+////   | "UntypedResolution"
+////   | "FalseESM"
+////   | "FalseCJS"
+////   | "CJSResolvesToESM"
+////   | "Wildcard"
+////   | "UnexpectedESMSyntax"
+////   | "UnexpectedCJSSyntax"
+////   | "FallbackCondition"
+////   | "CJSOnlyExportsDefault"
+////   | "FalseExportDefault";
+
+//// export interface Problem {
+////   kind: ProblemKind;
+////   entrypoint: string;
+//// }
+
+//// export interface ProblemSummary {
+////   kind: ProblemKind;
+////   title: string;
+////   messages: {
+////     messageText: string;
+////     messageHtml: string;
+////   }[];
+//// }|]
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts":
+``,
+
+        "/bar.ts":
+`import { } from './somefile';
+const a = 12;
+export type ProblemKind = "NoResolution" |
+    "UntypedResolution" |
+    "FalseESM" |
+    "FalseCJS" |
+    "CJSResolvesToESM" |
+    "Wildcard" |
+    "UnexpectedESMSyntax" |
+    "UnexpectedCJSSyntax" |
+    "FallbackCondition" |
+    "CJSOnlyExportsDefault" |
+    "FalseExportDefault";
+export interface Problem {
+    kind: ProblemKind;
+    entrypoint: string;
+}
+export interface ProblemSummary {
+    kind: ProblemKind;
+    title: string;
+    messages: {
+        messageText: string;
+        messageHtml: string;
+    }[];
+}
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/bar.ts" }
+});

--- a/tests/cases/fourslash/moveToFile_requireImport.ts
+++ b/tests/cases/fourslash/moveToFile_requireImport.ts
@@ -35,9 +35,9 @@ a; y; z;`,
 
 const x = 0;
 const y = p;
-    exports.y = y;
-    const z = 0;
-    exports.z = 0;
+exports.y = y;
+const z = 0;
+exports.z = 0;
 `,
     },
     interactiveRefactorArguments: { targetFile: "/bar.js" }

--- a/tests/cases/fourslash/moveToFile_requireImport.ts
+++ b/tests/cases/fourslash/moveToFile_requireImport.ts
@@ -35,9 +35,9 @@ a; y; z;`,
 
 const x = 0;
 const y = p;
-exports.y = y;
-const z = 0;
-exports.z = 0;
+    exports.y = y;
+    const z = 0;
+    exports.z = 0;
 `,
     },
     interactiveRefactorArguments: { targetFile: "/bar.js" }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/54073
