### PR TITLE
Proposal: Always allow type-only imports to reference .ts extensions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4905,8 +4905,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
             else if (resolvedModule.resolvedUsingTsExtension && !shouldAllowImportingTsExtension(compilerOptions, currentSourceFile.fileName)) {
-                const tsExtension = Debug.checkDefined(tryExtractTSExtension(moduleReference));
-                error(errorNode, Diagnostics.An_import_path_can_only_end_with_a_0_extension_when_allowImportingTsExtensions_is_enabled, tsExtension);
+                const importOrExport =
+                    findAncestor(location, isImportDeclaration)?.importClause ||
+                    findAncestor(location, or(isImportEqualsDeclaration, isExportDeclaration));
+                if (!(importOrExport?.isTypeOnly || findAncestor(location, isImportTypeNode))) {
+                    const tsExtension = Debug.checkDefined(tryExtractTSExtension(moduleReference));
+                    error(errorNode, Diagnostics.An_import_path_can_only_end_with_a_0_extension_when_allowImportingTsExtensions_is_enabled, tsExtension);
+                }
             }
 
             if (sourceFile.symbol) {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -5,6 +5,7 @@ import {
     arrayFrom,
     CancellationToken,
     cast,
+    changeAnyExtension,
     CodeAction,
     CodeFixAction,
     CodeFixContextBase,
@@ -42,10 +43,13 @@ import {
     getExportInfoMap,
     getMeaningFromDeclaration,
     getMeaningFromLocation,
+    getModeForUsageLocation,
     getNameForExportedSymbol,
     getNodeId,
+    getOutputExtension,
     getQuoteFromPreference,
     getQuotePreference,
+    getResolvedModule,
     getSourceFileOfNode,
     getSymbolId,
     getTokenAtPosition,
@@ -1344,6 +1348,15 @@ function promoteFromTypeOnly(changes: textChanges.ChangeTracker, aliasDeclaratio
 
     function promoteImportClause(importClause: ImportClause) {
         changes.delete(sourceFile, getTypeKeywordOfTypeOnlyImport(importClause, sourceFile));
+        // Change .ts extension to .js if necessary
+        if (!compilerOptions.allowImportingTsExtensions) {
+            const moduleSpecifier = tryGetModuleSpecifierFromDeclaration(importClause.parent);
+            const resolvedModule = moduleSpecifier && getResolvedModule(sourceFile, moduleSpecifier.text, getModeForUsageLocation(sourceFile, moduleSpecifier));
+            if (resolvedModule?.resolvedUsingTsExtension) {
+                const changedExtension = changeAnyExtension(moduleSpecifier!.text, getOutputExtension(moduleSpecifier!.text, compilerOptions));
+                changes.replaceNode(sourceFile, moduleSpecifier!, factory.createStringLiteral(changedExtension));
+            }
+        }
         if (convertExistingToTypeOnly) {
             const namedImports = tryCast(importClause.namedBindings, isNamedImports);
             if (namedImports && namedImports.elements.length > 1) {

--- a/tests/baselines/reference/allowsImportingTsExtension.errors.txt
+++ b/tests/baselines/reference/allowsImportingTsExtension.errors.txt
@@ -1,0 +1,21 @@
+b.ts(2,16): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+b.ts(3,30): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+b.ts(5,25): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+
+
+==== a.ts (0 errors) ====
+    export class A {}
+    
+==== b.ts (3 errors) ====
+    import type { A } from "./a.ts"; // ok
+    import {} from "./a.ts"; // error
+                   ~~~~~~~~
+!!! error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+    import { type A as _A } from "./a.ts"; // error
+                                 ~~~~~~~~
+!!! error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+    type __A = import("./a.ts").A; // ok
+    const aPromise = import("./a.ts"); // error
+                            ~~~~~~~~
+!!! error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+    

--- a/tests/baselines/reference/allowsImportingTsExtension.errors.txt
+++ b/tests/baselines/reference/allowsImportingTsExtension.errors.txt
@@ -1,9 +1,15 @@
 b.ts(2,16): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
 b.ts(3,30): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
 b.ts(5,25): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+c.ts(2,16): error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './a.js' instead?
+c.ts(3,30): error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './a.js' instead?
+c.ts(5,25): error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './a.js' instead?
 
 
 ==== a.ts (0 errors) ====
+    export class A {}
+    
+==== a.d.ts (0 errors) ====
     export class A {}
     
 ==== b.ts (3 errors) ====
@@ -18,4 +24,17 @@ b.ts(5,25): error TS5097: An import path can only end with a '.ts' extension whe
     const aPromise = import("./a.ts"); // error
                             ~~~~~~~~
 !!! error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
+    
+==== c.ts (3 errors) ====
+    import type { A } from "./a.d.ts"; // ok
+    import {} from "./a.d.ts"; // error
+                   ~~~~~~~~~~
+!!! error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './a.js' instead?
+    import { type A as _A } from "./a.d.ts"; // error
+                                 ~~~~~~~~~~
+!!! error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './a.js' instead?
+    type __A = import("./a.d.ts").A; // ok
+    const aPromise = import("./a.d.ts"); // error
+                            ~~~~~~~~~~
+!!! error TS2846: A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './a.js' instead?
     

--- a/tests/baselines/reference/allowsImportingTsExtension.js
+++ b/tests/baselines/reference/allowsImportingTsExtension.js
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts] ////
+
+//// [a.ts]
+export class A {}
+
+//// [b.ts]
+import type { A } from "./a.ts"; // ok
+import {} from "./a.ts"; // error
+import { type A as _A } from "./a.ts"; // error
+type __A = import("./a.ts").A; // ok
+const aPromise = import("./a.ts"); // error
+
+
+//// [a.js]
+export class A {
+}
+//// [b.js]
+const aPromise = import("./a.ts"); // error
+export {};

--- a/tests/baselines/reference/allowsImportingTsExtension.js
+++ b/tests/baselines/reference/allowsImportingTsExtension.js
@@ -3,6 +3,9 @@
 //// [a.ts]
 export class A {}
 
+//// [a.d.ts]
+export class A {}
+
 //// [b.ts]
 import type { A } from "./a.ts"; // ok
 import {} from "./a.ts"; // error
@@ -10,10 +13,20 @@ import { type A as _A } from "./a.ts"; // error
 type __A = import("./a.ts").A; // ok
 const aPromise = import("./a.ts"); // error
 
+//// [c.ts]
+import type { A } from "./a.d.ts"; // ok
+import {} from "./a.d.ts"; // error
+import { type A as _A } from "./a.d.ts"; // error
+type __A = import("./a.d.ts").A; // ok
+const aPromise = import("./a.d.ts"); // error
+
 
 //// [a.js]
 export class A {
 }
 //// [b.js]
 const aPromise = import("./a.ts"); // error
+export {};
+//// [c.js]
+const aPromise = import("./a.d.ts"); // error
 export {};

--- a/tests/baselines/reference/allowsImportingTsExtension.symbols
+++ b/tests/baselines/reference/allowsImportingTsExtension.symbols
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts] ////
+
+=== a.ts ===
+export class A {}
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+=== b.ts ===
+import type { A } from "./a.ts"; // ok
+>A : Symbol(A, Decl(b.ts, 0, 13))
+
+import {} from "./a.ts"; // error
+import { type A as _A } from "./a.ts"; // error
+>A : Symbol(A, Decl(a.ts, 0, 0))
+>_A : Symbol(_A, Decl(b.ts, 2, 8))
+
+type __A = import("./a.ts").A; // ok
+>__A : Symbol(__A, Decl(b.ts, 2, 38))
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+const aPromise = import("./a.ts"); // error
+>aPromise : Symbol(aPromise, Decl(b.ts, 4, 5))
+>"./a.ts" : Symbol("a", Decl(a.ts, 0, 0))
+

--- a/tests/baselines/reference/allowsImportingTsExtension.symbols
+++ b/tests/baselines/reference/allowsImportingTsExtension.symbols
@@ -4,6 +4,10 @@
 export class A {}
 >A : Symbol(A, Decl(a.ts, 0, 0))
 
+=== a.d.ts ===
+export class A {}
+>A : Symbol(A, Decl(a.d.ts, 0, 0))
+
 === b.ts ===
 import type { A } from "./a.ts"; // ok
 >A : Symbol(A, Decl(b.ts, 0, 13))
@@ -20,4 +24,21 @@ type __A = import("./a.ts").A; // ok
 const aPromise = import("./a.ts"); // error
 >aPromise : Symbol(aPromise, Decl(b.ts, 4, 5))
 >"./a.ts" : Symbol("a", Decl(a.ts, 0, 0))
+
+=== c.ts ===
+import type { A } from "./a.d.ts"; // ok
+>A : Symbol(A, Decl(c.ts, 0, 13))
+
+import {} from "./a.d.ts"; // error
+import { type A as _A } from "./a.d.ts"; // error
+>A : Symbol(A, Decl(a.ts, 0, 0))
+>_A : Symbol(_A, Decl(c.ts, 2, 8))
+
+type __A = import("./a.d.ts").A; // ok
+>__A : Symbol(__A, Decl(c.ts, 2, 40))
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+const aPromise = import("./a.d.ts"); // error
+>aPromise : Symbol(aPromise, Decl(c.ts, 4, 5))
+>"./a.d.ts" : Symbol("a", Decl(a.ts, 0, 0))
 

--- a/tests/baselines/reference/allowsImportingTsExtension.types
+++ b/tests/baselines/reference/allowsImportingTsExtension.types
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts] ////
+
+=== a.ts ===
+export class A {}
+>A : A
+
+=== b.ts ===
+import type { A } from "./a.ts"; // ok
+>A : A
+
+import {} from "./a.ts"; // error
+import { type A as _A } from "./a.ts"; // error
+>A : typeof A
+>_A : typeof A
+
+type __A = import("./a.ts").A; // ok
+>__A : A
+
+const aPromise = import("./a.ts"); // error
+>aPromise : Promise<typeof import("a")>
+>import("./a.ts") : Promise<typeof import("a")>
+>"./a.ts" : "./a.ts"
+

--- a/tests/baselines/reference/allowsImportingTsExtension.types
+++ b/tests/baselines/reference/allowsImportingTsExtension.types
@@ -4,6 +4,10 @@
 export class A {}
 >A : A
 
+=== a.d.ts ===
+export class A {}
+>A : A
+
 === b.ts ===
 import type { A } from "./a.ts"; // ok
 >A : A
@@ -20,4 +24,21 @@ const aPromise = import("./a.ts"); // error
 >aPromise : Promise<typeof import("a")>
 >import("./a.ts") : Promise<typeof import("a")>
 >"./a.ts" : "./a.ts"
+
+=== c.ts ===
+import type { A } from "./a.d.ts"; // ok
+>A : A
+
+import {} from "./a.d.ts"; // error
+import { type A as _A } from "./a.d.ts"; // error
+>A : typeof A
+>_A : typeof A
+
+type __A = import("./a.d.ts").A; // ok
+>__A : A
+
+const aPromise = import("./a.d.ts"); // error
+>aPromise : Promise<typeof import("a")>
+>import("./a.d.ts") : Promise<typeof import("a")>
+>"./a.d.ts" : "./a.d.ts"
 

--- a/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
@@ -1,0 +1,13 @@
+// @allowImportingTsExtensions: false
+// @target: esnext
+// @module: esnext
+
+// @Filename: a.ts
+export class A {}
+
+// @Filename: b.ts
+import type { A } from "./a.ts"; // ok
+import {} from "./a.ts"; // error
+import { type A as _A } from "./a.ts"; // error
+type __A = import("./a.ts").A; // ok
+const aPromise = import("./a.ts"); // error

--- a/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
@@ -5,9 +5,19 @@
 // @Filename: a.ts
 export class A {}
 
+// @Filename: a.d.ts
+export class A {}
+
 // @Filename: b.ts
 import type { A } from "./a.ts"; // ok
 import {} from "./a.ts"; // error
 import { type A as _A } from "./a.ts"; // error
 type __A = import("./a.ts").A; // ok
 const aPromise = import("./a.ts"); // error
+
+// @Filename: c.ts
+import type { A } from "./a.d.ts"; // ok
+import {} from "./a.d.ts"; // error
+import { type A as _A } from "./a.d.ts"; // error
+type __A = import("./a.d.ts").A; // ok
+const aPromise = import("./a.d.ts"); // error

--- a/tests/cases/fourslash/completionsImport_promoteTypeOnly6.ts
+++ b/tests/cases/fourslash/completionsImport_promoteTypeOnly6.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+// @module: nodenext
+// @allowImportingTsExtensions: false
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+//// export class SomePig {}
+
+// @Filename: /a.ts
+//// import type { SomePig } from "./exports.ts";
+//// new SomePig/**/
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "SomePig",
+    source: completion.CompletionSource.TypeOnlyAlias,
+    hasAction: true,
+  }]
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "SomePig",
+  source: completion.CompletionSource.TypeOnlyAlias,
+  description: `Remove 'type' from import declaration from "./exports.ts"`,
+  newFileContent:
+`import { SomePig } from "./exports.js";
+new SomePig`,
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeInsertTextCompletions: true,
+  },
+});

--- a/tests/cases/fourslash/completionsImport_promoteTypeOnly7.ts
+++ b/tests/cases/fourslash/completionsImport_promoteTypeOnly7.ts
@@ -1,0 +1,34 @@
+/// <reference path="fourslash.ts" />
+// @module: nodenext
+// @allowImportingTsExtensions: true
+
+// @Filename: /exports.ts
+//// export interface SomeInterface {}
+//// export class SomePig {}
+
+// @Filename: /a.ts
+//// import type { SomePig } from "./exports.ts";
+//// new SomePig/**/
+
+verify.completions({
+  marker: "",
+  includes: [{
+    name: "SomePig",
+    source: completion.CompletionSource.TypeOnlyAlias,
+    hasAction: true,
+  }]
+});
+
+verify.applyCodeActionFromCompletion("", {
+  name: "SomePig",
+  source: completion.CompletionSource.TypeOnlyAlias,
+  description: `Remove 'type' from import declaration from "./exports.ts"`,
+  newFileContent:
+`import { SomePig } from "./exports.ts";
+new SomePig`,
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+    includeInsertTextCompletions: true,
+  },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Currently, it’s an error to have a type-only import from a `.ts` extension unless `allowImportingTsExtensions` is enabled:

```ts
import type { JustAType } from "./justTypes.ts";
//                             ^^^^^^^^^^^^^^^^
// Error: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
```

I’m pretty sure this was an oversight in #51669/#52230 where I first introduced `allowImportingTsExtensions`. Whether the flag is set or not, type-only imports are allowed to import from a `.d.ts` extension, so it makes sense to allow it for `.ts` extensions too. What I intended to implement was:

1. Importing from a TS file extension always resolves
2. Importing from a TS file extension is allowed as long as it doesn’t emit to JS
3. `allowImportingTsExtensions` removes the “as long as it doesn’t emit to JS” exception from (2)

This was brought up as a complaint in #51876.
