### PR TITLE
Remove inference mode check in `getNarrowableTypeForrReference`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27758,8 +27758,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // control flow analysis an opportunity to narrow it further. For example, for a reference of a type
         // parameter type 'T extends string | undefined' with a contextual type 'string', we substitute
         // 'string | undefined' to give control flow analysis the opportunity to narrow to type 'string'.
-        const substituteConstraints = !(checkMode && checkMode & CheckMode.Inferential) &&
-            someType(type, isGenericTypeWithUnionConstraint) &&
+        const substituteConstraints = someType(type, isGenericTypeWithUnionConstraint) &&
             (isConstraintPosition(type, reference) || hasContextualTypeWithNoGenericTypes(reference, checkMode));
         return substituteConstraints ? mapType(type, getBaseConstraintOrType) : type;
     }

--- a/tests/baselines/reference/controlFlowGenericTypes.errors.txt
+++ b/tests/baselines/reference/controlFlowGenericTypes.errors.txt
@@ -1,4 +1,4 @@
-controlFlowGenericTypes.ts(49,15): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Box<T>'.
+controlFlowGenericTypes.ts(49,15): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Box<unknown>'.
 controlFlowGenericTypes.ts(55,15): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Box<unknown>'.
 controlFlowGenericTypes.ts(81,11): error TS2339: Property 'foo' does not exist on type 'MyUnion'.
   Property 'foo' does not exist on type 'AA'.
@@ -61,7 +61,7 @@ controlFlowGenericTypes.ts(168,9): error TS18048: 'iSpec' is possibly 'undefined
         if (!isBox(x)) {
             unbox(x);  // Error
                   ~
-!!! error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Box<T>'.
+!!! error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Box<unknown>'.
         }
     }
     
@@ -247,5 +247,19 @@ controlFlowGenericTypes.ts(168,9): error TS18048: 'iSpec' is possibly 'undefined
     
     function getColumnProperty<T>(column: Column<T>, key: keyof Column<T>) {
       return column[key];
+    }
+    
+    // Repro from #54405
+    
+    type Root = Record<string, string | number>;
+    
+    declare function bug<T>(cb: () => number): void;
+    
+    function foo<T extends Root>(root: T, key: keyof T) {
+      const union = root[key];
+      bug(() => {
+        if (typeof union === "string") throw new Error();
+        return union;
+      });
     }
     

--- a/tests/baselines/reference/controlFlowGenericTypes.js
+++ b/tests/baselines/reference/controlFlowGenericTypes.js
@@ -221,6 +221,20 @@ function getColumnProperty<T>(column: Column<T>, key: keyof Column<T>) {
   return column[key];
 }
 
+// Repro from #54405
+
+type Root = Record<string, string | number>;
+
+declare function bug<T>(cb: () => number): void;
+
+function foo<T extends Root>(root: T, key: keyof T) {
+  const union = root[key];
+  bug(() => {
+    if (typeof union === "string") throw new Error();
+    return union;
+  });
+}
+
 
 //// [controlFlowGenericTypes.js]
 "use strict";
@@ -380,4 +394,12 @@ function update(control, key, value) {
 }
 function getColumnProperty(column, key) {
     return column[key];
+}
+function foo(root, key) {
+    var union = root[key];
+    bug(function () {
+        if (typeof union === "string")
+            throw new Error();
+        return union;
+    });
 }

--- a/tests/baselines/reference/controlFlowGenericTypes.symbols
+++ b/tests/baselines/reference/controlFlowGenericTypes.symbols
@@ -654,3 +654,41 @@ function getColumnProperty<T>(column: Column<T>, key: keyof Column<T>) {
 >key : Symbol(key, Decl(controlFlowGenericTypes.ts, 216, 48))
 }
 
+// Repro from #54405
+
+type Root = Record<string, string | number>;
+>Root : Symbol(Root, Decl(controlFlowGenericTypes.ts, 218, 1))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+declare function bug<T>(cb: () => number): void;
+>bug : Symbol(bug, Decl(controlFlowGenericTypes.ts, 222, 44))
+>T : Symbol(T, Decl(controlFlowGenericTypes.ts, 224, 21))
+>cb : Symbol(cb, Decl(controlFlowGenericTypes.ts, 224, 24))
+
+function foo<T extends Root>(root: T, key: keyof T) {
+>foo : Symbol(foo, Decl(controlFlowGenericTypes.ts, 224, 48))
+>T : Symbol(T, Decl(controlFlowGenericTypes.ts, 226, 13))
+>Root : Symbol(Root, Decl(controlFlowGenericTypes.ts, 218, 1))
+>root : Symbol(root, Decl(controlFlowGenericTypes.ts, 226, 29))
+>T : Symbol(T, Decl(controlFlowGenericTypes.ts, 226, 13))
+>key : Symbol(key, Decl(controlFlowGenericTypes.ts, 226, 37))
+>T : Symbol(T, Decl(controlFlowGenericTypes.ts, 226, 13))
+
+  const union = root[key];
+>union : Symbol(union, Decl(controlFlowGenericTypes.ts, 227, 7))
+>root : Symbol(root, Decl(controlFlowGenericTypes.ts, 226, 29))
+>key : Symbol(key, Decl(controlFlowGenericTypes.ts, 226, 37))
+
+  bug(() => {
+>bug : Symbol(bug, Decl(controlFlowGenericTypes.ts, 222, 44))
+
+    if (typeof union === "string") throw new Error();
+>union : Symbol(union, Decl(controlFlowGenericTypes.ts, 227, 7))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    return union;
+>union : Symbol(union, Decl(controlFlowGenericTypes.ts, 227, 7))
+
+  });
+}
+

--- a/tests/baselines/reference/controlFlowGenericTypes.types
+++ b/tests/baselines/reference/controlFlowGenericTypes.types
@@ -143,7 +143,7 @@ function g3<T extends Box<T> | undefined>(x: T) {
 >x : Box<T> | undefined
 
         unbox(x);  // Error
->unbox(x) : T
+>unbox(x) : unknown
 >unbox : <T>(x: Box<T>) => T
 >x : undefined
     }
@@ -594,5 +594,44 @@ function getColumnProperty<T>(column: Column<T>, key: keyof Column<T>) {
 >column[key] : Column<T>["title" | keyof (keyof T extends never ? { id?: string | number | undefined; } : { id: T; })]
 >column : Column<T>
 >key : "title" | keyof (keyof T extends never ? { id?: string | number | undefined; } : { id: T; })
+}
+
+// Repro from #54405
+
+type Root = Record<string, string | number>;
+>Root : { [x: string]: string | number; }
+
+declare function bug<T>(cb: () => number): void;
+>bug : <T>(cb: () => number) => void
+>cb : () => number
+
+function foo<T extends Root>(root: T, key: keyof T) {
+>foo : <T extends Root>(root: T, key: keyof T) => void
+>root : T
+>key : keyof T
+
+  const union = root[key];
+>union : T[keyof T]
+>root[key] : T[keyof T]
+>root : T
+>key : keyof T
+
+  bug(() => {
+>bug(() => {    if (typeof union === "string") throw new Error();    return union;  }) : void
+>bug : <T>(cb: () => number) => void
+>() => {    if (typeof union === "string") throw new Error();    return union;  } : () => number
+
+    if (typeof union === "string") throw new Error();
+>typeof union === "string" : boolean
+>typeof union : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>union : T[keyof T]
+>"string" : "string"
+>new Error() : Error
+>Error : ErrorConstructor
+
+    return union;
+>union : number
+
+  });
 }
 

--- a/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
@@ -219,3 +219,17 @@ type Column<T> = (keyof T extends never ? { id?: number | string } : { id: T }) 
 function getColumnProperty<T>(column: Column<T>, key: keyof Column<T>) {
   return column[key];
 }
+
+// Repro from #54405
+
+type Root = Record<string, string | number>;
+
+declare function bug<T>(cb: () => number): void;
+
+function foo<T extends Root>(root: T, key: keyof T) {
+  const union = root[key];
+  bug(() => {
+    if (typeof union === "string") throw new Error();
+    return union;
+  });
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ x] There is an associated issue in the `Backlog` milestone (**required**)
* [x ] Code is up-to-date with the `main` branch
* [x ] You've successfully run `hereby runtests` locally
* [x ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54405

After some digging, it seems the problem is we call `getNarrowableTypeForReference` on the return type of the anonymous function while inferring the generic parameter of the call to `bug`.  This call has the `CheckMode.Inferential` flag set which means the `substituteConstraints` check returns false and the return type is just `T[keyof T]` which the flow checker can't narrow. This result is cached as the resolved return type function and is used when attempting to check whether the type of the function matches the first parameter of `bug`.  Since we've already calculated the return type to be `T[keyof T]` which is `string | number`, the assignment fails.  Allowing for type narrowing in inference mode means we get back `string | number` as the narrowed type which the flow checker can then narrow to `number`. 

This did end up changing slightly one of the error messages in the output for `controlFlowGenericTypes` .  Originally, it mentioned `Box<T>` but returns `Box<unkown>` now since we are resolving the generic type to the constraint rather than using `T` directly.  Since this behavior seems to be consistent with other similar failure modes (see the g3 and g4 functions in the test), I believe this behavior change is OK.
