### PR TITLE
Fixed baselines that were comitted using the old format

### DIFF
--- a/tests/baselines/reference/jsdocThisType.symbols
+++ b/tests/baselines/reference/jsdocThisType.symbols
@@ -1,3 +1,5 @@
+//// [tests/cases/conformance/jsdoc/jsdocThisType.ts] ////
+
 === /types.d.ts ===
 export interface Foo {
 >Foo : Symbol(Foo, Decl(types.d.ts, 0, 0))

--- a/tests/baselines/reference/jsdocThisType.types
+++ b/tests/baselines/reference/jsdocThisType.types
@@ -1,3 +1,5 @@
+//// [tests/cases/conformance/jsdoc/jsdocThisType.ts] ////
+
 === /types.d.ts ===
 export interface Foo {
     foo: () => void;


### PR DESCRIPTION
This should fix tests on `main`. https://github.com/microsoft/TypeScript/pull/54516 got merged without updating the baseline to the new format.