### PR TITLE
Adding an `outExtension` option to control the file extension of emitted files

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -90,6 +90,7 @@ import {
     normalizeSlashes,
     NumericLiteral,
     ObjectLiteralExpression,
+    OutExtensionKind,
     ParseConfigHost,
     ParsedCommandLine,
     parseJsonText,
@@ -699,10 +700,10 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
     {
         name: "outExtension",
         type: new Map(Object.entries({
-            cjs: Extension.Cjs,
-            mjs: Extension.Mjs,
-            js: Extension.Js,
-            infer: "infer",
+            infer: OutExtensionKind.InferFromModule,
+            js: OutExtensionKind.Js,
+            cjs: OutExtensionKind.Cjs,
+            mjs: OutExtensionKind.Mjs,
         })),
         defaultValueDescription: Diagnostics.undefined_will_determine_extension_based_on_the_input_file,
         affectsEmit: true,

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -700,16 +700,17 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
     {
         name: "outExtension",
         type: new Map(Object.entries({
-            infer: OutExtensionKind.InferFromModule,
+            input: OutExtensionKind.InferFromInput,
+            module: OutExtensionKind.InferFromModule,
             js: OutExtensionKind.Js,
             cjs: OutExtensionKind.Cjs,
             mjs: OutExtensionKind.Mjs,
         })),
-        defaultValueDescription: Diagnostics.undefined_will_determine_extension_based_on_the_input_file,
+        defaultValueDescription: "input",
         affectsEmit: true,
         affectsBuildInfo: true,
         category: Diagnostics.Emit,
-        description: Diagnostics.Specify_the_output_extension_for_all_emitted_files_infer_will_determine_extension_based_on_the_module_option,
+        description: Diagnostics.Specify_the_output_extension_for_all_emitted_files_input_will_determine_extension_based_on_the_extension_of_the_input_file_module_will_determine_extension_based_on_the_module_option,
     },
     {
         name: "rootDir",

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -697,6 +697,20 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
         description: Diagnostics.Specify_an_output_folder_for_all_emitted_files,
     },
     {
+        name: "outExtension",
+        type: new Map(Object.entries({
+            cjs: Extension.Cjs,
+            mjs: Extension.Mjs,
+            js: Extension.Js,
+            infer: "infer",
+        })),
+        defaultValueDescription: Diagnostics.undefined_will_determine_extension_based_on_the_input_file,
+        affectsEmit: true,
+        affectsBuildInfo: true,
+        category: Diagnostics.Emit,
+        description: Diagnostics.Specify_the_output_extension_for_all_emitted_files_infer_will_determine_extension_based_on_the_module_option,
+    },
+    {
         name: "rootDir",
         type: "string",
         affectsEmit: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6099,6 +6099,14 @@
         "category": "Message",
         "code": 6718
     },
+    "Specify the output extension for all emitted files. 'infer' will determine extension based on the `module` option.": {
+        "category": "Message",
+        "code": 6719
+    },
+    "`undefined` will determine extension based on the input file.": {
+        "category": "Message",
+        "code": 6720
+    },
     "Default catch clause variables as 'unknown' instead of 'any'.": {
         "category": "Message",
         "code": 6803

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -6099,13 +6099,9 @@
         "category": "Message",
         "code": 6718
     },
-    "Specify the output extension for all emitted files. 'infer' will determine extension based on the `module` option.": {
+    "Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option.": {
         "category": "Message",
         "code": 6719
-    },
-    "`undefined` will determine extension based on the input file.": {
-        "category": "Message",
-        "code": 6720
     },
     "Default catch clause variables as 'unknown' instead of 'any'.": {
         "category": "Message",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -574,6 +574,12 @@ function getSourceMapFilePath(jsFilePath: string, options: CompilerOptions) {
 export function getOutputExtension(fileName: string, options: CompilerOptions): Extension {
     return fileExtensionIs(fileName, Extension.Json) ? Extension.Json :
     options.jsx === JsxEmit.Preserve && fileExtensionIsOneOf(fileName, [Extension.Jsx, Extension.Tsx]) ? Extension.Jsx :
+    options.outExtension === "infer" ? (
+        options.module === ModuleKind.CommonJS ? Extension.Cjs :
+        options.module && options.module >= ModuleKind.ES2015 && options.module <= ModuleKind.ESNext ? Extension.Mjs :
+        Extension.Js
+    ) :
+    options.outExtension ? options.outExtension :
     fileExtensionIsOneOf(fileName, [Extension.Mts, Extension.Mjs]) ? Extension.Mjs :
     fileExtensionIsOneOf(fileName, [Extension.Cts, Extension.Cjs]) ? Extension.Cjs :
     Extension.Js;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -574,12 +574,14 @@ function getSourceMapFilePath(jsFilePath: string, options: CompilerOptions) {
 export function getOutputExtension(fileName: string, options: CompilerOptions): Extension {
     return fileExtensionIs(fileName, Extension.Json) ? Extension.Json :
     options.jsx === JsxEmit.Preserve && fileExtensionIsOneOf(fileName, [Extension.Jsx, Extension.Tsx]) ? Extension.Jsx :
-    options.outExtension === "infer" ? (
+    options.outExtension === ts.OutExtensionKind.InferFromModule ? (
         options.module === ModuleKind.CommonJS ? Extension.Cjs :
         options.module && options.module >= ModuleKind.ES2015 && options.module <= ModuleKind.ESNext ? Extension.Mjs :
         Extension.Js
     ) :
-    options.outExtension ? options.outExtension :
+    options.outExtension === ts.OutExtensionKind.Cjs ? Extension.Cjs :
+    options.outExtension === ts.OutExtensionKind.Mjs ? Extension.Mjs :
+    options.outExtension === ts.OutExtensionKind.Js ? Extension.Js :
     fileExtensionIsOneOf(fileName, [Extension.Mts, Extension.Mjs]) ? Extension.Mjs :
     fileExtensionIsOneOf(fileName, [Extension.Cts, Extension.Cjs]) ? Extension.Cjs :
     Extension.Js;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7171,6 +7171,7 @@ export interface CompilerOptions {
     noUncheckedIndexedAccess?: boolean;
     out?: string;
     outDir?: string;
+    outExtension?: Extension.Mjs | Extension.Cjs | Extension.Js | "infer";
     outFile?: string;
     paths?: MapLike<string[]>;
     /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -7171,7 +7171,7 @@ export interface CompilerOptions {
     noUncheckedIndexedAccess?: boolean;
     out?: string;
     outDir?: string;
-    outExtension?: Extension.Mjs | Extension.Cjs | Extension.Js | "infer";
+    outExtension?: OutExtensionKind;
     outFile?: string;
     paths?: MapLike<string[]>;
     /**
@@ -7708,6 +7708,14 @@ export const enum Extension {
     Cjs = ".cjs",
     Cts = ".cts",
     Dcts = ".d.cts",
+}
+
+export const enum OutExtensionKind {
+    InferFromInput = 0,
+    InferFromModule = 1,
+    Js = 2,
+    Cjs = 3,
+    Mjs = 4,
 }
 
 export interface ResolvedModuleWithFailedLookupLocations {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7231,6 +7231,7 @@ declare namespace ts {
         noUncheckedIndexedAccess?: boolean;
         out?: string;
         outDir?: string;
+        outExtension?: Extension.Mjs | Extension.Cjs | Extension.Js | "infer";
         outFile?: string;
         paths?: MapLike<string[]>;
         preserveConstEnums?: boolean;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7231,7 +7231,7 @@ declare namespace ts {
         noUncheckedIndexedAccess?: boolean;
         out?: string;
         outDir?: string;
-        outExtension?: Extension.Mjs | Extension.Cjs | Extension.Js | "infer";
+        outExtension?: OutExtensionKind;
         outFile?: string;
         paths?: MapLike<string[]>;
         preserveConstEnums?: boolean;
@@ -7468,6 +7468,13 @@ declare namespace ts {
         Cjs = ".cjs",
         Cts = ".cts",
         Dcts = ".d.cts"
+    }
+    enum OutExtensionKind {
+        InferFromInput = 0,
+        InferFromModule = 1,
+        Js = 2,
+        Cjs = 3,
+        Mjs = 4
     }
     interface ResolvedModuleWithFailedLookupLocations {
         readonly resolvedModule: ResolvedModuleFull | undefined;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3178,6 +3178,7 @@ declare namespace ts {
         noUncheckedIndexedAccess?: boolean;
         out?: string;
         outDir?: string;
+        outExtension?: Extension.Mjs | Extension.Cjs | Extension.Js | "infer";
         outFile?: string;
         paths?: MapLike<string[]>;
         preserveConstEnums?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3178,7 +3178,7 @@ declare namespace ts {
         noUncheckedIndexedAccess?: boolean;
         out?: string;
         outDir?: string;
-        outExtension?: Extension.Mjs | Extension.Cjs | Extension.Js | "infer";
+        outExtension?: OutExtensionKind;
         outFile?: string;
         paths?: MapLike<string[]>;
         preserveConstEnums?: boolean;
@@ -3415,6 +3415,13 @@ declare namespace ts {
         Cjs = ".cjs",
         Cts = ".cts",
         Dcts = ".d.cts"
+    }
+    enum OutExtensionKind {
+        InferFromInput = 0,
+        InferFromModule = 1,
+        Js = 2,
+        Cjs = 3,
+        Mjs = 4
     }
     interface ResolvedModuleWithFailedLookupLocations {
         readonly resolvedModule: ResolvedModuleFull | undefined;

--- a/tests/baselines/reference/config/initTSConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Default initialized TSConfig/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --help/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --help/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --watch/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with --watch/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with files options/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/config/initTSConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -56,6 +56,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "outExtension": "input",                          /* Specify the output extension for all emitted files. 'input' will determine extension based on the extension of the input file. 'module' will determine extension based on the `module` option. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/outExtension/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/outExtension/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "outExtension": "input"
+    }
+}

--- a/tests/baselines/reference/outExtensionCjs.js
+++ b/tests/baselines/reference/outExtensionCjs.js
@@ -1,0 +1,51 @@
+//// [tests/cases/compiler/outExtensionCjs.ts] ////
+
+//// [input-1.ts]
+export const ts = "foo";
+
+//// [input-2.mts]
+export const mts = "foo";
+
+//// [input-3.cts]
+export const cts = "foo";
+
+//// [input-4.js]
+export const js = "foo";
+
+//// [input-5.mjs]
+export const mjs = "foo";
+
+//// [input-6.cjs]
+export const cjs = "foo";
+
+
+//// [input-1.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ts = void 0;
+exports.ts = "foo";
+//// [input-2.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mts = void 0;
+exports.mts = "foo";
+//// [input-3.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cts = void 0;
+exports.cts = "foo";
+//// [input-4.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.js = void 0;
+exports.js = "foo";
+//// [input-5.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mjs = void 0;
+exports.mjs = "foo";
+//// [input-6.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cjs = void 0;
+exports.cjs = "foo";

--- a/tests/baselines/reference/outExtensionCjs.symbols
+++ b/tests/baselines/reference/outExtensionCjs.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : Symbol(ts, Decl(input-1.ts, 0, 12))
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : Symbol(mts, Decl(input-2.mts, 0, 12))
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : Symbol(cts, Decl(input-3.cts, 0, 12))
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : Symbol(js, Decl(input-4.js, 0, 12))
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : Symbol(mjs, Decl(input-5.mjs, 0, 12))
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : Symbol(cjs, Decl(input-6.cjs, 0, 12))
+

--- a/tests/baselines/reference/outExtensionCjs.types
+++ b/tests/baselines/reference/outExtensionCjs.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : "foo"
+>"foo" : "foo"
+

--- a/tests/baselines/reference/outExtensionInferFromInput.js
+++ b/tests/baselines/reference/outExtensionInferFromInput.js
@@ -1,0 +1,51 @@
+//// [tests/cases/compiler/outExtensionInferFromInput.ts] ////
+
+//// [input-1.ts]
+export const ts = "foo";
+
+//// [input-2.mts]
+export const mts = "foo";
+
+//// [input-3.cts]
+export const cts = "foo";
+
+//// [input-4.js]
+export const js = "foo";
+
+//// [input-5.mjs]
+export const mjs = "foo";
+
+//// [input-6.cjs]
+export const cjs = "foo";
+
+
+//// [input-1.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ts = void 0;
+exports.ts = "foo";
+//// [input-2.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mts = void 0;
+exports.mts = "foo";
+//// [input-3.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cts = void 0;
+exports.cts = "foo";
+//// [input-4.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.js = void 0;
+exports.js = "foo";
+//// [input-5.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mjs = void 0;
+exports.mjs = "foo";
+//// [input-6.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cjs = void 0;
+exports.cjs = "foo";

--- a/tests/baselines/reference/outExtensionInferFromInput.symbols
+++ b/tests/baselines/reference/outExtensionInferFromInput.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : Symbol(ts, Decl(input-1.ts, 0, 12))
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : Symbol(mts, Decl(input-2.mts, 0, 12))
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : Symbol(cts, Decl(input-3.cts, 0, 12))
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : Symbol(js, Decl(input-4.js, 0, 12))
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : Symbol(mjs, Decl(input-5.mjs, 0, 12))
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : Symbol(cjs, Decl(input-6.cjs, 0, 12))
+

--- a/tests/baselines/reference/outExtensionInferFromInput.types
+++ b/tests/baselines/reference/outExtensionInferFromInput.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : "foo"
+>"foo" : "foo"
+

--- a/tests/baselines/reference/outExtensionInferFromModuleCJS.js
+++ b/tests/baselines/reference/outExtensionInferFromModuleCJS.js
@@ -1,0 +1,51 @@
+//// [tests/cases/compiler/outExtensionInferFromModuleCJS.ts] ////
+
+//// [input-1.ts]
+export const ts = "foo";
+
+//// [input-2.mts]
+export const mts = "foo";
+
+//// [input-3.cts]
+export const cts = "foo";
+
+//// [input-4.js]
+export const js = "foo";
+
+//// [input-5.mjs]
+export const mjs = "foo";
+
+//// [input-6.cjs]
+export const cjs = "foo";
+
+
+//// [input-1.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ts = void 0;
+exports.ts = "foo";
+//// [input-2.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mts = void 0;
+exports.mts = "foo";
+//// [input-3.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cts = void 0;
+exports.cts = "foo";
+//// [input-4.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.js = void 0;
+exports.js = "foo";
+//// [input-5.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mjs = void 0;
+exports.mjs = "foo";
+//// [input-6.cjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cjs = void 0;
+exports.cjs = "foo";

--- a/tests/baselines/reference/outExtensionInferFromModuleCJS.symbols
+++ b/tests/baselines/reference/outExtensionInferFromModuleCJS.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : Symbol(ts, Decl(input-1.ts, 0, 12))
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : Symbol(mts, Decl(input-2.mts, 0, 12))
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : Symbol(cts, Decl(input-3.cts, 0, 12))
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : Symbol(js, Decl(input-4.js, 0, 12))
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : Symbol(mjs, Decl(input-5.mjs, 0, 12))
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : Symbol(cjs, Decl(input-6.cjs, 0, 12))
+

--- a/tests/baselines/reference/outExtensionInferFromModuleCJS.types
+++ b/tests/baselines/reference/outExtensionInferFromModuleCJS.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : "foo"
+>"foo" : "foo"
+

--- a/tests/baselines/reference/outExtensionInferFromModuleESM.js
+++ b/tests/baselines/reference/outExtensionInferFromModuleESM.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/outExtensionInferFromModuleESM.ts] ////
+
+//// [input-1.ts]
+export const ts = "foo";
+
+//// [input-2.mts]
+export const mts = "foo";
+
+//// [input-3.cts]
+export const cts = "foo";
+
+//// [input-4.js]
+export const js = "foo";
+
+//// [input-5.mjs]
+export const mjs = "foo";
+
+//// [input-6.cjs]
+export const cjs = "foo";
+
+
+//// [input-1.mjs]
+export var ts = "foo";
+//// [input-2.mjs]
+export var mts = "foo";
+//// [input-3.mjs]
+export var cts = "foo";
+//// [input-4.mjs]
+export var js = "foo";
+//// [input-5.mjs]
+export var mjs = "foo";
+//// [input-6.mjs]
+export var cjs = "foo";

--- a/tests/baselines/reference/outExtensionInferFromModuleESM.symbols
+++ b/tests/baselines/reference/outExtensionInferFromModuleESM.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : Symbol(ts, Decl(input-1.ts, 0, 12))
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : Symbol(mts, Decl(input-2.mts, 0, 12))
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : Symbol(cts, Decl(input-3.cts, 0, 12))
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : Symbol(js, Decl(input-4.js, 0, 12))
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : Symbol(mjs, Decl(input-5.mjs, 0, 12))
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : Symbol(cjs, Decl(input-6.cjs, 0, 12))
+

--- a/tests/baselines/reference/outExtensionInferFromModuleESM.types
+++ b/tests/baselines/reference/outExtensionInferFromModuleESM.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : "foo"
+>"foo" : "foo"
+

--- a/tests/baselines/reference/outExtensionMjs.js
+++ b/tests/baselines/reference/outExtensionMjs.js
@@ -1,0 +1,51 @@
+//// [tests/cases/compiler/outExtensionMjs.ts] ////
+
+//// [input-1.ts]
+export const ts = "foo";
+
+//// [input-2.mts]
+export const mts = "foo";
+
+//// [input-3.cts]
+export const cts = "foo";
+
+//// [input-4.js]
+export const js = "foo";
+
+//// [input-5.mjs]
+export const mjs = "foo";
+
+//// [input-6.cjs]
+export const cjs = "foo";
+
+
+//// [input-1.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ts = void 0;
+exports.ts = "foo";
+//// [input-2.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mts = void 0;
+exports.mts = "foo";
+//// [input-3.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cts = void 0;
+exports.cts = "foo";
+//// [input-4.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.js = void 0;
+exports.js = "foo";
+//// [input-5.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mjs = void 0;
+exports.mjs = "foo";
+//// [input-6.mjs]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cjs = void 0;
+exports.cjs = "foo";

--- a/tests/baselines/reference/outExtensionMjs.symbols
+++ b/tests/baselines/reference/outExtensionMjs.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : Symbol(ts, Decl(input-1.ts, 0, 12))
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : Symbol(mts, Decl(input-2.mts, 0, 12))
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : Symbol(cts, Decl(input-3.cts, 0, 12))
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : Symbol(js, Decl(input-4.js, 0, 12))
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : Symbol(mjs, Decl(input-5.mjs, 0, 12))
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : Symbol(cjs, Decl(input-6.cjs, 0, 12))
+

--- a/tests/baselines/reference/outExtensionMjs.types
+++ b/tests/baselines/reference/outExtensionMjs.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/input-1.ts ===
+export const ts = "foo";
+>ts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-2.mts ===
+export const mts = "foo";
+>mts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-3.cts ===
+export const cts = "foo";
+>cts : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-4.js ===
+export const js = "foo";
+>js : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-5.mjs ===
+export const mjs = "foo";
+>mjs : "foo"
+>"foo" : "foo"
+
+=== tests/cases/compiler/input-6.cjs ===
+export const cjs = "foo";
+>cjs : "foo"
+>"foo" : "foo"
+

--- a/tests/cases/compiler/outExtensionCjs.ts
+++ b/tests/cases/compiler/outExtensionCjs.ts
@@ -1,0 +1,21 @@
+// @allowJs: true
+// @outExtension: cjs
+// @outDir: dist
+
+// @filename: input-1.ts
+export const ts = "foo";
+
+// @filename: input-2.mts
+export const mts = "foo";
+
+// @filename: input-3.cts
+export const cts = "foo";
+
+// @filename: input-4.js
+export const js = "foo";
+
+// @filename: input-5.mjs
+export const mjs = "foo";
+
+// @filename: input-6.cjs
+export const cjs = "foo";

--- a/tests/cases/compiler/outExtensionInferFromInput.ts
+++ b/tests/cases/compiler/outExtensionInferFromInput.ts
@@ -1,0 +1,21 @@
+// @allowJs: true
+// @outExtension: input
+// @outDir: dist
+
+// @filename: input-1.ts
+export const ts = "foo";
+
+// @filename: input-2.mts
+export const mts = "foo";
+
+// @filename: input-3.cts
+export const cts = "foo";
+
+// @filename: input-4.js
+export const js = "foo";
+
+// @filename: input-5.mjs
+export const mjs = "foo";
+
+// @filename: input-6.cjs
+export const cjs = "foo";

--- a/tests/cases/compiler/outExtensionInferFromModuleCJS.ts
+++ b/tests/cases/compiler/outExtensionInferFromModuleCJS.ts
@@ -1,0 +1,22 @@
+// @module: commonjs
+// @allowJs: true
+// @outExtension: module
+// @outDir: dist
+
+// @filename: input-1.ts
+export const ts = "foo";
+
+// @filename: input-2.mts
+export const mts = "foo";
+
+// @filename: input-3.cts
+export const cts = "foo";
+
+// @filename: input-4.js
+export const js = "foo";
+
+// @filename: input-5.mjs
+export const mjs = "foo";
+
+// @filename: input-6.cjs
+export const cjs = "foo";

--- a/tests/cases/compiler/outExtensionInferFromModuleESM.ts
+++ b/tests/cases/compiler/outExtensionInferFromModuleESM.ts
@@ -1,0 +1,22 @@
+// @module: esnext
+// @allowJs: true
+// @outExtension: module
+// @outDir: dist
+
+// @filename: input-1.ts
+export const ts = "foo";
+
+// @filename: input-2.mts
+export const mts = "foo";
+
+// @filename: input-3.cts
+export const cts = "foo";
+
+// @filename: input-4.js
+export const js = "foo";
+
+// @filename: input-5.mjs
+export const mjs = "foo";
+
+// @filename: input-6.cjs
+export const cjs = "foo";

--- a/tests/cases/compiler/outExtensionMjs.ts
+++ b/tests/cases/compiler/outExtensionMjs.ts
@@ -1,0 +1,21 @@
+// @allowJs: true
+// @outExtension: mjs
+// @outDir: dist
+
+// @filename: input-1.ts
+export const ts = "foo";
+
+// @filename: input-2.mts
+export const mts = "foo";
+
+// @filename: input-3.cts
+export const cts = "foo";
+
+// @filename: input-4.js
+export const js = "foo";
+
+// @filename: input-5.mjs
+export const mjs = "foo";
+
+// @filename: input-6.cjs
+export const cjs = "foo";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54573 by adding a new `outExtension` option to control the extension of the emitted files (except `.tsx`, `.jsx` and `.json` input files which won't be affected by the `outExtension` option):
- `"input"` (default): Infers the extension of out files from the extension of the input file. This is the behaviour prior to this PR and I've added it to limit the intrusiveness of the fix.
- `"module"`: Infers the extension of out files from the `module` option, if `"commonjs"` the out files will use `.cjs`, if any `"es6"` through `"esnext"` the out files will use `.mjs` and `.js` will be used for any other case.
- `"cjs"`: Use `.cjs` for all out files.
- `"mjs"`: Use `.mjs` for all out files.
- `"js"`: Use `.js` for all out files.

Note: I'm drafting the PR until the associated issue in the `Backlog` milestone.