### PR TITLE
Add extra test cases for string literal completions

### DIFF
--- a/tests/cases/fourslash/completionsLiteralDirectlyInArgumentWithNullableConstraint.ts
+++ b/tests/cases/fourslash/completionsLiteralDirectlyInArgumentWithNullableConstraint.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+// @strict: true
+////
+//// declare function func<
+////   const T extends 'a' | 'b' | undefined = undefined,
+//// >(arg?: T): string;
+////
+//// func('/*1*/');
+
+verify.completions({ marker: ["1"], exact: [`a`, `b`] });

--- a/tests/cases/fourslash/completionsLiteralDirectlyInRestConstrainedToTupleType.ts
+++ b/tests/cases/fourslash/completionsLiteralDirectlyInRestConstrainedToTupleType.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+// @strict: true
+////
+//// interface Func {
+////   <Key extends "a" | "b">(
+////     ...args:
+////       | [key: Key, options?: any]
+////       | [key: Key, defaultValue: string, options?: any]
+////   ): string;
+//// }
+////
+//// declare const func: Func;
+////
+//// func("/*1*/");
+
+verify.completions({ marker: ["1"], exact: [`a`, `b`] });


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/54710
this was already fixed by https://github.com/microsoft/TypeScript/pull/54588