### PR TITLE
Enable parsing of nested parameters for `@callback` JSDoc tag.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
                 "fast-xml-parser": "^4.0.11",
                 "fs-extra": "^9.1.0",
                 "glob": "^8.1.0",
-                "hereby": "^1.6.4",
+                "hereby": "^1.8.1",
                 "jsonc-parser": "^3.2.0",
                 "minimist": "^1.2.8",
                 "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "fast-xml-parser": "^4.0.11",
         "fs-extra": "^9.1.0",
         "glob": "^8.1.0",
-        "hereby": "^1.6.4",
+        "hereby": "^1.8.1",
         "jsonc-parser": "^3.2.0",
         "minimist": "^1.2.8",
         "mocha": "^10.2.0",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -9150,7 +9150,7 @@ namespace Parser {
 
                 const comment = parseTrailingTagComments(start, getNodePos(), indent, indentText);
 
-                const nestedTypeLiteral = target !== PropertyLikeParse.CallbackParameter && parseNestedTypeLiteral(typeExpression, name, target, indent);
+                const nestedTypeLiteral = parseNestedTypeLiteral(typeExpression, name, target, indent);
                 if (nestedTypeLiteral) {
                     typeExpression = nestedTypeLiteral;
                     isNameFirst = true;
@@ -9465,7 +9465,6 @@ namespace Parser {
                             if (canParseTag) {
                                 const child = tryParseChildTag(target, indent);
                                 if (child && (child.kind === SyntaxKind.JSDocParameterTag || child.kind === SyntaxKind.JSDocPropertyTag) &&
-                                    target !== PropertyLikeParse.CallbackParameter &&
                                     name && (isIdentifierNode(child.name) || !escapedTextsEqual(name, child.name.left))) {
                                     return false;
                                 }

--- a/tests/baselines/reference/callbackTagNestedParameter.js
+++ b/tests/baselines/reference/callbackTagNestedParameter.js
@@ -1,0 +1,41 @@
+//// [tests/cases/conformance/jsdoc/callbackTagNestedParameter.ts] ////
+
+//// [cb_nested.js]
+/**
+ * @callback WorksWithPeopleCallback
+ * @param {Object} person
+ * @param {String} person.name
+ * @param {Number} [person.age]
+ * @returns {void}
+ */
+
+/**
+ * For each person, calls your callback.
+ * @param {WorksWithPeopleCallback} callback
+ * @returns {void}
+ */
+function eachPerson(callback) {
+    callback({ name: "Empty" });
+}
+
+
+
+
+//// [cb_nested.d.ts]
+/**
+ * @callback WorksWithPeopleCallback
+ * @param {Object} person
+ * @param {String} person.name
+ * @param {Number} [person.age]
+ * @returns {void}
+ */
+/**
+ * For each person, calls your callback.
+ * @param {WorksWithPeopleCallback} callback
+ * @returns {void}
+ */
+declare function eachPerson(callback: WorksWithPeopleCallback): void;
+type WorksWithPeopleCallback = (person: {
+    name: string;
+    age?: number;
+}) => void;

--- a/tests/baselines/reference/callbackTagNestedParameter.symbols
+++ b/tests/baselines/reference/callbackTagNestedParameter.symbols
@@ -1,0 +1,25 @@
+//// [tests/cases/conformance/jsdoc/callbackTagNestedParameter.ts] ////
+
+=== cb_nested.js ===
+/**
+ * @callback WorksWithPeopleCallback
+ * @param {Object} person
+ * @param {String} person.name
+ * @param {Number} [person.age]
+ * @returns {void}
+ */
+
+/**
+ * For each person, calls your callback.
+ * @param {WorksWithPeopleCallback} callback
+ * @returns {void}
+ */
+function eachPerson(callback) {
+>eachPerson : Symbol(eachPerson, Decl(cb_nested.js, 0, 0))
+>callback : Symbol(callback, Decl(cb_nested.js, 13, 20))
+
+    callback({ name: "Empty" });
+>callback : Symbol(callback, Decl(cb_nested.js, 13, 20))
+>name : Symbol(name, Decl(cb_nested.js, 14, 14))
+}
+

--- a/tests/baselines/reference/callbackTagNestedParameter.types
+++ b/tests/baselines/reference/callbackTagNestedParameter.types
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/jsdoc/callbackTagNestedParameter.ts] ////
+
+=== cb_nested.js ===
+/**
+ * @callback WorksWithPeopleCallback
+ * @param {Object} person
+ * @param {String} person.name
+ * @param {Number} [person.age]
+ * @returns {void}
+ */
+
+/**
+ * For each person, calls your callback.
+ * @param {WorksWithPeopleCallback} callback
+ * @returns {void}
+ */
+function eachPerson(callback) {
+>eachPerson : (callback: WorksWithPeopleCallback) => void
+>callback : WorksWithPeopleCallback
+
+    callback({ name: "Empty" });
+>callback({ name: "Empty" }) : void
+>callback : WorksWithPeopleCallback
+>{ name: "Empty" } : { name: string; }
+>name : string
+>"Empty" : "Empty"
+}
+

--- a/tests/cases/conformance/jsdoc/callbackTagNestedParameter.ts
+++ b/tests/cases/conformance/jsdoc/callbackTagNestedParameter.ts
@@ -1,0 +1,21 @@
+// @emitDeclarationOnly: true
+// @declaration: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: cb_nested.js
+/**
+ * @callback WorksWithPeopleCallback
+ * @param {Object} person
+ * @param {String} person.name
+ * @param {Number} [person.age]
+ * @returns {void}
+ */
+
+/**
+ * For each person, calls your callback.
+ * @param {WorksWithPeopleCallback} callback
+ * @returns {void}
+ */
+function eachPerson(callback) {
+    callback({ name: "Empty" });
+}


### PR DESCRIPTION
Fixes #36101

There was a conditional statement that prohibited parsing nested parameter types when the parent jsdoc tag is a `@callback`. The check was there, because a structure to store nested param information was not defined. 

The structure has been added and the parser code was cleaned up. We only need to enable parsing nested parameters in code.

Attached is a test and updated baseline.

I am unfamiliar with `tsc` codebase, so suggestions for additional tests are welcome!