### PR TITLE
Adds a error diagnostic with newlines if either source or target are longer than 30 characters on type is not assignable to type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20597,7 +20597,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             return;
                         }
                     }
-                    message = Diagnostics.Type_0_is_not_assignable_to_type_1;
+                    if (compilerOptions.pretty && useMultilineReportingForTypes(sourceType, targetType)) {
+                        message = Diagnostics.Type_Colon_n_0_n_nis_not_assignable_to_type_Colon_n_1;
+                    }
+                    else {
+                        message = Diagnostics.Type_0_is_not_assignable_to_type_1;
+                    }
                 }
             }
             else if (message === Diagnostics.Argument_of_type_0_is_not_assignable_to_parameter_of_type_1
@@ -20607,6 +20612,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             reportError(message, generalizedSourceType, targetType);
+        }
+
+        function useMultilineReportingForTypes(source: string, target: string) {
+            return source.length > 30 || target.length > 30;
         }
 
         function tryElaborateErrorsForPrimitivesAndObjects(source: Type, target: Type) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3659,7 +3659,7 @@
         "category": "Error",
         "code": 2854
     },
-    "Type:\\n{0}\\n\\nis not assignable to type:\\n.{1}": {
+    "Type:\\n{0}\\n\\nis not assignable to type:\\n{1}": {
         "category": "Error",
         "code": 2855
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3659,6 +3659,11 @@
         "category": "Error",
         "code": 2854
     },
+    "Type:\\n{0}\\n\\nis not assignable to type:\\n.{1}": {
+        "category": "Error",
+        "code": 2855
+    },
+
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/newlinesOnLongMessagesWithPretty.errors.txt
+++ b/tests/baselines/reference/newlinesOnLongMessagesWithPretty.errors.txt
@@ -1,0 +1,51 @@
+[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m6[0m:[93m1[0m - [91merror[0m[90m TS2855: [0mType:\nstring\n\nis not assignable to type:\n.{ b: { c: { e: { f: number; }; }; }; }
+
+[7m6[0m a = b
+[7m [0m [91m~[0m
+[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m8[0m:[93m1[0m - [91merror[0m[90m TS2855: [0mType:\n{ b: { c: { e: { f: number; }; }; }; }\n\nis not assignable to type:\n.string
+
+[7m8[0m b = a
+[7m [0m [91m~[0m
+[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m11[0m:[93m22[0m - [91merror[0m[90m TS2322: [0mType '{}' is not assignable to type 'number'.
+
+[7m11[0m a = { b: { c: { e: { f: {} } } } }
+[7m  [0m [91m                     ~[0m
+
+  [96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m2[0m:[93m26[0m
+    [7m2[0m let a = { b: { c: { e: { f: 123 } } } };
+    [7m [0m [96m                         ~~~~~~[0m
+    The expected type comes from property 'f' which is declared here on type '{ f: number; }'
+[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m14[0m:[93m1[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m14[0m b = 123123
+[7m  [0m [91m~[0m
+
+
+==== newlinesOnLongMessagesWithPretty.ts (4 errors) ====
+    // a is 31 chars long
+    let a = { b: { c: { e: { f: 123 } } } };
+    let b = "hello"
+    
+    // 'a' here is long enough to count in the source as a newline
+    a = b
+    ~
+!!! error TS2855: Type:\nstring\n\nis not assignable to type:\n.{ b: { c: { e: { f: number; }; }; }; }
+    // 'a' here is long enough to count in the target as a newline
+    b = a
+    ~
+!!! error TS2855: Type:\n{ b: { c: { e: { f: number; }; }; }; }\n\nis not assignable to type:\n.string
+    
+    // This won't trigger it because we only show the relation instead
+    a = { b: { c: { e: { f: {} } } } }
+                         ~
+!!! error TS2322: Type '{}' is not assignable to type 'number'.
+!!! related TS6500 newlinesOnLongMessagesWithPretty.ts:2:26: The expected type comes from property 'f' which is declared here on type '{ f: number; }'
+    
+    // No newlines here because they're both short
+    b = 123123
+    ~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+    
+    
+Found 4 errors in the same file, starting at: newlinesOnLongMessagesWithPretty.ts[90m:6[0m
+

--- a/tests/baselines/reference/newlinesOnLongMessagesWithPretty.errors.txt
+++ b/tests/baselines/reference/newlinesOnLongMessagesWithPretty.errors.txt
@@ -1,8 +1,8 @@
-[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m6[0m:[93m1[0m - [91merror[0m[90m TS2855: [0mType:\nstring\n\nis not assignable to type:\n.{ b: { c: { e: { f: number; }; }; }; }
+[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m6[0m:[93m1[0m - [91merror[0m[90m TS2855: [0mType:\nstring\n\nis not assignable to type:\n{ b: { c: { e: { f: number; }; }; }; }
 
 [7m6[0m a = b
 [7m [0m [91m~[0m
-[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m8[0m:[93m1[0m - [91merror[0m[90m TS2855: [0mType:\n{ b: { c: { e: { f: number; }; }; }; }\n\nis not assignable to type:\n.string
+[96mnewlinesOnLongMessagesWithPretty.ts[0m:[93m8[0m:[93m1[0m - [91merror[0m[90m TS2855: [0mType:\n{ b: { c: { e: { f: number; }; }; }; }\n\nis not assignable to type:\nstring
 
 [7m8[0m b = a
 [7m [0m [91m~[0m
@@ -29,11 +29,11 @@
     // 'a' here is long enough to count in the source as a newline
     a = b
     ~
-!!! error TS2855: Type:\nstring\n\nis not assignable to type:\n.{ b: { c: { e: { f: number; }; }; }; }
+!!! error TS2855: Type:\nstring\n\nis not assignable to type:\n{ b: { c: { e: { f: number; }; }; }; }
     // 'a' here is long enough to count in the target as a newline
     b = a
     ~
-!!! error TS2855: Type:\n{ b: { c: { e: { f: number; }; }; }; }\n\nis not assignable to type:\n.string
+!!! error TS2855: Type:\n{ b: { c: { e: { f: number; }; }; }; }\n\nis not assignable to type:\nstring
     
     // This won't trigger it because we only show the relation instead
     a = { b: { c: { e: { f: {} } } } }

--- a/tests/baselines/reference/newlinesOnLongMessagesWithPretty.js
+++ b/tests/baselines/reference/newlinesOnLongMessagesWithPretty.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/newlinesOnLongMessagesWithPretty.ts] ////
+
+//// [newlinesOnLongMessagesWithPretty.ts]
+// a is 31 chars long
+let a = { b: { c: { e: { f: 123 } } } };
+let b = "hello"
+
+// 'a' here is long enough to count in the source as a newline
+a = b
+// 'a' here is long enough to count in the target as a newline
+b = a
+
+// This won't trigger it because we only show the relation instead
+a = { b: { c: { e: { f: {} } } } }
+
+// No newlines here because they're both short
+b = 123123
+
+
+
+//// [newlinesOnLongMessagesWithPretty.js]
+// a is 31 chars long
+var a = { b: { c: { e: { f: 123 } } } };
+var b = "hello";
+// 'a' here is long enough to count in the source as a newline
+a = b;
+// 'a' here is long enough to count in the target as a newline
+b = a;
+// This won't trigger it because we only show the relation instead
+a = { b: { c: { e: { f: {} } } } };
+// No newlines here because they're both short
+b = 123123;

--- a/tests/baselines/reference/newlinesOnLongMessagesWithPretty.symbols
+++ b/tests/baselines/reference/newlinesOnLongMessagesWithPretty.symbols
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/newlinesOnLongMessagesWithPretty.ts] ////
+
+=== newlinesOnLongMessagesWithPretty.ts ===
+// a is 31 chars long
+let a = { b: { c: { e: { f: 123 } } } };
+>a : Symbol(a, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 3))
+>b : Symbol(b, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 9))
+>c : Symbol(c, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 14))
+>e : Symbol(e, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 19))
+>f : Symbol(f, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 24))
+
+let b = "hello"
+>b : Symbol(b, Decl(newlinesOnLongMessagesWithPretty.ts, 2, 3))
+
+// 'a' here is long enough to count in the source as a newline
+a = b
+>a : Symbol(a, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 3))
+>b : Symbol(b, Decl(newlinesOnLongMessagesWithPretty.ts, 2, 3))
+
+// 'a' here is long enough to count in the target as a newline
+b = a
+>b : Symbol(b, Decl(newlinesOnLongMessagesWithPretty.ts, 2, 3))
+>a : Symbol(a, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 3))
+
+// This won't trigger it because we only show the relation instead
+a = { b: { c: { e: { f: {} } } } }
+>a : Symbol(a, Decl(newlinesOnLongMessagesWithPretty.ts, 1, 3))
+>b : Symbol(b, Decl(newlinesOnLongMessagesWithPretty.ts, 10, 5))
+>c : Symbol(c, Decl(newlinesOnLongMessagesWithPretty.ts, 10, 10))
+>e : Symbol(e, Decl(newlinesOnLongMessagesWithPretty.ts, 10, 15))
+>f : Symbol(f, Decl(newlinesOnLongMessagesWithPretty.ts, 10, 20))
+
+// No newlines here because they're both short
+b = 123123
+>b : Symbol(b, Decl(newlinesOnLongMessagesWithPretty.ts, 2, 3))
+
+

--- a/tests/baselines/reference/newlinesOnLongMessagesWithPretty.types
+++ b/tests/baselines/reference/newlinesOnLongMessagesWithPretty.types
@@ -1,0 +1,53 @@
+//// [tests/cases/compiler/newlinesOnLongMessagesWithPretty.ts] ////
+
+=== newlinesOnLongMessagesWithPretty.ts ===
+// a is 31 chars long
+let a = { b: { c: { e: { f: 123 } } } };
+>a : { b: { c: { e: { f: number; }; }; }; }
+>{ b: { c: { e: { f: 123 } } } } : { b: { c: { e: { f: number; }; }; }; }
+>b : { c: { e: { f: number; }; }; }
+>{ c: { e: { f: 123 } } } : { c: { e: { f: number; }; }; }
+>c : { e: { f: number; }; }
+>{ e: { f: 123 } } : { e: { f: number; }; }
+>e : { f: number; }
+>{ f: 123 } : { f: number; }
+>f : number
+>123 : 123
+
+let b = "hello"
+>b : string
+>"hello" : "hello"
+
+// 'a' here is long enough to count in the source as a newline
+a = b
+>a = b : string
+>a : { b: { c: { e: { f: number; }; }; }; }
+>b : string
+
+// 'a' here is long enough to count in the target as a newline
+b = a
+>b = a : { b: { c: { e: { f: number; }; }; }; }
+>b : string
+>a : { b: { c: { e: { f: number; }; }; }; }
+
+// This won't trigger it because we only show the relation instead
+a = { b: { c: { e: { f: {} } } } }
+>a = { b: { c: { e: { f: {} } } } } : { b: { c: { e: { f: {}; }; }; }; }
+>a : { b: { c: { e: { f: number; }; }; }; }
+>{ b: { c: { e: { f: {} } } } } : { b: { c: { e: { f: {}; }; }; }; }
+>b : { c: { e: { f: {}; }; }; }
+>{ c: { e: { f: {} } } } : { c: { e: { f: {}; }; }; }
+>c : { e: { f: {}; }; }
+>{ e: { f: {} } } : { e: { f: {}; }; }
+>e : { f: {}; }
+>{ f: {} } : { f: {}; }
+>f : {}
+>{} : {}
+
+// No newlines here because they're both short
+b = 123123
+>b = 123123 : 123123
+>b : string
+>123123 : 123123
+
+

--- a/tests/cases/compiler/newlinesOnLongMessagesWithPretty.ts
+++ b/tests/cases/compiler/newlinesOnLongMessagesWithPretty.ts
@@ -1,0 +1,17 @@
+// @pretty: true
+
+// a is 31 chars long
+let a = { b: { c: { e: { f: 123 } } } };
+let b = "hello"
+
+// 'a' here is long enough to count in the source as a newline
+a = b
+// 'a' here is long enough to count in the target as a newline
+b = a
+
+// This won't trigger it because we only show the relation instead
+a = { b: { c: { e: { f: {} } } } }
+
+// No newlines here because they're both short
+b = 123123
+


### PR DESCRIPTION
Fixes #45896 - this keeps the formatting I recommended in that issue, but that doesn't have to be the answer:

```
// a is 31 chars long
let a = { b: { c: { e: { f: 123 } } } };
let b = "hello"

b=a
```

Gives:
```
Type:
{ b: { c: { e: { f: number; }; }; }; }

is not assignable to type:
string
```

Which is the simplest version of this PR via diagnostics, there's space here for a few answers which I can look at (having 3 diags, 1 with newlines for source, 1 with newlines for target, 1 with newlines for both) 