### PR TITLE
Fixed an issue with errors not being correctly reported after completion requests in nested calls

### DIFF
--- a/tests/cases/fourslash/typeErrorAfterStringCompletionsInNestedCall.ts
+++ b/tests/cases/fourslash/typeErrorAfterStringCompletionsInNestedCall.ts
@@ -1,0 +1,32 @@
+///<reference path="fourslash.ts"/>
+// @strict: true
+////
+//// type GreetingEvent =
+////   | { type: "MORNING" }
+////   | { type: "LUNCH_TIME" }
+////   | { type: "ALOHA" };
+////
+//// interface RaiseActionObject<TEvent extends { type: string }> {
+////   type: "raise";
+////   event: TEvent;
+//// }
+////
+//// declare function raise<TEvent extends { type: string }>(
+////   ev: TEvent
+//// ): RaiseActionObject<TEvent>;
+////
+//// declare function createMachine<TEvent extends { type: string }>(config: {
+////   actions: RaiseActionObject<TEvent>;
+//// }): void;
+////
+//// createMachine<GreetingEvent>({
+////   [|/*error*/actions|]: raise({ type: "ALOHA/*1*/" }),
+//// });
+
+goTo.marker("1");
+edit.insert(`x`)
+verify.completions({ exact: ["MORNING", "LUNCH_TIME", "ALOHA"] });
+verify.getSemanticDiagnostics([{
+    code: 2322,
+    message: `Type 'RaiseActionObject<{ type: "ALOHAx"; }>' is not assignable to type 'RaiseActionObject<GreetingEvent>'.\n  Type '{ type: "ALOHAx"; }' is not assignable to type 'GreetingEvent'.\n    Type '{ type: "ALOHAx"; }' is not assignable to type '{ type: "ALOHA"; }'.\n      Types of property 'type' are incompatible.\n        Type '"ALOHAx"' is not assignable to type '"ALOHA"'.`,
+}]);


### PR DESCRIPTION
Fixes an accidental 5.1 regression caused by my own https://github.com/microsoft/TypeScript/pull/52717 . Even though this particular situation showcased by the test case is a 5.1 regression, the code that I changed here was likely subtly broken before that - there just wasn't any test case that would catch this somehow.

cc @andrewbranch 