### PR TITLE
Additional fix to issue #50509

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28672,10 +28672,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         });
     }
 
-    function getThisTypeOfObjectLiteralFromContextualType(
-        containingLiteral: ObjectLiteralExpression,
-        contextualType = getApparentTypeOfContextualType(containingLiteral, /*contextFlags*/ undefined),
-    ) {
+    function getThisTypeOfObjectLiteralFromContextualType(containingLiteral: ObjectLiteralExpression, contextualType: Type | undefined) {
         let literal = containingLiteral;
         let type = contextualType;
         while (type) {
@@ -45433,7 +45430,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isFunctionLike(container)) {
                 const containingLiteral = getContainingObjectLiteral(container);
                 if (containingLiteral) {
-                    const type = getThisTypeOfObjectLiteralFromContextualType(containingLiteral);
+                    const contextualType = getApparentTypeOfContextualType(containingLiteral, /*contextFlags*/ undefined);
+                    const type = getThisTypeOfObjectLiteralFromContextualType(containingLiteral, contextualType);
                     return type && !isTypeAny(type);
                 }
             }

--- a/tests/baselines/reference/findAllRefsJsThisPropertyAssignment2.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsJsThisPropertyAssignment2.baseline.jsonc
@@ -1,0 +1,149 @@
+// === findAllReferences ===
+// === /tests/cases/fourslash/infer.d.ts ===
+// export declare function infer(o: { m: Record<string, Function> } & ThisType<{ <|[|{| isWriteAccess: true |}x|]: number|> }>): void;
+
+// === /tests/cases/fourslash/a.js ===
+// import { infer } from "./infer";
+// infer({
+//     m: {
+//         initData() {
+//             <|this.[|{| isWriteAccess: true |}x|] = 1;|>
+//             this./*FIND ALL REFS*/[|x|];
+//         },
+//     }
+// });
+
+// === /tests/cases/fourslash/b.ts ===
+// import { infer } from "./infer";
+// infer({
+//     m: {
+//         initData() {
+//             this.[|{| isWriteAccess: true |}x|] = 1;
+//             this.[|x|];
+//         },
+//     }
+// });
+
+  // === Definitions ===
+  // === /tests/cases/fourslash/infer.d.ts ===
+  // export declare function infer(o: { m: Record<string, Function> } & ThisType<{ <|[|x|]: number|> }>): void;
+
+  // === Details ===
+  [
+   {
+    "containerKind": "",
+    "containerName": "",
+    "kind": "property",
+    "name": "(property) x: number",
+    "displayParts": [
+     {
+      "text": "(",
+      "kind": "punctuation"
+     },
+     {
+      "text": "property",
+      "kind": "text"
+     },
+     {
+      "text": ")",
+      "kind": "punctuation"
+     },
+     {
+      "text": " ",
+      "kind": "space"
+     },
+     {
+      "text": "x",
+      "kind": "propertyName"
+     },
+     {
+      "text": ":",
+      "kind": "punctuation"
+     },
+     {
+      "text": " ",
+      "kind": "space"
+     },
+     {
+      "text": "number",
+      "kind": "keyword"
+     }
+    ]
+   }
+  ]
+
+
+
+// === findAllReferences ===
+// === /tests/cases/fourslash/infer.d.ts ===
+// export declare function infer(o: { m: Record<string, Function> } & ThisType<{ <|[|{| isWriteAccess: true |}x|]: number|> }>): void;
+
+// === /tests/cases/fourslash/a.js ===
+// import { infer } from "./infer";
+// infer({
+//     m: {
+//         initData() {
+//             <|this.[|{| isWriteAccess: true |}x|] = 1;|>
+//             this.[|x|];
+//         },
+//     }
+// });
+
+// === /tests/cases/fourslash/b.ts ===
+// import { infer } from "./infer";
+// infer({
+//     m: {
+//         initData() {
+//             this.[|{| isWriteAccess: true |}x|] = 1;
+//             this./*FIND ALL REFS*/[|x|];
+//         },
+//     }
+// });
+
+  // === Definitions ===
+  // === /tests/cases/fourslash/infer.d.ts ===
+  // export declare function infer(o: { m: Record<string, Function> } & ThisType<{ <|[|x|]: number|> }>): void;
+
+  // === Details ===
+  [
+   {
+    "containerKind": "",
+    "containerName": "",
+    "kind": "property",
+    "name": "(property) x: number",
+    "displayParts": [
+     {
+      "text": "(",
+      "kind": "punctuation"
+     },
+     {
+      "text": "property",
+      "kind": "text"
+     },
+     {
+      "text": ")",
+      "kind": "punctuation"
+     },
+     {
+      "text": " ",
+      "kind": "space"
+     },
+     {
+      "text": "x",
+      "kind": "propertyName"
+     },
+     {
+      "text": ":",
+      "kind": "punctuation"
+     },
+     {
+      "text": " ",
+      "kind": "space"
+     },
+     {
+      "text": "number",
+      "kind": "keyword"
+     }
+    ]
+   }
+  ]

--- a/tests/cases/fourslash/findAllRefsJsThisPropertyAssignment2.ts
+++ b/tests/cases/fourslash/findAllRefsJsThisPropertyAssignment2.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @noImplicitThis: true
+
+// @Filename: infer.d.ts
+//// export declare function infer(o: { m: Record<string, Function> } & ThisType<{ x: number }>): void;
+
+// @Filename: a.js
+//// import { infer } from "./infer";
+//// infer({
+////     m: {
+////         initData() {
+////             this.x = 1;
+////             this./*1*/x;
+////         },
+////     }
+//// });
+
+// @Filename: b.ts
+//// import { infer } from "./infer";
+//// infer({
+////     m: {
+////         initData() {
+////             this.x = 1;
+////             this./*2*/x;
+////         },
+////     }
+//// });
+
+verify.baselineFindAllReferences("1", "2");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

This is an additional fix to issue #50509. The issue has been closed by my previous PR #53000, but there is still an unexpected case left over.

I need to check if there is a `ThisType<T>` for `this` keyword in its contextual type. I was getting it's containing object literal then to call `getApparentTypeOfContextualType` and `getThisTypeArgument` to see what I got, but didn't know I need continue looking in any directly enclosing object literals. I found this already been took care of by some code in `getContextualThisParameterType`, so I move them into a new function `getThisTypeOfObjectLiteralFromContextualType` for reuse.

Sorry for have to fix the issue in twice.
