### PR TITLE
fix(dts): `JsxSpreadAttribute` - remove `name` from types

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3258,7 +3258,6 @@ export type JsxAttributeValue =
 
 export interface JsxSpreadAttribute extends ObjectLiteralElement {
     readonly kind: SyntaxKind.JsxSpreadAttribute;
-    readonly name: PropertyName;
     readonly parent: JsxAttributes;
     readonly expression: Expression;
 }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5451,7 +5451,6 @@ declare namespace ts {
     type JsxAttributeValue = StringLiteral | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
     interface JsxSpreadAttribute extends ObjectLiteralElement {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
-        readonly name: PropertyName;
         readonly parent: JsxAttributes;
         readonly expression: Expression;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1398,7 +1398,6 @@ declare namespace ts {
     type JsxAttributeValue = StringLiteral | JsxExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
     interface JsxSpreadAttribute extends ObjectLiteralElement {
         readonly kind: SyntaxKind.JsxSpreadAttribute;
-        readonly name: PropertyName;
         readonly parent: JsxAttributes;
         readonly expression: Expression;
     }


### PR DESCRIPTION
I think this was accidentally added in https://github.com/microsoft/TypeScript/pull/47356/files#diff-e9fd483341eea176a38fbd370590e1dc65ce2d9bf70bfd317c5407f04dba9560R3264
