### PR TITLE
Fixed a regression with string completions not being available directly in arguments typed using rest parameter

### DIFF
--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -388,7 +388,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
                 // Get string literal completions from specialized signatures of the target
                 // i.e. declare function f(a: 'A');
                 // f("/*completion position*/")
-                return argumentInfo && getStringLiteralCompletionsFromSignature(argumentInfo.invocation, node, argumentInfo, typeChecker) || fromContextualType();
+                return argumentInfo && getStringLiteralCompletionsFromSignature(argumentInfo.invocation, node, argumentInfo, typeChecker) || fromContextualType(ContextFlags.None);
             }
             // falls through (is `require("")` or `require(""` or `import("")`)
 

--- a/tests/cases/fourslash/completionsLiteralDirectlyInRestConstrainedToArrayType.ts
+++ b/tests/cases/fourslash/completionsLiteralDirectlyInRestConstrainedToArrayType.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+// @strict: true
+////
+//// function fn<T extends ('value1' | 'value2' | 'value3')[]>(...values: T): T { return values; }
+//// 
+//// const value1 = fn('/*1*/');
+//// const value2 = fn('value1', '/*2*/');
+
+verify.completions({ marker: ["1", "2"], includes: [`value1`, `value2`, `value3`] })


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/54572 (a regression from https://github.com/microsoft/TypeScript/pull/52717 )

cc @andrewbranch 