### PR TITLE
Attempt to fix corepack-using CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       with:
         node-version: 16
     - run: |
-        corepack enable npm
+        # corepack enable npm
         npm --version
     
     - run:  npm ci
@@ -151,7 +151,7 @@ jobs:
       with:
         node-version: 16
     - run: |
-        corepack enable npm
+        # corepack enable npm
         npm --version
 
     - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version: 16
     - run: |
         corepack enable npm
         npm --version
@@ -149,7 +149,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 20
+        node-version: 16
     - run: |
         corepack enable npm
         npm --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,6 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: actions/setup-node@v3
-      with:
-        node-version: "*"
-        check-latest: true
     - run: |
         corepack enable npm
         npm --version
@@ -149,9 +146,6 @@ jobs:
         ref: ${{ github.base_ref }}
 
     - uses: actions/setup-node@v3
-      with:
-        node-version: "*"
-        check-latest: true
     - run: |
         corepack enable npm
         npm --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: actions/setup-node@v3
+      with:
+        node-version: 20
     - run: |
         corepack enable npm
         npm --version
@@ -146,6 +148,8 @@ jobs:
         ref: ${{ github.base_ref }}
 
     - uses: actions/setup-node@v3
+      with:
+        node-version: 20
     - run: |
         corepack enable npm
         npm --version


### PR DESCRIPTION
There's something screwy going on in CI when:

- ~setup-node has version `"*"` and `check-latest`~
- corepack is enabled

~Other jobs don't set this combo so try and even it out and maybe this will work.~