### PR TITLE
Port pyright optimization that skips loop flow nodes that dont contain relevant references

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1295,8 +1295,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         return initFlowNode({ flags: FlowFlags.BranchLabel, antecedents: undefined });
     }
 
-    function createLoopLabel(): FlowLabel {
-        return initFlowNode({ flags: FlowFlags.LoopLabel, antecedents: undefined });
+    function createLoopLabel(node: NonNullable<FlowLabel["node"]>): FlowLabel {
+        return initFlowNode({ flags: FlowFlags.LoopLabel, antecedents: undefined, node });
     }
 
     function createReduceLabel(target: FlowLabel, antecedents: FlowNode[], antecedent: FlowNode): FlowReduceLabel {
@@ -1445,7 +1445,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     }
 
     function bindWhileStatement(node: WhileStatement): void {
-        const preWhileLabel = setContinueTarget(node, createLoopLabel());
+        const preWhileLabel = setContinueTarget(node, createLoopLabel(node));
         const preBodyLabel = createBranchLabel();
         const postWhileLabel = createBranchLabel();
         addAntecedent(preWhileLabel, currentFlow);
@@ -1458,7 +1458,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     }
 
     function bindDoStatement(node: DoStatement): void {
-        const preDoLabel = createLoopLabel();
+        const preDoLabel = createLoopLabel(node);
         const preConditionLabel = setContinueTarget(node, createBranchLabel());
         const postDoLabel = createBranchLabel();
         addAntecedent(preDoLabel, currentFlow);
@@ -1471,7 +1471,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     }
 
     function bindForStatement(node: ForStatement): void {
-        const preLoopLabel = setContinueTarget(node, createLoopLabel());
+        const preLoopLabel = setContinueTarget(node, createLoopLabel(node));
         const preBodyLabel = createBranchLabel();
         const postLoopLabel = createBranchLabel();
         bind(node.initializer);
@@ -1486,7 +1486,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     }
 
     function bindForInOrForOfStatement(node: ForInOrOfStatement): void {
-        const preLoopLabel = setContinueTarget(node, createLoopLabel());
+        const preLoopLabel = setContinueTarget(node, createLoopLabel(node));
         const postLoopLabel = createBranchLabel();
         bind(node.expression);
         addAntecedent(preLoopLabel, currentFlow);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4152,6 +4152,7 @@ export interface FlowStart extends FlowNodeBase {
 // FlowLabel represents a junction with multiple possible preceding control flows.
 export interface FlowLabel extends FlowNodeBase {
     antecedents: FlowNode[] | undefined;
+    node?: ForInOrOfStatement | ForStatement | WhileStatement | DoStatement;
 }
 
 // FlowAssignment represents a node that assigns a value to a narrowable reference,
@@ -6061,6 +6062,8 @@ export interface NodeLinks {
     parameterInitializerContainsUndefined?: boolean; // True if this is a parameter declaration whose type annotation contains "undefined".
     fakeScopeForSignatureDeclaration?: boolean; // True if this is a fake scope injected into an enclosing declaration chain.
     assertionExpressionType?: Type;     // Cached type of the expression of a type assertion
+    referenceCacheKey?: string;         // Cached reference equivalence cache key
+    containedReferences?: ReadonlySet<string>;  // Set of references contained within the node, including itself
 }
 
 /** @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6088,6 +6088,7 @@ declare namespace ts {
     }
     interface FlowLabel extends FlowNodeBase {
         antecedents: FlowNode[] | undefined;
+        node?: ForInOrOfStatement | ForStatement | WhileStatement | DoStatement;
     }
     interface FlowAssignment extends FlowNodeBase {
         node: Expression | VariableDeclaration | BindingElement;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2035,6 +2035,7 @@ declare namespace ts {
     }
     interface FlowLabel extends FlowNodeBase {
         antecedents: FlowNode[] | undefined;
+        node?: ForInOrOfStatement | ForStatement | WhileStatement | DoStatement;
     }
     interface FlowAssignment extends FlowNodeBase {
         node: Expression | VariableDeclaration | BindingElement;


### PR DESCRIPTION
Fixes #51525

This required reworking how we compare references so we could equate them within a `set` - that change, in and of itself, may actually also be perf positive (since we now get to cache the walk over the reference's AST), but both changes together is somewhere between neutral and 4% gains in local testing, depending on the suite. I'll need to see if this bears out on the much slower CI box, though, since 4% locally is < 0.1s, which is well in the realm of "OS scheduler variance" for some of these tests on my box. Do note, unlike pyright, which in the linked issue's change, calculates the references used within a loop during binding, we calculate it late on-demand and cache it in the checker. This is basically required for us, since we equate references using the identity of the resolved symbol of the root node of the reference (which... may be a bit circular with expression checking!). This means we don't get to collect the references for "free" while doing the binder AST walk; but given how often the set of references is referred to by control flow, it should probably still be an improvement in all but pathological cases (eg, thousands of references within a loop, none outside of it).
