### PR TITLE
fix(54580): Bad operation for find-all-references on import.meta when meta occurs in a comment

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1725,7 +1725,10 @@ export namespace Core {
     }
 
     function getPossibleSymbolReferenceNodes(sourceFile: SourceFile, symbolName: string, container: Node = sourceFile): readonly Node[] {
-        return getPossibleSymbolReferencePositions(sourceFile, symbolName, container).map(pos => getTouchingPropertyName(sourceFile, pos));
+        return mapDefined(getPossibleSymbolReferencePositions(sourceFile, symbolName, container), pos => {
+            const referenceLocation = getTouchingPropertyName(sourceFile, pos);
+            return referenceLocation === sourceFile ? undefined : referenceLocation;
+        });
     }
 
     function getPossibleSymbolReferencePositions(sourceFile: SourceFile, symbolName: string, container: Node = sourceFile): readonly number[] {

--- a/tests/baselines/reference/findAllReferencesImportMeta.baseline.jsonc
+++ b/tests/baselines/reference/findAllReferencesImportMeta.baseline.jsonc
@@ -1,0 +1,25 @@
+// === findAllReferences ===
+// === /tests/cases/fourslash/findAllReferencesImportMeta.ts ===
+// // Haha that's so meta!
+// 
+// let x = import.[|meta|]/*FIND ALL REFS*/;
+
+  // === Definitions ===
+  // === /tests/cases/fourslash/findAllReferencesImportMeta.ts ===
+  // // Haha that's so meta!
+  // 
+  // let x = import.[|meta|]/*FIND ALL REFS*/;
+
+  // === Details ===
+  [
+   {
+    "containerKind": "",
+    "containerName": "",
+    "kind": "keyword",
+    "displayParts": [
+     {
+      "kind": "keyword"
+     }
+    ]
+   }
+  ]

--- a/tests/cases/fourslash/findAllReferencesImportMeta.ts
+++ b/tests/cases/fourslash/findAllReferencesImportMeta.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////// Haha that's so meta!
+////
+////let x = import.meta/**/;
+
+verify.baselineFindAllReferences("");


### PR DESCRIPTION
Fixes #54580