### PR TITLE
`isolatedModules` does not imply every file is a module

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1857,7 +1857,7 @@ function isCommonJSContainingModuleKind(kind: ModuleKind) {
 
 /** @internal */
 export function isEffectiveExternalModule(node: SourceFile, compilerOptions: CompilerOptions) {
-    return isExternalModule(node) || getIsolatedModules(compilerOptions) || (isCommonJSContainingModuleKind(getEmitModuleKind(compilerOptions)) && !!node.commonJsModuleIndicator);
+    return isExternalModule(node) || (isCommonJSContainingModuleKind(getEmitModuleKind(compilerOptions)) && !!node.commonJsModuleIndicator);
 }
 
 /**

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -21,6 +21,7 @@ import {
     hasProperty,
     isString,
     MapLike,
+    ModuleDetectionKind,
     normalizePath,
     optionDeclarations,
     parseCustomTypeOption,
@@ -54,6 +55,7 @@ const optionsRedundantWithVerbatimModuleSyntax = new Set([
  * If not options are provided - it will use a set of default compiler options.
  * Extra compiler options that will unconditionally be used by this function are:
  * - isolatedModules = true
+ * - moduleDetection = force
  * - allowNonTsExtensions = true
  * - noLib = true
  * - noResolve = true
@@ -85,6 +87,10 @@ export function transpileModule(input: string, transpileOptions: TranspileOption
 
     // Filename can be non-ts file.
     options.allowNonTsExtensions = true;
+
+    // Inputs are always assumed to be modules. This used to be implied by `isolatedModules` for emit purposes,
+    // but that changed in 5.0, so we set `moduleDetection` now.
+    // options.moduleDetection = ModuleDetectionKind.Force;
 
     const newLine = getNewLineCharacter(options);
     // Create a compilerHost object to allow the compiler to read and write files

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -21,7 +21,6 @@ import {
     hasProperty,
     isString,
     MapLike,
-    ModuleDetectionKind,
     normalizePath,
     optionDeclarations,
     parseCustomTypeOption,
@@ -55,7 +54,6 @@ const optionsRedundantWithVerbatimModuleSyntax = new Set([
  * If not options are provided - it will use a set of default compiler options.
  * Extra compiler options that will unconditionally be used by this function are:
  * - isolatedModules = true
- * - moduleDetection = force
  * - allowNonTsExtensions = true
  * - noLib = true
  * - noResolve = true
@@ -87,10 +85,6 @@ export function transpileModule(input: string, transpileOptions: TranspileOption
 
     // Filename can be non-ts file.
     options.allowNonTsExtensions = true;
-
-    // Inputs are always assumed to be modules. This used to be implied by `isolatedModules` for emit purposes,
-    // but that changed in 5.0, so we set `moduleDetection` now.
-    // options.moduleDetection = ModuleDetectionKind.Force;
 
     const newLine = getNewLineCharacter(options);
     // Create a compilerHost object to allow the compiler to read and write files

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -130,7 +130,7 @@ var x = 0;`, {
         testVerbatimModuleSyntax: true
     });
 
-    transpilesCorrectly("Generates module output", `var x = 0;`, {
+    transpilesCorrectly("Generates module output", `var x = 0; export {};`, {
         options: { compilerOptions: { module: ts.ModuleKind.AMD } }
     });
 
@@ -139,7 +139,7 @@ var x = 0;`, {
         testVerbatimModuleSyntax: true
     });
 
-    transpilesCorrectly("Sets module name", "var x = 1;", {
+    transpilesCorrectly("Sets module name", "var x = 1; export {};", {
         options: { compilerOptions: { module: ts.ModuleKind.System, newLine: ts.NewLineKind.LineFeed }, moduleName: "NamedModule" }
     });
 

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -304,6 +304,7 @@ describe("unittests:: TransformAPI", () => {
                 target: ts.ScriptTarget.ES5,
                 module: ts.ModuleKind.System,
                 newLine: ts.NewLineKind.CarriageReturnLineFeed,
+                moduleDetection: ts.ModuleDetectionKind.Force,
             }
         }).outputText;
 

--- a/tests/baselines/reference/importHelpersInIsolatedModules.js
+++ b/tests/baselines/reference/importHelpersInIsolatedModules.js
@@ -69,14 +69,40 @@ var C = /** @class */ (function () {
     return C;
 }());
 //// [script.js]
-var tslib_1 = require("tslib");
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __param = (this && this.__param) || function (paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+};
 var A = /** @class */ (function () {
     function A() {
     }
     return A;
 }());
 var B = /** @class */ (function (_super) {
-    tslib_1.__extends(B, _super);
+    __extends(B, _super);
     function B() {
         return _super !== null && _super.apply(this, arguments) || this;
     }
@@ -87,13 +113,13 @@ var C = /** @class */ (function () {
     }
     C.prototype.method = function (x) {
     };
-    tslib_1.__decorate([
-        tslib_1.__param(0, dec),
-        tslib_1.__metadata("design:type", Function),
-        tslib_1.__metadata("design:paramtypes", [Number]),
-        tslib_1.__metadata("design:returntype", void 0)
+    __decorate([
+        __param(0, dec),
+        __metadata("design:type", Function),
+        __metadata("design:paramtypes", [Number]),
+        __metadata("design:returntype", void 0)
     ], C.prototype, "method", null);
-    C = tslib_1.__decorate([
+    C = __decorate([
         dec
     ], C);
     return C;

--- a/tests/baselines/reference/isolatedModulesPlainFile-AMD.js
+++ b/tests/baselines/reference/isolatedModulesPlainFile-AMD.js
@@ -4,7 +4,4 @@ run(1);
 
 
 //// [isolatedModulesPlainFile-AMD.js]
-define(["require", "exports"], function (require, exports) {
-    "use strict";
-    run(1);
-});
+run(1);

--- a/tests/baselines/reference/isolatedModulesPlainFile-System.js
+++ b/tests/baselines/reference/isolatedModulesPlainFile-System.js
@@ -4,12 +4,4 @@ run(1);
 
 
 //// [isolatedModulesPlainFile-System.js]
-System.register([], function (exports_1, context_1) {
-    var __moduleName = context_1 && context_1.id;
-    return {
-        setters: [],
-        execute: function () {
-            run(1);
-        }
-    };
-});
+run(1);

--- a/tests/baselines/reference/isolatedModulesPlainFile-UMD.js
+++ b/tests/baselines/reference/isolatedModulesPlainFile-UMD.js
@@ -4,15 +4,4 @@ run(1);
 
 
 //// [isolatedModulesPlainFile-UMD.js]
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
-    }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports"], factory);
-    }
-})(function (require, exports) {
-    "use strict";
-    run(1);
-});
+run(1);

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformAddImportStar.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformAddImportStar.js
@@ -1,1 +1,14 @@
-import * as i0 from "./comp1";
+System.register(["./comp1"], function (exports_1, context_1) {
+    "use strict";
+    var i0;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [
+            function (i0_1) {
+                i0 = i0_1;
+            }
+        ],
+        execute: function () {
+        }
+    };
+});

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformAddImportStar.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformAddImportStar.js
@@ -1,13 +1,1 @@
-System.register(["./comp1"], function (exports_1, context_1) {
-    var i0;
-    var __moduleName = context_1 && context_1.id;
-    return {
-        setters: [
-            function (i0_1) {
-                i0 = i0_1;
-            }
-        ],
-        execute: function () {
-        }
-    };
-});
+import * as i0 from "./comp1";

--- a/tests/baselines/reference/transpile/Generates module output.errors.txt
+++ b/tests/baselines/reference/transpile/Generates module output.errors.txt
@@ -3,4 +3,4 @@ error TS5107: Option 'target=ES3' is deprecated and will stop functioning in Typ
 
 !!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
-    var x = 0;
+    var x = 0; export {};

--- a/tests/baselines/reference/transpile/Generates module output.js
+++ b/tests/baselines/reference/transpile/Generates module output.js
@@ -1,2 +1,6 @@
-var x = 0;
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    var x = 0;
+});
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates module output.js
+++ b/tests/baselines/reference/transpile/Generates module output.js
@@ -1,5 +1,2 @@
-define(["require", "exports"], function (require, exports) {
-    "use strict";
-    var x = 0;
-});
+var x = 0;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates module output.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Generates module output.oldTranspile.errors.txt
@@ -3,4 +3,4 @@ error TS5107: Option 'target=ES3' is deprecated and will stop functioning in Typ
 
 !!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
-    var x = 0;
+    var x = 0; export {};

--- a/tests/baselines/reference/transpile/Generates module output.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates module output.oldTranspile.js
@@ -1,2 +1,6 @@
-var x = 0;
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    var x = 0;
+});
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates module output.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Generates module output.oldTranspile.js
@@ -1,5 +1,2 @@
-define(["require", "exports"], function (require, exports) {
-    "use strict";
-    var x = 0;
-});
+var x = 0;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Sets module name.errors.txt
+++ b/tests/baselines/reference/transpile/Sets module name.errors.txt
@@ -3,4 +3,4 @@ error TS5107: Option 'target=ES3' is deprecated and will stop functioning in Typ
 
 !!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
-    var x = 1;
+    var x = 1; export {};

--- a/tests/baselines/reference/transpile/Sets module name.js
+++ b/tests/baselines/reference/transpile/Sets module name.js
@@ -1,11 +1,2 @@
-System.register("NamedModule", [], function (exports_1, context_1) {
-    var x;
-    var __moduleName = context_1 && context_1.id;
-    return {
-        setters: [],
-        execute: function () {
-            x = 1;
-        }
-    };
-});
+var x = 1;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Sets module name.js
+++ b/tests/baselines/reference/transpile/Sets module name.js
@@ -1,2 +1,12 @@
-var x = 1;
+System.register("NamedModule", [], function (exports_1, context_1) {
+    "use strict";
+    var x;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            x = 1;
+        }
+    };
+});
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Sets module name.oldTranspile.errors.txt
+++ b/tests/baselines/reference/transpile/Sets module name.oldTranspile.errors.txt
@@ -3,4 +3,4 @@ error TS5107: Option 'target=ES3' is deprecated and will stop functioning in Typ
 
 !!! error TS5107: Option 'target=ES3' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.
 ==== file.ts (0 errors) ====
-    var x = 1;
+    var x = 1; export {};

--- a/tests/baselines/reference/transpile/Sets module name.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Sets module name.oldTranspile.js
@@ -1,11 +1,2 @@
-System.register("NamedModule", [], function (exports_1, context_1) {
-    var x;
-    var __moduleName = context_1 && context_1.id;
-    return {
-        setters: [],
-        execute: function () {
-            x = 1;
-        }
-    };
-});
+var x = 1;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Sets module name.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Sets module name.oldTranspile.js
@@ -1,2 +1,12 @@
-var x = 1;
+System.register("NamedModule", [], function (exports_1, context_1) {
+    "use strict";
+    var x;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            x = 1;
+        }
+    };
+});
 //# sourceMappingURL=file.js.map


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54094 

Checking (scope considerations) has always considered these input files scripts, but in `isolatedModules`, compiling scripts used to be an error, so emit treated them as modules. Scripts are allowed in `isolatedModules` as of 5.0, but I didn’t realize they were being emitted as modules when I made that change. We need emit to be consistent with checking here, now that there’s no error for compiling a script.
