### PR TITLE
Improve LS when a flow.js file opened

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6600,6 +6600,10 @@
         "category": "Error",
         "code": 8039
     },
+    "It seems like you have misconfigured your editor to analyze Flow.js with TypeScript language service. TypeScript cannot recognize Flow.js syntax and may give inaccurate results.": {
+        "category": "Error",
+        "code": 8040
+    },
 
     "Declaration emit for this file requires using private name '{0}'. An explicit type annotation may unblock declaration emit.": {
         "category": "Error",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2943,7 +2943,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             return diagnostics;
 
             function walk(node: Node, parent: Node) {
-                // Return directly from the case if the given node doesnt want to visit each child
+                // Return directly from the case if the given node doesn't want to visit each child
                 // Otherwise break to visit each child
 
                 switch (parent.kind) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -9942,6 +9942,7 @@ export interface CommentDirectivesMap {
 }
 
 export interface UserPreferences {
+    readonly enableFlowJSDiagnostic?: boolean;
     readonly disableSuggestions?: boolean;
     readonly quotePreference?: "auto" | "double" | "single";
     readonly includeCompletionsForModuleExports?: boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3456,6 +3456,17 @@ export function isInJSFile(node: Node | undefined): boolean {
 }
 
 /** @internal */
+export function getFlowDirectiveRange(sourceFile: SourceFile) {
+    const leading = getLeadingCommentRangesOfNode(sourceFile, sourceFile);
+    if (!leading) return false;
+    for (const range of leading) {
+        const comment = sourceFile.text.slice(range.pos, range.end);
+        if (comment.includes("@flow")) return range;
+    }
+    return false;
+}
+
+/** @internal */
 export function isInJsonFile(node: Node | undefined): boolean {
     return !!node && !!(node.flags & NodeFlags.JsonFile);
 }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3461,6 +3461,7 @@ export interface FormatCodeSettings extends EditorSettings {
 }
 
 export interface UserPreferences {
+    readonly enableFlowJSDiagnostic?: boolean;
     readonly disableSuggestions?: boolean;
     readonly quotePreference?: "auto" | "double" | "single";
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1236,14 +1236,14 @@ export class Session<TMessage = string> implements EventSender {
         tracing?.push(tracing.Phase.Session, "semanticCheck", { file, configFilePath: (project as ConfiguredProject).canonicalConfigFilePath }); // undefined is fine if the cast fails
         const diags = isDeclarationFileInJSOnlyNonConfiguredProject(project, file)
             ? emptyArray
-            : project.getLanguageService().getSemanticDiagnostics(file).filter(d => !!d.file);
+            : project.getLanguageService().getSemanticDiagnostics(file, this.getPreferences(file).enableFlowJSDiagnostic).filter(d => !!d.file);
         this.sendDiagnosticsEvent(file, project, diags, "semanticDiag");
         tracing?.pop();
     }
 
     private syntacticCheck(file: NormalizedPath, project: Project) {
         tracing?.push(tracing.Phase.Session, "syntacticCheck", { file, configFilePath: (project as ConfiguredProject).canonicalConfigFilePath }); // undefined is fine if the cast fails
-        this.sendDiagnosticsEvent(file, project, project.getLanguageService().getSyntacticDiagnostics(file), "syntaxDiag");
+        this.sendDiagnosticsEvent(file, project, project.getLanguageService().getSyntacticDiagnostics(file, this.getPreferences(file).enableFlowJSDiagnostic), "syntaxDiag");
         tracing?.pop();
     }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -465,6 +465,9 @@ export interface LanguageService {
      * @param fileName A path to the file you want syntactic diagnostics for
      */
     getSyntacticDiagnostics(fileName: string): DiagnosticWithLocation[];
+    /** @internal */
+    // eslint-disable-next-line @typescript-eslint/unified-signatures
+    getSyntacticDiagnostics(fileName: string, checkFlow?: boolean): DiagnosticWithLocation[];
 
     /**
      * Gets warnings or errors indicating type system issues in a given file.
@@ -482,6 +485,9 @@ export interface LanguageService {
      * @param fileName A path to the file you want semantic diagnostics for
      */
     getSemanticDiagnostics(fileName: string): Diagnostic[];
+    /** @internal */
+    // eslint-disable-next-line @typescript-eslint/unified-signatures
+    getSemanticDiagnostics(fileName: string, checkFlow?: boolean): Diagnostic[];
 
     /**
      * Gets suggestion diagnostics for a specific file. These diagnostics tend to

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2759,6 +2759,7 @@ declare namespace ts {
                 indentSwitchCase?: boolean;
             }
             interface UserPreferences {
+                readonly enableFlowJSDiagnostic?: boolean;
                 readonly disableSuggestions?: boolean;
                 readonly quotePreference?: "auto" | "double" | "single";
                 /**
@@ -3930,6 +3931,7 @@ declare namespace ts {
             private getCompilerOptionsDiagnostics;
             private convertToDiagnosticsWithLinePosition;
             private getDiagnosticsWorker;
+            private silenceDiagnosticsIfFlow;
             private getDefinition;
             private mapDefinitionInfoLocations;
             private getDefinitionAndBoundSpan;
@@ -8357,6 +8359,7 @@ declare namespace ts {
         JSDocComment = 33
     }
     interface UserPreferences {
+        readonly enableFlowJSDiagnostic?: boolean;
         readonly disableSuggestions?: boolean;
         readonly quotePreference?: "auto" | "double" | "single";
         readonly includeCompletionsForModuleExports?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4310,6 +4310,7 @@ declare namespace ts {
         JSDocComment = 33
     }
     interface UserPreferences {
+        readonly enableFlowJSDiagnostic?: boolean;
         readonly disableSuggestions?: boolean;
         readonly quotePreference?: "auto" | "double" | "single";
         readonly includeCompletionsForModuleExports?: boolean;


### PR DESCRIPTION
This PR improves the LS experience when opening a flow.js file by suppressing all errors as suggestions.

Before:

![IMAGE](https://github.com/microsoft/TypeScript/assets/5390719/5b3aa82a-aac0-431f-b1b9-68e804a68df8)

After:

![IMAGE](https://github.com/microsoft/TypeScript/assets/5390719/02f60b69-a75d-4f89-a86d-2adb9fb0486f)
![IMAGE](https://github.com/microsoft/TypeScript/assets/5390719/90ccc1cc-0835-4703-b0b2-d4b8d1f1d67f)

