### PR TITLE
Don't use text change's `createNewFile` for existing empty file

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -1,4 +1,3 @@
-import { GetApplicableRefactorsRequestArgs, GetEditsForRefactorRequestArgs } from "../server/protocol.js";
 import {
     ApplicableRefactorInfo,
     CallHierarchyIncomingCall,
@@ -800,7 +799,7 @@ export class SessionClient implements LanguageService {
         if (preferences) { // Temporarily set preferences
             this.configure(preferences);
         }
-        const args: GetApplicableRefactorsRequestArgs = this.createFileLocationOrRangeRequestArgs(positionOrRange, fileName);
+        const args: protocol.GetApplicableRefactorsRequestArgs = this.createFileLocationOrRangeRequestArgs(positionOrRange, fileName);
         args.triggerReason = triggerReason;
         args.kind = kind;
         args.includeInteractiveActions = includeInteractiveActions;
@@ -831,7 +830,8 @@ export class SessionClient implements LanguageService {
         if (preferences) { // Temporarily set preferences
             this.configure(preferences);
         }
-        const args: GetEditsForRefactorRequestArgs = this.createFileLocationOrRangeRequestArgs(positionOrRange, fileName) as protocol.GetEditsForRefactorRequestArgs;
+        const args =
+            this.createFileLocationOrRangeRequestArgs(positionOrRange, fileName) as protocol.GetEditsForRefactorRequestArgs;
         args.refactor = refactorName;
         args.action = actionName;
         args.interactiveRefactorArguments = interactiveRefactorArguments;

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -827,7 +827,7 @@ export class SessionClient implements LanguageService {
         refactorName: string,
         actionName: string,
         preferences: UserPreferences | undefined,
-        interactiveRefactorArguments?: InteractiveRefactorArguments): RefactorEditInfo { // >> Update here
+        interactiveRefactorArguments?: InteractiveRefactorArguments): RefactorEditInfo {
         if (preferences) { // Temporarily set preferences
             this.configure(preferences);
         }

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -177,7 +177,7 @@ function doChange(context: RefactorContext, oldFile: SourceFile, targetFile: str
     const checker = program.getTypeChecker();
     const usage = getUsageInfo(oldFile, toMove.all, checker);
     //For a new file or an existing blank target file
-    if (!host.fileExists(targetFile) || host.fileExists(targetFile) && program.getSourceFile(targetFile)?.statements.length === 0) {
+    if (!host.fileExists(targetFile)) {
         changes.createNewFile(oldFile, targetFile, getNewStatementsAndRemoveFromOldFile(oldFile, targetFile, usage, changes, toMove, program, host, preferences));
         addNewFileToTsconfig(program, changes, oldFile.fileName, targetFile, hostGetCanonicalFileName(host));
     }
@@ -189,7 +189,15 @@ function doChange(context: RefactorContext, oldFile: SourceFile, targetFile: str
 }
 
 function getNewStatementsAndRemoveFromOldFile(
-    oldFile: SourceFile, targetFile: string | SourceFile, usage: UsageInfo, changes: textChanges.ChangeTracker, toMove: ToMove, program: Program, host: LanguageServiceHost, preferences: UserPreferences, importAdder?: codefix.ImportAdder
+    oldFile: SourceFile,
+    targetFile: string | SourceFile,
+    usage: UsageInfo,
+    changes: textChanges.ChangeTracker,
+    toMove: ToMove,
+    program: Program,
+    host: LanguageServiceHost,
+    preferences: UserPreferences,
+    importAdder?: codefix.ImportAdder
 ) {
     const checker = program.getTypeChecker();
     const prologueDirectives = takeWhile(oldFile.statements, isPrologueDirective);
@@ -217,6 +225,9 @@ function getNewStatementsAndRemoveFromOldFile(
     if (typeof targetFile !== "string") {
         if (targetFile.statements.length > 0) {
             changes.insertNodesAfter(targetFile, targetFile.statements[targetFile.statements.length - 1], body);
+        }
+        else {
+            changes.insertNodesAtEndOfFile(targetFile, body, /*blankLineBetween*/ false);
         }
         if (imports.length > 0) {
             insertImports(changes, targetFile, imports, /*blankLineBetween*/ true, preferences);

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -176,7 +176,7 @@ registerRefactor(refactorNameForMoveToFile, {
 function doChange(context: RefactorContext, oldFile: SourceFile, targetFile: string, program: Program, toMove: ToMove, changes: textChanges.ChangeTracker, host: LanguageServiceHost, preferences: UserPreferences): void {
     const checker = program.getTypeChecker();
     const usage = getUsageInfo(oldFile, toMove.all, checker);
-    //For a new file or an existing blank target file
+    //For a new file
     if (!host.fileExists(targetFile)) {
         changes.createNewFile(oldFile, targetFile, getNewStatementsAndRemoveFromOldFile(oldFile, targetFile, usage, changes, toMove, program, host, preferences));
         addNewFileToTsconfig(program, changes, oldFile.fileName, targetFile, hostGetCanonicalFileName(host));

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -631,6 +631,25 @@ export class ChangeTracker {
         }
     }
 
+    public insertNodesAtEndOfFile(
+        sourceFile: SourceFile,
+        newNodes: readonly Statement[],
+        blankLineBetween: boolean): void {
+        this.insertAtEndOfFile(sourceFile, newNodes, blankLineBetween);
+    }
+
+    private insertAtEndOfFile(
+        sourceFile: SourceFile,
+        insert: readonly Statement[],
+        blankLineBetween: boolean): void {
+        const pos = sourceFile.end + 1;
+        const options = {
+            prefix: this.newLineCharacter,
+            suffix: blankLineBetween ? this.newLineCharacter : "",
+        };
+        this.insertNodesAt(sourceFile, pos, insert, options);
+    }
+
     private insertStatementsInNewFile(fileName: string, statements: readonly (Statement | SyntaxKind.NewLineTrivia)[], oldFile?: SourceFile): void {
         if (!this.newFileChanges) {
             this.newFileChanges = createMultiMap<string, NewFileInsertion>();

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -645,7 +645,7 @@ export class ChangeTracker {
         const pos = sourceFile.end + 1;
         const options = {
             prefix: this.newLineCharacter,
-            suffix: blankLineBetween ? this.newLineCharacter : "",
+            suffix: this.newLineCharacter + (blankLineBetween ? this.newLineCharacter : ""),
         };
         this.insertNodesAt(sourceFile, pos, insert, options);
     }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -6,5 +6,5 @@
         { "path": "../compiler" },
         { "path": "../jsTyping" }
     ],
-    "include": ["**/*", "refactors/moveToFile.ts"]
+    "include": ["**/*"]
 }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -6,5 +6,5 @@
         { "path": "../compiler" },
         { "path": "../jsTyping" }
     ],
-    "include": ["**/*"]
+    "include": ["**/*", "refactors/moveToFile.ts"]
 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -652,7 +652,7 @@ export interface LanguageService {
      * arguments for any interactive action before offering it.
      */
     getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractiveActions?: boolean): ApplicableRefactorInfo[];
-    getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined, includeInteractiveActions?: InteractiveRefactorArguments): RefactorEditInfo | undefined;
+    getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined, interactiveRefactorArguments?: InteractiveRefactorArguments): RefactorEditInfo | undefined;
     getMoveToRefactoringFileSuggestions(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string): { newFileName: string, files: string[] };
     organizeImports(args: OrganizeImportsArgs, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): readonly FileTextChanges[];
     getEditsForFileRename(oldFilePath: string, newFilePath: string, formatOptions: FormatCodeSettings, preferences: UserPreferences | undefined): readonly FileTextChanges[];

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -10196,7 +10196,7 @@ declare namespace ts {
          * arguments for any interactive action before offering it.
          */
         getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractiveActions?: boolean): ApplicableRefactorInfo[];
-        getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined, includeInteractiveActions?: InteractiveRefactorArguments): RefactorEditInfo | undefined;
+        getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined, interactiveRefactorArguments?: InteractiveRefactorArguments): RefactorEditInfo | undefined;
         getMoveToRefactoringFileSuggestions(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string): {
             newFileName: string;
             files: string[];

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6227,7 +6227,7 @@ declare namespace ts {
          * arguments for any interactive action before offering it.
          */
         getApplicableRefactors(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string, includeInteractiveActions?: boolean): ApplicableRefactorInfo[];
-        getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined, includeInteractiveActions?: InteractiveRefactorArguments): RefactorEditInfo | undefined;
+        getEditsForRefactor(fileName: string, formatOptions: FormatCodeSettings, positionOrRange: number | TextRange, refactorName: string, actionName: string, preferences: UserPreferences | undefined, interactiveRefactorArguments?: InteractiveRefactorArguments): RefactorEditInfo | undefined;
         getMoveToRefactoringFileSuggestions(fileName: string, positionOrRange: number | TextRange, preferences: UserPreferences | undefined, triggerReason?: RefactorTriggerReason, kind?: string): {
             newFileName: string;
             files: string[];

--- a/tests/cases/fourslash/moveToFile_blankExistingFile.ts
+++ b/tests/cases/fourslash/moveToFile_blankExistingFile.ts
@@ -25,7 +25,8 @@ import { p } from './a';
 import { b } from "./other";
 
 
-const y: Date = p + b;`,
+const y: Date = p + b;
+`,
     },
     interactiveRefactorArguments: {targetFile: "/bar.ts"},
 });

--- a/tests/cases/fourslash/moveToFile_blankExistingFile.ts
+++ b/tests/cases/fourslash/moveToFile_blankExistingFile.ts
@@ -18,11 +18,14 @@ verify.moveToFile({
 `,
 
         "/bar.ts":
-`import { b } from './other';
+`//
 import { p } from './a';
 
-const y: Date = p + b;
-`,
+
+import { b } from "./other";
+
+
+const y: Date = p + b;`,
     },
     interactiveRefactorArguments: {targetFile: "/bar.ts"},
 });

--- a/tests/cases/fourslash/moveToFile_differentDirectories2.ts
+++ b/tests/cases/fourslash/moveToFile_differentDirectories2.ts
@@ -23,11 +23,12 @@ export const a = 10;
 y;`,
 
         "/src/dir2/bar.ts":
-`import { b } from '../dir1/other';
-import { a } from '../dir1/a';
+`import { a } from '../dir1/a';
 
-export const y = b + a;
-`,
+import { b } from "../dir1/other";
+
+
+export const y = b + a;`,
     },
     interactiveRefactorArguments: { targetFile: "/src/dir2/bar.ts" }
 });

--- a/tests/cases/fourslash/moveToFile_differentDirectories2.ts
+++ b/tests/cases/fourslash/moveToFile_differentDirectories2.ts
@@ -28,7 +28,8 @@ y;`,
 import { b } from "../dir1/other";
 
 
-export const y = b + a;`,
+export const y = b + a;
+`,
     },
     interactiveRefactorArguments: { targetFile: "/src/dir2/bar.ts" }
 });

--- a/tests/cases/fourslash/server/moveToFile_emptyTargetFile.ts
+++ b/tests/cases/fourslash/server/moveToFile_emptyTargetFile.ts
@@ -1,0 +1,27 @@
+/// <reference path='../fourslash.ts' />
+
+// @Filename: /source.ts
+////[|export const a = 1;|]
+////const b = 2;
+////console.log(a, b);
+
+// @Filename: /target.ts
+/////** empty */
+
+// @Filename: /tsconfig.json
+///// { "compilerOptions": { "newLine": "lf" } }
+
+verify.moveToFile({
+    newFileContents: {
+        "/source.ts":
+`import { a } from "./target";
+
+const b = 2;
+console.log(a, b);`,
+        "/target.ts":
+`/** empty */
+export const a = 1;
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/target.ts" },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54285.

This fix updates our handling of move to file when the target file already exists, but doesn't yet have any statements (i.e. is "empty"). Previously, we'd treat this empty file as a new file for the purposes of writing text changes to it, but this caused the reported crash, and it also had the consequence of us overwriting possibly existing comments in this empty target file.

This fix, however, uncovered a problem with how new lines are handled when we insert imports into a target file in move to file. The issue was already present, but now it also occurs when the target is an empty file. The issue is that we end up with extra new lines between the import statements the refactoring inserts, as witnessed by the test baselines that changed in this PR. There is also an inconsistency between choice of quotes that shows up in the tests. Both problems seem to be caused by us using `ImportAdder` to add some of the imports in the target file, but also adding imports not using the `ImportAdder`, and it seems like ideally we'd unify that so that we're consistent with new lines and quotes.
