### PR TITLE
Return early on intrinsics in couldContainTypeVariables

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24004,6 +24004,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // we perform type inference (i.e. a type parameter of a generic function). We cache
     // results for union and intersection types for performance reasons.
     function couldContainTypeVariables(type: Type): boolean {
+        if (type.flags & TypeFlags.Intrinsic) return false;
         const objectFlags = getObjectFlags(type);
         if (objectFlags & ObjectFlags.CouldContainTypeVariablesComputed) {
             return !!(objectFlags & ObjectFlags.CouldContainTypeVariables);


### PR DESCRIPTION
Fixes #54348

The problem in the issue is that both source and target are the wildcard type, and so this recurses forever.

But, one thing that fixes this is to just bail early on intrinsics, as those can't actually contain type vars (which then does prevent the inference loop).

I could send a more targeted fix but I think this might actually help perf.

Needs a test.