### PR TITLE
Switch close-issues to typescript-bot token

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Close issues
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
         run: |
           DATE=$(date --date='2 days ago' --iso-8601)
 


### PR DESCRIPTION
This is purely cosmetic but means that `typescript-bot` will close the issues instead of `github-actions[bot]`.