### PR TITLE
Remove missing type from tuple type arguments under `exactOptionalPropertyTypes`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15217,7 +15217,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const typeArguments = !node ? emptyArray :
                 node.kind === SyntaxKind.TypeReference ? concatenate(type.target.outerTypeParameters, getEffectiveTypeArguments(node, type.target.localTypeParameters!)) :
                 node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] :
-                map(node.elements, getTypeFromTypeNode);
+                map(node.elements, element => removeMissingType(getTypeFromTypeNode(element), element.kind === SyntaxKind.OptionalType));
             if (popTypeResolution()) {
                 type.resolvedTypeArguments = type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
             }

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=es5).errors.txt
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=es5).errors.txt
@@ -1,0 +1,20 @@
+forOfOptionalTupleMember.ts(12,3): error TS18048: 'item' is possibly 'undefined'.
+
+
+==== forOfOptionalTupleMember.ts (1 errors) ====
+    // repro from https://github.com/microsoft/TypeScript/issues/54302
+    
+    type Item = {
+      value: string;
+    };
+    
+    type Foo = [Item?];
+    
+    declare const foo: Foo;
+    
+    for (let item of foo) {
+      item.value;
+      ~~~~
+!!! error TS18048: 'item' is possibly 'undefined'.
+    }
+    

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=es5).symbols
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=es5).symbols
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+  value: string;
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+
+};
+
+type Foo = [Item?];
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+declare const foo: Foo;
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+
+for (let item of foo) {
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+
+  item.value;
+>item.value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+}
+

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=es5).types
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=es5).types
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : { value: string; }
+
+  value: string;
+>value : string
+
+};
+
+type Foo = [Item?];
+>Foo : [(Item | undefined)?]
+
+declare const foo: Foo;
+>foo : Foo
+
+for (let item of foo) {
+>item : Item | undefined
+>foo : Foo
+
+  item.value;
+>item.value : string
+>item : Item | undefined
+>value : string
+}
+

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=esnext).errors.txt
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=esnext).errors.txt
@@ -1,0 +1,20 @@
+forOfOptionalTupleMember.ts(12,3): error TS18048: 'item' is possibly 'undefined'.
+
+
+==== forOfOptionalTupleMember.ts (1 errors) ====
+    // repro from https://github.com/microsoft/TypeScript/issues/54302
+    
+    type Item = {
+      value: string;
+    };
+    
+    type Foo = [Item?];
+    
+    declare const foo: Foo;
+    
+    for (let item of foo) {
+      item.value;
+      ~~~~
+!!! error TS18048: 'item' is possibly 'undefined'.
+    }
+    

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=esnext).symbols
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=esnext).symbols
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+  value: string;
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+
+};
+
+type Foo = [Item?];
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+declare const foo: Foo;
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+
+for (let item of foo) {
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+
+  item.value;
+>item.value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+}
+

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=esnext).types
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=false,target=esnext).types
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : { value: string; }
+
+  value: string;
+>value : string
+
+};
+
+type Foo = [Item?];
+>Foo : [(Item | undefined)?]
+
+declare const foo: Foo;
+>foo : Foo
+
+for (let item of foo) {
+>item : Item | undefined
+>foo : Foo
+
+  item.value;
+>item.value : string
+>item : Item | undefined
+>value : string
+}
+

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=es5).symbols
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=es5).symbols
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+  value: string;
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+
+};
+
+type Foo = [Item?];
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+declare const foo: Foo;
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+
+for (let item of foo) {
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+
+  item.value;
+>item.value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+}
+

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=es5).types
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=es5).types
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : { value: string; }
+
+  value: string;
+>value : string
+
+};
+
+type Foo = [Item?];
+>Foo : [Item?]
+
+declare const foo: Foo;
+>foo : Foo
+
+for (let item of foo) {
+>item : Item
+>foo : Foo
+
+  item.value;
+>item.value : string
+>item : Item
+>value : string
+}
+

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=esnext).symbols
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=esnext).symbols
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+  value: string;
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+
+};
+
+type Foo = [Item?];
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+>Item : Symbol(Item, Decl(forOfOptionalTupleMember.ts, 0, 0))
+
+declare const foo: Foo;
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+>Foo : Symbol(Foo, Decl(forOfOptionalTupleMember.ts, 4, 2))
+
+for (let item of foo) {
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>foo : Symbol(foo, Decl(forOfOptionalTupleMember.ts, 8, 13))
+
+  item.value;
+>item.value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+>item : Symbol(item, Decl(forOfOptionalTupleMember.ts, 10, 8))
+>value : Symbol(value, Decl(forOfOptionalTupleMember.ts, 2, 13))
+}
+

--- a/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=esnext).types
+++ b/tests/baselines/reference/forOfOptionalTupleMember(exactoptionalpropertytypes=true,target=esnext).types
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/forOfOptionalTupleMember.ts] ////
+
+=== forOfOptionalTupleMember.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+>Item : { value: string; }
+
+  value: string;
+>value : string
+
+};
+
+type Foo = [Item?];
+>Foo : [Item?]
+
+declare const foo: Foo;
+>foo : Foo
+
+for (let item of foo) {
+>item : Item
+>foo : Foo
+
+  item.value;
+>item.value : string
+>item : Item
+>value : string
+}
+

--- a/tests/cases/compiler/forOfOptionalTupleMember.ts
+++ b/tests/cases/compiler/forOfOptionalTupleMember.ts
@@ -1,0 +1,18 @@
+// @strict: true
+// @target: es5, esnext
+// @exactOptionalPropertyTypes: true, false
+// @noEmit: true
+
+// repro from https://github.com/microsoft/TypeScript/issues/54302
+
+type Item = {
+  value: string;
+};
+
+type Foo = [Item?];
+
+declare const foo: Foo;
+
+for (let item of foo) {
+  item.value;
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/54302