### PR TITLE
Proposal: compute module format based on package.json visible to `declarationDir`/`outDir`

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1659,6 +1659,10 @@
         "category": "Message",
         "code": 2212
     },
+    "The project root is ambiguous, but is required to determine the module format of output '.js' files. Supply the `rootDir` compiler option to disambiguate.": {
+        "category": "Error",
+        "code": 2213
+    },
 
     "Duplicate identifier '{0}'.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -597,6 +597,19 @@ export function getOutputDeclarationFileName(inputFileName: string, configFile: 
 }
 
 /** @internal */
+export function getOutputDeclarationFileNameWithoutConfigFile(inputFileName: string, options: CompilerOptions, ignoreCase: boolean, currentDirectory: string, getCommonSourceDirectory: () => string) {
+    const directory = (options.outDir || options.declarationDir) ? getNormalizedAbsolutePath(options.outDir || options.declarationDir!, currentDirectory) : undefined;
+    const outputPathWithoutChangedExtension = directory
+        ? resolvePath(directory, getRelativePathFromDirectory(getCommonSourceDirectory(), inputFileName, ignoreCase))
+        : inputFileName;
+    const outputFileName = changeExtension(
+        outputPathWithoutChangedExtension,
+        getDeclarationEmitExtensionForPath(inputFileName)
+    );
+    return outputFileName;
+}
+
+/** @internal */
 export function getOutputJSFileName(inputFileName: string, configFile: ParsedCommandLine, ignoreCase: boolean, getCommonSourceDirectory?: () => string) {
     if (configFile.options.emitDeclarationOnly) return undefined;
     const isJsonFile = fileExtensionIs(inputFileName, Extension.Json);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -598,7 +598,7 @@ export function getOutputDeclarationFileName(inputFileName: string, configFile: 
 
 /** @internal */
 export function getOutputDeclarationFileNameWithoutConfigFile(inputFileName: string, options: CompilerOptions, ignoreCase: boolean, currentDirectory: string, getCommonSourceDirectory: () => string) {
-    const directory = (options.outDir || options.declarationDir) ? getNormalizedAbsolutePath(options.outDir || options.declarationDir!, currentDirectory) : undefined;
+    const directory = (options.declarationDir || options.outDir) ? getNormalizedAbsolutePath(options.declarationDir || options.outDir!, currentDirectory) : undefined;
     const outputPathWithoutChangedExtension = directory
         ? resolvePath(directory, getRelativePathFromDirectory(getCommonSourceDirectory(), inputFileName, ignoreCase))
         : inputFileName;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -596,7 +596,8 @@ export function getOutputDeclarationFileName(inputFileName: string, configFile: 
     );
 }
 
-function getOutputJSFileName(inputFileName: string, configFile: ParsedCommandLine, ignoreCase: boolean, getCommonSourceDirectory?: () => string) {
+/** @internal */
+export function getOutputJSFileName(inputFileName: string, configFile: ParsedCommandLine, ignoreCase: boolean, getCommonSourceDirectory?: () => string) {
     if (configFile.options.emitDeclarationOnly) return undefined;
     const isJsonFile = fileExtensionIs(inputFileName, Extension.Json);
     const outputFileName = changeExtension(
@@ -604,6 +605,23 @@ function getOutputJSFileName(inputFileName: string, configFile: ParsedCommandLin
         getOutputExtension(inputFileName, configFile.options)
     );
     return !isJsonFile || comparePaths(inputFileName, outputFileName, Debug.checkDefined(configFile.options.configFilePath), ignoreCase) !== Comparison.EqualTo ?
+        outputFileName :
+        undefined;
+}
+
+/** @internal */
+export function getOutputJSFileNameWithoutConfigFile(inputFileName: string, options: CompilerOptions, ignoreCase: boolean, currentDirectory: string, getCommonSourceDirectory: () => string) {
+    if (options.emitDeclarationOnly) return undefined;
+    const isJsonFile = fileExtensionIs(inputFileName, Extension.Json);
+    const outDir = options.outDir ? getNormalizedAbsolutePath(options.outDir, currentDirectory) : undefined;
+    const outputPathWithoutChangedExtension = outDir
+        ? resolvePath(outDir, getRelativePathFromDirectory(getCommonSourceDirectory(), inputFileName, ignoreCase))
+        : inputFileName;
+    const outputFileName = changeExtension(
+        outputPathWithoutChangedExtension,
+        getOutputExtension(inputFileName, options)
+    );
+    return !isJsonFile || !options.configFilePath || comparePaths(inputFileName, outputFileName, options.configFilePath, ignoreCase) !== Comparison.EqualTo ?
         outputFileName :
         undefined;
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -336,6 +336,7 @@ import {
     WriteFileCallbackData,
     writeFileEnsuringDirectories,
     zipToModeAwareCache,
+    getOutputDeclarationFileNameWithoutConfigFile,
 } from "./_namespaces/ts";
 import * as performance from "./_namespaces/ts.performance";
 
@@ -3533,16 +3534,38 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 // We have a source file that is an input to a referenced project.
                 // This should only happen with `useSourceOfProjectReferenceRedirect` enabled.
                 Debug.assert(useSourceOfProjectReferenceRedirect);
-                const outputFile = getOutputJSFileName(
-                    fileNameForModuleFormatDetection,
-                    projectReference.commandLine,
-                    !host.useCaseSensitiveFileNames());
-                if (outputFile) {
-                    fileNameForModuleFormatDetection = outputFile;
+                if (projectReference.commandLine.options.outDir) {
+                    const outputFile = getOutputJSFileName(
+                        fileNameForModuleFormatDetection,
+                        projectReference.commandLine,
+                        !host.useCaseSensitiveFileNames());
+                    if (outputFile) {
+                        fileNameForModuleFormatDetection = outputFile;
+                    }
+                }
+                else if (projectReference.commandLine.options.declaration && projectReference.commandLine.options.declarationDir) {
+                    const outputFile = getOutputDeclarationFileName(
+                        fileNameForModuleFormatDetection,
+                        projectReference.commandLine,
+                        !host.useCaseSensitiveFileNames());
+                    if (outputFile) {
+                        fileNameForModuleFormatDetection = outputFile;
+                    }
                 }
             }
             else if (options.outDir) {
                 const outputFile = getOutputJSFileNameWithoutConfigFile(
+                    fileNameForModuleFormatDetection,
+                    options,
+                    !host.useCaseSensitiveFileNames(),
+                    currentDirectory,
+                    getAssumedCommonSourceDirectory);
+                if (outputFile) {
+                    fileNameForModuleFormatDetection = outputFile;
+                }
+            }
+            else if (options.declaration && options.declarationDir) {
+                const outputFile = getOutputDeclarationFileNameWithoutConfigFile(
                     fileNameForModuleFormatDetection,
                     options,
                     !host.useCaseSensitiveFileNames(),

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -134,6 +134,7 @@ import {
     getNormalizedAbsolutePathWithoutRoot,
     getNormalizedPathComponents,
     getOutputDeclarationFileName,
+    getOutputDeclarationFileNameWithoutConfigFile,
     getOutputJSFileName,
     getOutputJSFileNameWithoutConfigFile,
     getOutputPathsForBundle,
@@ -336,7 +337,6 @@ import {
     WriteFileCallbackData,
     writeFileEnsuringDirectories,
     zipToModeAwareCache,
-    getOutputDeclarationFileNameWithoutConfigFile,
 } from "./_namespaces/ts";
 import * as performance from "./_namespaces/ts.performance";
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3530,6 +3530,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         if (moduleFormatNeedsPackageJsonLookup(fileName, options)) {
             const projectReference = getResolvedProjectReferenceToRedirect(fileName);
             if (projectReference) {
+                // We have a source file that is an input to a referenced project.
+                // This should only happen with `useSourceOfProjectReferenceRedirect` enabled.
+                Debug.assert(useSourceOfProjectReferenceRedirect);
                 const outputFile = getOutputJSFileName(
                     fileNameForModuleFormatDetection,
                     projectReference.commandLine,

--- a/src/testRunner/tests.ts
+++ b/src/testRunner/tests.ts
@@ -80,6 +80,7 @@ import "./unittests/tsbuild/lateBoundSymbol";
 import "./unittests/tsbuild/libraryResolution";
 import "./unittests/tsbuild/moduleResolution";
 import "./unittests/tsbuild/moduleSpecifiers";
+import "./unittests/tsbuild/nodeModulesOutDirPackageJson";
 import "./unittests/tsbuild/noEmit";
 import "./unittests/tsbuild/noEmitOnError";
 import "./unittests/tsbuild/outFile";

--- a/src/testRunner/unittests/tsbuild/nodeModulesOutDirPackageJson.ts
+++ b/src/testRunner/unittests/tsbuild/nodeModulesOutDirPackageJson.ts
@@ -1,0 +1,33 @@
+import {
+    verifyTsc,
+} from "../helpers/tsc";
+import { loadProjectFromFiles } from "../helpers/vfs";
+
+describe("unittests:: tsbuild:: nodeModulesOutDirPackageJson", () => {
+    verifyTsc({
+        scenario: "nodeModulesOutDirPackageJson",
+        subScenario: "recognizes package.json in outDir of referenced project",
+        commandLineArgs: ["-b", "/src/tsconfig.json", "-v"],
+        fs: () => loadProjectFromFiles({
+            "/shared/tsconfig.json": JSON.stringify({
+                compilerOptions: {
+                    target: "es5",
+                    composite: true,
+                    outDir: "dist"
+                }
+            }),
+            "/shared/red.ts": "export const red = 'fish';",
+            "/shared/dist/package.json": JSON.stringify({ type: "module" }),
+
+            "/src/tsconfig.json": JSON.stringify({
+                compilerOptions: {
+                    target: "es5",
+                    module: "nodenext",
+                    noEmit: true,
+                },
+                references: [{ path: "../shared" }]
+            }),
+            "/src/index.ts": "import { red } from '../shared/red';",
+        }),
+    });
+});

--- a/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.errors.txt
+++ b/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.errors.txt
@@ -1,0 +1,26 @@
+/src/a.ts(1,19): error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './b.js'?
+
+
+==== /tsconfig.json (0 errors) ====
+    {
+      "compilerOptions": {
+        "module": "nodenext",
+        "declaration": true,
+        "declarationDir": "out",
+        "emitDeclarationOnly": true,
+        "rootDir": "."
+      },
+      "include": ["src"]
+    }
+    
+==== /src/a.ts (1 errors) ====
+    import { b } from "./b";
+                      ~~~~~
+!!! error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './b.js'?
+    
+==== /src/b.ts (0 errors) ====
+    export const b = 0;
+    
+==== /out/package.json (0 errors) ====
+    { "type": "module" }
+    

--- a/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.js
+++ b/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.js
@@ -1,4 +1,4 @@
-//// [tests/cases/conformance/node/nodeMOdulesOutDirPackageJson05_declarationDir.ts] ////
+//// [tests/cases/conformance/node/nodeModulesOutDirPackageJson05_declarationDir.ts] ////
 
 //// [package.json]
 { "type": "module" }

--- a/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.js
+++ b/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.js
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/node/nodeMOdulesOutDirPackageJson05_declarationDir.ts] ////
+
+//// [package.json]
+{ "type": "module" }
+
+//// [a.ts]
+import { b } from "./b";
+
+//// [b.ts]
+export const b = 0;
+
+
+
+
+//// [a.d.ts]
+export {};
+//// [b.d.ts]
+export declare const b = 0;

--- a/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.symbols
+++ b/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.symbols
@@ -1,0 +1,8 @@
+=== /src/a.ts ===
+import { b } from "./b";
+>b : Symbol(b, Decl(a.ts, 0, 8))
+
+=== /src/b.ts ===
+export const b = 0;
+>b : Symbol(b, Decl(b.ts, 0, 12))
+

--- a/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.types
+++ b/tests/baselines/reference/nodeMOdulesOutDirPackageJson05_declarationDir.types
@@ -1,0 +1,9 @@
+=== /src/a.ts ===
+import { b } from "./b";
+>b : any
+
+=== /src/b.ts ===
+export const b = 0;
+>b : 0
+>0 : 0
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson01.errors.txt
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson01.errors.txt
@@ -1,0 +1,14 @@
+/src/a.ts(1,19): error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './b.js'?
+
+
+==== /out/package.json (0 errors) ====
+    { "type": "module" }
+    
+==== /src/a.ts (1 errors) ====
+    import { b } from "./b";
+                      ~~~~~
+!!! error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './b.js'?
+    
+==== /src/b.ts (0 errors) ====
+    export const b = 0;
+    

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson01.js
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson01.js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/node/nodeModulesOutDirPackageJson01.ts] ////
+
+//// [package.json]
+{ "type": "module" }
+
+//// [a.ts]
+import { b } from "./b";
+
+//// [b.ts]
+export const b = 0;
+
+
+//// [/out/a.js]
+export {};
+//// [/out/b.js]
+export var b = 0;

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson01.symbols
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson01.symbols
@@ -1,0 +1,8 @@
+=== /src/a.ts ===
+import { b } from "./b";
+>b : Symbol(b, Decl(a.ts, 0, 8))
+
+=== /src/b.ts ===
+export const b = 0;
+>b : Symbol(b, Decl(b.ts, 0, 12))
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson01.types
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson01.types
@@ -1,0 +1,9 @@
+=== /src/a.ts ===
+import { b } from "./b";
+>b : any
+
+=== /src/b.ts ===
+export const b = 0;
+>b : 0
+>0 : 0
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.errors.txt
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.errors.txt
@@ -1,0 +1,22 @@
+/src/a.ts(1,19): error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './b.js'?
+
+
+==== /tsconfig.json (0 errors) ====
+    {
+      "compilerOptions": {
+        "module": "nodenext",
+        "outDir": "out"
+      }
+    }
+    
+==== /src/a.ts (1 errors) ====
+    import { b } from "./b";
+                      ~~~~~
+!!! error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './b.js'?
+    
+==== /src/b.ts (0 errors) ====
+    export const b = 0;
+    
+==== /out/package.json (0 errors) ====
+    { "type": "module" }
+    

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.js
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/node/nodeModulesOutDirPackageJson02_tsconfig.ts] ////
+
+//// [package.json]
+{ "type": "module" }
+
+//// [a.ts]
+import { b } from "./b";
+
+//// [b.ts]
+export const b = 0;
+
+
+//// [/out/a.js]
+export {};
+//// [/out/b.js]
+export const b = 0;

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.symbols
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.symbols
@@ -1,0 +1,8 @@
+=== /src/a.ts ===
+import { b } from "./b";
+>b : Symbol(b, Decl(a.ts, 0, 8))
+
+=== /src/b.ts ===
+export const b = 0;
+>b : Symbol(b, Decl(b.ts, 0, 12))
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.types
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson02_tsconfig.types
@@ -1,0 +1,9 @@
+=== /src/a.ts ===
+import { b } from "./b";
+>b : any
+
+=== /src/b.ts ===
+export const b = 0;
+>b : 0
+>0 : 0
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.errors.txt
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.errors.txt
@@ -1,0 +1,26 @@
+error TS2213: The project root is ambiguous, but is required to determine the module format of output '.js' files. Supply the `rootDir` compiler option to disambiguate.
+
+
+!!! error TS2213: The project root is ambiguous, but is required to determine the module format of output '.js' files. Supply the `rootDir` compiler option to disambiguate.
+==== /tsconfig.json (0 errors) ====
+    {
+      "compilerOptions": {
+        "module": "nodenext",
+        "outDir": "out"
+      },
+      "include": ["src"]
+    }
+    
+==== /src/a.ts (0 errors) ====
+    import { b } from "./b.js";
+    
+==== /src/b.ts (0 errors) ====
+    export const b = 0;
+    export * from "../c.js";
+    
+==== /out/package.json (0 errors) ====
+    { "type": "module" }
+    
+==== /c.ts (0 errors) ====
+    export {};
+    

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.js
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.js
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/node/nodeModulesOutDirPackageJson03_ambiguousRoot.ts] ////
+
+//// [package.json]
+{ "type": "module" }
+
+//// [c.ts]
+export {};
+
+//// [a.ts]
+import { b } from "./b.js";
+
+//// [b.ts]
+export const b = 0;
+export * from "../c.js";
+
+
+//// [/out/c.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//// [/out/src/b.js]
+export const b = 0;
+export * from "../c.js";
+//// [/out/src/a.js]
+export {};

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.symbols
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.symbols
@@ -1,0 +1,14 @@
+=== /src/a.ts ===
+import { b } from "./b.js";
+>b : Symbol(b, Decl(a.ts, 0, 8))
+
+=== /src/b.ts ===
+export const b = 0;
+>b : Symbol(b, Decl(b.ts, 0, 12))
+
+export * from "../c.js";
+
+=== /c.ts ===
+
+export {};
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.types
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson03_ambiguousRoot.types
@@ -1,0 +1,15 @@
+=== /src/a.ts ===
+import { b } from "./b.js";
+>b : 0
+
+=== /src/b.ts ===
+export const b = 0;
+>b : 0
+>0 : 0
+
+export * from "../c.js";
+
+=== /c.ts ===
+
+export {};
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson04_disambiguateRoot.js
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson04_disambiguateRoot.js
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/node/nodeModulesOutDirPackageJson04_disambiguateRoot.ts] ////
+
+//// [package.json]
+{ "type": "module" }
+
+//// [c.ts]
+export {};
+
+//// [a.ts]
+import { b } from "./b.js";
+
+//// [b.ts]
+export const b = 0;
+export * from "../c.js";
+
+
+//// [c.js]
+export {};
+//// [b.js]
+export const b = 0;
+export * from "../c.js";
+//// [a.js]
+export {};

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson04_disambiguateRoot.symbols
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson04_disambiguateRoot.symbols
@@ -1,0 +1,14 @@
+=== /src/a.ts ===
+import { b } from "./b.js";
+>b : Symbol(b, Decl(a.ts, 0, 8))
+
+=== /src/b.ts ===
+export const b = 0;
+>b : Symbol(b, Decl(b.ts, 0, 12))
+
+export * from "../c.js";
+
+=== /c.ts ===
+
+export {};
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson04_disambiguateRoot.types
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson04_disambiguateRoot.types
@@ -1,0 +1,15 @@
+=== /src/a.ts ===
+import { b } from "./b.js";
+>b : 0
+
+=== /src/b.ts ===
+export const b = 0;
+>b : 0
+>0 : 0
+
+export * from "../c.js";
+
+=== /c.ts ===
+
+export {};
+

--- a/tests/baselines/reference/nodeModulesOutDirPackageJson_useSourceOfProjectReferenceRedirect.baseline
+++ b/tests/baselines/reference/nodeModulesOutDirPackageJson_useSourceOfProjectReferenceRedirect.baseline
@@ -1,0 +1,20 @@
+Syntactic Diagnostics for file '/tests/cases/fourslash/server/nodeModulesOutDirPackageJson_useSourceOfProjectReferenceRedirect.ts':
+
+
+==== /shared/red.ts (0 errors) ====
+    export const red = 'fish';
+==== /src/index.ts (0 errors) ====
+    import { red } from '../shared/red';
+
+Semantic Diagnostics for file '/tests/cases/fourslash/server/nodeModulesOutDirPackageJson_useSourceOfProjectReferenceRedirect.ts':
+/src/index.ts(1,21): error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("../shared/red")' call instead.
+  To convert this file to an ECMAScript module, change its file extension to '.mts' or create a local package.json file with `{ "type": "module" }`.
+
+
+==== /shared/red.ts (0 errors) ====
+    export const red = 'fish';
+==== /src/index.ts (1 errors) ====
+    import { red } from '../shared/red';
+                        ~~~~~~~~~~~~~~~
+!!! error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("../shared/red")' call instead.
+!!! error TS1479:   To convert this file to an ECMAScript module, change its file extension to '.mts' or create a local package.json file with `{ "type": "module" }`.

--- a/tests/baselines/reference/tsbuild/nodeModulesOutDirPackageJson/recognizes-package.json-in-outDir-of-referenced-project.js
+++ b/tests/baselines/reference/tsbuild/nodeModulesOutDirPackageJson/recognizes-package.json-in-outDir-of-referenced-project.js
@@ -1,0 +1,123 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Input::
+//// [/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+//// [/shared/dist/package.json]
+{"type":"module"}
+
+//// [/shared/red.ts]
+export const red = 'fish';
+
+//// [/shared/tsconfig.json]
+{"compilerOptions":{"target":"es5","composite":true,"outDir":"dist"}}
+
+//// [/src/index.ts]
+import { red } from '../shared/red';
+
+//// [/src/tsconfig.json]
+{"compilerOptions":{"target":"es5","module":"nodenext","noEmit":true},"references":[{"path":"../shared"}]}
+
+
+
+Output::
+/lib/tsc -b /src/tsconfig.json -v
+[[90m12:00:13 AM[0m] Projects in this build: 
+    * shared/tsconfig.json
+    * src/tsconfig.json
+
+[[90m12:00:14 AM[0m] Project 'shared/tsconfig.json' is out of date because output file 'shared/dist/tsconfig.tsbuildinfo' does not exist
+
+[[90m12:00:15 AM[0m] Building project '/shared/tsconfig.json'...
+
+[[90m12:00:21 AM[0m] Project 'src/tsconfig.json' is out of date because output file 'src/index.js' does not exist
+
+[[90m12:00:22 AM[0m] Building project '/src/tsconfig.json'...
+
+[96msrc/index.ts[0m:[93m1[0m:[93m21[0m - [91merror[0m[90m TS1479: [0mThe current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("../shared/red")' call instead.
+  To convert this file to an ECMAScript module, change its file extension to '.mts' or create a local package.json file with `{ "type": "module" }`.
+
+[7m1[0m import { red } from '../shared/red';
+[7m [0m [91m                    ~~~~~~~~~~~~~~~[0m
+
+
+Found 1 error.
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/shared/dist/red.d.ts]
+export declare const red = "fish";
+
+
+//// [/shared/dist/red.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.red = void 0;
+exports.red = 'fish';
+
+
+//// [/shared/dist/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../lib/lib.d.ts","../red.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"-12638551303-export const red = 'fish';","signature":"-3876195575-export declare const red = \"fish\";\n"}],"root":[2],"options":{"composite":true,"outDir":"./","target":1},"referencedMap":[],"exportedModulesMap":[],"semanticDiagnosticsPerFile":[1,2],"latestChangedDtsFile":"./red.d.ts"},"version":"FakeTSVersion"}
+
+//// [/shared/dist/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../lib/lib.d.ts",
+      "../red.ts"
+    ],
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "../red.ts": {
+        "original": {
+          "version": "-12638551303-export const red = 'fish';",
+          "signature": "-3876195575-export declare const red = \"fish\";\n"
+        },
+        "version": "-12638551303-export const red = 'fish';",
+        "signature": "-3876195575-export declare const red = \"fish\";\n"
+      }
+    },
+    "root": [
+      [
+        2,
+        "../red.ts"
+      ]
+    ],
+    "options": {
+      "composite": true,
+      "outDir": "./",
+      "target": 1
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../red.ts"
+    ],
+    "latestChangedDtsFile": "./red.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 877
+}
+

--- a/tests/cases/conformance/node/nodeMOdulesOutDirPackageJson05_declarationDir.ts
+++ b/tests/cases/conformance/node/nodeMOdulesOutDirPackageJson05_declarationDir.ts
@@ -1,0 +1,20 @@
+// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "declaration": true,
+    "declarationDir": "out",
+    "emitDeclarationOnly": true,
+    "rootDir": "."
+  },
+  "include": ["src"]
+}
+
+// @Filename: /out/package.json
+{ "type": "module" }
+
+// @Filename: /src/a.ts
+import { b } from "./b";
+
+// @Filename: /src/b.ts
+export const b = 0;

--- a/tests/cases/conformance/node/nodeModulesOutDirPackageJson01.ts
+++ b/tests/cases/conformance/node/nodeModulesOutDirPackageJson01.ts
@@ -1,0 +1,12 @@
+// @module: nodenext
+// @outDir: /out
+// @fullEmitPaths: true
+
+// @Filename: /out/package.json
+{ "type": "module" }
+
+// @Filename: /src/a.ts
+import { b } from "./b";
+
+// @Filename: /src/b.ts
+export const b = 0;

--- a/tests/cases/conformance/node/nodeModulesOutDirPackageJson02_tsconfig.ts
+++ b/tests/cases/conformance/node/nodeModulesOutDirPackageJson02_tsconfig.ts
@@ -1,0 +1,18 @@
+// @fullEmitPaths: true
+
+// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "outDir": "out"
+  }
+}
+
+// @Filename: /out/package.json
+{ "type": "module" }
+
+// @Filename: /src/a.ts
+import { b } from "./b";
+
+// @Filename: /src/b.ts
+export const b = 0;

--- a/tests/cases/conformance/node/nodeModulesOutDirPackageJson03_ambiguousRoot.ts
+++ b/tests/cases/conformance/node/nodeModulesOutDirPackageJson03_ambiguousRoot.ts
@@ -1,0 +1,23 @@
+// @fullEmitPaths: true
+
+// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "outDir": "out"
+  },
+  "include": ["src"]
+}
+
+// @Filename: /out/package.json
+{ "type": "module" }
+
+// @Filename: /src/a.ts
+import { b } from "./b.js";
+
+// @Filename: /src/b.ts
+export const b = 0;
+export * from "../c.js";
+
+// @Filename: /c.ts
+export {};

--- a/tests/cases/conformance/node/nodeModulesOutDirPackageJson04_disambiguateRoot.ts
+++ b/tests/cases/conformance/node/nodeModulesOutDirPackageJson04_disambiguateRoot.ts
@@ -1,0 +1,22 @@
+// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "outDir": "out",
+    "rootDir": "."
+  },
+  "include": ["src"]
+}
+
+// @Filename: /out/package.json
+{ "type": "module" }
+
+// @Filename: /src/a.ts
+import { b } from "./b.js";
+
+// @Filename: /src/b.ts
+export const b = 0;
+export * from "../c.js";
+
+// @Filename: /c.ts
+export {};

--- a/tests/cases/fourslash/server/nodeModulesOutDirPackageJson_useSourceOfProjectReferenceRedirect.ts
+++ b/tests/cases/fourslash/server/nodeModulesOutDirPackageJson_useSourceOfProjectReferenceRedirect.ts
@@ -1,0 +1,32 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /shared/tsconfig.json
+//// {
+////   compilerOptions: {
+////       target: "es5",
+////       composite: true,
+////       outDir: "dist"
+////   }
+//// }
+
+// @Filename: /shared/red.ts
+//// export const red = 'fish';
+
+// @Filename: /shared/dist/package.json
+//// { "type": "module" }
+
+// @Filename: /src/tsconfig.json
+//// {
+////   compilerOptions: {
+////       target: "es5",
+////       module: "nodenext",
+////       noEmit: true,
+////   },
+////   references: [{ path: "../shared" }]
+//// }
+
+// @Filename: /src/index.ts
+//// import { red } from [|'../shared/red'|];
+
+goTo.file("/src/index.ts");
+verify.baselineSyntacticAndSemanticDiagnostics();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

**Note:** there are good reasons not to publish dual CJS/ESM npm packages. This is not a blanket endorsement of the practice. However, we’ve noticed that many existing dual packages ship types that [don’t correctly describe](https://github.com/arethetypeswrong/arethetypeswrong.github.io) the JS contents of the package. I believe this is in no small part because doing dual CJS/ESM emit with tsc is a cumbersome UX (and completely undocumented). This is a small change that significantly improves the experience.

In `--module nodenext`, we decide whether a file `index.ts` is ESM or CJS by looking up through its containing directories for the nearest package.json file so we can see whether it includes `"type": "module"`. With this PR, we instead begin that search with the file’s `declarationDir` or `outDir`. This allows the developer to pre-seed an `outDir` per module format with a package.json, and run a compilation into each:

`dist/esm/package.json`:

```json
{ "type": "module" }
```

`dist/cjs/package.json`:

```json
{}
```

```sh
# Produce an ESM build with types
tsc --module nodenext --outDir dist/esm --declaration index.ts

# Produce a CJS build with types
tsc --module nodenext --outDir dist/cjs --declaration index.ts
```

These builds can be linked with a solution-style tsconfig.json:

```json5
// tsconfig.json
{
  "files": [],
  "references": [
    { "path": "./tsconfig.cjs.json" },
    { "path": "./tsconfig.esm.json" },
  ]
}
```

Note that in this configuration, where the input files are covered by two different tsconfigs, TS Server picks uses the second one in the array for errors and intellisense. #54476 discusses ideas for improvements to the editor and orchestration experience.
