### PR TITLE
Switch from corepack to a global npm install for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
         node-version: "*"
         check-latest: true
     - run: |
-        corepack enable npm
+        npm --version
+        # corepack enable npm
+        npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
     
     - run:  npm ci
@@ -153,7 +155,9 @@ jobs:
         node-version: "*"
         check-latest: true
     - run: |
-        corepack enable npm
+        npm --version
+        # corepack enable npm
+        npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
 
     - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,11 @@ jobs:
     - run: |
         npm --version
         # corepack enable npm
+
+    - run: |
         npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
+      working-directory: ./pr
 
     - run: npm ci
       working-directory: ./pr

--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -23,7 +23,9 @@ jobs:
     steps:
     - uses: actions/setup-node@v3
     - run: |
-        corepack enable npm
+        npm --version
+        # corepack enable npm
+        npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -29,7 +29,9 @@ jobs:
         # Use NODE_AUTH_TOKEN environment variable to authenticate to this registry.
         registry-url: https://registry.npmjs.org/
     - run: |
-        corepack enable npm
+        npm --version
+        # corepack enable npm
+        npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
     - name: Setup and publish nightly
       run: |

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -22,7 +22,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - run: |
-        corepack enable npm
+        npm --version
+        # corepack enable npm
+        npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
     - name: npm install and test
       run: |

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -26,7 +26,9 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.branch_name }}
     - run: |
-        corepack enable npm
+        npm --version
+        # corepack enable npm
+        npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
     # notably, this is essentially the same script as `new-release-branch.yaml` (with fewer inputs), but it assumes the branch already exists
     # do note that executing the transform below will prevent the `configurePrerelease` script from running on the source, as it makes the

--- a/.github/workflows/update-package-lock.yaml
+++ b/.github/workflows/update-package-lock.yaml
@@ -32,7 +32,9 @@ jobs:
       with:
         node-version: 16
     - run: |
-        corepack enable npm
+        npm --version
+        # corepack enable npm
+        npm install -g $(jq -r '.packageManager' < package.json)
         npm --version
 
     - name: Update package-lock.json and push


### PR DESCRIPTION
npm installed with corepack in some CI workflows is failing with a segfault. I have yet to see anyone else reporting this on node, npm, corepack, github actions, anywhere.

For now, just disable corepack and instead use an npm global install of the `packageManager` property. This property is a valid package name plus version so is a decent way to install a package manager of a particular version.