### PR TITLE
add new compiler option

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19912,7 +19912,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (reportErrors && !(checkMode & SignatureCheckMode.StrictArity)) {
                     // the second condition should be redundant, because there is no error reporting when comparing signatures by strict arity
                     // since it is only done for subtype reduction
-                    errorReporter!(Diagnostics.Target_signature_provides_too_many_arguments_Expected_0_or_more_but_got_1, getParameterCount(source),getMinArgumentCount(target) );
+                    errorReporter!(Diagnostics.Target_signature_provides_too_many_arguments_Expected_0_or_more_but_got_1, getParameterCount(source),getMinArgumentCount(target));
                 }
                 return Ternary.False;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19905,6 +19905,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return Ternary.False;
         }
 
+        if (compilerOptions.veryStrictArity) {
+            const targetHasMoreParameters = !hasEffectiveRestParameter(source) &&
+                (checkMode & SignatureCheckMode.StrictArity ? hasEffectiveRestParameter(target) || targetCount > getParameterCount(source) : getMinArgumentCount(target) > getParameterCount(source));
+            if (targetHasMoreParameters) {
+                if (reportErrors && !(checkMode & SignatureCheckMode.StrictArity)) {
+                    // the second condition should be redundant, because there is no error reporting when comparing signatures by strict arity
+                    // since it is only done for subtype reduction
+                    errorReporter!(Diagnostics.Target_signature_provides_too_many_arguments_Expected_0_or_more_but_got_1, getParameterCount(source),getMinArgumentCount(target) );
+                }
+                return Ternary.False;
+            }
+        }
+
         if (source.typeParameters && source.typeParameters !== target.typeParameters) {
             target = getCanonicalSignature(target);
             source = instantiateSignatureInContextOf(source, target, /*inferenceContext*/ undefined, compareTypes);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -951,6 +951,15 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         defaultValueDescription: false,
     },
     {
+        name: "veryStrictArity",
+        type: "boolean",
+        affectsSemanticDiagnostics: true,
+        affectsBuildInfo: true,
+        category: Diagnostics.Type_Checking,
+        description: Diagnostics.Target_signature_provides_too_many_arguments_Expected_0_or_more_but_got_1,
+        defaultValueDescription: false,
+    },
+    {
         name: "noImplicitOverride",
         type: "boolean",
         affectsSemanticDiagnostics: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3631,7 +3631,10 @@
         "category": "Error",
         "code": 2849
     },
-
+    "Target signature provides too many arguments. Expected {0} or more, but got {1}.": {
+        "category": "Error",
+        "code": 2850
+    },
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
         "code": 4000

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7208,6 +7208,7 @@ export interface CompilerOptions {
     strictBindCallApply?: boolean;  // Always combine with strict property
     strictNullChecks?: boolean;  // Always combine with strict property
     strictPropertyInitialization?: boolean;  // Always combine with strict property
+    veryStrictArity?: boolean;
     stripInternal?: boolean;
     suppressExcessPropertyErrors?: boolean;
     suppressImplicitAnyIndexErrors?: boolean;

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -158,6 +158,7 @@ class CompilerTest {
         "useDefineForClassFields",
         "useUnknownInCatchVariables",
         "noUncheckedIndexedAccess",
+        "veryStrictArity",
         "noPropertyAccessFromIndexSignature",
         "resolvePackageJsonExports",
         "resolvePackageJsonImports",

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7259,6 +7259,7 @@ declare namespace ts {
         strictBindCallApply?: boolean;
         strictNullChecks?: boolean;
         strictPropertyInitialization?: boolean;
+        veryStrictArity?: boolean;
         stripInternal?: boolean;
         suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3206,6 +3206,7 @@ declare namespace ts {
         strictBindCallApply?: boolean;
         strictNullChecks?: boolean;
         strictPropertyInitialization?: boolean;
+        veryStrictArity?: boolean;
         stripInternal?: boolean;
         suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;

--- a/tests/baselines/reference/config/initTSConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Default initialized TSConfig/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --help/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --help/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --watch/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --watch/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with files options/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -97,6 +97,7 @@
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "veryStrictArity": true,                          /* Target signature provides too many arguments. Expected {0} or more, but got {1}. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/veryStrictArity/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/veryStrictArity/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "veryStrictArity": true
+    }
+}


### PR DESCRIPTION
implement new optional type checking flag veryStirctArity
by default false
when turn on more strictly check arity of methods
Actually add opportunity to fix  https://github.com/microsoft/TypeScript/wiki/FAQ#why-are-functions-with-fewer-parameters-assignable-to-functions-that-take-more-parameters
so if new compilations flag is applied we would get error when try to assign function with fewer parameters to 
function that take more parameters

This will help to catch some errors during compile time like explained in playground and in 
comments bellow 

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ x] Code is up-to-date with the `main` branch
* [ x] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
https://github.com/microsoft/TypeScript/issues/46881 
although it is closed , maybe will this PR reconsider issue
First issue I open as a bug but probably should be improvement
I found this very useful improvement 

playground link
https://www.typescriptlang.org/play?ts=5.1.0-beta#code/JYOwLgpgTgZghgYwgAgJLIN4FgBQzkAWwAFHAFzIDOYUoA5gDTIBGF1tIdAlBQG4D2wACYBuXAF9cuBABs4lSsgCCyYAFsADjIhqI4Remw4peQiXJUa9HsgHDMyAPSPkAOQDyyAKIAlH+59kAAlfL2QAd2AwAmQQCHDkGDk6ZGjoFGBFX38fXHx8aKh+BLiErygiqGIAIgBZCGj+IVj+MFVNbV1wCCEAOmrkAGpkOC4xU0ljHEnpOQVkACF2rR09MANMEzyzUjYrTiZWSw5GZAQ9k5s7ZqN81IIikvjvCv4quoaCJpa29RWuyB9AbDOBDFhjbYzaZbHBwZjsRBtWTyRRKEDqOAyTamOEIhBtNRwADWEAAyvwAK4gITESiU6kXax8QSiEz4NT8XgQYhXFnYu4IfggOnaXoyfh0Go+fhwNT0e4oCBwKDRXpq6oQiYSEzI+YAEQlyAgAA9INTUejCVjbshCSTyVSaVwHM43J5sgFgqEIlEYqVEskFVAMlk-AFtvhBcL+KLxZLqgB1fj8GAAQmQSZTqY143wkyhUeoyCEhoAvLFngbJZqS3RenayfSnSInC5M2mM8m07ha-XOdyxq3kNLZfK0kblaq1SZcTREWc5ooAFrAARgUAAK1BNtnUHnDYd1NpTYA-IzOLzhONthyuTzmfYbZGhSKIGKJVKZXLOAqJyqCGq-Sanm2pTLqigAAryEapp6EIy6rq0m6gvytrEo2jo8i6LgeN4YaBCEPhhJE0QVgkSRwCkzAQAgcAUpQKB0o6qiKPwGjriAmIRmcL4xm+cY1O26ZCTmkKgbgQA