### PR TITLE
Use function that doesn't return unknown type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10169,6 +10169,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return getTypeOfPropertyOfType(type, name) || getApplicableIndexInfoForName(type, name)?.type || unknownType;
     }
 
+    /**
+     * Similar to `getTypeOfPropertyOrIndexSignature`,
+     * but returns `undefined` if there is no matching property or index signature,
+     * and adds optionality to index signature types.
+     */
+    function getTypeOfPropertyOrIndexSignatureOfType(type: Type, name: __String): Type | undefined {
+        let propType;
+        return getTypeOfPropertyOfType(type, name) ||
+            (propType = getApplicableIndexInfoForName(type, name)?.type) &&
+            addOptionality(propType, /*isProperty*/ true, /*isOptional*/ true);
+    }
+
     function isTypeAny(type: Type | undefined) {
         return type && (type.flags & TypeFlags.Any) !== 0;
     }
@@ -22718,13 +22730,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const filtered = contains(include, Ternary.False) ? getUnionType(types.filter((_, i) => include[i])) : target;
         return filtered.flags & TypeFlags.Never ? target : filtered;
-
-        function getTypeOfPropertyOrIndexSignatureOfType(type: Type, name: __String): Type | undefined {
-            let propType;
-            return getTypeOfPropertyOfType(type, name) ||
-                (propType = getApplicableIndexInfoForName(type, name)?.type) &&
-                addOptionality(propType, /*isProperty*/ true, /*isOptional*/ true);
-        }
     }
 
     /**

--- a/tests/baselines/reference/discriminateWithMissingProperty.errors.txt
+++ b/tests/baselines/reference/discriminateWithMissingProperty.errors.txt
@@ -1,0 +1,22 @@
+discriminateWithMissingProperty.ts(12,5): error TS2345: Argument of type '{ mode: "numeric"; data: Uint8Array; }' is not assignable to parameter of type 'Arg'.
+  Types of property 'data' are incompatible.
+    Type 'Uint8Array' is not assignable to type 'number'.
+
+
+==== discriminateWithMissingProperty.ts (1 errors) ====
+    type Arg = {
+        mode: "numeric",
+        data: number,
+    } | {
+        mode: "alphabetic",
+        data: string,
+    } | {
+        data: string | Uint8Array;
+    }
+    
+    declare function foo(arg: Arg): void;
+    foo({ mode: "numeric", data: new Uint8Array([30]) }); // Should error
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ mode: "numeric"; data: Uint8Array; }' is not assignable to parameter of type 'Arg'.
+!!! error TS2345:   Types of property 'data' are incompatible.
+!!! error TS2345:     Type 'Uint8Array' is not assignable to type 'number'.

--- a/tests/baselines/reference/discriminateWithMissingProperty.symbols
+++ b/tests/baselines/reference/discriminateWithMissingProperty.symbols
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/discriminateWithMissingProperty.ts] ////
+
+=== discriminateWithMissingProperty.ts ===
+type Arg = {
+>Arg : Symbol(Arg, Decl(discriminateWithMissingProperty.ts, 0, 0))
+
+    mode: "numeric",
+>mode : Symbol(mode, Decl(discriminateWithMissingProperty.ts, 0, 12))
+
+    data: number,
+>data : Symbol(data, Decl(discriminateWithMissingProperty.ts, 1, 20))
+
+} | {
+    mode: "alphabetic",
+>mode : Symbol(mode, Decl(discriminateWithMissingProperty.ts, 3, 5))
+
+    data: string,
+>data : Symbol(data, Decl(discriminateWithMissingProperty.ts, 4, 23))
+
+} | {
+    data: string | Uint8Array;
+>data : Symbol(data, Decl(discriminateWithMissingProperty.ts, 6, 5))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+}
+
+declare function foo(arg: Arg): void;
+>foo : Symbol(foo, Decl(discriminateWithMissingProperty.ts, 8, 1))
+>arg : Symbol(arg, Decl(discriminateWithMissingProperty.ts, 10, 21))
+>Arg : Symbol(Arg, Decl(discriminateWithMissingProperty.ts, 0, 0))
+
+foo({ mode: "numeric", data: new Uint8Array([30]) }); // Should error
+>foo : Symbol(foo, Decl(discriminateWithMissingProperty.ts, 8, 1))
+>mode : Symbol(mode, Decl(discriminateWithMissingProperty.ts, 11, 5))
+>data : Symbol(data, Decl(discriminateWithMissingProperty.ts, 11, 22))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/discriminateWithMissingProperty.types
+++ b/tests/baselines/reference/discriminateWithMissingProperty.types
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/discriminateWithMissingProperty.ts] ////
+
+=== discriminateWithMissingProperty.ts ===
+type Arg = {
+>Arg : { mode: "numeric"; data: number; } | { mode: "alphabetic"; data: string; } | { data: string | Uint8Array; }
+
+    mode: "numeric",
+>mode : "numeric"
+
+    data: number,
+>data : number
+
+} | {
+    mode: "alphabetic",
+>mode : "alphabetic"
+
+    data: string,
+>data : string
+
+} | {
+    data: string | Uint8Array;
+>data : string | Uint8Array
+}
+
+declare function foo(arg: Arg): void;
+>foo : (arg: Arg) => void
+>arg : Arg
+
+foo({ mode: "numeric", data: new Uint8Array([30]) }); // Should error
+>foo({ mode: "numeric", data: new Uint8Array([30]) }) : void
+>foo : (arg: Arg) => void
+>{ mode: "numeric", data: new Uint8Array([30]) } : { mode: "numeric"; data: Uint8Array; }
+>mode : "numeric"
+>"numeric" : "numeric"
+>data : Uint8Array
+>new Uint8Array([30]) : Uint8Array
+>Uint8Array : Uint8ArrayConstructor
+>[30] : number[]
+>30 : 30
+

--- a/tests/cases/compiler/discriminateWithMissingProperty.ts
+++ b/tests/cases/compiler/discriminateWithMissingProperty.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @noEmit: true
+
+type Arg = {
+    mode: "numeric",
+    data: number,
+} | {
+    mode: "alphabetic",
+    data: string,
+} | {
+    data: string | Uint8Array;
+}
+
+declare function foo(arg: Arg): void;
+foo({ mode: "numeric", data: new Uint8Array([30]) }); // Should error


### PR DESCRIPTION
When refactoring #54596, I introduced a bug by using a function that returns `unknownType` when a property or index signature is missing. Instead, we need to use a function that returns `undefined` when the property or index signature is missing.
Fixes the failing package `qrcode` on the nightly DT run (https://typescript.visualstudio.com/TypeScript/_build/results?buildId=155426&view=logs&j=71179031-6417-5a2f-3d87-af6fce2011e4&t=69c46c41-df19-593d-5ed2-0b9c514993a3).
