### PR TITLE
Add test which would fail if SFT behavior differs in variance checking

### DIFF
--- a/tests/baselines/reference/varianceCantBeStrictWhileStructureIsnt.js
+++ b/tests/baselines/reference/varianceCantBeStrictWhileStructureIsnt.js
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts] ////
+
+//// [varianceCantBeStrictWhileStructureIsnt.ts]
+// under non-strict-function-types, all the below should work
+interface Foo<T> {
+    member: (cb: T) => void;
+}
+
+interface Bar<T> {
+    member: (cb: T) => void;
+}
+
+declare var a: Foo<string>;
+declare var b: Foo<"">;
+
+declare var a2: Bar<string>;
+declare var b2: Bar<"">;
+
+a = b;
+b = a;
+
+a2 = b2;
+b2 = a2;
+
+a = b2;
+b = a2;
+
+a2 = b;
+b2 = a;
+
+//// [varianceCantBeStrictWhileStructureIsnt.js]
+a = b;
+b = a;
+a2 = b2;
+b2 = a2;
+a = b2;
+b = a2;
+a2 = b;
+b2 = a;

--- a/tests/baselines/reference/varianceCantBeStrictWhileStructureIsnt.symbols
+++ b/tests/baselines/reference/varianceCantBeStrictWhileStructureIsnt.symbols
@@ -1,0 +1,72 @@
+//// [tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts] ////
+
+=== varianceCantBeStrictWhileStructureIsnt.ts ===
+// under non-strict-function-types, all the below should work
+interface Foo<T> {
+>Foo : Symbol(Foo, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 0, 0))
+>T : Symbol(T, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 1, 14))
+
+    member: (cb: T) => void;
+>member : Symbol(Foo.member, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 1, 18))
+>cb : Symbol(cb, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 2, 13))
+>T : Symbol(T, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 1, 14))
+}
+
+interface Bar<T> {
+>Bar : Symbol(Bar, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 3, 1))
+>T : Symbol(T, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 5, 14))
+
+    member: (cb: T) => void;
+>member : Symbol(Bar.member, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 5, 18))
+>cb : Symbol(cb, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 6, 13))
+>T : Symbol(T, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 5, 14))
+}
+
+declare var a: Foo<string>;
+>a : Symbol(a, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 9, 11))
+>Foo : Symbol(Foo, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 0, 0))
+
+declare var b: Foo<"">;
+>b : Symbol(b, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 10, 11))
+>Foo : Symbol(Foo, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 0, 0))
+
+declare var a2: Bar<string>;
+>a2 : Symbol(a2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 12, 11))
+>Bar : Symbol(Bar, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 3, 1))
+
+declare var b2: Bar<"">;
+>b2 : Symbol(b2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 13, 11))
+>Bar : Symbol(Bar, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 3, 1))
+
+a = b;
+>a : Symbol(a, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 9, 11))
+>b : Symbol(b, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 10, 11))
+
+b = a;
+>b : Symbol(b, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 10, 11))
+>a : Symbol(a, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 9, 11))
+
+a2 = b2;
+>a2 : Symbol(a2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 12, 11))
+>b2 : Symbol(b2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 13, 11))
+
+b2 = a2;
+>b2 : Symbol(b2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 13, 11))
+>a2 : Symbol(a2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 12, 11))
+
+a = b2;
+>a : Symbol(a, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 9, 11))
+>b2 : Symbol(b2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 13, 11))
+
+b = a2;
+>b : Symbol(b, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 10, 11))
+>a2 : Symbol(a2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 12, 11))
+
+a2 = b;
+>a2 : Symbol(a2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 12, 11))
+>b : Symbol(b, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 10, 11))
+
+b2 = a;
+>b2 : Symbol(b2, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 13, 11))
+>a : Symbol(a, Decl(varianceCantBeStrictWhileStructureIsnt.ts, 9, 11))
+

--- a/tests/baselines/reference/varianceCantBeStrictWhileStructureIsnt.types
+++ b/tests/baselines/reference/varianceCantBeStrictWhileStructureIsnt.types
@@ -1,0 +1,68 @@
+//// [tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts] ////
+
+=== varianceCantBeStrictWhileStructureIsnt.ts ===
+// under non-strict-function-types, all the below should work
+interface Foo<T> {
+    member: (cb: T) => void;
+>member : (cb: T) => void
+>cb : T
+}
+
+interface Bar<T> {
+    member: (cb: T) => void;
+>member : (cb: T) => void
+>cb : T
+}
+
+declare var a: Foo<string>;
+>a : Foo<string>
+
+declare var b: Foo<"">;
+>b : Foo<"">
+
+declare var a2: Bar<string>;
+>a2 : Bar<string>
+
+declare var b2: Bar<"">;
+>b2 : Bar<"">
+
+a = b;
+>a = b : Foo<"">
+>a : Foo<string>
+>b : Foo<"">
+
+b = a;
+>b = a : Foo<string>
+>b : Foo<"">
+>a : Foo<string>
+
+a2 = b2;
+>a2 = b2 : Bar<"">
+>a2 : Bar<string>
+>b2 : Bar<"">
+
+b2 = a2;
+>b2 = a2 : Bar<string>
+>b2 : Bar<"">
+>a2 : Bar<string>
+
+a = b2;
+>a = b2 : Bar<"">
+>a : Foo<string>
+>b2 : Bar<"">
+
+b = a2;
+>b = a2 : Bar<string>
+>b : Foo<"">
+>a2 : Bar<string>
+
+a2 = b;
+>a2 = b : Foo<"">
+>a2 : Bar<string>
+>b : Foo<"">
+
+b2 = a;
+>b2 = a : Foo<string>
+>b2 : Bar<"">
+>a : Foo<string>
+

--- a/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
+++ b/tests/cases/compiler/varianceCantBeStrictWhileStructureIsnt.ts
@@ -1,0 +1,28 @@
+// @strict: false
+// @strictFunctionTypes: false
+// under non-strict-function-types, all the below should work
+interface Foo<T> {
+    member: (cb: T) => void;
+}
+
+interface Bar<T> {
+    member: (cb: T) => void;
+}
+
+declare var a: Foo<string>;
+declare var b: Foo<"">;
+
+declare var a2: Bar<string>;
+declare var b2: Bar<"">;
+
+a = b;
+b = a;
+
+a2 = b2;
+b2 = a2;
+
+a = b2;
+b = a2;
+
+a2 = b;
+b2 = a;


### PR DESCRIPTION
While looking at #54542, since the issue doesn't reproduce when strict function types isn't enabled, it was pretty easy to fall into the trap of thinking that maybe variance checking should just have strict function types enabled all the time.

However, working through it, you can come up with some pretty simple examples that divergent behavior of that sort would break, which, amazingly, aren't covered at all in our test suite (so you can actually make a PR that locks SFT to on during variance checking and all the tests pass, even though it breaks some pretty simple stuff!).

So this is just to improve our test coverage, so the next time someone (like me) starts thinking this way, this test can quickly point out why that's not really a viable solution.