### PR TITLE
fix: no variable suggestions without semicolon

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2439,7 +2439,7 @@ export function getCompletionEntriesFromSymbols(
     includeSymbol = false
 ): UniqueNameSet {
     const start = timestamp();
-    const variableOrParameterDeclaration = getVariableOrParameterDeclaration(contextToken);
+    const variableOrParameterDeclaration = getVariableOrParameterDeclaration(contextToken, location);
     const useSemicolons = probablyUsesSemicolons(sourceFile);
     const typeChecker = program.getTypeChecker();
     // Tracks unique names.
@@ -5516,14 +5516,18 @@ function isModuleSpecifierMissingOrEmpty(specifier: ModuleReference | Expression
     return !tryCast(isExternalModuleReference(specifier) ? specifier.expression : specifier, isStringLiteralLike)?.text;
 }
 
-function getVariableOrParameterDeclaration(contextToken: Node | undefined) {
+function getVariableOrParameterDeclaration(contextToken: Node | undefined, location: Node) {
     if (!contextToken) return;
 
-    const declaration = findAncestor(contextToken, node =>
+    const possiblyParameterDeclaration = findAncestor(contextToken, node =>
         isFunctionBlock(node) || isArrowFunctionBody(node) || isBindingPattern(node)
             ? "quit"
-            : isVariableDeclaration(node) || ((isParameter(node) || isTypeParameterDeclaration(node)) && !isIndexSignatureDeclaration(node.parent)));
-    return declaration as ParameterDeclaration | TypeParameterDeclaration | VariableDeclaration | undefined;
+            : ((isParameter(node) || isTypeParameterDeclaration(node)) && !isIndexSignatureDeclaration(node.parent)));
+    const possiblyVariableDeclaration = findAncestor(location, (node) => {
+        return isFunctionBlock(node) || isArrowFunctionBody(node) || isBindingPattern(node) ?
+            "quit" : isVariableDeclaration(node)
+    })
+    return (possiblyVariableDeclaration || possiblyParameterDeclaration) as ParameterDeclaration | TypeParameterDeclaration | VariableDeclaration | undefined;
 }
 
 function isArrowFunctionBody(node: Node) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5525,8 +5525,8 @@ function getVariableOrParameterDeclaration(contextToken: Node | undefined, locat
             : ((isParameter(node) || isTypeParameterDeclaration(node)) && !isIndexSignatureDeclaration(node.parent)));
     const possiblyVariableDeclaration = findAncestor(location, (node) => {
         return isFunctionBlock(node) || isArrowFunctionBody(node) || isBindingPattern(node) ?
-            "quit" : isVariableDeclaration(node)
-    })
+            "quit" : isVariableDeclaration(node);
+    });
     return (possiblyVariableDeclaration || possiblyParameterDeclaration) as ParameterDeclaration | TypeParameterDeclaration | VariableDeclaration | undefined;
 }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5523,10 +5523,12 @@ function getVariableOrParameterDeclaration(contextToken: Node | undefined, locat
         isFunctionBlock(node) || isArrowFunctionBody(node) || isBindingPattern(node)
             ? "quit"
             : ((isParameter(node) || isTypeParameterDeclaration(node)) && !isIndexSignatureDeclaration(node.parent)));
-    const possiblyVariableDeclaration = findAncestor(location, (node) => {
-        return isFunctionBlock(node) || isArrowFunctionBody(node) || isBindingPattern(node) ?
-            "quit" : isVariableDeclaration(node);
-    });
+
+    const possiblyVariableDeclaration = findAncestor(location, node =>
+        isFunctionBlock(node) || isArrowFunctionBody(node) || isBindingPattern(node)
+            ? "quit"
+            : isVariableDeclaration(node));
+
     return (possiblyParameterDeclaration || possiblyVariableDeclaration) as ParameterDeclaration | TypeParameterDeclaration | VariableDeclaration | undefined;
 }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5527,7 +5527,7 @@ function getVariableOrParameterDeclaration(contextToken: Node | undefined, locat
         return isFunctionBlock(node) || isArrowFunctionBody(node) || isBindingPattern(node) ?
             "quit" : isVariableDeclaration(node);
     });
-    return (possiblyVariableDeclaration || possiblyParameterDeclaration) as ParameterDeclaration | TypeParameterDeclaration | VariableDeclaration | undefined;
+    return (possiblyParameterDeclaration || possiblyVariableDeclaration) as ParameterDeclaration | TypeParameterDeclaration | VariableDeclaration | undefined;
 }
 
 function isArrowFunctionBody(node: Node) {

--- a/tests/cases/fourslash/completionEntryForConst.ts
+++ b/tests/cases/fourslash/completionEntryForConst.ts
@@ -1,9 +1,13 @@
 ///<reference path="fourslash.ts" />
 
+//@Filename
 ////const c = "s";
 /////*1*/
 ////const d = 1
-/////*2*/
+////d/*2*/
+////const e = 1
+/////*3*/
 
 verify.completions({ marker: ["1"], includes: { name: "c", text: 'const c: "s"', kind: "const" } });
 verify.completions({ marker: ["2"], includes: { name: "d", text: 'const d: 1', kind: "const" } });
+verify.completions({ marker: ["3"], includes: { name: "e", text: 'const e: 1', kind: "const" } });

--- a/tests/cases/fourslash/completionEntryForConst.ts
+++ b/tests/cases/fourslash/completionEntryForConst.ts
@@ -1,6 +1,5 @@
 ///<reference path="fourslash.ts" />
 
-//@Filename
 ////const c = "s";
 /////*1*/
 ////const d = 1

--- a/tests/cases/fourslash/completionEntryForConst.ts
+++ b/tests/cases/fourslash/completionEntryForConst.ts
@@ -1,6 +1,9 @@
 ///<reference path="fourslash.ts" />
 
 ////const c = "s";
-/////**/
+/////*1*/
+////const d = 1
+/////*2*/
 
-verify.completions({ marker: "", includes: { name: "c", text: 'const c: "s"', kind: "const" } });
+verify.completions({ marker: ["1"], includes: { name: "c", text: 'const c: "s"', kind: "const" } });
+verify.completions({ marker: ["2"], includes: { name: "d", text: 'const d: 1', kind: "const" } });


### PR DESCRIPTION
don't use contextToken for finding closest variable declaration

Fixes #54654

I think there could be a better fix (rather than using location and contextToken at the same time)