### PR TITLE
Handle already released source files that dont match scriptKind

### DIFF
--- a/src/testRunner/unittests/tsserver/documentRegistry.ts
+++ b/src/testRunner/unittests/tsserver/documentRegistry.ts
@@ -1,8 +1,11 @@
 import * as ts from "../../_namespaces/ts";
 import {
     baselineTsserverLogs,
+    closeFilesForSession,
     createLoggerWithInMemoryLogs,
     createProjectService,
+    createSession,
+    openFilesForSession,
     TestProjectService,
 } from "../helpers/tsserver";
 import {
@@ -101,5 +104,41 @@ describe("unittests:: tsserver:: documentRegistry:: document registry in project
         assert.equal(project.getSourceFile(moduleInfo.path), moduleInfo.cacheSourceFile!.sourceFile);
         assert.equal(moduleInfo.cacheSourceFile!.sourceFile.text, updatedModuleContent);
         baselineTsserverLogs("documentRegistry", "Caches the source file if script info is orphan, and orphan script info changes", service);
+    });
+});
+
+describe("unittests:: tsserver:: documentRegistry:: works when reusing orphan script info with different scriptKind", () => {
+    it("works when reusing orphan script info with different scriptKind", () => {
+        const host = createServerHost({});
+        const session = createSession(host, { useInferredProjectPerProjectRoot: true, logger: createLoggerWithInMemoryLogs(host) });
+        const newText = "exrpot const x = 10;";
+        const content = `import x from 'react';\n${newText}`;
+        openFilesForSession([
+            { file: "^/inmemory/model/6", content, scriptKindName: "TSX", projectRootPath: "/users/user/projects/san" },
+            { file: "^/inmemory/model/4", content, scriptKindName: "TSX", projectRootPath: "/users/user/projects/san" },
+        ], session);
+        closeFilesForSession(["^/inmemory/model/4"], session);
+        session.executeCommandSeq<ts.server.protocol.UpdateOpenRequest>({
+            command: ts.server.protocol.CommandTypes.UpdateOpen,
+            arguments: {
+                changedFiles: [{
+                    fileName: "^/inmemory/model/6",
+                    textChanges: [{
+                        newText,
+                        start: { line: 1, offset: 1 },
+                        end: { line: 2, offset: newText.length + 1 } // Remove the import so that structure is not reused
+                    }]
+                }],
+                openFiles: [
+                    {
+                        file: "^/inmemory/model/4",
+                        fileContent: newText,
+                        projectRootPath: "/users/user/projects/san", // Add same document with different script kind
+                        scriptKindName: "TS"
+                    },
+                ]
+            }
+        });
+        baselineTsserverLogs("documentRegistry", "works when reusing orphan script info with different scriptKind", session);
     });
 });

--- a/tests/baselines/reference/tsserver/documentRegistry/works-when-reusing-orphan-script-info-with-different-scriptKind.js
+++ b/tests/baselines/reference/tsserver/documentRegistry/works-when-reusing-orphan-script-info-with-different-scriptKind.js
@@ -1,0 +1,203 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/a/lib/typesMap.json" doesn't exist
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "^/inmemory/model/6",
+        "projectRootPath": "/users/user/projects/san",
+        "fileContent": "import x from 'react';\nexrpot const x = 10;",
+        "scriptKindName": "TSX"
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Search path: ^/inmemory/model
+Info seq  [hh:mm:ss:mss] For info: ^/inmemory/model/6 :: No config files found.
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/san/^ 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/san/^ 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/san/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/san/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /dev/null/inferredProject1* WatchType: Missing file
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/san/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/san/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /users/user/projects/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+	^/inmemory/model/6 SVC-1-0 "import x from 'react';\nexrpot const x = 10;"
+
+
+	^/inmemory/model/6
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: ^/inmemory/model/6 ProjectRootPath: /users/user/projects/san
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+PolledWatches::
+/a/lib/lib.d.ts: *new*
+  {"pollingInterval":500}
+/users/user/projects/node_modules: *new*
+  {"pollingInterval":500}
+/users/user/projects/node_modules/@types: *new*
+  {"pollingInterval":500}
+/users/user/projects/san/^: *new*
+  {"pollingInterval":500}
+/users/user/projects/san/node_modules: *new*
+  {"pollingInterval":500}
+/users/user/projects/san/node_modules/@types: *new*
+  {"pollingInterval":500}
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "^/inmemory/model/4",
+        "projectRootPath": "/users/user/projects/san",
+        "fileContent": "import x from 'react';\nexrpot const x = 10;",
+        "scriptKindName": "TSX"
+      },
+      "seq": 2,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Search path: ^/inmemory/model
+Info seq  [hh:mm:ss:mss] For info: ^/inmemory/model/4 :: No config files found.
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 2 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	^/inmemory/model/6 SVC-1-0 "import x from 'react';\nexrpot const x = 10;"
+	^/inmemory/model/4 SVC-1-0 "import x from 'react';\nexrpot const x = 10;"
+
+
+	^/inmemory/model/6
+	  Root file specified for compilation
+	^/inmemory/model/4
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: ^/inmemory/model/6 ProjectRootPath: /users/user/projects/san
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 	FileName: ^/inmemory/model/4 ProjectRootPath: /users/user/projects/san
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "close",
+      "arguments": {
+        "file": "^/inmemory/model/4"
+      },
+      "seq": 3,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: ^/inmemory/model/6 ProjectRootPath: /users/user/projects/san
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "updateOpen",
+      "arguments": {
+        "changedFiles": [
+          {
+            "fileName": "^/inmemory/model/6",
+            "textChanges": [
+              {
+                "newText": "exrpot const x = 10;",
+                "start": {
+                  "line": 1,
+                  "offset": 1
+                },
+                "end": {
+                  "line": 2,
+                  "offset": 21
+                }
+              }
+            ]
+          }
+        ],
+        "openFiles": [
+          {
+            "file": "^/inmemory/model/4",
+            "fileContent": "exrpot const x = 10;",
+            "projectRootPath": "/users/user/projects/san",
+            "scriptKindName": "TS"
+          }
+        ]
+      },
+      "seq": 4,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Search path: ^/inmemory/model
+Info seq  [hh:mm:ss:mss] For info: ^/inmemory/model/4 :: No config files found.
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 3 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	^/inmemory/model/6 SVC-1-1 "exrpot const x = 10;"
+	^/inmemory/model/4 SVC-2-0 "exrpot const x = 10;"
+
+
+	^/inmemory/model/6
+	  Root file specified for compilation
+	^/inmemory/model/4
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: ^/inmemory/model/6 ProjectRootPath: /users/user/projects/san
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 	FileName: ^/inmemory/model/4 ProjectRootPath: /users/user/projects/san
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "response": true,
+      "responseRequired": true
+    }
+After request


### PR DESCRIPTION
In LS we have document registry which maintain the cache by the `scriptKind` but there is not such concept at program level. 
So when we try to reuse program there is no fail-safe way to check if `scriptKind` doesn't match between program reuse unless we create the new source files.
But this also means that we could try to get new `sourceFile` two times from the host.
1. when trying to see if we can reuse the program structure using old source file list and checking if new source file makes it such that program structure can be reused or does it need to be constructed from scratch.
2. When we decide that we cant reuse the structure so we try to build program by scratch by processing root files, dependencies etc.

In LS when we try to get the source file, we see if we already have the source file from old program and if yes and their script kinds don't match we just get updated source file from the document registry,
But if the old Source file's `scriptKind` doesn't match then we release that source file (removing our ref count) and acquiring the new source file with correct script kind. 
What this resulted was, when we try to create source file when trying to determine if program structure can be reused, we would release the old document with script kind and acquire new document with correct script kind. But when the program structure is not reused, we would try to release the document with old Script kind but the bucket had the document with new script kind.

Fixes #54381

