### PR TITLE
Also auto-close "Out of Scope", "Declined", "Won't Fix", and "Too Complex"

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -46,3 +46,4 @@ jobs:
           close_issues "Out of Scope"
           close_issues "Declined"
           close_issues "Won't Fix"
+          close_issues "Too Complex"

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -33,7 +33,7 @@ jobs:
             echo "Closing issues marked as '$1'."
             for issue in $(gh issue list --limit 100 --label "$1" --repo ${{ github.repository }} --state open --search "updated:<$DATE" --json number --jq '.[].number'); do
               echo "Closing https://github.com/${{ github.repository }}/issues/$issue"
-              gh issue close $issue --repo ${{ github.repository }} --reason "not planned" --comment "This issue has been marked as '$1' and has seen no recent activity. It has been automatically closed for house-keeping purposes."
+              gh issue close $issue --repo ${{ github.repository }} --reason "not planned" --comment "This issue has been marked as \"$1\" and has seen no recent activity. It has been automatically closed for house-keeping purposes."
             done
           }
 

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -31,7 +31,7 @@ jobs:
 
           close_issues() {
             echo "Closing issues marked as '$1'."
-            for issue in $(gh issue list --label "$1" --repo ${{ github.repository }} --state open --search "updated:<$DATE" --json number --jq '.[].number'); do
+            for issue in $(gh issue list --limit 100 --label "$1" --repo ${{ github.repository }} --state open --search "updated:<$DATE" --json number --jq '.[].number'); do
               echo "Closing https://github.com/${{ github.repository }}/issues/$issue"
               gh issue close $issue --repo ${{ github.repository }} --reason "not planned" --comment "This issue has been marked as '$1' and has seen no recent activity. It has been automatically closed for house-keeping purposes."
             done
@@ -43,3 +43,6 @@ jobs:
           close_issues "External"
           close_issues "Working as Intended"
           close_issues "Question"
+          close_issues "Out of Scope"
+          close_issues "Declined"
+          close_issues "Won't Fix"


### PR DESCRIPTION
I noticed that we have a few more labels that look like they're intended to be "dead ends" (and the "how to triage" doc says get closed).

- https://github.com/microsoft/TypeScript/issues?q=label%3A%22Declined%22+is%3Aopen+sort%3Aupdated-desc
- https://github.com/microsoft/TypeScript/issues?q=label%3A%22Out+of+Scope%22+is%3Aopen+sort%3Aupdated-desc+
- https://github.com/microsoft/TypeScript/issues?q=label%3A%22Won%27t+Fix%22+is%3Aopen+sort%3Aupdated-desc

Currently roughly 78 issues have these labels.

There's also "Too Complex" which the triage doc says is also a close (28 currently open), but I'm less sure about that conceptually.

If desired, I can also make some of these closed after longer periods of inactivity; it's not too hard to do.