### PR TITLE
fix(54760): Report error for 'declare type' followed by newline

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7093,13 +7093,20 @@ namespace Parser {
                 case SyntaxKind.PrivateKeyword:
                 case SyntaxKind.ProtectedKeyword:
                 case SyntaxKind.PublicKeyword:
-                case SyntaxKind.ReadonlyKeyword:
+                case SyntaxKind.ReadonlyKeyword: {
+                    const previousToken = token();
                     nextToken();
                     // ASI takes effect for this modifier.
                     if (scanner.hasPrecedingLineBreak()) {
                         return false;
                     }
+                    if (previousToken === SyntaxKind.DeclareKeyword && token() === SyntaxKind.TypeKeyword) {
+                        // If we see 'declare type', then commit to parsing a type alias. parseTypeAliasDeclaration will
+                        // report Line_break_not_permitted_here if needed.
+                        return true;
+                    }
                     continue;
+                }
 
                 case SyntaxKind.GlobalKeyword:
                     nextToken();
@@ -8092,6 +8099,9 @@ namespace Parser {
 
     function parseTypeAliasDeclaration(pos: number, hasJSDoc: boolean, modifiers: NodeArray<ModifierLike> | undefined): TypeAliasDeclaration {
         parseExpected(SyntaxKind.TypeKeyword);
+        if (scanner.hasPrecedingLineBreak()) {
+            parseErrorAtCurrentToken(Diagnostics.Line_break_not_permitted_here);
+        }
         const name = parseIdentifier();
         const typeParameters = parseTypeParameters();
         parseExpected(SyntaxKind.EqualsToken);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7093,7 +7093,7 @@ namespace Parser {
                 case SyntaxKind.PrivateKeyword:
                 case SyntaxKind.ProtectedKeyword:
                 case SyntaxKind.PublicKeyword:
-                case SyntaxKind.ReadonlyKeyword: {
+                case SyntaxKind.ReadonlyKeyword:
                     const previousToken = token();
                     nextToken();
                     // ASI takes effect for this modifier.
@@ -7106,7 +7106,6 @@ namespace Parser {
                         return true;
                     }
                     continue;
-                }
 
                 case SyntaxKind.GlobalKeyword:
                     nextToken();

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.errors.txt
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.errors.txt
@@ -2,14 +2,14 @@ typeAliasDeclareKeywordNewlines.ts(5,1): error TS1142: Line break not permitted 
 
 
 ==== typeAliasDeclareKeywordNewlines.ts (1 errors) ====
-    var declare: any, type: any;
+    var declare: string, type: number;
     
     // The following is invalid but should declare a type alias named 'T1':
     declare type /*unexpected newline*/
     T1 = null;
     ~~
 !!! error TS1142: Line break not permitted here.
-    const t1: T1 = null;
+    const t1: T1 = null; // Assert that T1 is the null type.
     
     let T: null;
     // The following should use a variable named 'declare', use a variable named
@@ -22,5 +22,5 @@ typeAliasDeclareKeywordNewlines.ts(5,1): error TS1142: Line break not permitted 
     // named 'T2':
     declare /*ASI*/
     type T2 = null;
-    const t2: T2 = null;
+    const t2: T2 = null; // Assert that T2 is the null type.
     

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.errors.txt
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.errors.txt
@@ -1,18 +1,26 @@
-typeAliasDeclareKeywordNewlines.ts(4,1): error TS1142: Line break not permitted here.
+typeAliasDeclareKeywordNewlines.ts(5,1): error TS1142: Line break not permitted here.
 
 
 ==== typeAliasDeclareKeywordNewlines.ts (1 errors) ====
-    var declare, type, T;
+    var declare: any, type: any;
     
+    // The following is invalid but should declare a type alias named 'T1':
     declare type /*unexpected newline*/
     T1 = null;
     ~~
 !!! error TS1142: Line break not permitted here.
+    const t1: T1 = null;
     
+    let T: null;
+    // The following should use a variable named 'declare', use a variable named
+    // 'type', and assign to a variable named 'T'.
     declare /*ASI*/
     type /*ASI*/
     T = null;
     
+    // The following should use a variable named 'declare' and declare a type alias
+    // named 'T2':
     declare /*ASI*/
     type T2 = null;
+    const t2: T2 = null;
     

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.errors.txt
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.errors.txt
@@ -1,0 +1,18 @@
+typeAliasDeclareKeywordNewlines.ts(4,1): error TS1142: Line break not permitted here.
+
+
+==== typeAliasDeclareKeywordNewlines.ts (1 errors) ====
+    var declare, type, T;
+    
+    declare type /*unexpected newline*/
+    T1 = null;
+    ~~
+!!! error TS1142: Line break not permitted here.
+    
+    declare /*ASI*/
+    type /*ASI*/
+    T = null;
+    
+    declare /*ASI*/
+    type T2 = null;
+    

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.js
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.js
@@ -1,12 +1,12 @@
 //// [tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts] ////
 
 //// [typeAliasDeclareKeywordNewlines.ts]
-var declare: any, type: any;
+var declare: string, type: number;
 
 // The following is invalid but should declare a type alias named 'T1':
 declare type /*unexpected newline*/
 T1 = null;
-const t1: T1 = null;
+const t1: T1 = null; // Assert that T1 is the null type.
 
 let T: null;
 // The following should use a variable named 'declare', use a variable named
@@ -19,12 +19,12 @@ T = null;
 // named 'T2':
 declare /*ASI*/
 type T2 = null;
-const t2: T2 = null;
+const t2: T2 = null; // Assert that T2 is the null type.
 
 
 //// [typeAliasDeclareKeywordNewlines.js]
 var declare, type;
-var t1 = null;
+var t1 = null; // Assert that T1 is the null type.
 var T;
 // The following should use a variable named 'declare', use a variable named
 // 'type', and assign to a variable named 'T'.
@@ -34,4 +34,4 @@ T = null;
 // The following should use a variable named 'declare' and declare a type alias
 // named 'T2':
 declare; /*ASI*/
-var t2 = null;
+var t2 = null; // Assert that T2 is the null type.

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.js
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.js
@@ -1,22 +1,37 @@
 //// [tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts] ////
 
 //// [typeAliasDeclareKeywordNewlines.ts]
-var declare, type, T;
+var declare: any, type: any;
 
+// The following is invalid but should declare a type alias named 'T1':
 declare type /*unexpected newline*/
 T1 = null;
+const t1: T1 = null;
 
+let T: null;
+// The following should use a variable named 'declare', use a variable named
+// 'type', and assign to a variable named 'T'.
 declare /*ASI*/
 type /*ASI*/
 T = null;
 
+// The following should use a variable named 'declare' and declare a type alias
+// named 'T2':
 declare /*ASI*/
 type T2 = null;
+const t2: T2 = null;
 
 
 //// [typeAliasDeclareKeywordNewlines.js]
-var declare, type, T;
+var declare, type;
+var t1 = null;
+var T;
+// The following should use a variable named 'declare', use a variable named
+// 'type', and assign to a variable named 'T'.
 declare; /*ASI*/
 type; /*ASI*/
 T = null;
+// The following should use a variable named 'declare' and declare a type alias
+// named 'T2':
 declare; /*ASI*/
+var t2 = null;

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.js
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.js
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts] ////
+
+//// [typeAliasDeclareKeywordNewlines.ts]
+var declare, type, T;
+
+declare type /*unexpected newline*/
+T1 = null;
+
+declare /*ASI*/
+type /*ASI*/
+T = null;
+
+declare /*ASI*/
+type T2 = null;
+
+
+//// [typeAliasDeclareKeywordNewlines.js]
+var declare, type, T;
+declare; /*ASI*/
+type; /*ASI*/
+T = null;
+declare; /*ASI*/

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.symbols
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.symbols
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts] ////
+
+=== typeAliasDeclareKeywordNewlines.ts ===
+var declare: any, type: any;
+>declare : Symbol(declare, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 3))
+>type : Symbol(type, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 17))
+
+// The following is invalid but should declare a type alias named 'T1':
+declare type /*unexpected newline*/
+T1 = null;
+>T1 : Symbol(T1, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 28))
+
+const t1: T1 = null;
+>t1 : Symbol(t1, Decl(typeAliasDeclareKeywordNewlines.ts, 5, 5))
+>T1 : Symbol(T1, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 28))
+
+let T: null;
+>T : Symbol(T, Decl(typeAliasDeclareKeywordNewlines.ts, 7, 3))
+
+// The following should use a variable named 'declare', use a variable named
+// 'type', and assign to a variable named 'T'.
+declare /*ASI*/
+>declare : Symbol(declare, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 3))
+
+type /*ASI*/
+>type : Symbol(type, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 17))
+
+T = null;
+>T : Symbol(T, Decl(typeAliasDeclareKeywordNewlines.ts, 7, 3))
+
+// The following should use a variable named 'declare' and declare a type alias
+// named 'T2':
+declare /*ASI*/
+>declare : Symbol(declare, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 3))
+
+type T2 = null;
+>T2 : Symbol(T2, Decl(typeAliasDeclareKeywordNewlines.ts, 16, 7))
+
+const t2: T2 = null;
+>t2 : Symbol(t2, Decl(typeAliasDeclareKeywordNewlines.ts, 18, 5))
+>T2 : Symbol(T2, Decl(typeAliasDeclareKeywordNewlines.ts, 16, 7))
+

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.symbols
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.symbols
@@ -1,18 +1,18 @@
 //// [tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts] ////
 
 === typeAliasDeclareKeywordNewlines.ts ===
-var declare: any, type: any;
+var declare: string, type: number;
 >declare : Symbol(declare, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 3))
->type : Symbol(type, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 17))
+>type : Symbol(type, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 20))
 
 // The following is invalid but should declare a type alias named 'T1':
 declare type /*unexpected newline*/
 T1 = null;
->T1 : Symbol(T1, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 28))
+>T1 : Symbol(T1, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 34))
 
-const t1: T1 = null;
+const t1: T1 = null; // Assert that T1 is the null type.
 >t1 : Symbol(t1, Decl(typeAliasDeclareKeywordNewlines.ts, 5, 5))
->T1 : Symbol(T1, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 28))
+>T1 : Symbol(T1, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 34))
 
 let T: null;
 >T : Symbol(T, Decl(typeAliasDeclareKeywordNewlines.ts, 7, 3))
@@ -23,7 +23,7 @@ declare /*ASI*/
 >declare : Symbol(declare, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 3))
 
 type /*ASI*/
->type : Symbol(type, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 17))
+>type : Symbol(type, Decl(typeAliasDeclareKeywordNewlines.ts, 0, 20))
 
 T = null;
 >T : Symbol(T, Decl(typeAliasDeclareKeywordNewlines.ts, 7, 3))
@@ -36,7 +36,7 @@ declare /*ASI*/
 type T2 = null;
 >T2 : Symbol(T2, Decl(typeAliasDeclareKeywordNewlines.ts, 16, 7))
 
-const t2: T2 = null;
+const t2: T2 = null; // Assert that T2 is the null type.
 >t2 : Symbol(t2, Decl(typeAliasDeclareKeywordNewlines.ts, 18, 5))
 >T2 : Symbol(T2, Decl(typeAliasDeclareKeywordNewlines.ts, 16, 7))
 

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.types
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.types
@@ -1,16 +1,16 @@
 //// [tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts] ////
 
 === typeAliasDeclareKeywordNewlines.ts ===
-var declare: any, type: any;
->declare : any
->type : any
+var declare: string, type: number;
+>declare : string
+>type : number
 
 // The following is invalid but should declare a type alias named 'T1':
 declare type /*unexpected newline*/
 T1 = null;
 >T1 : null
 
-const t1: T1 = null;
+const t1: T1 = null; // Assert that T1 is the null type.
 >t1 : null
 
 let T: null;
@@ -19,10 +19,10 @@ let T: null;
 // The following should use a variable named 'declare', use a variable named
 // 'type', and assign to a variable named 'T'.
 declare /*ASI*/
->declare : any
+>declare : string
 
 type /*ASI*/
->type : any
+>type : number
 
 T = null;
 >T = null : null
@@ -31,11 +31,11 @@ T = null;
 // The following should use a variable named 'declare' and declare a type alias
 // named 'T2':
 declare /*ASI*/
->declare : any
+>declare : string
 
 type T2 = null;
 >T2 : null
 
-const t2: T2 = null;
+const t2: T2 = null; // Assert that T2 is the null type.
 >t2 : null
 

--- a/tests/baselines/reference/typeAliasDeclareKeywordNewlines.types
+++ b/tests/baselines/reference/typeAliasDeclareKeywordNewlines.types
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts] ////
+
+=== typeAliasDeclareKeywordNewlines.ts ===
+var declare: any, type: any;
+>declare : any
+>type : any
+
+// The following is invalid but should declare a type alias named 'T1':
+declare type /*unexpected newline*/
+T1 = null;
+>T1 : null
+
+const t1: T1 = null;
+>t1 : null
+
+let T: null;
+>T : null
+
+// The following should use a variable named 'declare', use a variable named
+// 'type', and assign to a variable named 'T'.
+declare /*ASI*/
+>declare : any
+
+type /*ASI*/
+>type : any
+
+T = null;
+>T = null : null
+>T : null
+
+// The following should use a variable named 'declare' and declare a type alias
+// named 'T2':
+declare /*ASI*/
+>declare : any
+
+type T2 = null;
+>T2 : null
+
+const t2: T2 = null;
+>t2 : null
+

--- a/tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts
+++ b/tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts
@@ -1,12 +1,19 @@
-// @noTypesAndSymbols: true
-var declare, type, T;
+var declare: any, type: any;
 
+// The following is invalid but should declare a type alias named 'T1':
 declare type /*unexpected newline*/
 T1 = null;
+const t1: T1 = null;
 
+let T: null;
+// The following should use a variable named 'declare', use a variable named
+// 'type', and assign to a variable named 'T'.
 declare /*ASI*/
 type /*ASI*/
 T = null;
 
+// The following should use a variable named 'declare' and declare a type alias
+// named 'T2':
 declare /*ASI*/
 type T2 = null;
+const t2: T2 = null;

--- a/tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts
+++ b/tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts
@@ -1,0 +1,12 @@
+// @noTypesAndSymbols: true
+var declare, type, T;
+
+declare type /*unexpected newline*/
+T1 = null;
+
+declare /*ASI*/
+type /*ASI*/
+T = null;
+
+declare /*ASI*/
+type T2 = null;

--- a/tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts
+++ b/tests/cases/compiler/typeAliasDeclareKeywordNewlines.ts
@@ -1,9 +1,9 @@
-var declare: any, type: any;
+var declare: string, type: number;
 
 // The following is invalid but should declare a type alias named 'T1':
 declare type /*unexpected newline*/
 T1 = null;
-const t1: T1 = null;
+const t1: T1 = null; // Assert that T1 is the null type.
 
 let T: null;
 // The following should use a variable named 'declare', use a variable named
@@ -16,4 +16,4 @@ T = null;
 // named 'T2':
 declare /*ASI*/
 type T2 = null;
-const t2: T2 = null;
+const t2: T2 = null; // Assert that T2 is the null type.


### PR DESCRIPTION
The following TypeScript code does not report a diagnostic. Instead, the TypeScript copmiler parses the code as if ASI was applied between two tokens on the same line:

    var declare, type, T;

    declare /*ASI*/ type /*ASI*/
    T = null;

I think this behavior is confusing. TypeScript v4.3.5 used to report a diagnostic for this code, which I think is better than the current behavior of allowing this code without any diagnostic.

Instead of performing ASI between 'declare' and 'type', report a diagnostic telling the user that a newline shouldn't be written after 'type'.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54760
