### PR TITLE
Fix newlines in PR bot reply

### DIFF
--- a/.github/workflows/pr-modified-files.yml
+++ b/.github/workflows/pr-modified-files.yml
@@ -125,7 +125,8 @@ jobs:
             MESSAGE="Looks like you're introducing a change to the public API surface area."
             MESSAGE+=" If this includes breaking changes, please document them"
             MESSAGE+=" [on our wiki's API Breaking Changes page](https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes)."
-            MESSAGE+="\n\nAlso, please make sure @DanielRosenwasser and @RyanCavanaugh are aware of the changes, just as a heads up."
+            MESSAGE+=$'\n\n'
+            MESSAGE+="Also, please make sure @DanielRosenwasser and @RyanCavanaugh are aware of the changes, just as a heads up."
 
             if ./already_commented.sh "Looks like you're introducing a change to the public API surface area."; then
               echo "Already commented."


### PR DESCRIPTION
I tested these string concats... in zsh, not realizing that bash would not behave the same way. Fix this by putting the newlines into a `$''` string which does support escaping.

https://github.com/microsoft/TypeScript/pull/54788#issuecomment-1610236558