### PR TITLE
Only gitignore lib dir at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ TEST-results.xml
 package-lock.json
 .eslintcache
 *v8.log
-lib/
+/lib/


### PR DESCRIPTION
See: https://github.com/microsoft/TypeScript/pull/54637#issuecomment-1591618733

When I deleted the top-level lib dir, I gitignored it. However, gitignore entries are not absolute and so `lib/` matched any dir named `lib` anywhere in the repo, including `src/lib`.