### PR TITLE
Formatter: fix indentation of comments at end of range

### DIFF
--- a/tests/cases/fourslash/formatSelectionWithTrivia3.ts
+++ b/tests/cases/fourslash/formatSelectionWithTrivia3.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// Tests comment indentation with range ending before next token (end block)
+
+////if (true) {
+/////*begin*/// test comment
+/////*end*/}
+
+format.selection('begin', 'end');
+
+verify.currentFileContentIs("if (true) {\n    // test comment\n}");

--- a/tests/cases/fourslash/formatSelectionWithTrivia4.ts
+++ b/tests/cases/fourslash/formatSelectionWithTrivia4.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// Tests comment indentation with range ending before next token (statement)
+
+////if (true) {
+/////*begin*/// test comment
+/////*end*/console.log();
+////}
+
+format.selection('begin', 'end');
+
+verify.currentFileContentIs("if (true) {\n    // test comment\nconsole.log();\n}");

--- a/tests/cases/fourslash/formatSelectionWithTrivia5.ts
+++ b/tests/cases/fourslash/formatSelectionWithTrivia5.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// Tests comment indentation with range ending before next token (statement w/ preceding whitespace)
+
+////if (true) {
+/////*begin*/// test comment
+/////*end*/    console.log();
+////}
+
+format.selection('begin', 'end');
+
+verify.currentFileContentIs("if (true) {\n    // test comment\n    console.log();\n}");

--- a/tests/cases/fourslash/formatSelectionWithTrivia6.ts
+++ b/tests/cases/fourslash/formatSelectionWithTrivia6.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// Tests comment indentation with range ending before next token (end of file)
+
+/////*begin*/    // test comment
+/////*end*/
+
+format.selection('begin', 'end');
+
+verify.currentFileContentIs("// test comment\n");

--- a/tests/cases/fourslash/formatSelectionWithTrivia7.ts
+++ b/tests/cases/fourslash/formatSelectionWithTrivia7.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// Tests comment indentation with range ending before next token (same line)
+
+////if (true) {
+/////*begin*/// test comment/*end*/
+////}
+
+format.selection('begin', 'end');
+
+verify.currentFileContentIs("if (true) {\n    // test comment\n}");

--- a/tests/cases/fourslash/formatSelectionWithTrivia8.ts
+++ b/tests/cases/fourslash/formatSelectionWithTrivia8.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// Same as formatSelectionWithTrivia2, but range is immediately proceeded by a token
+
+/////*begin*/;
+////    
+/////*end*/console.log();
+
+format.selection('begin', 'end');
+
+verify.currentFileContentIs(";\n\nconsole.log();");


### PR DESCRIPTION
Fixes #54243

This builds on top of the fix at #5983, which fixed indentation of whitespace at the end of a range, but didn't handle comments.
