### PR TITLE
Bugfix/union excess property check

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20902,10 +20902,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return false;
                     }
                 }
-                if (reportErrors) {
-                    const undecidedProperties = [...excessProperties].filter((p: any) => assignableProperties.has(p)).join(", ").toString();
-                    reportError(Diagnostics.Excess_properties_detected_in_Object_literal_0_combination_of_properties_1_make_type_2_undeducible, typeToString(source), undecidedProperties, typeToString(excessPropertyTarget));
-                }
             }
             for (const prop of getPropertiesOfType(source)) {
                 if (assignableProperties.has(prop)) {
@@ -20971,6 +20967,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return true;
                     }
                 }
+            }
+            const undecidedProperties = [...excessProperties].filter((p: any) => assignableProperties.has(p));
+            if (undecidedProperties.length) {
+                if (reportErrors) {
+                    reportError(Diagnostics.Properties_1_can_t_be_assigned_to_any_type_in_union_2_and_make_0_unassignable, typeToString(source), undecidedProperties.join(", "), typeToString(excessPropertyTarget));
+                }
+                return true;
             }
             return false;
         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3659,6 +3659,10 @@
         "category": "Error",
         "code": 2854
     },
+    "Excess properties detected in Object literal '{0}' combination of properties '{1}' make type '{2}' undeducible": {
+        "category": "Error",
+        "code": 2855
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3659,7 +3659,7 @@
         "category": "Error",
         "code": 2854
     },
-    "Excess properties detected in Object literal '{0}' combination of properties '{1}' make type '{2}' undeducible": {
+    "Properties '{1}' can't be assigned to any type in union '{2}' and make '{0}' unassignable": {
         "category": "Error",
         "code": 2855
     },

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.errors.txt
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.errors.txt
@@ -1,10 +1,14 @@
-unionTypeExcessPropertyCheck.ts(10,9): error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'AC'.
+unionTypeExcessPropertyCheck.ts(11,9): error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'AC'.
   Object literal may only specify known properties, and 'b' does not exist in type 'AC'.
-unionTypeExcessPropertyCheck.ts(15,9): error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'B'.
+unionTypeExcessPropertyCheck.ts(17,9): error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'B'.
   Object literal may only specify known properties, and 'c' does not exist in type 'B'.
+unionTypeExcessPropertyCheck.ts(27,5): error TS2322: Type '{ b: string; x: string; }' is not assignable to type 'AC | B'.
+  Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
+unionTypeExcessPropertyCheck.ts(33,5): error TS2322: Type '{ a: string; c: string; x: string; }' is not assignable to type 'AC | B'.
+  Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
 
 
-==== unionTypeExcessPropertyCheck.ts (2 errors) ====
+==== unionTypeExcessPropertyCheck.ts (4 errors) ====
     type AC = {
         a: string, 
         c: string
@@ -13,21 +17,42 @@ unionTypeExcessPropertyCheck.ts(15,9): error TS2322: Type '{ b: string; c: strin
         b: string
     };
     
-    const ShouldAndDoesFail: AC = {
-            b: 'value for b',
+    // Fails correctly as `b` is not in `AC`
+    const ac_b: AC = {
+            b: '',
             ~
 !!! error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'AC'.
 !!! error TS2322:   Object literal may only specify known properties, and 'b' does not exist in type 'AC'.
-            c: 'value for c'
+            c: ''
     };
-    const ShouldAndDoesFailToo: B = {
-            b: 'value for b',
-            c: 'value for c'
+    // Fails correctly as `c` is not in `B`
+    const b_c: B = {
+            b: '',
+            c: ''
             ~
 !!! error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'B'.
 !!! error TS2322:   Object literal may only specify known properties, and 'c' does not exist in type 'B'.
     };
-    const ShouldFailButWorks: AC|B = {
-            b: 'value for b',
-            c: 'value for c'
+    // Should fail because `c` is not in `B` while `b` is not in `AB`, but works instead
+    const acb_bc: AC|B = {
+            b: '',
+            c: ''
     };
+    // Fails correctly as `x` in in neither `AC` nor `B`
+    const acb_bx: AC|B = {
+        b: '',
+        x: ''
+        ~
+!!! error TS2322: Type '{ b: string; x: string; }' is not assignable to type 'AC | B'.
+!!! error TS2322:   Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
+    };
+    // Fails correctly as `x` in in neither `AC` nor `B`
+    const acb_acx: AC|B = {
+        a: '',
+        c: '',
+        x: ''
+        ~
+!!! error TS2322: Type '{ a: string; c: string; x: string; }' is not assignable to type 'AC | B'.
+!!! error TS2322:   Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
+    };
+    

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.errors.txt
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.errors.txt
@@ -1,0 +1,33 @@
+unionTypeExcessPropertyCheck.ts(10,9): error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'AC'.
+  Object literal may only specify known properties, and 'b' does not exist in type 'AC'.
+unionTypeExcessPropertyCheck.ts(15,9): error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'B'.
+  Object literal may only specify known properties, and 'c' does not exist in type 'B'.
+
+
+==== unionTypeExcessPropertyCheck.ts (2 errors) ====
+    type AC = {
+        a: string, 
+        c: string
+    };
+    type B = {
+        b: string
+    };
+    
+    const ShouldAndDoesFail: AC = {
+            b: 'value for b',
+            ~
+!!! error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'AC'.
+!!! error TS2322:   Object literal may only specify known properties, and 'b' does not exist in type 'AC'.
+            c: 'value for c'
+    };
+    const ShouldAndDoesFailToo: B = {
+            b: 'value for b',
+            c: 'value for c'
+            ~
+!!! error TS2322: Type '{ b: string; c: string; }' is not assignable to type 'B'.
+!!! error TS2322:   Object literal may only specify known properties, and 'c' does not exist in type 'B'.
+    };
+    const ShouldFailButWorks: AC|B = {
+            b: 'value for b',
+            c: 'value for c'
+    };

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.errors.txt
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.errors.txt
@@ -4,8 +4,10 @@ unionTypeExcessPropertyCheck.ts(17,9): error TS2322: Type '{ b: string; c: strin
   Object literal may only specify known properties, and 'c' does not exist in type 'B'.
 unionTypeExcessPropertyCheck.ts(27,5): error TS2322: Type '{ b: string; x: string; }' is not assignable to type 'AC | B'.
   Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
+    Excess properties detected in Object literal '{ b: string; x: string; }' combination of properties '[object Object]' make type 'AC | B' undeducible
 unionTypeExcessPropertyCheck.ts(33,5): error TS2322: Type '{ a: string; c: string; x: string; }' is not assignable to type 'AC | B'.
   Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
+    Excess properties detected in Object literal '{ a: string; c: string; x: string; }' combination of properties '[object Object], [object Object]' make type 'AC | B' undeducible
 
 
 ==== unionTypeExcessPropertyCheck.ts (4 errors) ====
@@ -45,6 +47,7 @@ unionTypeExcessPropertyCheck.ts(33,5): error TS2322: Type '{ a: string; c: strin
         ~
 !!! error TS2322: Type '{ b: string; x: string; }' is not assignable to type 'AC | B'.
 !!! error TS2322:   Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
+!!! error TS2322:     Excess properties detected in Object literal '{ b: string; x: string; }' combination of properties '[object Object]' make type 'AC | B' undeducible
     };
     // Fails correctly as `x` in in neither `AC` nor `B`
     const acb_acx: AC|B = {
@@ -54,5 +57,6 @@ unionTypeExcessPropertyCheck.ts(33,5): error TS2322: Type '{ a: string; c: strin
         ~
 !!! error TS2322: Type '{ a: string; c: string; x: string; }' is not assignable to type 'AC | B'.
 !!! error TS2322:   Object literal may only specify known properties, and 'x' does not exist in type 'AC | B'.
+!!! error TS2322:     Excess properties detected in Object literal '{ a: string; c: string; x: string; }' combination of properties '[object Object], [object Object]' make type 'AC | B' undeducible
     };
     

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.js
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.js
@@ -9,29 +9,58 @@ type B = {
     b: string
 };
 
-const ShouldAndDoesFail: AC = {
-        b: 'value for b',
-        c: 'value for c'
+// Fails correctly as `b` is not in `AC`
+const ac_b: AC = {
+        b: '',
+        c: ''
 };
-const ShouldAndDoesFailToo: B = {
-        b: 'value for b',
-        c: 'value for c'
+// Fails correctly as `c` is not in `B`
+const b_c: B = {
+        b: '',
+        c: ''
 };
-const ShouldFailButWorks: AC|B = {
-        b: 'value for b',
-        c: 'value for c'
+// Should fail because `c` is not in `B` while `b` is not in `AB`, but works instead
+const acb_bc: AC|B = {
+        b: '',
+        c: ''
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_bx: AC|B = {
+    b: '',
+    x: ''
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_acx: AC|B = {
+    a: '',
+    c: '',
+    x: ''
 };
 
+
 //// [unionTypeExcessPropertyCheck.js]
-var ShouldAndDoesFail = {
-    b: 'value for b',
-    c: 'value for c'
+// Fails correctly as `b` is not in `AC`
+var ac_b = {
+    b: '',
+    c: ''
 };
-var ShouldAndDoesFailToo = {
-    b: 'value for b',
-    c: 'value for c'
+// Fails correctly as `c` is not in `B`
+var b_c = {
+    b: '',
+    c: ''
 };
-var ShouldFailButWorks = {
-    b: 'value for b',
-    c: 'value for c'
+// Should fail because `c` is not in `B` while `b` is not in `AB`, but works instead
+var acb_bc = {
+    b: '',
+    c: ''
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+var acb_bx = {
+    b: '',
+    x: ''
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+var acb_acx = {
+    a: '',
+    c: '',
+    x: ''
 };

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.js
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/types/union/unionTypeExcessPropertyCheck.ts] ////
+
+//// [unionTypeExcessPropertyCheck.ts]
+type AC = {
+    a: string, 
+    c: string
+};
+type B = {
+    b: string
+};
+
+const ShouldAndDoesFail: AC = {
+        b: 'value for b',
+        c: 'value for c'
+};
+const ShouldAndDoesFailToo: B = {
+        b: 'value for b',
+        c: 'value for c'
+};
+const ShouldFailButWorks: AC|B = {
+        b: 'value for b',
+        c: 'value for c'
+};
+
+//// [unionTypeExcessPropertyCheck.js]
+var ShouldAndDoesFail = {
+    b: 'value for b',
+    c: 'value for c'
+};
+var ShouldAndDoesFailToo = {
+    b: 'value for b',
+    c: 'value for c'
+};
+var ShouldFailButWorks = {
+    b: 'value for b',
+    c: 'value for c'
+};

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.symbols
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.symbols
@@ -19,37 +19,70 @@ type B = {
 
 };
 
-const ShouldAndDoesFail: AC = {
->ShouldAndDoesFail : Symbol(ShouldAndDoesFail, Decl(unionTypeExcessPropertyCheck.ts, 8, 5))
+// Fails correctly as `b` is not in `AC`
+const ac_b: AC = {
+>ac_b : Symbol(ac_b, Decl(unionTypeExcessPropertyCheck.ts, 9, 5))
 >AC : Symbol(AC, Decl(unionTypeExcessPropertyCheck.ts, 0, 0))
 
-        b: 'value for b',
->b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 8, 31))
+        b: '',
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 9, 18))
 
-        c: 'value for c'
->c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 9, 25))
+        c: ''
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 10, 14))
 
 };
-const ShouldAndDoesFailToo: B = {
->ShouldAndDoesFailToo : Symbol(ShouldAndDoesFailToo, Decl(unionTypeExcessPropertyCheck.ts, 12, 5))
+// Fails correctly as `c` is not in `B`
+const b_c: B = {
+>b_c : Symbol(b_c, Decl(unionTypeExcessPropertyCheck.ts, 14, 5))
 >B : Symbol(B, Decl(unionTypeExcessPropertyCheck.ts, 3, 2))
 
-        b: 'value for b',
->b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 12, 33))
+        b: '',
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 14, 16))
 
-        c: 'value for c'
->c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 13, 25))
+        c: ''
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 15, 14))
 
 };
-const ShouldFailButWorks: AC|B = {
->ShouldFailButWorks : Symbol(ShouldFailButWorks, Decl(unionTypeExcessPropertyCheck.ts, 16, 5))
+// Should fail because `c` is not in `B` while `b` is not in `AB`, but works instead
+const acb_bc: AC|B = {
+>acb_bc : Symbol(acb_bc, Decl(unionTypeExcessPropertyCheck.ts, 19, 5))
 >AC : Symbol(AC, Decl(unionTypeExcessPropertyCheck.ts, 0, 0))
 >B : Symbol(B, Decl(unionTypeExcessPropertyCheck.ts, 3, 2))
 
-        b: 'value for b',
->b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 16, 34))
+        b: '',
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 19, 22))
 
-        c: 'value for c'
->c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 17, 25))
+        c: ''
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 20, 14))
 
 };
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_bx: AC|B = {
+>acb_bx : Symbol(acb_bx, Decl(unionTypeExcessPropertyCheck.ts, 24, 5))
+>AC : Symbol(AC, Decl(unionTypeExcessPropertyCheck.ts, 0, 0))
+>B : Symbol(B, Decl(unionTypeExcessPropertyCheck.ts, 3, 2))
+
+    b: '',
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 24, 22))
+
+    x: ''
+>x : Symbol(x, Decl(unionTypeExcessPropertyCheck.ts, 25, 10))
+
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_acx: AC|B = {
+>acb_acx : Symbol(acb_acx, Decl(unionTypeExcessPropertyCheck.ts, 29, 5))
+>AC : Symbol(AC, Decl(unionTypeExcessPropertyCheck.ts, 0, 0))
+>B : Symbol(B, Decl(unionTypeExcessPropertyCheck.ts, 3, 2))
+
+    a: '',
+>a : Symbol(a, Decl(unionTypeExcessPropertyCheck.ts, 29, 23))
+
+    c: '',
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 30, 10))
+
+    x: ''
+>x : Symbol(x, Decl(unionTypeExcessPropertyCheck.ts, 31, 10))
+
+};
+

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.symbols
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.symbols
@@ -1,0 +1,55 @@
+//// [tests/cases/conformance/types/union/unionTypeExcessPropertyCheck.ts] ////
+
+=== unionTypeExcessPropertyCheck.ts ===
+type AC = {
+>AC : Symbol(AC, Decl(unionTypeExcessPropertyCheck.ts, 0, 0))
+
+    a: string, 
+>a : Symbol(a, Decl(unionTypeExcessPropertyCheck.ts, 0, 11))
+
+    c: string
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 1, 14))
+
+};
+type B = {
+>B : Symbol(B, Decl(unionTypeExcessPropertyCheck.ts, 3, 2))
+
+    b: string
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 4, 10))
+
+};
+
+const ShouldAndDoesFail: AC = {
+>ShouldAndDoesFail : Symbol(ShouldAndDoesFail, Decl(unionTypeExcessPropertyCheck.ts, 8, 5))
+>AC : Symbol(AC, Decl(unionTypeExcessPropertyCheck.ts, 0, 0))
+
+        b: 'value for b',
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 8, 31))
+
+        c: 'value for c'
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 9, 25))
+
+};
+const ShouldAndDoesFailToo: B = {
+>ShouldAndDoesFailToo : Symbol(ShouldAndDoesFailToo, Decl(unionTypeExcessPropertyCheck.ts, 12, 5))
+>B : Symbol(B, Decl(unionTypeExcessPropertyCheck.ts, 3, 2))
+
+        b: 'value for b',
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 12, 33))
+
+        c: 'value for c'
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 13, 25))
+
+};
+const ShouldFailButWorks: AC|B = {
+>ShouldFailButWorks : Symbol(ShouldFailButWorks, Decl(unionTypeExcessPropertyCheck.ts, 16, 5))
+>AC : Symbol(AC, Decl(unionTypeExcessPropertyCheck.ts, 0, 0))
+>B : Symbol(B, Decl(unionTypeExcessPropertyCheck.ts, 3, 2))
+
+        b: 'value for b',
+>b : Symbol(b, Decl(unionTypeExcessPropertyCheck.ts, 16, 34))
+
+        c: 'value for c'
+>c : Symbol(c, Decl(unionTypeExcessPropertyCheck.ts, 17, 25))
+
+};

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.types
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.types
@@ -1,0 +1,60 @@
+//// [tests/cases/conformance/types/union/unionTypeExcessPropertyCheck.ts] ////
+
+=== unionTypeExcessPropertyCheck.ts ===
+type AC = {
+>AC : { a: string; c: string; }
+
+    a: string, 
+>a : string
+
+    c: string
+>c : string
+
+};
+type B = {
+>B : { b: string; }
+
+    b: string
+>b : string
+
+};
+
+const ShouldAndDoesFail: AC = {
+>ShouldAndDoesFail : AC
+>{        b: 'value for b',        c: 'value for c'} : { b: string; c: string; }
+
+        b: 'value for b',
+>b : string
+>'value for b' : "value for b"
+
+        c: 'value for c'
+>c : string
+>'value for c' : "value for c"
+
+};
+const ShouldAndDoesFailToo: B = {
+>ShouldAndDoesFailToo : B
+>{        b: 'value for b',        c: 'value for c'} : { b: string; c: string; }
+
+        b: 'value for b',
+>b : string
+>'value for b' : "value for b"
+
+        c: 'value for c'
+>c : string
+>'value for c' : "value for c"
+
+};
+const ShouldFailButWorks: AC|B = {
+>ShouldFailButWorks : AC | B
+>{        b: 'value for b',        c: 'value for c'} : { b: string; c: string; }
+
+        b: 'value for b',
+>b : string
+>'value for b' : "value for b"
+
+        c: 'value for c'
+>c : string
+>'value for c' : "value for c"
+
+};

--- a/tests/baselines/reference/unionTypeExcessPropertyCheck.types
+++ b/tests/baselines/reference/unionTypeExcessPropertyCheck.types
@@ -19,42 +19,78 @@ type B = {
 
 };
 
-const ShouldAndDoesFail: AC = {
->ShouldAndDoesFail : AC
->{        b: 'value for b',        c: 'value for c'} : { b: string; c: string; }
+// Fails correctly as `b` is not in `AC`
+const ac_b: AC = {
+>ac_b : AC
+>{        b: '',        c: ''} : { b: string; c: string; }
 
-        b: 'value for b',
+        b: '',
 >b : string
->'value for b' : "value for b"
+>'' : ""
 
-        c: 'value for c'
+        c: ''
 >c : string
->'value for c' : "value for c"
+>'' : ""
 
 };
-const ShouldAndDoesFailToo: B = {
->ShouldAndDoesFailToo : B
->{        b: 'value for b',        c: 'value for c'} : { b: string; c: string; }
+// Fails correctly as `c` is not in `B`
+const b_c: B = {
+>b_c : B
+>{        b: '',        c: ''} : { b: string; c: string; }
 
-        b: 'value for b',
+        b: '',
 >b : string
->'value for b' : "value for b"
+>'' : ""
 
-        c: 'value for c'
+        c: ''
 >c : string
->'value for c' : "value for c"
+>'' : ""
 
 };
-const ShouldFailButWorks: AC|B = {
->ShouldFailButWorks : AC | B
->{        b: 'value for b',        c: 'value for c'} : { b: string; c: string; }
+// Should fail because `c` is not in `B` while `b` is not in `AB`, but works instead
+const acb_bc: AC|B = {
+>acb_bc : AC | B
+>{        b: '',        c: ''} : { b: string; c: string; }
 
-        b: 'value for b',
+        b: '',
 >b : string
->'value for b' : "value for b"
+>'' : ""
 
-        c: 'value for c'
+        c: ''
 >c : string
->'value for c' : "value for c"
+>'' : ""
 
 };
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_bx: AC|B = {
+>acb_bx : AC | B
+>{    b: '',    x: ''} : { b: string; x: string; }
+
+    b: '',
+>b : string
+>'' : ""
+
+    x: ''
+>x : string
+>'' : ""
+
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_acx: AC|B = {
+>acb_acx : AC | B
+>{    a: '',    c: '',    x: ''} : { a: string; c: string; x: string; }
+
+    a: '',
+>a : string
+>'' : ""
+
+    c: '',
+>c : string
+>'' : ""
+
+    x: ''
+>x : string
+>'' : ""
+
+};
+

--- a/tests/cases/conformance/types/union/unionTypeExcessPropertyCheck.ts
+++ b/tests/cases/conformance/types/union/unionTypeExcessPropertyCheck.ts
@@ -6,15 +6,29 @@ type B = {
     b: string
 };
 
-const ShouldAndDoesFail: AC = {
-        b: 'value for b',
-        c: 'value for c'
+// Fails correctly as `b` is not in `AC`
+const ac_b: AC = {
+        b: '',
+        c: ''
 };
-const ShouldAndDoesFailToo: B = {
-        b: 'value for b',
-        c: 'value for c'
+// Fails correctly as `c` is not in `B`
+const b_c: B = {
+        b: '',
+        c: ''
 };
-const ShouldFailButWorks: AC|B = {
-        b: 'value for b',
-        c: 'value for c'
+// Should fail because `c` is not in `B` while `b` is not in `AB`, but works instead
+const acb_bc: AC|B = {
+        b: '',
+        c: ''
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_bx: AC|B = {
+    b: '',
+    x: ''
+};
+// Fails correctly as `x` in in neither `AC` nor `B`
+const acb_acx: AC|B = {
+    a: '',
+    c: '',
+    x: ''
 };

--- a/tests/cases/conformance/types/union/unionTypeExcessPropertyCheck.ts
+++ b/tests/cases/conformance/types/union/unionTypeExcessPropertyCheck.ts
@@ -1,0 +1,20 @@
+type AC = {
+    a: string, 
+    c: string
+};
+type B = {
+    b: string
+};
+
+const ShouldAndDoesFail: AC = {
+        b: 'value for b',
+        c: 'value for c'
+};
+const ShouldAndDoesFailToo: B = {
+        b: 'value for b',
+        c: 'value for c'
+};
+const ShouldFailButWorks: AC|B = {
+        b: 'value for b',
+        c: 'value for c'
+};


### PR DESCRIPTION
Fixes #54784

We'd like to improve the behavior of error messages for `Union` types. Currently, the compiler does not detect that object literal `{a: ..., b: ...}` can't be assigned to either type in the union `A|B`:

```typescript
type A = {a:number};
type B = {b:number};

let x: A|B  = {a:0, b:0};
```

There is another #12936 which aims to solve the problem in general.

Please, do not merge yet.