### PR TITLE
[WIP] fix(54655): Regression: bug in emitted declarations involving branded types since 5.1

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18995,7 +18995,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function instantiateAnonymousType(type: AnonymousType, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]): AnonymousType {
-        const result = createObjectType(type.objectFlags & ~(ObjectFlags.CouldContainTypeVariablesComputed | ObjectFlags.CouldContainTypeVariables) | ObjectFlags.Instantiated, type.symbol) as AnonymousType;
+        const result = createObjectType(type.objectFlags | ObjectFlags.Instantiated, type.symbol) as AnonymousType;
         if (type.objectFlags & ObjectFlags.Mapped) {
             (result as MappedType).declaration = (type as MappedType).declaration;
             // C.f. instantiateSignature

--- a/tests/baselines/reference/carryingForwardTypeVariableContainment.js
+++ b/tests/baselines/reference/carryingForwardTypeVariableContainment.js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/types/typeParameters/typeParameterLists/carryingForwardTypeVariableContainment.ts] ////
+
+//// [a.ts]
+export type Brand<Base, Branding, ReservedName extends string = "__type__"> =
+    Base & { [K in ReservedName]: Branding } & { __witness__: Base };
+export type BoundedInteger<LowerBound extends number, UpperBound extends number> =
+    Brand<number, "BoundedInteger">;
+export const toBoundedInteger =
+    <LowerBound extends number, UpperBound extends number>(bounds: { lowerBound: LowerBound; upperBound: UpperBound; }) =>
+        (n: number): BoundedInteger<LowerBound, UpperBound> => ({} as any);
+
+//// [b.ts]
+export type LexicalCommand<TPayload> = Record<string, never>;
+export type InsertTextPayload = Readonly<{ text: string }>;
+function createCommand<T>(): LexicalCommand<T> {
+    return { };
+}
+export const INSERT_TEXT_COMMAND = createCommand();
+
+
+
+
+//// [a.d.ts]
+export type Brand<Base, Branding, ReservedName extends string = "__type__"> = Base & {
+    [K in ReservedName]: Branding;
+} & {
+    __witness__: Base;
+};
+export type BoundedInteger<LowerBound extends number, UpperBound extends number> = Brand<number, "BoundedInteger">;
+export declare const toBoundedInteger: <LowerBound extends number, UpperBound extends number>(bounds: {
+    lowerBound: LowerBound;
+    upperBound: UpperBound;
+}) => (n: number) => BoundedInteger<LowerBound, UpperBound>;
+//// [b.d.ts]
+export type LexicalCommand<TPayload> = Record<string, never>;
+export type InsertTextPayload = Readonly<{
+    text: string;
+}>;
+export declare const INSERT_TEXT_COMMAND: LexicalCommand<unknown>;

--- a/tests/baselines/reference/carryingForwardTypeVariableContainment.symbols
+++ b/tests/baselines/reference/carryingForwardTypeVariableContainment.symbols
@@ -1,0 +1,66 @@
+//// [tests/cases/conformance/types/typeParameters/typeParameterLists/carryingForwardTypeVariableContainment.ts] ////
+
+=== /a.ts ===
+export type Brand<Base, Branding, ReservedName extends string = "__type__"> =
+>Brand : Symbol(Brand, Decl(a.ts, 0, 0))
+>Base : Symbol(Base, Decl(a.ts, 0, 18))
+>Branding : Symbol(Branding, Decl(a.ts, 0, 23))
+>ReservedName : Symbol(ReservedName, Decl(a.ts, 0, 33))
+
+    Base & { [K in ReservedName]: Branding } & { __witness__: Base };
+>Base : Symbol(Base, Decl(a.ts, 0, 18))
+>K : Symbol(K, Decl(a.ts, 1, 14))
+>ReservedName : Symbol(ReservedName, Decl(a.ts, 0, 33))
+>Branding : Symbol(Branding, Decl(a.ts, 0, 23))
+>__witness__ : Symbol(__witness__, Decl(a.ts, 1, 48))
+>Base : Symbol(Base, Decl(a.ts, 0, 18))
+
+export type BoundedInteger<LowerBound extends number, UpperBound extends number> =
+>BoundedInteger : Symbol(BoundedInteger, Decl(a.ts, 1, 69))
+>LowerBound : Symbol(LowerBound, Decl(a.ts, 2, 27))
+>UpperBound : Symbol(UpperBound, Decl(a.ts, 2, 53))
+
+    Brand<number, "BoundedInteger">;
+>Brand : Symbol(Brand, Decl(a.ts, 0, 0))
+
+export const toBoundedInteger =
+>toBoundedInteger : Symbol(toBoundedInteger, Decl(a.ts, 4, 12))
+
+    <LowerBound extends number, UpperBound extends number>(bounds: { lowerBound: LowerBound; upperBound: UpperBound; }) =>
+>LowerBound : Symbol(LowerBound, Decl(a.ts, 5, 5))
+>UpperBound : Symbol(UpperBound, Decl(a.ts, 5, 31))
+>bounds : Symbol(bounds, Decl(a.ts, 5, 59))
+>lowerBound : Symbol(lowerBound, Decl(a.ts, 5, 68))
+>LowerBound : Symbol(LowerBound, Decl(a.ts, 5, 5))
+>upperBound : Symbol(upperBound, Decl(a.ts, 5, 92))
+>UpperBound : Symbol(UpperBound, Decl(a.ts, 5, 31))
+
+        (n: number): BoundedInteger<LowerBound, UpperBound> => ({} as any);
+>n : Symbol(n, Decl(a.ts, 6, 9))
+>BoundedInteger : Symbol(BoundedInteger, Decl(a.ts, 1, 69))
+>LowerBound : Symbol(LowerBound, Decl(a.ts, 5, 5))
+>UpperBound : Symbol(UpperBound, Decl(a.ts, 5, 31))
+
+=== /b.ts ===
+export type LexicalCommand<TPayload> = Record<string, never>;
+>LexicalCommand : Symbol(LexicalCommand, Decl(b.ts, 0, 0))
+>TPayload : Symbol(TPayload, Decl(b.ts, 0, 27))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+export type InsertTextPayload = Readonly<{ text: string }>;
+>InsertTextPayload : Symbol(InsertTextPayload, Decl(b.ts, 0, 61))
+>Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
+>text : Symbol(text, Decl(b.ts, 1, 42))
+
+function createCommand<T>(): LexicalCommand<T> {
+>createCommand : Symbol(createCommand, Decl(b.ts, 1, 59))
+>T : Symbol(T, Decl(b.ts, 2, 23))
+>LexicalCommand : Symbol(LexicalCommand, Decl(b.ts, 0, 0))
+>T : Symbol(T, Decl(b.ts, 2, 23))
+
+    return { };
+}
+export const INSERT_TEXT_COMMAND = createCommand();
+>INSERT_TEXT_COMMAND : Symbol(INSERT_TEXT_COMMAND, Decl(b.ts, 5, 12))
+>createCommand : Symbol(createCommand, Decl(b.ts, 1, 59))
+

--- a/tests/baselines/reference/carryingForwardTypeVariableContainment.types
+++ b/tests/baselines/reference/carryingForwardTypeVariableContainment.types
@@ -1,0 +1,48 @@
+//// [tests/cases/conformance/types/typeParameters/typeParameterLists/carryingForwardTypeVariableContainment.ts] ////
+
+=== /a.ts ===
+export type Brand<Base, Branding, ReservedName extends string = "__type__"> =
+>Brand : Brand<Base, Branding, ReservedName>
+
+    Base & { [K in ReservedName]: Branding } & { __witness__: Base };
+>__witness__ : Base
+
+export type BoundedInteger<LowerBound extends number, UpperBound extends number> =
+>BoundedInteger : BoundedInteger<LowerBound, UpperBound>
+
+    Brand<number, "BoundedInteger">;
+export const toBoundedInteger =
+>toBoundedInteger : <LowerBound extends number, UpperBound extends number>(bounds: { lowerBound: LowerBound; upperBound: UpperBound; }) => (n: number) => BoundedInteger<LowerBound, UpperBound>
+
+    <LowerBound extends number, UpperBound extends number>(bounds: { lowerBound: LowerBound; upperBound: UpperBound; }) =>
+><LowerBound extends number, UpperBound extends number>(bounds: { lowerBound: LowerBound; upperBound: UpperBound; }) =>        (n: number): BoundedInteger<LowerBound, UpperBound> => ({} as any) : <LowerBound extends number, UpperBound extends number>(bounds: { lowerBound: LowerBound; upperBound: UpperBound; }) => (n: number) => BoundedInteger<LowerBound, UpperBound>
+>bounds : { lowerBound: LowerBound; upperBound: UpperBound; }
+>lowerBound : LowerBound
+>upperBound : UpperBound
+
+        (n: number): BoundedInteger<LowerBound, UpperBound> => ({} as any);
+>(n: number): BoundedInteger<LowerBound, UpperBound> => ({} as any) : (n: number) => BoundedInteger<LowerBound, UpperBound>
+>n : number
+>({} as any) : any
+>{} as any : any
+>{} : {}
+
+=== /b.ts ===
+export type LexicalCommand<TPayload> = Record<string, never>;
+>LexicalCommand : LexicalCommand<TPayload>
+
+export type InsertTextPayload = Readonly<{ text: string }>;
+>InsertTextPayload : Readonly<{ text: string; }>
+>text : string
+
+function createCommand<T>(): LexicalCommand<T> {
+>createCommand : <T>() => LexicalCommand<T>
+
+    return { };
+>{ } : {}
+}
+export const INSERT_TEXT_COMMAND = createCommand();
+>INSERT_TEXT_COMMAND : LexicalCommand<unknown>
+>createCommand() : LexicalCommand<unknown>
+>createCommand : <T>() => LexicalCommand<T>
+

--- a/tests/cases/conformance/types/typeParameters/typeParameterLists/carryingForwardTypeVariableContainment.ts
+++ b/tests/cases/conformance/types/typeParameters/typeParameterLists/carryingForwardTypeVariableContainment.ts
@@ -1,0 +1,19 @@
+// @declaration: true
+// @emitDeclarationOnly: true
+
+// @filename: /a.ts
+export type Brand<Base, Branding, ReservedName extends string = "__type__"> =
+    Base & { [K in ReservedName]: Branding } & { __witness__: Base };
+export type BoundedInteger<LowerBound extends number, UpperBound extends number> =
+    Brand<number, "BoundedInteger">;
+export const toBoundedInteger =
+    <LowerBound extends number, UpperBound extends number>(bounds: { lowerBound: LowerBound; upperBound: UpperBound; }) =>
+        (n: number): BoundedInteger<LowerBound, UpperBound> => ({} as any);
+
+// @filename: /b.ts
+export type LexicalCommand<TPayload> = Record<string, never>;
+export type InsertTextPayload = Readonly<{ text: string }>;
+function createCommand<T>(): LexicalCommand<T> {
+    return { };
+}
+export const INSERT_TEXT_COMMAND = createCommand();


### PR DESCRIPTION
Fixes #54655
Fixes #54805

Both of them are related to #53246 / #54538. Since there are no tests available for both PRs, I am uncertain whether it is necessary to exclude `ObjectFlags.CouldContainTypeVariablesComputed` / `ObjectFlags.CouldContainTypeVariables` for all anonymous type instantiations...

/cc @weswigham @ahejlsberg 