### PR TITLE
Check the provided type argument with this argument against the similarly obtained instantiated constraint

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32586,7 +32586,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 const typeArgument = typeArgumentTypes[i];
                 if (!checkTypeAssignableTo(
-                    typeArgument,
+                    getTypeWithThisArgument(typeArgument, typeArgument),
                     getTypeWithThisArgument(instantiateType(constraint, mapper), typeArgument),
                     reportErrors ? typeArgumentNodes[i] : undefined,
                     typeArgumentHeadMessage,


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/54260

**Before**
<img width="1727" alt="Profiler trace with getVariancesWorker clearly visible on the flame graph" src="https://github.com/microsoft/TypeScript/assets/9800850/dde44345-02b9-4ee5-96e6-cfdec1d47ea9">
**After**
<img width="1727" alt="Profiler trace without noticeable call to getVariancesWorker" src="https://github.com/microsoft/TypeScript/assets/9800850/b5f9a1a0-54d1-4651-beec-a079d9b6447f">

We can see here that the big call to the `getVariancesWorker` has been removed from the trace with this change applied. 

The reason behind that is that the compiler doesn't have to go through it when receiving an explicit `babel.PluginObj` type argument. It doesn't have to go through it because the logic can be bypassed based on the matching `type.id`s between the `getTypeWithThisArgument(typeArgument, typeArgument)` and `getTypeWithThisArgument(instantiateType(constraint, mapper), typeArgument)`.

`babel.PluginObj` is a huge type so it takes a while to measure variance of its type parameter. This was an unexpected effect because the provided type argument **matched** the declared constraint (but `getTypeWithThisArgument` was called on that constraint, resulting in a different `.id`)