### PR TITLE
Ensure we don't overwrite computed CouldContainTypeVariables in new optimization

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18800,8 +18800,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // If none of the type arguments for the outer type parameters contain type variables, it follows
                 // that the instantiated type doesn't reference type variables.
                 if (result.flags & TypeFlags.ObjectFlagsType && !((result as ObjectFlagsType).objectFlags & ObjectFlags.CouldContainTypeVariablesComputed)) {
-                    (result as ObjectFlagsType).objectFlags |= ObjectFlags.CouldContainTypeVariablesComputed |
-                        (some(typeArguments, couldContainTypeVariables) ? ObjectFlags.CouldContainTypeVariables : 0);
+                    const resultCouldContainTypeVariables = some(typeArguments, couldContainTypeVariables);
+                    // The above check may have caused the result's objectFlags to update if the result is referenced via typeArguments.
+                    if (!((result as ObjectFlagsType).objectFlags & ObjectFlags.CouldContainTypeVariablesComputed)) {
+                        (result as ObjectFlagsType).objectFlags |= ObjectFlags.CouldContainTypeVariablesComputed |
+                            (resultCouldContainTypeVariables ? ObjectFlags.CouldContainTypeVariables : 0);
+                    }
                 }
                 target.instantiations.set(id, result);
             }


### PR DESCRIPTION
Fixes #54348

In this branch (added in #53246), we checked that `result` didn't already have `CouldContainTypeVariables` calculated. If not, then we instead calculate it directly by only checking `typeArguments`.

However, if `result` happens to be mentioned in `typeArguments`, the call to `couldContainTypeVariables` may change `result.objectFlags`. When this happens, we stomp over the previous computation with our own.

Normally, this is harmless because `CouldContainTypeVariables` is realistically just an optimization to prevent unnecessary type traversals.

However, `result` can in fact be `neverType` or `wildcardType` (and maybe others)! If we accidentally overwrite the previously computed result with "true" (a more conservative calculation), this can actually cause a problem later, as seen in #54348. This is because `inferTypes` may end up with two identical source and targets.

In the bug's case, `source == target == wildcardType`. `wildcardType` is a special case for `inferTypes`, which for "reasons" can only stop infinitely recursing by seeing that `wildcardType` cannot contain type variables. So, if we stomp over a previously calculated "false" answer here with a more conservative "true", what was just a missing optimization turns into a stack overflow. (Theoretically, I think we should also make `inferTypes` _not_ depend on this optimization flag and just directly check for the infinite recursion. But, it did catch this bug...)

This PR "fixes" the problem by double checking that someone else hasn't already calculated the value while we were. If it's already calculated, then we just skip over. I also verified that the speedup in material-ui is not broken by this fix (phew).

I haven't been able to produce a decent test case. There are actually 15 test cases in our test suite which hit this new branch, but none with observable behavior differences. All provided tests in the issue are massive and I can't minimize them.

I am also not 100% sure of this fix; most of the time, the optimization from #53246 is operating on a freshly instantiated type (which is why the optimization is valid). But sometimes, it's not actually operating on a new type. Perhaps the "right" fix is to skip this code when the type isn't a newly created one just for this section? Because those types shouldn't be involved in this optimization anyway?