### PR TITLE
Preserve type parameter constraint in emitted mapped types while preserving their distributivity

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6638,22 +6638,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const questionToken = type.declaration.questionToken ? factory.createToken(type.declaration.questionToken.kind) as QuestionToken | PlusToken | MinusToken : undefined;
                 let appropriateConstraintTypeNode: TypeNode;
                 let newTypeVariable: TypeReferenceNode | undefined;
+                let templateType = getTemplateTypeFromMappedType(type);
+                let typeParameter = getTypeParameterFromMappedType(type);
                 if (isMappedTypeWithKeyofConstraintDeclaration(type)) {
                     // We have a { [P in keyof T]: X }
                     // We do this to ensure we retain the toplevel keyof-ness of the type which may be lost due to keyof distribution during `getConstraintTypeFromMappedType`
                     if (isHomomorphicMappedTypeWithNonHomomorphicInstantiation(type) && context.flags & NodeBuilderFlags.GenerateNamesForShadowedTypeParams) {
-                        const newParam = createTypeParameter(createSymbol(SymbolFlags.TypeParameter, "T" as __String));
-                        const name = typeParameterToName(newParam, context);
+                        const newConstraintParam = createTypeParameter(createSymbol(SymbolFlags.TypeParameter, "T" as __String));
+                        const newTypeParam = createTypeParameter(createSymbol(SymbolFlags.TypeParameter, "K" as __String));
+                        const name = typeParameterToName(newConstraintParam, context);
+                        const target = type.target as MappedType;
+                        typeParameter = newTypeParam;
                         newTypeVariable = factory.createTypeReferenceNode(name);
+                        templateType = instantiateType(
+                            getTemplateTypeFromMappedType(target),
+                            makeArrayTypeMapper([getTypeParameterFromMappedType(target), getModifiersTypeFromMappedType(target)], [newTypeParam, newConstraintParam])
+                        );
                     }
                     appropriateConstraintTypeNode = factory.createTypeOperatorNode(SyntaxKind.KeyOfKeyword, newTypeVariable || typeToTypeNodeHelper(getModifiersTypeFromMappedType(type), context));
                 }
                 else {
                     appropriateConstraintTypeNode = typeToTypeNodeHelper(getConstraintTypeFromMappedType(type), context);
                 }
-                const typeParameterNode = typeParameterToDeclarationWithConstraint(getTypeParameterFromMappedType(type), context, appropriateConstraintTypeNode);
+                const typeParameterNode = typeParameterToDeclarationWithConstraint(typeParameter, context, appropriateConstraintTypeNode);
                 const nameTypeNode = type.declaration.nameType ? typeToTypeNodeHelper(getNameTypeFromMappedType(type)!, context) : undefined;
-                const templateTypeNode = typeToTypeNodeHelper(removeMissingType(getTemplateTypeFromMappedType(type), !!(getMappedTypeModifiers(type) & MappedTypeModifiers.IncludeOptional)), context);
+                const templateTypeNode = typeToTypeNodeHelper(removeMissingType(templateType, !!(getMappedTypeModifiers(type) & MappedTypeModifiers.IncludeOptional)), context);
                 const mappedTypeNode = factory.createMappedTypeNode(readonlyToken, typeParameterNode, nameTypeNode, questionToken, templateTypeNode, /*members*/ undefined);
                 context.approximateLength += 10;
                 const result = setEmitFlags(mappedTypeNode, EmitFlags.SingleLine);

--- a/tests/baselines/reference/declarationEmitMappedTypeDistributivityPreservesConstraints.js
+++ b/tests/baselines/reference/declarationEmitMappedTypeDistributivityPreservesConstraints.js
@@ -52,10 +52,10 @@ declare const _default: {
         fn: <T_1 extends {
             x: T_1["x"] extends infer T extends {
                 [x: string]: (...params: unknown[]) => unknown;
-            } ? { [K in keyof T]: T_1["x"][K]; } : never;
+            } ? { [K in keyof T]: T[K]; } : never;
         }>(sliceIndex: T_1) => T_1["x"] extends infer T_2 extends {
             [x: string]: (...params: unknown[]) => unknown;
-        } ? { [K_1 in keyof T_2]: Parameters<T_1["x"][K_1]>; } : never;
+        } ? { [K_1 in keyof T_2]: Parameters<T_2[K_1]>; } : never;
     };
 };
 export default _default;

--- a/tests/baselines/reference/declarationEmitMappedTypePreservesTypeParameterConstraint.js
+++ b/tests/baselines/reference/declarationEmitMappedTypePreservesTypeParameterConstraint.js
@@ -1,0 +1,82 @@
+//// [tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts] ////
+
+//// [declarationEmitMappedTypePreservesTypeParameterConstraint.ts]
+// repro from https://github.com/microsoft/TypeScript/issues/54560
+
+declare type requiredKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? never : k;
+}[keyof T];
+
+declare type addQuestionMarks<
+  T extends object,
+  R extends keyof T = requiredKeys<T>
+> = Pick<Required<T>, R> & Partial<T>;
+
+declare type identity<T> = T;
+
+declare type flatten<T> = identity<{
+  [k in keyof T]: T[k];
+}>;
+
+export declare abstract class ZodType<Output = any> {
+  readonly _output: Output;
+}
+
+export declare class ZodLiteral<T> extends ZodType<T> {}
+
+export declare type ZodTypeAny = ZodType<any>;
+
+export declare type baseObjectOutputType<Shape extends ZodRawShape> = {
+  [k in keyof Shape]: Shape[k]["_output"];
+};
+
+export declare type objectOutputType<Shape extends ZodRawShape> = flatten<
+  addQuestionMarks<baseObjectOutputType<Shape>>
+>;
+
+export declare type ZodRawShape = {
+  [k: string]: ZodTypeAny;
+};
+
+export const buildSchema = <V extends string>(
+  version: V
+): objectOutputType<{
+  version: ZodLiteral<V>;
+}> => ({} as any);
+
+
+//// [declarationEmitMappedTypePreservesTypeParameterConstraint.js]
+"use strict";
+// repro from https://github.com/microsoft/TypeScript/issues/54560
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildSchema = void 0;
+var buildSchema = function (version) { return ({}); };
+exports.buildSchema = buildSchema;
+
+
+//// [declarationEmitMappedTypePreservesTypeParameterConstraint.d.ts]
+declare type requiredKeys<T extends object> = {
+    [k in keyof T]: undefined extends T[k] ? never : k;
+}[keyof T];
+declare type addQuestionMarks<T extends object, R extends keyof T = requiredKeys<T>> = Pick<Required<T>, R> & Partial<T>;
+declare type identity<T> = T;
+declare type flatten<T> = identity<{
+    [k in keyof T]: T[k];
+}>;
+export declare abstract class ZodType<Output = any> {
+    readonly _output: Output;
+}
+export declare class ZodLiteral<T> extends ZodType<T> {
+}
+export declare type ZodTypeAny = ZodType<any>;
+export declare type baseObjectOutputType<Shape extends ZodRawShape> = {
+    [k in keyof Shape]: Shape[k]["_output"];
+};
+export declare type objectOutputType<Shape extends ZodRawShape> = flatten<addQuestionMarks<baseObjectOutputType<Shape>>>;
+export declare type ZodRawShape = {
+    [k: string]: ZodTypeAny;
+};
+export declare const buildSchema: <V extends string>(version: V) => addQuestionMarks<baseObjectOutputType<{
+    version: ZodLiteral<V>;
+}>, undefined extends V ? never : "version"> extends infer T ? { [K in keyof T]: T[K]; } : never;
+export {};

--- a/tests/baselines/reference/declarationEmitMappedTypePreservesTypeParameterConstraint.symbols
+++ b/tests/baselines/reference/declarationEmitMappedTypePreservesTypeParameterConstraint.symbols
@@ -1,0 +1,129 @@
+//// [tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts] ////
+
+=== declarationEmitMappedTypePreservesTypeParameterConstraint.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54560
+
+declare type requiredKeys<T extends object> = {
+>requiredKeys : Symbol(requiredKeys, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 2, 26))
+
+  [k in keyof T]: undefined extends T[k] ? never : k;
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 3, 3))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 2, 26))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 2, 26))
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 3, 3))
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 3, 3))
+
+}[keyof T];
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 2, 26))
+
+declare type addQuestionMarks<
+>addQuestionMarks : Symbol(addQuestionMarks, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 4, 11))
+
+  T extends object,
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 6, 30))
+
+  R extends keyof T = requiredKeys<T>
+>R : Symbol(R, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 7, 19))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 6, 30))
+>requiredKeys : Symbol(requiredKeys, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 6, 30))
+
+> = Pick<Required<T>, R> & Partial<T>;
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 6, 30))
+>R : Symbol(R, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 7, 19))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 6, 30))
+
+declare type identity<T> = T;
+>identity : Symbol(identity, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 9, 38))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 11, 22))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 11, 22))
+
+declare type flatten<T> = identity<{
+>flatten : Symbol(flatten, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 11, 29))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 13, 21))
+>identity : Symbol(identity, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 9, 38))
+
+  [k in keyof T]: T[k];
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 14, 3))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 13, 21))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 13, 21))
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 14, 3))
+
+}>;
+
+export declare abstract class ZodType<Output = any> {
+>ZodType : Symbol(ZodType, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 15, 3))
+>Output : Symbol(Output, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 17, 38))
+
+  readonly _output: Output;
+>_output : Symbol(ZodType._output, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 17, 53))
+>Output : Symbol(Output, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 17, 38))
+}
+
+export declare class ZodLiteral<T> extends ZodType<T> {}
+>ZodLiteral : Symbol(ZodLiteral, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 19, 1))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 21, 32))
+>ZodType : Symbol(ZodType, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 15, 3))
+>T : Symbol(T, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 21, 32))
+
+export declare type ZodTypeAny = ZodType<any>;
+>ZodTypeAny : Symbol(ZodTypeAny, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 21, 56))
+>ZodType : Symbol(ZodType, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 15, 3))
+
+export declare type baseObjectOutputType<Shape extends ZodRawShape> = {
+>baseObjectOutputType : Symbol(baseObjectOutputType, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 23, 46))
+>Shape : Symbol(Shape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 25, 41))
+>ZodRawShape : Symbol(ZodRawShape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 31, 2))
+
+  [k in keyof Shape]: Shape[k]["_output"];
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 26, 3))
+>Shape : Symbol(Shape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 25, 41))
+>Shape : Symbol(Shape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 25, 41))
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 26, 3))
+
+};
+
+export declare type objectOutputType<Shape extends ZodRawShape> = flatten<
+>objectOutputType : Symbol(objectOutputType, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 27, 2))
+>Shape : Symbol(Shape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 29, 37))
+>ZodRawShape : Symbol(ZodRawShape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 31, 2))
+>flatten : Symbol(flatten, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 11, 29))
+
+  addQuestionMarks<baseObjectOutputType<Shape>>
+>addQuestionMarks : Symbol(addQuestionMarks, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 4, 11))
+>baseObjectOutputType : Symbol(baseObjectOutputType, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 23, 46))
+>Shape : Symbol(Shape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 29, 37))
+
+>;
+
+export declare type ZodRawShape = {
+>ZodRawShape : Symbol(ZodRawShape, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 31, 2))
+
+  [k: string]: ZodTypeAny;
+>k : Symbol(k, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 34, 3))
+>ZodTypeAny : Symbol(ZodTypeAny, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 21, 56))
+
+};
+
+export const buildSchema = <V extends string>(
+>buildSchema : Symbol(buildSchema, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 37, 12))
+>V : Symbol(V, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 37, 28))
+
+  version: V
+>version : Symbol(version, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 37, 46))
+>V : Symbol(V, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 37, 28))
+
+): objectOutputType<{
+>objectOutputType : Symbol(objectOutputType, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 27, 2))
+
+  version: ZodLiteral<V>;
+>version : Symbol(version, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 39, 21))
+>ZodLiteral : Symbol(ZodLiteral, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 19, 1))
+>V : Symbol(V, Decl(declarationEmitMappedTypePreservesTypeParameterConstraint.ts, 37, 28))
+
+}> => ({} as any);
+

--- a/tests/baselines/reference/declarationEmitMappedTypePreservesTypeParameterConstraint.types
+++ b/tests/baselines/reference/declarationEmitMappedTypePreservesTypeParameterConstraint.types
@@ -1,0 +1,77 @@
+//// [tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts] ////
+
+=== declarationEmitMappedTypePreservesTypeParameterConstraint.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54560
+
+declare type requiredKeys<T extends object> = {
+>requiredKeys : requiredKeys<T>
+
+  [k in keyof T]: undefined extends T[k] ? never : k;
+}[keyof T];
+
+declare type addQuestionMarks<
+>addQuestionMarks : addQuestionMarks<T, R>
+
+  T extends object,
+  R extends keyof T = requiredKeys<T>
+> = Pick<Required<T>, R> & Partial<T>;
+
+declare type identity<T> = T;
+>identity : T
+
+declare type flatten<T> = identity<{
+>flatten : { [k in keyof T]: T[k]; }
+
+  [k in keyof T]: T[k];
+}>;
+
+export declare abstract class ZodType<Output = any> {
+>ZodType : ZodType<Output>
+
+  readonly _output: Output;
+>_output : Output
+}
+
+export declare class ZodLiteral<T> extends ZodType<T> {}
+>ZodLiteral : ZodLiteral<T>
+>ZodType : ZodType<T>
+
+export declare type ZodTypeAny = ZodType<any>;
+>ZodTypeAny : ZodType<any>
+
+export declare type baseObjectOutputType<Shape extends ZodRawShape> = {
+>baseObjectOutputType : baseObjectOutputType<Shape>
+
+  [k in keyof Shape]: Shape[k]["_output"];
+};
+
+export declare type objectOutputType<Shape extends ZodRawShape> = flatten<
+>objectOutputType : { [k in keyof addQuestionMarks<baseObjectOutputType<Shape>, requiredKeys<baseObjectOutputType<Shape>>>]: addQuestionMarks<baseObjectOutputType<Shape>, requiredKeys<baseObjectOutputType<Shape>>>[k]; }
+
+  addQuestionMarks<baseObjectOutputType<Shape>>
+>;
+
+export declare type ZodRawShape = {
+>ZodRawShape : { [k: string]: ZodTypeAny; }
+
+  [k: string]: ZodTypeAny;
+>k : string
+
+};
+
+export const buildSchema = <V extends string>(
+>buildSchema : <V extends string>(version: V) => { [k in keyof addQuestionMarks<baseObjectOutputType<{ version: ZodLiteral<V>; }>, undefined extends V ? never : "version">]: addQuestionMarks<baseObjectOutputType<{ version: ZodLiteral<V>; }>, undefined extends V ? never : "version">[k]; }
+><V extends string>(  version: V): objectOutputType<{  version: ZodLiteral<V>;}> => ({} as any) : <V extends string>(version: V) => { [k in keyof addQuestionMarks<baseObjectOutputType<{ version: ZodLiteral<V>; }>, undefined extends V ? never : "version">]: addQuestionMarks<baseObjectOutputType<{ version: ZodLiteral<V>; }>, undefined extends V ? never : "version">[k]; }
+
+  version: V
+>version : V
+
+): objectOutputType<{
+  version: ZodLiteral<V>;
+>version : ZodLiteral<V>
+
+}> => ({} as any);
+>({} as any) : any
+>{} as any : any
+>{} : {}
+

--- a/tests/baselines/reference/mappedTypeGenericInstantiationPreservesHomomorphism.js
+++ b/tests/baselines/reference/mappedTypeGenericInstantiationPreservesHomomorphism.js
@@ -35,4 +35,4 @@ type PrivateMapped<Obj> = {
 };
 export {};
 //// [api.d.ts]
-export declare const mappedUnionWithPrivateType: <T extends unknown[]>(...args: T) => T[any] extends infer T_1 ? { [K in keyof T_1]: T[any][K]; } : never;
+export declare const mappedUnionWithPrivateType: <T extends unknown[]>(...args: T) => T[any] extends infer T_1 ? { [K in keyof T_1]: T_1[K]; } : never;

--- a/tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts
+++ b/tests/cases/compiler/declarationEmitMappedTypePreservesTypeParameterConstraint.ts
@@ -1,0 +1,45 @@
+// @strict: true
+// @declaration: true
+
+// repro from https://github.com/microsoft/TypeScript/issues/54560
+
+declare type requiredKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? never : k;
+}[keyof T];
+
+declare type addQuestionMarks<
+  T extends object,
+  R extends keyof T = requiredKeys<T>
+> = Pick<Required<T>, R> & Partial<T>;
+
+declare type identity<T> = T;
+
+declare type flatten<T> = identity<{
+  [k in keyof T]: T[k];
+}>;
+
+export declare abstract class ZodType<Output = any> {
+  readonly _output: Output;
+}
+
+export declare class ZodLiteral<T> extends ZodType<T> {}
+
+export declare type ZodTypeAny = ZodType<any>;
+
+export declare type baseObjectOutputType<Shape extends ZodRawShape> = {
+  [k in keyof Shape]: Shape[k]["_output"];
+};
+
+export declare type objectOutputType<Shape extends ZodRawShape> = flatten<
+  addQuestionMarks<baseObjectOutputType<Shape>>
+>;
+
+export declare type ZodRawShape = {
+  [k: string]: ZodTypeAny;
+};
+
+export const buildSchema = <V extends string>(
+  version: V
+): objectOutputType<{
+  version: ZodLiteral<V>;
+}> => ({} as any);


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/issues/54560

The idea behind this PR is that:
- a different emit has to be done when a homomorphic mapped type has a non-homomorphic instantiation because distributivity has to be preserved
- the `mappedType.target` is the homomorphic one so it feels like it can be used to create a proper instantiation
- we only need to create type params for both `K` and `T` and instantiate the target's template type with them properly