### PR TITLE
Add --coverage option to build scripts for tests

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,6 @@
+{
+    "reporter": ["lcovonly"],
+    "src": "src",
+    "include": ["src/**", "built/local/**"],
+    "exclude": ["**/node_modules/**"]
+}

--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -577,6 +577,7 @@ export const runTests = task({
 // task("runtests").flags = {
 //     "-t --tests=<regex>": "Pattern for tests to run.",
 //     "   --failed": "Runs tests listed in '.failed-tests'.",
+//     "   --coverage": "Generate test coverage using c8",
 //     "-r --reporter=<reporter>": "The mocha reporter to use.",
 //     "-i --break": "Runs tests in inspector mode (NodeJS 8 and later)",
 //     "   --keepFailed": "Keep tests in .failed-tests even if they pass",
@@ -714,6 +715,7 @@ export const runTestsParallel = task({
 });
 
 // task("runtests-parallel").flags = {
+//     "   --coverage": "Generate test coverage using c8",
 //     "   --light": "Run tests in light mode (fewer verifications, but tests run faster).",
 //     "   --keepFailed": "Keep tests in .failed-tests even if they pass.",
 //     "   --dirty": "Run tests without first cleaning test output directories.",

--- a/scripts/build/options.mjs
+++ b/scripts/build/options.mjs
@@ -4,7 +4,7 @@ import os from "os";
 const ci = ["1", "true"].includes(process.env.CI ?? "");
 
 const parsed = minimist(process.argv.slice(2), {
-    boolean: ["dirty", "light", "colors", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built", "ci", "bundle", "typecheck", "lint"],
+    boolean: ["dirty", "light", "colors", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built", "ci", "bundle", "typecheck", "lint", "coverage"],
     string: ["browser", "tests", "break", "host", "reporter", "stackTraceLimit", "timeout", "shards", "shardId"],
     alias: {
         /* eslint-disable quote-props */
@@ -42,6 +42,7 @@ const parsed = minimist(process.argv.slice(2), {
         bundle: true,
         typecheck: true,
         lint: true,
+        coverage: false,
     }
 });
 
@@ -88,5 +89,6 @@ export default options;
  * @property {boolean} bundle
  * @property {boolean} typecheck
  * @property {boolean} lint
+ * @property {boolean} coverage
  */
 void 0;

--- a/scripts/build/tests.mjs
+++ b/scripts/build/tests.mjs
@@ -35,6 +35,7 @@ export async function runConsoleTests(runJs, defaultReporter, runInParallel, opt
     const keepFailed = cmdLineOptions.keepFailed;
     const shards = +cmdLineOptions.shards || undefined;
     const shardId = +cmdLineOptions.shardId || undefined;
+    const coverage = cmdLineOptions.coverage;
     if (!cmdLineOptions.dirty) {
         if (options.watching) {
             console.log(chalk.yellowBright(`[watch] cleaning test directories...`));
@@ -81,6 +82,13 @@ export async function runConsoleTests(runJs, defaultReporter, runInParallel, opt
 
     /** @type {string[]} */
     const args = [];
+
+    // enable code coverage using 'c8'
+    let execPath = process.execPath;
+    if (coverage) {
+        args.push("exec", "c8", "--clean", execPath);
+        execPath = "npm";
+    }
 
     // timeout normally isn't necessary but Travis-CI has been timing out on compiler baselines occasionally
     // default timeout is 2sec which really should be enough, but maybe we just need a small amount longer
@@ -131,7 +139,7 @@ export async function runConsoleTests(runJs, defaultReporter, runInParallel, opt
     try {
         setNodeEnvToDevelopment();
 
-        const { exitCode } = await exec(process.execPath, args, { token: options.token });
+        const { exitCode } = await exec(execPath, args, { token: options.token });
         if (exitCode !== 0) {
             errorStatus = exitCode;
             error = new Error(`Process exited with status code ${errorStatus}.`);


### PR DESCRIPTION
This adds a `--coverage` option to our build scripts for use with `runtests`, `runtests-parallel`, and `runtests-watch`. When `--coverage` is specified, tests will be run through `c8` and dump an `lcov` format file to `coverage/lcov.info` for use with a code coverage extension for VS Code or other tooling.