### PR TITLE
fix(compiler): synthetic comment is duplicated on class with experimental decorators

### DIFF
--- a/src/compiler/transformers/legacyDecorators.ts
+++ b/src/compiler/transformers/legacyDecorators.ts
@@ -70,6 +70,7 @@ import {
     setEmitFlags,
     setOriginalNode,
     setSourceMapRange,
+    setSyntheticLeadingComments,
     setTextRange,
     singleOrMany,
     some,
@@ -370,11 +371,15 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
         setOriginalNode(classExpression, node);
         setTextRange(classExpression, location);
 
+        setSyntheticLeadingComments(classExpression, undefined);
+
         //  let ${name} = ${classExpression} where name is either declaredName if the class doesn't contain self-reference
         //                                         or decoratedClassAlias if the class contain self-reference.
         const varInitializer = classAlias && !assignClassAliasInStaticBlock ? factory.createAssignment(classAlias, classExpression) : classExpression;
         const varDecl = factory.createVariableDeclaration(declName, /*exclamationToken*/ undefined, /*type*/ undefined, varInitializer);
         setOriginalNode(varDecl, node);
+
+        setSyntheticLeadingComments(varDecl, undefined);
 
         const varDeclList = factory.createVariableDeclarationList([varDecl], NodeFlags.Let);
         const varStatement = factory.createVariableStatement(/*modifiers*/ undefined, varDeclList);
@@ -653,7 +658,7 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
     function addConstructorDecorationStatement(statements: Statement[], node: ClassDeclaration) {
         const expression = generateConstructorDecorationExpression(node);
         if (expression) {
-            statements.push(setOriginalNode(factory.createExpressionStatement(expression), node));
+            statements.push(setSyntheticLeadingComments(setOriginalNode(factory.createExpressionStatement(expression), node), undefined));
         }
     }
 

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -942,9 +942,6 @@ export function transformTypeScript(context: TransformationContext) {
             setCommentRange(varStatement, node);
             setSourceMapRange(varStatement, moveRangePastDecorators(node));
             startOnNewLine(varStatement);
-
-            setSyntheticLeadingComments(node, undefined);
-
             statement = varStatement;
         }
         else {

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -942,6 +942,9 @@ export function transformTypeScript(context: TransformationContext) {
             setCommentRange(varStatement, node);
             setSourceMapRange(varStatement, moveRangePastDecorators(node));
             startOnNewLine(varStatement);
+
+            setSyntheticLeadingComments(node, undefined);
+
             statement = varStatement;
         }
         else {

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -696,5 +696,31 @@ function test () {
             }
         }).outputText;
     });
+
+    // https://github.com/microsoft/TypeScript/issues/54742
+    testBaseline("transformSyntheticCommentInClassDeclarationWithDecorator", () => {
+        const myTransformer = () => {
+            return (sf: any) => {
+                ts.setSyntheticLeadingComments(sf.statements[0], [
+                    { text: "from transformer", kind: ts.SyntaxKind.MultiLineCommentTrivia, pos: -1, end: -1 },
+                ]);
+                return sf;
+            };
+        };
+
+        return ts.transpileModule(` 
+@decorate()
+class Foo {}
+`, {
+            transformers: {
+                before: [myTransformer],
+            },
+            compilerOptions: {
+              experimentalDecorators: true,
+              module: ts.ModuleKind.CommonJS,
+              target: ts.ScriptTarget.ESNext,
+            },
+          }).outputText;
+    });
 });
 

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformSyntheticCommentInClassDeclarationWithDecorator.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformSyntheticCommentInClassDeclarationWithDecorator.js
@@ -1,0 +1,11 @@
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+/*from transformer*/ let Foo = class Foo {
+};
+Foo = __decorate([
+    decorate()
+], Foo);


### PR DESCRIPTION
Synthetic comments were duplicated multiple times on class declaration with decorators.

For example:
```
/*from transformer*/
@decorate()
class Foo {}
`;
```

Becomes:
```
/*from transformer*/ let /*from transformer*/ Foo = /*from transformer*/ class Foo {
};
/*from transformer*/ Foo = __decorate([
    decorate()
], Foo);
```

This fix removes the duplicates, resulting in:
```
/*from transformer*/ let Foo = class Foo {
};
Foo = __decorate([
    decorate()
], Foo);
```

Fixes #54742
