### PR TITLE
Adds tests and fixes issues by verifying incremental project updates are handling language service ref counting correctly

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -72,6 +72,7 @@ import {
     ObjectFlags,
     ObjectType,
     RelationComparisonResult,
+    ScriptKind,
     Signature,
     SignatureCheckMode,
     SignatureFlags,
@@ -437,6 +438,10 @@ export namespace Debug {
 
     export function formatSnippetKind(kind: SnippetKind | undefined): string {
         return formatEnum(kind, (ts as any).SnippetKind, /*isFlags*/ false);
+    }
+
+    export function formatScriptKind(kind: ScriptKind | undefined): string {
+        return formatEnum(kind, (ts as any).ScriptKind, /*isFlags*/ false);
     }
 
     export function formatNodeFlags(flags: NodeFlags | undefined): string {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -880,7 +880,7 @@ function compilerOptionValueToString(value: unknown): string {
 
 /** @internal */
 export function getKeyForCompilerOptions(options: CompilerOptions, affectingOptionDeclarations: readonly CommandLineOption[]) {
-    return affectingOptionDeclarations.map(option => compilerOptionValueToString(getCompilerOptionValue(options, option))).join("|") + (options.pathsBasePath ? `|${options.pathsBasePath}` : undefined);
+    return affectingOptionDeclarations.map(option => compilerOptionValueToString(getCompilerOptionValue(options, option))).join("|") + `|${options.pathsBasePath}`;
 }
 
 /** @internal */

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2369,8 +2369,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         for (const oldSourceFile of oldSourceFiles) {
             const sourceFileOptions = getCreateSourceFileOptions(oldSourceFile.fileName, moduleResolutionCache, host, options);
             let newSourceFile = host.getSourceFileByPath
-                ? host.getSourceFileByPath(oldSourceFile.fileName, oldSourceFile.resolvedPath, sourceFileOptions, /*onError*/ undefined, shouldCreateNewSourceFile || sourceFileOptions.impliedNodeFormat !== oldSourceFile.impliedNodeFormat)
-                : host.getSourceFile(oldSourceFile.fileName, sourceFileOptions, /*onError*/ undefined, shouldCreateNewSourceFile || sourceFileOptions.impliedNodeFormat !== oldSourceFile.impliedNodeFormat); // TODO: GH#18217
+                ? host.getSourceFileByPath(oldSourceFile.fileName, oldSourceFile.resolvedPath, sourceFileOptions, /*onError*/ undefined, shouldCreateNewSourceFile)
+                : host.getSourceFile(oldSourceFile.fileName, sourceFileOptions, /*onError*/ undefined, shouldCreateNewSourceFile); // TODO: GH#18217
 
             if (!newSourceFile) {
                 return StructureIsReused.Not;
@@ -3615,7 +3615,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             fileName,
             sourceFileOptions,
             hostErrorMessage => addFilePreprocessingFileExplainingDiagnostic(/*file*/ undefined, reason, Diagnostics.Cannot_read_file_0_Colon_1, [fileName, hostErrorMessage]),
-            shouldCreateNewSourceFile || (oldProgram?.getSourceFileByPath(toPath(fileName))?.impliedNodeFormat !== sourceFileOptions.impliedNodeFormat)
+            shouldCreateNewSourceFile,
         );
 
         if (packageId) {

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -724,7 +724,8 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
         }
 
         // Create new source file if requested or the versions dont match
-        if (hostSourceFile === undefined || shouldCreateNewSourceFile || isFilePresenceUnknownOnHost(hostSourceFile)) {
+        const impliedNodeFormat = typeof languageVersionOrOptions === "object" ? languageVersionOrOptions.impliedNodeFormat : undefined;
+        if (hostSourceFile === undefined || shouldCreateNewSourceFile || isFilePresenceUnknownOnHost(hostSourceFile) || hostSourceFile.sourceFile.impliedNodeFormat !== impliedNodeFormat) {
             const sourceFile = getNewSourceFile(fileName, languageVersionOrOptions, onError);
             if (hostSourceFile) {
                 if (sourceFile) {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -9,6 +9,7 @@ import * as ts from "./_namespaces/ts";
 import { getNewLineCharacter } from "./_namespaces/ts";
 import * as vfs from "./_namespaces/vfs";
 import * as vpath from "./_namespaces/vpath";
+import { incrementalVerifier } from "./incrementalUtils";
 
 export function makeDefaultProxy(info: ts.server.PluginCreateInfo): ts.LanguageService {
     const proxy = Object.create(/*o*/ null); // eslint-disable-line no-null/no-null
@@ -1016,7 +1017,8 @@ export class ServerLanguageServiceAdapter implements LanguageServiceAdapter {
             byteLength: Buffer.byteLength,
             hrtime: process.hrtime,
             logger: serverHost,
-            canUseEvents: true
+            canUseEvents: true,
+            incrementalVerifier,
         };
         this.server = new FourslashSession(opts);
 

--- a/src/harness/incrementalUtils.ts
+++ b/src/harness/incrementalUtils.ts
@@ -1,0 +1,100 @@
+import * as ts from "./_namespaces/ts";
+
+export function reportDocumentRegistryStats(documentRegistry: ts.DocumentRegistry) {
+    const str: string[] = [];
+    documentRegistry.getBuckets().forEach((bucketEntries, key) => {
+        str.push(`  Key:: ${key}`);
+        bucketEntries.forEach((entry, path) => {
+            if (ts.isDocumentRegistryEntry(entry)) {
+                str.push(`    ${path}: ${ts.Debug.formatScriptKind(entry.sourceFile.scriptKind)} ${entry.languageServiceRefCount}`);
+            }
+            else {
+                entry.forEach((real, kind) => str.push(`    ${path}: ${ts.Debug.formatScriptKind(kind)} ${real.languageServiceRefCount}`));
+            }
+        });
+    });
+    return str;
+}
+
+type DocumentRegistryExpectedStats = Map<ts.DocumentRegistryBucketKeyWithMode, Map<ts.Path, Map<ts.ScriptKind, number>>>;
+function verifyDocumentRegistryStats(
+    documentRegistry: ts.DocumentRegistry,
+    stats: DocumentRegistryExpectedStats,
+) {
+    documentRegistry.getBuckets().forEach((bucketEntries, key) => {
+        const statsByPath = stats.get(key);
+        bucketEntries.forEach((entry, path) => {
+            const expected = statsByPath?.get(path);
+            if (ts.isDocumentRegistryEntry(entry)) {
+                ts.Debug.assert(
+                    expected?.size === 1 && expected.has(entry.sourceFile.scriptKind) && expected.get(entry.sourceFile.scriptKind) === entry.languageServiceRefCount,
+                    `Document registry has unexpected language service ref count for ${key} ${path} ${ts.Debug.formatScriptKind(entry.sourceFile.scriptKind)} ${entry.languageServiceRefCount}`,
+                    reportStats,
+                );
+            }
+            else {
+                entry.forEach((real, kind) => ts.Debug.assert(
+                    real.languageServiceRefCount === expected?.get(kind),
+                    `Document registry has unexpected language service ref count for ${key} ${path} ${ts.Debug.formatScriptKind(kind)} ${real.languageServiceRefCount}`,
+                    reportStats,
+                ));
+                expected?.forEach((value, kind) => ts.Debug.assert(
+                    entry.has(kind),
+                    `Document registry expected language service ref count for ${key} ${path} ${ts.Debug.formatScriptKind(kind)} ${value}`,
+                    reportStats,
+                ));
+            }
+        });
+        statsByPath?.forEach((_value, path) => ts.Debug.assert(
+            bucketEntries.has(path),
+            `Document registry does not contain entry for ${key}, ${path}`,
+            reportStats,
+        ));
+    });
+    stats.forEach((_value, key) => ts.Debug.assert(
+        documentRegistry.getBuckets().has(key),
+        `Document registry does not contain entry for key: ${key}`,
+        reportStats,
+    ));
+
+    function reportStats() {
+        const str: string[] = ["", "Actual::", ...reportDocumentRegistryStats(documentRegistry)];
+        str.push("Expected::");
+        stats?.forEach((statsByPath, key) => {
+            str.push(`  Key:: ${key}`);
+            statsByPath.forEach((entry, path) => entry.forEach((refCount, kind) => str.push(`    ${path}: ${ts.Debug.formatScriptKind(kind)} ${refCount}`)));
+        });
+        return str.join("\n");
+    }
+}
+
+function verifyDocumentRegistry(service: ts.server.ProjectService) {
+    const stats: DocumentRegistryExpectedStats = new Map();
+    const collectStats = (project: ts.server.Project) => {
+        if (project.autoImportProviderHost) collectStats(project.autoImportProviderHost);
+        if (project.noDtsResolutionProject) collectStats(project.noDtsResolutionProject);
+        const program = project.getCurrentLSProgram();
+        if (!program) return;
+        const key = service.documentRegistry.getKeyForCompilationSettings(program.getCompilerOptions());
+        program.getSourceFiles().forEach(f => {
+            const keyWithMode = service.documentRegistry.getDocumentRegistryBucketKeyWithMode(key, f.impliedNodeFormat);
+            let mapForKeyWithMode = stats.get(keyWithMode);
+            let result: Map<ts.ScriptKind, number> | undefined;
+            if (mapForKeyWithMode === undefined) {
+                stats.set(keyWithMode, mapForKeyWithMode = new Map());
+                mapForKeyWithMode.set(f.resolvedPath, result = new Map());
+            }
+            else {
+                result = mapForKeyWithMode.get(f.resolvedPath);
+                if (!result) mapForKeyWithMode.set(f.resolvedPath, result = new Map());
+            }
+            result.set(f.scriptKind, (result.get(f.scriptKind) || 0) + 1);
+        });
+    };
+    service.forEachProject(collectStats);
+    verifyDocumentRegistryStats(service.documentRegistry, stats);
+}
+
+export function incrementalVerifier(service: ts.server.ProjectService) {
+    service.verifyDocumentRegistry = () => verifyDocumentRegistry(service);
+}

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -590,6 +590,7 @@ export interface ProjectServiceOptions {
     typesMapLocation?: string;
     serverMode?: LanguageServiceMode;
     session: Session<unknown> | undefined;
+    /** @internal */ incrementalVerifier?: (service: ProjectService) => void;
 }
 
 interface OriginalFileInfo { fileName: NormalizedPath; path: Path; }
@@ -989,11 +990,12 @@ export class ProjectService {
     /** @internal */
     readonly session: Session<unknown> | undefined;
 
-
     private performanceEventHandler?: PerformanceEventHandler;
 
     private pendingPluginEnablements?: Map<Project, Promise<BeginEnablePluginResult>[]>;
     private currentPluginEnablementPromise?: Promise<void>;
+
+    /** @internal */ verifyDocumentRegistry = noop;
 
     constructor(opts: ProjectServiceOptions) {
         this.host = opts.host;
@@ -1057,6 +1059,7 @@ export class ProjectService {
                 watchDirectory: returnNoopFileWatcher,
             } :
             getWatchFactory(this.host, watchLogLevel, log, getDetailWatchInfo);
+        opts.incrementalVerifier?.(this);
     }
 
     toPath(fileName: string) {
@@ -1334,7 +1337,7 @@ export class ProjectService {
     }
 
     /** @internal */
-    private forEachProject(cb: (project: Project) => void) {
+    forEachProject(cb: (project: Project) => void) {
         this.externalProjects.forEach(cb);
         this.configuredProjects.forEach(cb);
         this.inferredProjects.forEach(cb);

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -946,6 +946,7 @@ export interface SessionOptions {
     pluginProbeLocations?: readonly string[];
     allowLocalPluginLoads?: boolean;
     typesMapLocation?: string;
+    /** @internal */ incrementalVerifier?: (service: ProjectService) => void;
 }
 
 export class Session<TMessage = string> implements EventSender {
@@ -1010,7 +1011,8 @@ export class Session<TMessage = string> implements EventSender {
             allowLocalPluginLoads: opts.allowLocalPluginLoads,
             typesMapLocation: opts.typesMapLocation,
             serverMode: opts.serverMode,
-            session: this
+            session: this,
+            incrementalVerifier: opts.incrementalVerifier,
         };
         this.projectService = new ProjectService(settings);
         this.projectService.setPerformanceEventHandler(this.performanceEventHandler.bind(this));

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -117,6 +117,8 @@ export interface DocumentRegistry {
     ): SourceFile;
 
     getKeyForCompilationSettings(settings: CompilerOptions): DocumentRegistryBucketKey;
+    /** @internal */
+    getDocumentRegistryBucketKeyWithMode(key: DocumentRegistryBucketKey, mode: ResolutionMode): DocumentRegistryBucketKeyWithMode;
     /**
      * Informs the DocumentRegistry that a file is not needed any longer.
      *
@@ -147,10 +149,8 @@ export interface DocumentRegistry {
     releaseDocumentWithKey(path: Path, key: DocumentRegistryBucketKey, scriptKind?: ScriptKind): void;
     releaseDocumentWithKey(path: Path, key: DocumentRegistryBucketKey, scriptKind: ScriptKind, impliedNodeFormat: ResolutionMode): void; // eslint-disable-line @typescript-eslint/unified-signatures
 
-    /** @internal */
-    getLanguageServiceRefCounts(path: Path, scriptKind: ScriptKind): [string, number | undefined][];
-
     reportStats(): string;
+    /** @internal */ getBuckets(): Map<DocumentRegistryBucketKeyWithMode, Map<Path, BucketEntry>>;
 }
 
 /** @internal */
@@ -161,7 +161,8 @@ export interface ExternalDocumentCache {
 
 export type DocumentRegistryBucketKey = string & { __bucketKey: any };
 
-interface DocumentRegistryEntry {
+/** @internal */
+export interface DocumentRegistryEntry {
     sourceFile: SourceFile;
 
     // The number of language services that this source file is referenced in.   When no more
@@ -170,8 +171,10 @@ interface DocumentRegistryEntry {
     languageServiceRefCount: number;
 }
 
-type BucketEntry = DocumentRegistryEntry | Map<ScriptKind, DocumentRegistryEntry>;
-function isDocumentRegistryEntry(entry: BucketEntry): entry is DocumentRegistryEntry {
+/** @internal */
+export type BucketEntry = DocumentRegistryEntry | Map<ScriptKind, DocumentRegistryEntry>;
+/** @internal */
+export function isDocumentRegistryEntry(entry: BucketEntry): entry is DocumentRegistryEntry {
     return !!(entry as DocumentRegistryEntry).sourceFile;
 }
 
@@ -383,14 +386,6 @@ export function createDocumentRegistryInternal(useCaseSensitiveFileNames?: boole
         }
     }
 
-    function getLanguageServiceRefCounts(path: Path, scriptKind: ScriptKind) {
-        return arrayFrom(buckets.entries(), ([key, bucket]): [string, number | undefined] => {
-            const bucketEntry = bucket.get(path);
-            const entry = bucketEntry && getDocumentRegistryEntry(bucketEntry, scriptKind);
-            return [key, entry && entry.languageServiceRefCount];
-        });
-    }
-
     return {
         acquireDocument,
         acquireDocumentWithKey,
@@ -398,9 +393,10 @@ export function createDocumentRegistryInternal(useCaseSensitiveFileNames?: boole
         updateDocumentWithKey,
         releaseDocument,
         releaseDocumentWithKey,
-        getLanguageServiceRefCounts,
+        getKeyForCompilationSettings,
+        getDocumentRegistryBucketKeyWithMode,
         reportStats,
-        getKeyForCompilationSettings
+        getBuckets: () => buckets,
     };
 }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1937,10 +1937,6 @@ export function createLanguageService(
     }
 
     function cleanupSemanticCache(): void {
-        program = undefined!; // TODO: GH#18217
-    }
-
-    function dispose(): void {
         if (program) {
             // Use paths to ensure we are using correct key and paths as document registry could be created with different current directory than host
             const key = documentRegistry.getKeyForCompilationSettings(program.getCompilerOptions());
@@ -1948,6 +1944,10 @@ export function createLanguageService(
                 documentRegistry.releaseDocumentWithKey(f.resolvedPath, key, f.scriptKind, f.impliedNodeFormat));
             program = undefined!; // TODO: GH#18217
         }
+    }
+
+    function dispose(): void {
+        cleanupSemanticCache();
         host = undefined!;
     }
 

--- a/src/testRunner/unittests/helpers/tsserver.ts
+++ b/src/testRunner/unittests/helpers/tsserver.ts
@@ -1,3 +1,4 @@
+import { incrementalVerifier } from "../../../harness/incrementalUtils";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import { ActionWatchTypingLocations } from "../../_namespaces/ts.server";
@@ -553,7 +554,8 @@ export function createSession(host: TestServerHost, opts: Partial<TestSessionOpt
         byteLength: Buffer.byteLength,
         hrtime: process.hrtime,
         logger,
-        canUseEvents: false
+        canUseEvents: false,
+        incrementalVerifier,
     };
 
     return new TestSession({ ...sessionOptions, ...opts });
@@ -606,6 +608,7 @@ export class TestProjectService extends ts.server.ProjectService {
             useInferredProjectPerProjectRoot: false,
             typingsInstaller,
             typesMapLocation: customTypesMap.path,
+            incrementalVerifier,
             ...opts
         });
         ts.Debug.assert(opts.allowNonBaseliningLogger || this.logger.hasLevel(ts.server.LogLevel.verbose), "Use Baselining logger and baseline tsserver log or create using allowNonBaseliningLogger");

--- a/src/testRunner/unittests/tsserver/documentRegistry.ts
+++ b/src/testRunner/unittests/tsserver/documentRegistry.ts
@@ -1,3 +1,4 @@
+import { reportDocumentRegistryStats } from "../../../harness/incrementalUtils";
 import * as ts from "../../_namespaces/ts";
 import {
     baselineTsserverLogs,
@@ -40,8 +41,8 @@ describe("unittests:: tsserver:: documentRegistry:: document registry in project
         const moduleInfo = service.getScriptInfo(moduleFile.path)!;
         assert.isDefined(moduleInfo);
         assert.equal(moduleInfo.isOrphan(), moduleIsOrphan);
-        const key = service.documentRegistry.getKeyForCompilationSettings(project.getCompilationSettings());
-        assert.deepEqual(service.documentRegistry.getLanguageServiceRefCounts(moduleInfo.path, moduleInfo.scriptKind), [[key, moduleIsOrphan ? undefined : 1]]);
+        service.logger.log("DocumentRegistry::");
+        service.logger.log(reportDocumentRegistryStats(service.documentRegistry).join("\n"));
     }
 
     function createServiceAndHost() {

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import { incrementalVerifier } from "../../../harness/incrementalUtils";
 import * as Harness from "../../_namespaces/Harness";
 import * as ts from "../../_namespaces/ts";
 import {
@@ -55,7 +56,8 @@ describe("unittests:: tsserver:: Session:: General functionality", () => {
             byteLength: Buffer.byteLength,
             hrtime: process.hrtime,
             logger: nullLogger(),
-            canUseEvents: true
+            canUseEvents: true,
+            incrementalVerifier,
         };
         return new TestSession(opts);
     }
@@ -387,7 +389,8 @@ describe("unittests:: tsserver:: Session:: exceptions", () => {
                 byteLength: Buffer.byteLength,
                 hrtime: process.hrtime,
                 logger: nullLogger(),
-                canUseEvents: true
+                canUseEvents: true,
+                incrementalVerifier,
             });
             this.addProtocolHandler(command, this.exceptionRaisingHandler);
         }
@@ -434,7 +437,8 @@ describe("unittests:: tsserver:: Session:: how Session is extendable via subclas
                 byteLength: Buffer.byteLength,
                 hrtime: process.hrtime,
                 logger: createHasErrorMessageLogger(),
-                canUseEvents: true
+                canUseEvents: true,
+                incrementalVerifier,
             });
             this.addProtocolHandler(this.customHandler, () => {
                 return { response: undefined, responseRequired: true };
@@ -502,7 +506,8 @@ describe("unittests:: tsserver:: Session:: an example of using the Session API t
                 byteLength: Buffer.byteLength,
                 hrtime: process.hrtime,
                 logger: createHasErrorMessageLogger(),
-                canUseEvents: true
+                canUseEvents: true,
+                incrementalVerifier,
             });
             this.addProtocolHandler("echo", (req: ts.server.protocol.Request) => ({
                 response: req.arguments,

--- a/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan,-and-orphan-script-info-changes.js
+++ b/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan,-and-orphan-script-info-changes.js
@@ -68,6 +68,11 @@ Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
 Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/myproject/index.ts ProjectRootPath: undefined
 Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/myproject/tsconfig.json
+DocumentRegistry::
+  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+    /user/username/projects/myproject/index.ts: TS 1
+    /user/username/projects/myproject/module1.d.ts: TS 1
+    /a/lib/lib.d.ts: TS 1
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -82,6 +87,10 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+DocumentRegistry::
+  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+    /user/username/projects/myproject/index.ts: TS 1
+    /a/lib/lib.d.ts: TS 1
 Info seq  [hh:mm:ss:mss] FileWatcher:: Triggered with /user/username/projects/myproject/module1.d.ts 1:: WatchInfo: /user/username/projects/myproject/module1.d.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms FileWatcher:: Triggered with /user/username/projects/myproject/module1.d.ts 1:: WatchInfo: /user/username/projects/myproject/module1.d.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
@@ -101,3 +110,8 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+DocumentRegistry::
+  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+    /user/username/projects/myproject/index.ts: TS 1
+    /a/lib/lib.d.ts: TS 1
+    /user/username/projects/myproject/module1.d.ts: TS 1

--- a/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan.js
+++ b/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan.js
@@ -68,6 +68,11 @@ Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
 Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/myproject/index.ts ProjectRootPath: undefined
 Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/myproject/tsconfig.json
+DocumentRegistry::
+  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+    /user/username/projects/myproject/index.ts: TS 1
+    /user/username/projects/myproject/module1.d.ts: TS 1
+    /a/lib/lib.d.ts: TS 1
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 2 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -82,6 +87,10 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+DocumentRegistry::
+  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+    /user/username/projects/myproject/index.ts: TS 1
+    /a/lib/lib.d.ts: TS 1
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json Version: 3 structureChanged: true structureIsReused:: SafeModules Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/myproject/tsconfig.json' (Configured)
@@ -99,3 +108,8 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 	  Part of 'files' list in tsconfig.json
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
+DocumentRegistry::
+  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+    /user/username/projects/myproject/index.ts: TS 1
+    /a/lib/lib.d.ts: TS 1
+    /user/username/projects/myproject/module1.d.ts: TS 1

--- a/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited-when-package-json-with-type-module-exists.js
+++ b/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited-when-package-json-with-type-module-exists.js
@@ -581,6 +581,13 @@ Info seq  [hh:mm:ss:mss] File '/user/username/projects/package.json' does not ex
 Info seq  [hh:mm:ss:mss] File '/user/username/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/user/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/package.json' does not exist according to earlier cached lookups.
+Info seq  [hh:mm:ss:mss] ======== Resolving module './fileB.mjs' from '/user/username/projects/myproject/src/fileA.ts'. ========
+Info seq  [hh:mm:ss:mss] Module resolution kind is not specified, using 'Node16'.
+Info seq  [hh:mm:ss:mss] Resolving in CJS mode with conditions 'require', 'types', 'node'.
+Info seq  [hh:mm:ss:mss] Loading module as file / folder, candidate module location '/user/username/projects/myproject/src/fileB.mjs', target file types: TypeScript, JavaScript, Declaration.
+Info seq  [hh:mm:ss:mss] File name '/user/username/projects/myproject/src/fileB.mjs' has a '.mjs' extension - stripping it.
+Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/fileB.mts' exists - use it as a name resolution result.
+Info seq  [hh:mm:ss:mss] ======== Module name './fileB.mjs' was successfully resolved to '/user/username/projects/myproject/src/fileB.mts'. ========
 Info seq  [hh:mm:ss:mss] File '/a/lib/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/a/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/package.json' does not exist according to earlier cached lookups.
@@ -770,13 +777,7 @@ Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/package.jso
 Info seq  [hh:mm:ss:mss] Found 'package.json' at '/user/username/projects/myproject/package.json'.
 Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/package.json' exists according to earlier cached lookups.
-Info seq  [hh:mm:ss:mss] ======== Resolving module './fileB.mjs' from '/user/username/projects/myproject/src/fileA.ts'. ========
-Info seq  [hh:mm:ss:mss] Module resolution kind is not specified, using 'Node16'.
-Info seq  [hh:mm:ss:mss] Resolving in CJS mode with conditions 'require', 'types', 'node'.
-Info seq  [hh:mm:ss:mss] Loading module as file / folder, candidate module location '/user/username/projects/myproject/src/fileB.mjs', target file types: TypeScript, JavaScript, Declaration.
-Info seq  [hh:mm:ss:mss] File name '/user/username/projects/myproject/src/fileB.mjs' has a '.mjs' extension - stripping it.
-Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/fileB.mts' exists - use it as a name resolution result.
-Info seq  [hh:mm:ss:mss] ======== Module name './fileB.mjs' was successfully resolved to '/user/username/projects/myproject/src/fileB.mts'. ========
+Info seq  [hh:mm:ss:mss] Reusing resolution of module './fileB.mjs' from '/user/username/projects/myproject/src/fileA.ts' of old program, it was successfully resolved to '/user/username/projects/myproject/src/fileB.mts'.
 Info seq  [hh:mm:ss:mss] File '/a/lib/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/a/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/package.json' does not exist according to earlier cached lookups.

--- a/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited.js
+++ b/tests/baselines/reference/tsserver/moduleResolution/package-json-file-is-edited.js
@@ -771,6 +771,13 @@ Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/package.jso
 Info seq  [hh:mm:ss:mss] Found 'package.json' at '/user/username/projects/myproject/package.json'.
 Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/package.json' exists according to earlier cached lookups.
+Info seq  [hh:mm:ss:mss] ======== Resolving module './fileB.mjs' from '/user/username/projects/myproject/src/fileA.ts'. ========
+Info seq  [hh:mm:ss:mss] Module resolution kind is not specified, using 'Node16'.
+Info seq  [hh:mm:ss:mss] Resolving in ESM mode with conditions 'import', 'types', 'node'.
+Info seq  [hh:mm:ss:mss] Loading module as file / folder, candidate module location '/user/username/projects/myproject/src/fileB.mjs', target file types: TypeScript, JavaScript, Declaration.
+Info seq  [hh:mm:ss:mss] File name '/user/username/projects/myproject/src/fileB.mjs' has a '.mjs' extension - stripping it.
+Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/fileB.mts' exists - use it as a name resolution result.
+Info seq  [hh:mm:ss:mss] ======== Module name './fileB.mjs' was successfully resolved to '/user/username/projects/myproject/src/fileB.mts'. ========
 Info seq  [hh:mm:ss:mss] File '/a/lib/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/a/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/package.json' does not exist according to earlier cached lookups.
@@ -954,6 +961,13 @@ Info seq  [hh:mm:ss:mss] File '/user/username/projects/package.json' does not ex
 Info seq  [hh:mm:ss:mss] File '/user/username/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/user/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/package.json' does not exist according to earlier cached lookups.
+Info seq  [hh:mm:ss:mss] ======== Resolving module './fileB.mjs' from '/user/username/projects/myproject/src/fileA.ts'. ========
+Info seq  [hh:mm:ss:mss] Module resolution kind is not specified, using 'Node16'.
+Info seq  [hh:mm:ss:mss] Resolving in CJS mode with conditions 'require', 'types', 'node'.
+Info seq  [hh:mm:ss:mss] Loading module as file / folder, candidate module location '/user/username/projects/myproject/src/fileB.mjs', target file types: TypeScript, JavaScript, Declaration.
+Info seq  [hh:mm:ss:mss] File name '/user/username/projects/myproject/src/fileB.mjs' has a '.mjs' extension - stripping it.
+Info seq  [hh:mm:ss:mss] File '/user/username/projects/myproject/src/fileB.mts' exists - use it as a name resolution result.
+Info seq  [hh:mm:ss:mss] ======== Module name './fileB.mjs' was successfully resolved to '/user/username/projects/myproject/src/fileB.mts'. ========
 Info seq  [hh:mm:ss:mss] File '/a/lib/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/a/package.json' does not exist according to earlier cached lookups.
 Info seq  [hh:mm:ss:mss] File '/package.json' does not exist according to earlier cached lookups.


### PR DESCRIPTION
- e228e1b9de27a41fce24cb2e1754bf43431c3038 Whenever LS updates the program, we are ensuring the expected ref counting based on source files in all projects matches with whats currently in the document registry. While looking into #54401 i realised that there are more scenarios where language ref counting is not correct and identified more as well when creating this test framework.
- 533145d219d143d949a4cb9ede716a95536ae3cd This fixes issue where documents were not released from cache whenever clearing semantic cache. which meants we held onto documents even though we dont need them
- ff40714272f4a51c0c919c638b237185b9f89e4d implied node format change was causing to increase the language service ref count to increment incorrectly and incorrect module resolution reuse.