### PR TITLE
Fix close-issues workflow token

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - name: Close issues
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           DATE=$(date --date='2 days ago' --iso-8601)
 


### PR DESCRIPTION
Quick fixup for https://github.com/microsoft/TypeScript/actions/runs/5207079149/jobs/9394280606 which thankfully gives you exactly the fix.