### PR TITLE
Emit `@overload` comments on generated overloads in.d.ts

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1257,8 +1257,8 @@ export const enum CheckMode {
     IsForSignatureHelp = 1 << 4,                    // Call resolution for purposes of signature help
     IsForStringLiteralArgumentCompletions = 1 << 5, // Do not infer from the argument currently being typed
     RestBindingElement = 1 << 6,                    // Checking a type that is going to be used to determine the type of a rest binding element
-                                                    //   e.g. in `const { a, ...rest } = foo`, when checking the type of `foo` to determine the type of `rest`,
-                                                    //   we need to preserve generic types instead of substituting them for constraints
+    //   e.g. in `const { a, ...rest } = foo`, when checking the type of `foo` to determine the type of `rest`,
+    //   we need to preserve generic types instead of substituting them for constraints
     TypeOnly = 1 << 7,                              // Called from getTypeOfExpression, diagnostics may be omitted
 }
 
@@ -2352,7 +2352,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
     }
     function errorOrSuggestion(isError: boolean, location: Node, message: DiagnosticMessage | DiagnosticMessageChain, ...args: DiagnosticArguments): void {
-         // Pseudo-synthesized input node
+        // Pseudo-synthesized input node
         if (location.pos < 0 || location.end < 0) {
             if (!isError) {
                 return; // Drop suggestions (we have no span to suggest on)
@@ -2534,7 +2534,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const isEitherBlockScoped = !!(target.flags & SymbolFlags.BlockScopedVariable || source.flags & SymbolFlags.BlockScopedVariable);
             const message = isEitherEnum ? Diagnostics.Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations
                 : isEitherBlockScoped ? Diagnostics.Cannot_redeclare_block_scoped_variable_0
-                : Diagnostics.Duplicate_identifier_0;
+                    : Diagnostics.Duplicate_identifier_0;
             const sourceSymbolFile = source.declarations && getSourceFileOfNode(source.declarations[0]);
             const targetSymbolFile = target.declarations && getSourceFileOfNode(target.declarations[0]);
 
@@ -2784,8 +2784,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             else if (isParameterPropertyDeclaration(declaration, declaration.parent)) {
                 // foo = this.bar is illegal in esnext+useDefineForClassFields when bar is a parameter property
                 return !(getEmitScriptTarget(compilerOptions) === ScriptTarget.ESNext && useDefineForClassFields
-                         && getContainingClass(declaration) === getContainingClass(usage)
-                         && isUsedInFunctionOrInstanceProperty(usage, declaration));
+                    && getContainingClass(declaration) === getContainingClass(usage)
+                    && isUsedInFunctionOrInstanceProperty(usage, declaration));
             }
             return true;
         }
@@ -2907,8 +2907,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // even when stopping at any property declaration, they need to come from the same class
                         return stopAtAnyPropertyDeclaration &&
                             (isPropertyDeclaration(declaration) && node.parent === declaration.parent
-                             || isParameterPropertyDeclaration(declaration, declaration.parent) && node.parent === declaration.parent.parent)
-                            ? "quit": true;
+                                || isParameterPropertyDeclaration(declaration, declaration.parent) && node.parent === declaration.parent.parent)
+                            ? "quit" : true;
                     case SyntaxKind.Block:
                         switch (node.parent.kind) {
                             case SyntaxKind.GetAccessor:
@@ -3106,7 +3106,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.SourceFile:
                     if (!isExternalOrCommonJsModule(location as SourceFile)) break;
                     isInExternalModule = true;
-                    // falls through
+                // falls through
                 case SyntaxKind.ModuleDeclaration:
                     const moduleExports = getSymbolOfDeclaration(location as SourceFile | ModuleDeclaration)?.exports || emptySymbols;
                     if (location.kind === SyntaxKind.SourceFile || (isModuleDeclaration(location) && location.flags & NodeFlags.Ambient && !isGlobalScopeAugmentation(location))) {
@@ -3250,7 +3250,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (getEmitScriptTarget(compilerOptions) >= ScriptTarget.ES2015) {
                         break;
                     }
-                    // falls through
+                // falls through
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.Constructor:
                 case SyntaxKind.GetAccessor:
@@ -3355,7 +3355,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             lastLocation = location;
             location = isJSDocTemplateTag(location) ? getEffectiveContainerForJSDocTemplateTag(location) || location.parent :
                 isJSDocParameterTag(location) || isJSDocReturnTag(location) ? getHostSignatureFromJSDoc(location) || location.parent :
-                location.parent;
+                    location.parent;
         }
 
         // We just climbed up parents looking for the name, meaning that we started in a descendant node of `lastLocation`.
@@ -3437,7 +3437,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 const isUncheckedJS = isUncheckedJSSuggestion(originalLocation, suggestion, /*excludeClasses*/ false);
                                 const message = meaning === SymbolFlags.Namespace || nameArg && typeof nameArg !== "string" && nodeIsSynthesized(nameArg) ? Diagnostics.Cannot_find_namespace_0_Did_you_mean_1
                                     : isUncheckedJS ? Diagnostics.Could_not_find_name_0_Did_you_mean_1
-                                    : Diagnostics.Cannot_find_name_0_Did_you_mean_1;
+                                        : Diagnostics.Cannot_find_name_0_Did_you_mean_1;
                                 const diagnostic = createError(errorLocation, message, diagnosticName(nameArg!), suggestionName);
                                 addErrorOrSuggestion(!isUncheckedJS, diagnostic);
                                 if (suggestion.valueDeclaration) {
@@ -3478,7 +3478,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // we want to check for block-scoped
                 if (errorLocation &&
                     (meaning & SymbolFlags.BlockScopedVariable ||
-                     ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))) {
+                        ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))) {
                     const exportOrLocalSymbol = getExportSymbolOfValueSymbolIfExported(result!);
                     if (exportOrLocalSymbol.flags & SymbolFlags.BlockScopedVariable || exportOrLocalSymbol.flags & SymbolFlags.Class || exportOrLocalSymbol.flags & SymbolFlags.Enum) {
                         checkResolvedBlockScopedVariable(exportOrLocalSymbol, errorLocation);
@@ -3655,7 +3655,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isEntityNameExpression((node as ExpressionWithTypeArguments).expression)) {
                     return (node as ExpressionWithTypeArguments).expression as EntityNameExpression;
                 }
-                // falls through
+            // falls through
             default:
                 return undefined;
         }
@@ -3745,7 +3745,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isExtendedByInterface(node: Node): boolean {
         const grandparent = node.parent.parent;
         const parentOfGrandparent = grandparent.parent;
-        if(grandparent && parentOfGrandparent){
+        if (grandparent && parentOfGrandparent) {
             const isExtending = isHeritageClause(grandparent) && grandparent.token === SyntaxKind.ExtendsKeyword;
             const isInterface = isInterfaceDeclaration(parentOfGrandparent);
             return isExtending && isInterface;
@@ -3885,10 +3885,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             || node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(node as ExportAssignment)
             || isBinaryExpression(node) && getAssignmentDeclarationKind(node) === AssignmentDeclarationKind.ModuleExports && exportAssignmentIsAlias(node)
             || isAccessExpression(node)
-                && isBinaryExpression(node.parent)
-                && node.parent.left === node
-                && node.parent.operatorToken.kind === SyntaxKind.EqualsToken
-                && isAliasableOrJsExpression(node.parent.right)
+            && isBinaryExpression(node.parent)
+            && node.parent.left === node
+            && node.parent.operatorToken.kind === SyntaxKind.EqualsToken
+            && isAliasableOrJsExpression(node.parent.right)
             || node.kind === SyntaxKind.ShorthandPropertyAssignment
             || node.kind === SyntaxKind.PropertyAssignment && isAliasableOrJsExpression((node as PropertyAssignment).initializer)
             || node.kind === SyntaxKind.VariableDeclaration && isVariableDeclarationInitializedToBareOrAccessedRequire(node)
@@ -4084,7 +4084,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (exportStar) {
                 const defaultExport = exportStar.declarations?.find(decl => !!(
                     isExportDeclaration(decl) && decl.moduleSpecifier &&
-                        resolveExternalModuleName(decl, decl.moduleSpecifier)?.exports?.has(InternalSymbolName.Default)
+                    resolveExternalModuleName(decl, decl.moduleSpecifier)?.exports?.has(InternalSymbolName.Default)
                 ));
                 if (defaultExport) {
                     addRelatedInfo(diagnostic, createDiagnosticForNode(defaultExport, Diagnostics.export_Asterisk_does_not_re_export_a_default));
@@ -4458,31 +4458,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * combined flags of all alias targets otherwise.
      */
     function getAllSymbolFlags(symbol: Symbol): SymbolFlags {
-      let flags = symbol.flags;
-      let seenSymbols;
-      while (symbol.flags & SymbolFlags.Alias) {
-          const target = resolveAlias(symbol);
-          if (target === unknownSymbol) {
-              return SymbolFlags.All;
-          }
+        let flags = symbol.flags;
+        let seenSymbols;
+        while (symbol.flags & SymbolFlags.Alias) {
+            const target = resolveAlias(symbol);
+            if (target === unknownSymbol) {
+                return SymbolFlags.All;
+            }
 
-          // Optimizations - try to avoid creating or adding to
-          // `seenSymbols` if possible
-          if (target === symbol || seenSymbols?.has(target)) {
-              break;
-          }
-          if (target.flags & SymbolFlags.Alias) {
-              if (seenSymbols) {
-                  seenSymbols.add(target);
-              }
-              else {
-                  seenSymbols = new Set([symbol, target]);
-              }
-          }
-          flags |= target.flags;
-          symbol = target;
-      }
-      return flags;
+            // Optimizations - try to avoid creating or adding to
+            // `seenSymbols` if possible
+            if (target === symbol || seenSymbols?.has(target)) {
+                break;
+            }
+            if (target.flags & SymbolFlags.Alias) {
+                if (seenSymbols) {
+                    seenSymbols.add(target);
+                }
+                else {
+                    seenSymbols = new Set([symbol, target]);
+                }
+            }
+            flags |= target.flags;
+            symbol = target;
+        }
+        return flags;
     }
 
     /**
@@ -4823,7 +4823,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const initializer = isAssignmentDeclaration(decl) ? getAssignedExpandoInitializer(decl) :
             hasOnlyExpressionInitializer(decl) ? getDeclaredExpandoInitializer(decl) :
-            undefined;
+                undefined;
         return initializer || decl;
     }
 
@@ -4849,9 +4849,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function resolveExternalModuleName(location: Node, moduleReferenceExpression: Expression, ignoreErrors?: boolean): Symbol | undefined {
         const isClassic = getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Classic;
-        const errorMessage = isClassic?
-                                Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
-                              : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
+        const errorMessage = isClassic ?
+            Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
+            : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
         return resolveExternalModuleNameWorker(location, moduleReferenceExpression, ignoreErrors ? undefined : errorMessage);
     }
 
@@ -4875,12 +4875,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const currentSourceFile = getSourceFileOfNode(location);
         const contextSpecifier = isStringLiteralLike(location)
             ? location
-            :   findAncestor(location, isImportCall)?.arguments[0] ||
-                findAncestor(location, isImportDeclaration)?.moduleSpecifier ||
-                findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression ||
-                findAncestor(location, isExportDeclaration)?.moduleSpecifier ||
-                (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name ||
-                (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal;
+            : findAncestor(location, isImportCall)?.arguments[0] ||
+            findAncestor(location, isImportDeclaration)?.moduleSpecifier ||
+            findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression ||
+            findAncestor(location, isExportDeclaration)?.moduleSpecifier ||
+            (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name ||
+            (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal;
         const mode = contextSpecifier && isStringLiteralLike(contextSpecifier) ? getModeForUsageLocation(currentSourceFile, contextSpecifier) : currentSourceFile.impliedNodeFormat;
         const moduleResolutionKind = getEmitModuleResolutionKind(compilerOptions);
         const resolvedModule = getResolvedModule(currentSourceFile, moduleReference, mode);
@@ -5058,8 +5058,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const preferTs = isDeclarationFileName(moduleReference) && shouldAllowImportingTsExtension(compilerOptions);
                 const ext =
                     tsExtension === Extension.Mts || tsExtension === Extension.Dmts ? preferTs ? ".mts" : ".mjs" :
-                    tsExtension === Extension.Cts || tsExtension === Extension.Dmts ? preferTs ? ".cts" : ".cjs" :
-                    preferTs ? ".ts" : ".js";
+                        tsExtension === Extension.Cts || tsExtension === Extension.Dmts ? preferTs ? ".cts" : ".cjs" :
+                            preferTs ? ".ts" : ".js";
                 return importSourceWithoutExtension + ext;
             }
             return importSourceWithoutExtension;
@@ -5248,16 +5248,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function shouldTreatPropertiesOfExternalModuleAsExports(resolvedExternalModuleType: Type) {
         return !(resolvedExternalModuleType.flags & TypeFlags.Primitive ||
-                getObjectFlags(resolvedExternalModuleType) & ObjectFlags.Class ||
-                // `isArrayOrTupleLikeType` is too expensive to use in this auto-imports hot path
-                isArrayType(resolvedExternalModuleType) ||
-                isTupleType(resolvedExternalModuleType));
+            getObjectFlags(resolvedExternalModuleType) & ObjectFlags.Class ||
+            // `isArrayOrTupleLikeType` is too expensive to use in this auto-imports hot path
+            isArrayType(resolvedExternalModuleType) ||
+            isTupleType(resolvedExternalModuleType));
     }
 
     function getExportsOfSymbol(symbol: Symbol): SymbolTable {
         return symbol.flags & SymbolFlags.LateBindingContainer ? getResolvedMembersOrExportsOfSymbol(symbol, MembersOrExportsResolutionKind.resolvedExports) :
             symbol.flags & SymbolFlags.Module ? getExportsOfModule(symbol) :
-            symbol.exports || emptySymbols;
+                symbol.exports || emptySymbols;
     }
 
     function getExportsOfModule(moduleSymbol: Symbol): SymbolTable {
@@ -5467,20 +5467,20 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 && container.flags & SymbolFlags.Type
                 && getDeclaredTypeOfSymbol(container).flags & TypeFlags.Object
                 && meaning === SymbolFlags.Value
-            ? forEachSymbolTableInScope(enclosingDeclaration, t => {
-                return forEachEntry(t, s => {
-                    if (s.flags & getQualifiedLeftMeaning(meaning) && getTypeOfSymbol(s) === getDeclaredTypeOfSymbol(container)) {
-                        return s;
-                    }
-                });
-            }) : undefined;
+                ? forEachSymbolTableInScope(enclosingDeclaration, t => {
+                    return forEachEntry(t, s => {
+                        if (s.flags & getQualifiedLeftMeaning(meaning) && getTypeOfSymbol(s) === getDeclaredTypeOfSymbol(container)) {
+                            return s;
+                        }
+                    });
+                }) : undefined;
             let res = firstVariableMatch ? [firstVariableMatch, ...additionalContainers, container] : [...additionalContainers, container];
             res = append(res, objectLiteralContainer);
             res = addRange(res, reexportContainers);
             return res;
         }
         const candidates = mapDefined(symbol.declarations, d => {
-            if (!isAmbientModule(d) && d.parent){
+            if (!isAmbientModule(d) && d.parent) {
                 // direct children of a module
                 if (hasNonGlobalAugmentationExternalModuleSymbol(d.parent)) {
                     return getSymbolOfDeclaration(d.parent as Declaration);
@@ -5702,7 +5702,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (!isExternalOrCommonJsModule(location as SourceFile)) {
                         break;
                     }
-                    // falls through
+                // falls through
                 case SyntaxKind.ModuleDeclaration:
                     const sym = getSymbolOfDeclaration(location as ModuleDeclaration);
                     // `sym` may not have exports if this module declaration is backed by the symbol for a `const` that's being rewritten
@@ -6269,8 +6269,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 const nameType = getSymbolLinks(symbol).nameType;
                 if (nameType && nameType.flags & (TypeFlags.EnumLiteral | TypeFlags.UniqueESSymbol)) {
-                   context.enclosingDeclaration = nameType.symbol.valueDeclaration;
-                   return factory.createComputedPropertyName(symbolToExpression(nameType.symbol, context, meaning));
+                    context.enclosingDeclaration = nameType.symbol.valueDeclaration;
+                    return factory.createComputedPropertyName(symbolToExpression(nameType.symbol, context, meaning));
                 }
             }
             return symbolToExpression(symbol, context, meaning);
@@ -6280,8 +6280,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             Debug.assert(enclosingDeclaration === undefined || (enclosingDeclaration.flags & NodeFlags.Synthesized) === 0);
             const moduleResolverHost =
                 tracker?.trackSymbol ? tracker.moduleResolverHost :
-                flags! & NodeBuilderFlags.DoNotIncludeSymbolChain ? createBasicNodeBuilderModuleSpecifierResolutionHost(host) :
-                undefined;
+                    flags! & NodeBuilderFlags.DoNotIncludeSymbolChain ? createBasicNodeBuilderModuleSpecifierResolutionHost(host) :
+                        undefined;
             const context: NodeBuilderContext = {
                 enclosingDeclaration,
                 flags: flags || NodeBuilderFlags.None,
@@ -6743,8 +6743,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const isConstructorObject = getObjectFlags(type) & ObjectFlags.Anonymous && type.symbol && type.symbol.flags & SymbolFlags.Class;
                 const id = getObjectFlags(type) & ObjectFlags.Reference && (type as TypeReference & T).node ? "N" + getNodeId((type as TypeReference & T).node!) :
                     type.flags & TypeFlags.Conditional ? "N" + getNodeId((type as ConditionalType & T).root.node) :
-                    type.symbol ? (isConstructorObject ? "+" : "") + getSymbolId(type.symbol) :
-                    undefined;
+                        type.symbol ? (isConstructorObject ? "+" : "") + getSymbolId(type.symbol) :
+                            undefined;
                 // Since instantiations of the same anonymous type have the same symbol, tracking symbols instead
                 // of types allows us to catch circular references to instantiations of the same anonymous type
                 if (!context.visitedTypes) {
@@ -6899,14 +6899,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                         factory.createIdentifier(unescapeLeadingUnderscores(getTupleElementLabel(labeledElementDeclaration))),
                                         flags & ElementFlags.Optional ? factory.createToken(SyntaxKind.QuestionToken) : undefined,
                                         flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) :
-                                        tupleConstituentNodes[i]
+                                            tupleConstituentNodes[i]
                                     );
                                 }
                                 else {
                                     tupleConstituentNodes[i] =
                                         flags & ElementFlags.Variable ? factory.createRestTypeNode(flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) : tupleConstituentNodes[i]) :
-                                        flags & ElementFlags.Optional ? factory.createOptionalTypeNode(tupleConstituentNodes[i]) :
-                                        tupleConstituentNodes[i];
+                                            flags & ElementFlags.Optional ? factory.createOptionalTypeNode(tupleConstituentNodes[i]) :
+                                                tupleConstituentNodes[i];
                                 }
                             }
                             const tupleTypeNode = setEmitFlags(factory.createTupleTypeNode(tupleConstituentNodes), EmitFlags.SingleLine);
@@ -7419,7 +7419,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const flags = modifiersToFlags(modifiers);
                 modifiers = factory.createModifiersFromModifierFlags(flags | ModifierFlags.Abstract);
             }
-
             const node =
                 kind === SyntaxKind.CallSignature ? factory.createCallSignature(typeParameters, parameters, returnTypeNode) :
                 kind === SyntaxKind.ConstructSignature ? factory.createConstructSignature(typeParameters, parameters, returnTypeNode) :
@@ -7439,6 +7438,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             if (typeArguments) {
                 node.typeArguments = factory.createNodeArray(typeArguments);
+            }
+            if (signature.declaration?.kind === SyntaxKind.JSDocSignature && signature.declaration.parent.kind === SyntaxKind.JSDocOverloadTag) {
+                addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, getTextOfNode(signature.declaration.parent.parent, /*includeTrivia*/ true).slice(2, -2), /*hasTrailingNewLine*/ true);
             }
 
             cleanup?.();
@@ -7496,8 +7498,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const dotDotDotToken = isRest ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined;
             const name = parameterDeclaration ? parameterDeclaration.name ?
                 parameterDeclaration.name.kind === SyntaxKind.Identifier ? setEmitFlags(factory.cloneNode(parameterDeclaration.name), EmitFlags.NoAsciiEscaping) :
-                parameterDeclaration.name.kind === SyntaxKind.QualifiedName ? setEmitFlags(factory.cloneNode(parameterDeclaration.name.right), EmitFlags.NoAsciiEscaping) :
-                cloneBindingName(parameterDeclaration.name) :
+                    parameterDeclaration.name.kind === SyntaxKind.QualifiedName ? setEmitFlags(factory.cloneNode(parameterDeclaration.name.right), EmitFlags.NoAsciiEscaping) :
+                        cloneBindingName(parameterDeclaration.name) :
                 symbolName(parameterSymbol) :
                 symbolName(parameterSymbol);
             const isOptional = parameterDeclaration && isOptionalParameter(parameterDeclaration) || getCheckFlags(parameterSymbol) & CheckFlags.OptionalParameter;
@@ -7733,7 +7735,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         importModuleSpecifierPreference: isBundle ? "non-relative" : "project-relative",
                         importModuleSpecifierEnding: isBundle ? "minimal"
                             : resolutionMode === ModuleKind.ESNext ? "js"
-                            : undefined,
+                                : undefined,
                     },
                     { overrideImportMode }
                 ));
@@ -8014,7 +8016,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     let expression: Expression | undefined;
                     if (isSingleOrDoubleQuote(firstChar) && !(symbol.flags & SymbolFlags.EnumMember)) {
-                       expression = factory.createStringLiteral(stripQuotes(symbolName).replace(/\\./g, s => s.substring(1)), firstChar === CharacterCodes.singleQuote);
+                        expression = factory.createStringLiteral(stripQuotes(symbolName).replace(/\\./g, s => s.substring(1)), firstChar === CharacterCodes.singleQuote);
                     }
                     else if (("" + +symbolName) === symbolName) {
                         expression = factory.createNumericLiteral(+symbolName);
@@ -8337,7 +8339,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 function getNameForJSDocFunctionParameter(p: ParameterDeclaration, index: number) {
                     return p.name && isIdentifier(p.name) && p.name.escapedText === "this" ? "this"
                         : getEffectiveDotDotDotForParameter(p) ? `args`
-                        : `arg${index}`;
+                            : `arg${index}`;
                 }
 
                 function rewriteModuleSpecifier(parent: ImportTypeNode, lit: StringLiteral) {
@@ -8640,7 +8642,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return; // If we need to emit a private with a keyword name, we're done for, since something else will try to refer to it by that name
                 }
                 let needsPostExportDefault = isDefault && !!(
-                       symbol.flags & SymbolFlags.ExportDoesNotSupportDefaultModifier
+                    symbol.flags & SymbolFlags.ExportDoesNotSupportDefaultModifier
                     || (symbol.flags & SymbolFlags.Function && length(getPropertiesOfType(getTypeOfSymbol(symbol))))
                 ) && !(symbol.flags & SymbolFlags.Alias); // An alias symbol should preclude needing to make an alias ourselves
                 let needsExportDeclaration = !needsPostExportDefault && !isPrivate && isStringANonContextualKeyword(symbolName) && !isDefault;
@@ -8789,7 +8791,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         for (const node of symbol.declarations) {
                             const resolvedModule = resolveExternalModuleName(node, (node as ExportDeclaration).moduleSpecifier!);
                             if (!resolvedModule) continue;
-                            addResult(factory.createExportDeclaration(/*modifiers*/ undefined, /*isTypeOnly*/ (node as ExportDeclaration).isTypeOnly, /*exportClause*/ undefined, factory.createStringLiteral(getSpecifierForModuleSymbol(resolvedModule, context))), ModifierFlags.None);
+                            addResult(factory.createExportDeclaration(/*modifiers*/ undefined, /*isTypeOnly*/(node as ExportDeclaration).isTypeOnly, /*exportClause*/ undefined, factory.createStringLiteral(getSpecifierForModuleSymbol(resolvedModule, context))), ModifierFlags.None);
                         }
                     }
                 }
@@ -8962,7 +8964,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const initializedValue = p.declarations && p.declarations[0] && isEnumMember(p.declarations[0]) ? getConstantValue(p.declarations[0]) : undefined;
                         return factory.createEnumMember(unescapeLeadingUnderscores(p.escapedName), initializedValue === undefined ? undefined :
                             typeof initializedValue === "string" ? factory.createStringLiteral(initializedValue) :
-                            factory.createNumericLiteral(initializedValue));
+                                factory.createNumericLiteral(initializedValue));
                     })
                 ), modifierFlags);
             }
@@ -9257,7 +9259,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             ), modifierFlags);
                             break;
                         }
-                        // else fall through and treat commonjs require just like import=
+                    // else fall through and treat commonjs require just like import=
                     case SyntaxKind.ImportEqualsDeclaration:
                         // This _specifically_ only exists to handle json declarations - where we make aliases, but since
                         // we emit no declarations for the json document, must not refer to it in the declarations
@@ -9459,8 +9461,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // Otherwise, the type itself should be exported.
                         addResult(statement,
                             target && target.flags & SymbolFlags.Property && target.escapedName === InternalSymbolName.ExportEquals ? ModifierFlags.Ambient
-                            : name === varName ? ModifierFlags.Export
-                            : ModifierFlags.None);
+                                : name === varName ? ModifierFlags.Export
+                                    : ModifierFlags.None);
                     }
                     if (isExportAssignmentCompatibleSymbolName) {
                         results.push(factory.createExportAssignment(
@@ -9484,15 +9486,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // whose input is not type annotated (if the input symbol has an annotation we can reuse, we should prefer it)
                 const ctxSrc = getSourceFileOfNode(context.enclosingDeclaration);
                 return getObjectFlags(typeToSerialize) & (ObjectFlags.Anonymous | ObjectFlags.Mapped) &&
-                !length(getIndexInfosOfType(typeToSerialize)) &&
-                !isClassInstanceSide(typeToSerialize) && // While a class instance is potentially representable as a NS, prefer printing a reference to the instance type and serializing the class
-                !!(length(filter(getPropertiesOfType(typeToSerialize), isNamespaceMember)) || length(getSignaturesOfType(typeToSerialize, SignatureKind.Call))) &&
-                !length(getSignaturesOfType(typeToSerialize, SignatureKind.Construct)) && // TODO: could probably serialize as function + ns + class, now that that's OK
-                !getDeclarationWithTypeAnnotation(hostSymbol, enclosingDeclaration) &&
-                !(typeToSerialize.symbol && some(typeToSerialize.symbol.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
-                !some(getPropertiesOfType(typeToSerialize), p => isLateBoundName(p.escapedName)) &&
-                !some(getPropertiesOfType(typeToSerialize), p => some(p.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
-                every(getPropertiesOfType(typeToSerialize), p => isIdentifierText(symbolName(p), languageVersion));
+                    !length(getIndexInfosOfType(typeToSerialize)) &&
+                    !isClassInstanceSide(typeToSerialize) && // While a class instance is potentially representable as a NS, prefer printing a reference to the instance type and serializing the class
+                    !!(length(filter(getPropertiesOfType(typeToSerialize), isNamespaceMember)) || length(getSignaturesOfType(typeToSerialize, SignatureKind.Call))) &&
+                    !length(getSignaturesOfType(typeToSerialize, SignatureKind.Construct)) && // TODO: could probably serialize as function + ns + class, now that that's OK
+                    !getDeclarationWithTypeAnnotation(hostSymbol, enclosingDeclaration) &&
+                    !(typeToSerialize.symbol && some(typeToSerialize.symbol.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
+                    !some(getPropertiesOfType(typeToSerialize), p => isLateBoundName(p.escapedName)) &&
+                    !some(getPropertiesOfType(typeToSerialize), p => some(p.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
+                    every(getPropertiesOfType(typeToSerialize), p => isIdentifierText(symbolName(p), languageVersion));
             }
 
             function makeSerializePropertySymbol<T extends Node>(createProperty: (
@@ -9526,9 +9528,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     if (p.flags & SymbolFlags.Prototype || p.escapedName === "constructor" ||
                         (baseType && getPropertyOfType(baseType, p.escapedName)
-                         && isReadonlySymbol(getPropertyOfType(baseType, p.escapedName)!) === isReadonlySymbol(p)
-                         && (p.flags & SymbolFlags.Optional) === (getPropertyOfType(baseType, p.escapedName)!.flags & SymbolFlags.Optional)
-                         && isTypeIdenticalTo(getTypeOfSymbol(p), getTypeOfPropertyOfType(baseType, p.escapedName)!))) {
+                            && isReadonlySymbol(getPropertyOfType(baseType, p.escapedName)!) === isReadonlySymbol(p)
+                            && (p.flags & SymbolFlags.Optional) === (getPropertyOfType(baseType, p.escapedName)!.flags & SymbolFlags.Optional)
+                            && isTypeIdenticalTo(getTypeOfSymbol(p), getTypeOfPropertyOfType(baseType, p.escapedName)!))) {
                         return [];
                     }
                     const flag = (modifierFlags & ~ModifierFlags.Async) | (isStatic ? ModifierFlags.Static : 0);
@@ -9649,7 +9651,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (privateProtected) {
                         return [setTextRange(factory.createConstructorDeclaration(
                             factory.createModifiersFromModifierFlags(privateProtected),
-                            /*parameters*/ [],
+                            /*parameters*/[],
                             /*body*/ undefined,
                         ), signatures[0].declaration)];
                     }
@@ -9877,10 +9879,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (context && symbol.escapedName === InternalSymbolName.Default && !(context.flags & NodeBuilderFlags.UseAliasDefinedOutsideCurrentScope) &&
             // If it's not the first part of an entity name, it must print as `default`
             (!(context.flags & NodeBuilderFlags.InInitialEntityName) ||
-            // if the symbol is synthesized, it will only be referenced externally it must print as `default`
-            !symbol.declarations ||
-            // if not in the same binding context (source file, module declaration), it must print as `default`
-            (context.enclosingDeclaration && findAncestor(symbol.declarations[0], isDefaultBindingContext) !== findAncestor(context.enclosingDeclaration, isDefaultBindingContext)))) {
+                // if the symbol is synthesized, it will only be referenced externally it must print as `default`
+                !symbol.declarations ||
+                // if not in the same binding context (source file, module declaration), it must print as `default`
+                (context.enclosingDeclaration && findAncestor(symbol.declarations[0], isDefaultBindingContext) !== findAncestor(context.enclosingDeclaration, isDefaultBindingContext)))) {
             return "default";
         }
         if (symbol.declarations && symbol.declarations.length) {
@@ -9949,7 +9951,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // If the binding pattern is empty, this variable declaration is not visible
                         return false;
                     }
-                    // falls through
+                // falls through
                 case SyntaxKind.ModuleDeclaration:
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.InterfaceDeclaration:
@@ -9980,8 +9982,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // Private/protected properties/methods are not visible
                         return false;
                     }
-                    // Public properties/methods are visible if its parents are visible, so:
-                    // falls through
+                // Public properties/methods are visible if its parents are visible, so:
+                // falls through
 
                 case SyntaxKind.Constructor:
                 case SyntaxKind.ConstructSignature:
@@ -10548,14 +10550,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const constructor = findConstructorDeclaration(declaration.parent);
                 const type = constructor ? getFlowTypeInConstructor(declaration.symbol, constructor) :
                     getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :
-                    undefined;
+                        undefined;
                 return type && addOptionality(type, /*isProperty*/ true, isOptional);
             }
             else {
                 const staticBlocks = filter(declaration.parent.members, isClassStaticBlockDeclaration);
                 const type = staticBlocks.length ? getFlowTypeInStaticBlocks(declaration.symbol, staticBlocks) :
                     getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :
-                    undefined;
+                        undefined;
                 return type && addOptionality(type, /*isProperty*/ true, isOptional);
             }
         }
@@ -10703,7 +10705,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 for (const declaration of symbol.declarations) {
                     const expression = (isBinaryExpression(declaration) || isCallExpression(declaration)) ? declaration :
                         isAccessExpression(declaration) ? isBinaryExpression(declaration.parent) ? declaration.parent : declaration :
-                        undefined;
+                            undefined;
                     if (!expression) {
                         continue; // Non-assignment declaration merged in (eg, an Identifier to mark the thing as a namespace) - skip over it and pull type info from elsewhere
                     }
@@ -10831,7 +10833,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const isDirectExport = kind === AssignmentDeclarationKind.ExportsProperty && (isPropertyAccessExpression(expression.left) || isElementAccessExpression(expression.left)) && (isModuleExportsAccessExpression(expression.left.expression) || (isIdentifier(expression.left.expression) && isExportsIdentifier(expression.left.expression)));
         const type = resolvedSymbol ? getTypeOfSymbol(resolvedSymbol)
             : isDirectExport ? getRegularTypeOfLiteralType(checkExpressionCached(expression.right))
-            : getWidenedLiteralType(checkExpressionCached(expression.right));
+                : getWidenedLiteralType(checkExpressionCached(expression.right));
         if (type.flags & TypeFlags.Object &&
             kind === AssignmentDeclarationKind.ModuleExports &&
             symbol.escapedName === InternalSymbolName.ExportEquals) {
@@ -11171,7 +11173,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         else if (
             isBinaryExpression(declaration) ||
             (isInJSFile(declaration) &&
-            (isCallExpression(declaration) || (isPropertyAccessExpression(declaration) || isBindableStaticElementAccessExpression(declaration)) && isBinaryExpression(declaration.parent)))) {
+                (isCallExpression(declaration) || (isPropertyAccessExpression(declaration) || isBindableStaticElementAccessExpression(declaration)) && isBinaryExpression(declaration.parent)))) {
             type = getWidenedTypeForAssignmentDeclaration(symbol);
         }
         else if (isPropertyAccessExpression(declaration)
@@ -11205,11 +11207,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             type = tryGetTypeFromEffectiveTypeNode(declaration) || checkObjectLiteralMethod(declaration, CheckMode.Normal);
         }
         else if (isParameter(declaration)
-                 || isPropertyDeclaration(declaration)
-                 || isPropertySignature(declaration)
-                 || isVariableDeclaration(declaration)
-                 || isBindingElement(declaration)
-                 || isJSDocPropertyLikeTag(declaration)) {
+            || isPropertyDeclaration(declaration)
+            || isPropertySignature(declaration)
+            || isVariableDeclaration(declaration)
+            || isBindingElement(declaration)
+            || isJSDocPropertyLikeTag(declaration)) {
             type = getWidenedTypeForVariableLikeDeclaration(declaration, /*reportErrors*/ true);
         }
         // getTypeOfSymbol dispatches some JS merges incorrectly because their symbol flags are not mutually exclusive.
@@ -11342,7 +11344,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const baseConstructorType = getBaseConstructorTypeOfClass(getDeclaredTypeOfClassOrInterface(symbol));
         return baseConstructorType.flags & TypeFlags.TypeVariable ? baseConstructorType :
             baseConstructorType.flags & TypeFlags.Intersection ? find((baseConstructorType as IntersectionType).types, t => !!(t.flags & TypeFlags.TypeVariable)) :
-            undefined;
+                undefined;
     }
 
     function getTypeOfFuncClassEnumModule(symbol: Symbol): Type {
@@ -11369,8 +11371,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return anyType;
         }
         else if (declaration && (declaration.kind === SyntaxKind.BinaryExpression ||
-                 isAccessExpression(declaration) &&
-                 declaration.parent.kind === SyntaxKind.BinaryExpression)) {
+            isAccessExpression(declaration) &&
+            declaration.parent.kind === SyntaxKind.BinaryExpression)) {
             return getWidenedTypeForAssignmentDeclaration(symbol);
         }
         else if (symbol.flags & SymbolFlags.ValueModule && declaration && isSourceFile(declaration) && declaration.commonJsModuleIndicator) {
@@ -11415,9 +11417,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // up recursively calling getTypeOfAlias, causing a stack overflow.
             links.type = exportSymbol?.declarations && isDuplicatedCommonJSExport(exportSymbol.declarations) && symbol.declarations!.length ? getFlowTypeFromCommonJSExport(exportSymbol)
                 : isDuplicatedCommonJSExport(symbol.declarations) ? autoType
-                : declaredType ? declaredType
-                : getAllSymbolFlags(targetSymbol) & SymbolFlags.Value ? getTypeOfSymbol(targetSymbol)
-                : errorType;
+                    : declaredType ? declaredType
+                        : getAllSymbolFlags(targetSymbol) & SymbolFlags.Value ? getTypeOfSymbol(targetSymbol)
+                            : errorType;
         }
         return links.type;
     }
@@ -12252,10 +12254,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!derived
                 // non-constructor/static-block assignment declarations are ignored here; they're not treated as overrides
                 || derived.valueDeclaration
-                    && isBinaryExpression(derived.valueDeclaration)
-                    && !isConstructorDeclaredProperty(derived)
-                    && !getContainingClassStaticBlock(derived.valueDeclaration)) {
-                    symbols.set(base.escapedName, base);
+                && isBinaryExpression(derived.valueDeclaration)
+                && !isConstructorDeclaredProperty(derived)
+                && !getContainingClassStaticBlock(derived.valueDeclaration)) {
+                symbols.set(base.escapedName, base);
                 symbols.set(base.escapedName, base);
             }
         }
@@ -12359,7 +12361,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!symbol.declarations) {
             symbol.declarations = [member];
         }
-        else if(!member.symbol.isReplaceableByMethod) {
+        else if (!member.symbol.isReplaceableByMethod) {
             symbol.declarations.push(member);
         }
         if (symbolFlags & SymbolFlags.Value) {
@@ -12447,7 +12449,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const isStatic = resolutionKind === MembersOrExportsResolutionKind.resolvedExports;
             const earlySymbols = !isStatic ? symbol.members :
                 symbol.flags & SymbolFlags.Module ? getExportsOfModuleWorker(symbol).exports :
-                symbol.exports;
+                    symbol.exports;
 
             // In the event we recursively resolve the members/exports of the symbol, we
             // set the initial value of resolvedMembers/resolvedExports to the early-bound
@@ -12881,8 +12883,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const paramName = leftName === rightName ? leftName :
                 !leftName ? rightName :
-                !rightName ? leftName :
-                undefined;
+                    !rightName ? leftName :
+                        undefined;
             const paramSymbol = createSymbol(
                 SymbolFlags.FunctionScopedVariable | (isOptional && !isRestParam ? SymbolFlags.Optional : 0),
                 paramName || `arg${i}` as __String
@@ -13293,7 +13295,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             else if (isValidIndexKeyType(propNameType) || propNameType.flags & (TypeFlags.Any | TypeFlags.Enum)) {
                 const indexKeyType = propNameType.flags & (TypeFlags.Any | TypeFlags.String) ? stringType :
                     propNameType.flags & (TypeFlags.Number | TypeFlags.Enum) ? numberType :
-                    propNameType;
+                        propNameType;
                 const propType = instantiateType(templateType, appendTypeMapping(type.mapper, typeParameter, keyType));
                 const indexInfo = createIndexInfo(indexKeyType, propType, !!(templateModifiers & MappedTypeModifiers.IncludeReadonly));
                 indexInfos = appendIndexInfo(indexInfos, indexInfo, /*union*/ true);
@@ -13316,7 +13318,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // mode, if the underlying property is optional we remove 'undefined' from the type.
             let type = strictNullChecks && symbol.flags & SymbolFlags.Optional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true) :
                 symbol.links.checkFlags & CheckFlags.StripOptional ? removeMissingOrUndefinedType(propType) :
-                propType;
+                    propType;
             if (!popTypeResolution()) {
                 error(currentNode, Diagnostics.Type_of_property_0_circularly_references_itself_in_mapped_type_1, symbolToString(symbol), typeToString(mappedType));
                 type = errorType;
@@ -13552,8 +13554,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getConstraintOfType(type: InstantiableType | UnionOrIntersectionType): Type | undefined {
         return type.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(type as TypeParameter) :
             type.flags & TypeFlags.IndexedAccess ? getConstraintOfIndexedAccess(type as IndexedAccessType) :
-            type.flags & TypeFlags.Conditional ? getConstraintOfConditionalType(type as ConditionalType) :
-            getBaseConstraintOfType(type);
+                type.flags & TypeFlags.Conditional ? getConstraintOfConditionalType(type as ConditionalType) :
+                    getBaseConstraintOfType(type);
     }
 
     function getConstraintOfTypeParameter(typeParameter: TypeParameter): Type | undefined {
@@ -13791,7 +13793,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 return t.flags & TypeFlags.Union && baseTypes.length === types.length ? getUnionType(baseTypes) :
                     t.flags & TypeFlags.Intersection && baseTypes.length ? getIntersectionType(baseTypes) :
-                    undefined;
+                        undefined;
             }
             if (t.flags & TypeFlags.Index) {
                 return keyofConstraintType;
@@ -13919,16 +13921,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const objectFlags = getObjectFlags(t);
         return objectFlags & ObjectFlags.Mapped ? getApparentTypeOfMappedType(t as MappedType) :
             objectFlags & ObjectFlags.Reference && t !== type ? getTypeWithThisArgument(t, type) :
-            t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(t as IntersectionType, type) :
-            t.flags & TypeFlags.StringLike ? globalStringType :
-            t.flags & TypeFlags.NumberLike ? globalNumberType :
-            t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType() :
-            t.flags & TypeFlags.BooleanLike ? globalBooleanType :
-            t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType() :
-            t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
-            t.flags & TypeFlags.Index ? keyofConstraintType :
-            t.flags & TypeFlags.Unknown && !strictNullChecks ? emptyObjectType :
-            t;
+                t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(t as IntersectionType, type) :
+                    t.flags & TypeFlags.StringLike ? globalStringType :
+                        t.flags & TypeFlags.NumberLike ? globalNumberType :
+                            t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType() :
+                                t.flags & TypeFlags.BooleanLike ? globalBooleanType :
+                                    t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType() :
+                                        t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
+                                            t.flags & TypeFlags.Index ? keyofConstraintType :
+                                                t.flags & TypeFlags.Unknown && !strictNullChecks ? emptyObjectType :
+                                                    t;
     }
 
     function getReducedApparentType(type: Type): Type {
@@ -14260,8 +14262,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (skipObjectFunctionPropertyAugment) return undefined;
             const functionType = resolved === anyFunctionType ? globalFunctionType :
                 resolved.callSignatures.length ? globalCallableFunctionType :
-                resolved.constructSignatures.length ? globalNewableFunctionType :
-                undefined;
+                    resolved.constructSignatures.length ? globalNewableFunctionType :
+                        undefined;
             if (functionType) {
                 const symbol = getPropertyOfObjectType(functionType, name);
                 if (symbol) {
@@ -14347,10 +14349,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // the intersected key type, we just use unknownType for the key type as nothing actually depends on the
         // keyType property of the returned IndexInfo.
         return applicableInfos ? createIndexInfo(unknownType, getIntersectionType(map(applicableInfos, info => info.type)),
-                reduceLeft(applicableInfos, (isReadonly, info) => isReadonly && info.isReadonly, /*initial*/ true)) :
+            reduceLeft(applicableInfos, (isReadonly, info) => isReadonly && info.isReadonly, /*initial*/ true)) :
             applicableInfo ? applicableInfo :
-            stringIndexInfo && isApplicableIndexType(keyType, stringType) ? stringIndexInfo :
-            undefined;
+                stringIndexInfo && isApplicableIndexType(keyType, stringType) ? stringIndexInfo :
+                    undefined;
     }
 
     function isApplicableIndexType(source: Type, target: Type): boolean {
@@ -14406,7 +14408,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         return result?.length ? result
             : isFunctionDeclaration(declaration) ? getSignatureOfTypeTag(declaration)?.typeParameters
-            : undefined;
+                : undefined;
     }
 
     function symbolsToArray(symbols: SymbolTable): Symbol[] {
@@ -14738,7 +14740,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 (!isFunctionExpressionOrArrowFunction(decl) &&
                     !isObjectLiteralMethod(decl) &&
                     getSignatureOfTypeTag(decl)) ||
-                    getSignatureFromDeclaration(decl)
+                getSignatureFromDeclaration(decl)
             );
         }
         return result;
@@ -14809,8 +14811,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             let type = signature.target ? instantiateType(getReturnTypeOfSignature(signature.target), signature.mapper) :
                 signature.compositeSignatures ? instantiateType(getUnionOrIntersectionType(map(signature.compositeSignatures, getReturnTypeOfSignature), signature.compositeKind, UnionReduction.Subtype), signature.mapper) :
-                getReturnTypeFromAnnotation(signature.declaration!) ||
-                (nodeIsMissing((signature.declaration as FunctionLikeDeclaration).body) ? anyType : getReturnTypeFromBody(signature.declaration as FunctionLikeDeclaration));
+                    getReturnTypeFromAnnotation(signature.declaration!) ||
+                    (nodeIsMissing((signature.declaration as FunctionLikeDeclaration).body) ? anyType : getReturnTypeFromBody(signature.declaration as FunctionLikeDeclaration));
             if (signature.flags & SignatureFlags.IsInnerCallChain) {
                 type = addOptionalTypeMarker(type);
             }
@@ -15240,8 +15242,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const node = type.node;
             const typeArguments = !node ? emptyArray :
                 node.kind === SyntaxKind.TypeReference ? concatenate(type.target.outerTypeParameters, getEffectiveTypeArguments(node, type.target.localTypeParameters!)) :
-                node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] :
-                map(node.elements, getTypeFromTypeNode);
+                    node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] :
+                        map(node.elements, getTypeFromTypeNode);
             if (popTypeResolution()) {
                 type.resolvedTypeArguments = type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
             }
@@ -15408,12 +15410,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getUnresolvedSymbolForEntityName(name: EntityNameOrEntityNameExpression) {
         const identifier = name.kind === SyntaxKind.QualifiedName ? name.right :
             name.kind === SyntaxKind.PropertyAccessExpression ? name.name :
-            name;
+                name;
         const text = identifier.escapedText;
         if (text) {
             const parentSymbol = name.kind === SyntaxKind.QualifiedName ? getUnresolvedSymbolForEntityName(name.left) :
                 name.kind === SyntaxKind.PropertyAccessExpression ? getUnresolvedSymbolForEntityName(name.expression) :
-                undefined;
+                    undefined;
             const path = parentSymbol ? `${getSymbolPath(parentSymbol)}.${text}` : text as string;
             let result = unresolvedSymbols.get(path);
             if (!result) {
@@ -15514,7 +15516,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getImpliedConstraint(type: Type, checkNode: TypeNode, extendsNode: TypeNode): Type | undefined {
         return isUnaryTupleTypeNode(checkNode) && isUnaryTupleTypeNode(extendsNode) ? getImpliedConstraint(type, (checkNode as TupleTypeNode).elements[0], (extendsNode as TupleTypeNode).elements[0]) :
             getActualTypeVariable(getTypeFromTypeNode(checkNode)) === getActualTypeVariable(type) ? getTypeFromTypeNode(extendsNode) :
-            undefined;
+                undefined;
     }
 
     function getConditionalFlowTypeOfType(type: Type, node: Node) {
@@ -15947,7 +15949,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.NamedTupleMember:
                 return (node as NamedTupleMember).questionToken ? ElementFlags.Optional :
                     (node as NamedTupleMember).dotDotDotToken ? getRestTypeElementFlags(node as NamedTupleMember) :
-                    ElementFlags.Required;
+                        ElementFlags.Required;
             default:
                 return ElementFlags.Required;
         }
@@ -15976,8 +15978,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isDeferredTypeReferenceNode(node: TypeReferenceNode | ArrayTypeNode | TupleTypeNode, hasDefaultTypeArguments?: boolean) {
         return !!getAliasSymbolForTypeNode(node) || isResolvedByTypeAlias(node) && (
             node.kind === SyntaxKind.ArrayType ? mayResolveTypeAlias(node.elementType) :
-            node.kind === SyntaxKind.TupleType ? some(node.elements, mayResolveTypeAlias) :
-            hasDefaultTypeArguments || some(node.typeArguments, mayResolveTypeAlias));
+                node.kind === SyntaxKind.TupleType ? some(node.elements, mayResolveTypeAlias) :
+                    hasDefaultTypeArguments || some(node.typeArguments, mayResolveTypeAlias));
     }
 
     // Return true when the given node is transitively contained in type constructs that eagerly
@@ -16062,7 +16064,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const tupleTarget = getTupleTargetType(elementFlags || map(elementTypes, _ => ElementFlags.Required), readonly, namedMemberDeclarations);
         return tupleTarget === emptyGenericType ? emptyObjectType :
             elementTypes.length ? createNormalizedTypeReference(tupleTarget, elementTypes) :
-            tupleTarget;
+                tupleTarget;
     }
 
     function getTupleTargetType(elementFlags: readonly ElementFlags[], readonly: boolean, namedMemberDeclarations: readonly (NamedTupleMember | ParameterDeclaration | undefined)[]): GenericType {
@@ -16218,7 +16220,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const tupleTarget = getTupleTargetType(expandedFlags, target.readonly, expandedDeclarations);
         return tupleTarget === emptyGenericType ? emptyObjectType :
             expandedFlags.length ? createTypeReference(tupleTarget, expandedTypes) :
-            tupleTarget;
+                tupleTarget;
 
         function addElement(type: Type, flags: ElementFlags, declaration: NamedTupleMember | ParameterDeclaration | undefined) {
             if (flags & ElementFlags.Required) {
@@ -16518,7 +16520,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (typeSet.length === 0) {
                 return includes & TypeFlags.Null ? includes & TypeFlags.IncludesNonWideningType ? nullType : nullWideningType :
                     includes & TypeFlags.Undefined ? includes & TypeFlags.IncludesNonWideningType ? undefinedType : undefinedWideningType :
-                    neverType;
+                        neverType;
             }
         }
         if (!origin && includes & TypeFlags.Union) {
@@ -16590,8 +16592,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const typeKey = !origin ? getTypeListId(types) :
             origin.flags & TypeFlags.Union ? `|${getTypeListId((origin as UnionType).types)}` :
-            origin.flags & TypeFlags.Intersection ? `&${getTypeListId((origin as IntersectionType).types)}` :
-            `#${(origin as IndexType).type.id}|${getTypeListId(types)}`; // origin type id alone is insufficient, as `keyof x` may resolve to multiple WIP values while `x` is still resolving
+                origin.flags & TypeFlags.Intersection ? `&${getTypeListId((origin as IntersectionType).types)}` :
+                    `#${(origin as IndexType).type.id}|${getTypeListId(types)}`; // origin type id alone is insufficient, as `keyof x` may resolve to multiple WIP values while `x` is still resolving
         const id = typeKey + getAliasId(aliasSymbol, aliasTypeArguments);
         let type = unionTypes.get(id);
         if (!type) {
@@ -16689,9 +16691,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!containsType(u.types, type)) {
                 const primitive = type.flags & TypeFlags.StringLiteral ? stringType :
                     type.flags & (TypeFlags.Enum | TypeFlags.NumberLiteral) ? numberType :
-                    type.flags & TypeFlags.BigIntLiteral ? bigintType :
-                    type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
-                    undefined;
+                        type.flags & TypeFlags.BigIntLiteral ? bigintType :
+                            type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
+                                undefined;
                 if (!primitive || !containsType(u.types, primitive)) {
                     return false;
                 }
@@ -16924,7 +16926,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getConstituentCount(type: Type): number {
         return !(type.flags & TypeFlags.UnionOrIntersection) || type.aliasSymbol ? 1 :
             type.flags & TypeFlags.Union && (type as UnionType).origin ? getConstituentCount((type as UnionType).origin!) :
-            getConstituentCountOfTypes((type as UnionOrIntersectionType).types);
+                getConstituentCountOfTypes((type as UnionOrIntersectionType).types);
     }
 
     function getConstituentCountOfTypes(types: Type[]): number {
@@ -17006,7 +17008,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // we had to pick apart the constraintType to potentially map/filter it - compare the final resulting list with the original constraintType,
         // so we can return the union that preserves aliases/origin data if possible
         const result = indexFlags & IndexFlags.NoIndexSignatures ? filterType(getUnionType(keyTypes), t => !(t.flags & (TypeFlags.Any | TypeFlags.String))) : getUnionType(keyTypes);
-        if (result.flags & TypeFlags.Union && constraintType.flags & TypeFlags.Union && getTypeListId((result as UnionType).types) === getTypeListId((constraintType as UnionType).types)){
+        if (result.flags & TypeFlags.Union && constraintType.flags & TypeFlags.Union && getTypeListId((result as UnionType).types) === getTypeListId((constraintType as UnionType).types)) {
             return constraintType;
         }
         return result;
@@ -17030,11 +17032,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function isDistributive(type: Type): boolean {
             return type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Primitive | TypeFlags.Never | TypeFlags.TypeParameter | TypeFlags.Object | TypeFlags.NonPrimitive) ? true :
                 type.flags & TypeFlags.Conditional ? (type as ConditionalType).root.isDistributive && (type as ConditionalType).checkType === typeVariable :
-                type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral) ? every((type as UnionOrIntersectionType | TemplateLiteralType).types, isDistributive) :
-                type.flags & TypeFlags.IndexedAccess ? isDistributive((type as IndexedAccessType).objectType) && isDistributive((type as IndexedAccessType).indexType) :
-                type.flags & TypeFlags.Substitution ? isDistributive((type as SubstitutionType).baseType) && isDistributive((type as SubstitutionType).constraint):
-                type.flags & TypeFlags.StringMapping ? isDistributive((type as StringMappingType).type) :
-                false;
+                    type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral) ? every((type as UnionOrIntersectionType | TemplateLiteralType).types, isDistributive) :
+                        type.flags & TypeFlags.IndexedAccess ? isDistributive((type as IndexedAccessType).objectType) && isDistributive((type as IndexedAccessType).indexType) :
+                            type.flags & TypeFlags.Substitution ? isDistributive((type as SubstitutionType).baseType) && isDistributive((type as SubstitutionType).constraint) :
+                                type.flags & TypeFlags.StringMapping ? isDistributive((type as StringMappingType).type) :
+                                    false;
         }
     }
 
@@ -17098,13 +17100,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         type = getReducedType(type);
         return shouldDeferIndexType(type, indexFlags) ? getIndexTypeForGenericType(type as InstantiableType | UnionOrIntersectionType, indexFlags) :
             type.flags & TypeFlags.Union ? getIntersectionType(map((type as UnionType).types, t => getIndexType(t, indexFlags))) :
-            type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags))) :
-            getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags) :
-            type === wildcardType ? wildcardType :
-            type.flags & TypeFlags.Unknown ? neverType :
-            type.flags & (TypeFlags.Any | TypeFlags.Never) ? keyofConstraintType :
-            getLiteralTypeFromProperties(type, (indexFlags & IndexFlags.NoIndexSignatures ? TypeFlags.StringLiteral : TypeFlags.StringLike) | (indexFlags & IndexFlags.StringsOnly ? 0 : TypeFlags.NumberLike | TypeFlags.ESSymbolLike),
-                indexFlags === defaultIndexFlags);
+                type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags))) :
+                    getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags) :
+                        type === wildcardType ? wildcardType :
+                            type.flags & TypeFlags.Unknown ? neverType :
+                                type.flags & (TypeFlags.Any | TypeFlags.Never) ? keyofConstraintType :
+                                    getLiteralTypeFromProperties(type, (indexFlags & IndexFlags.NoIndexSignatures ? TypeFlags.StringLiteral : TypeFlags.StringLike) | (indexFlags & IndexFlags.StringsOnly ? 0 : TypeFlags.NumberLike | TypeFlags.ESSymbolLike),
+                                        indexFlags === defaultIndexFlags);
     }
 
     function getExtractStringType(type: Type) {
@@ -17216,9 +17218,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTemplateStringForType(type: Type) {
         return type.flags & TypeFlags.StringLiteral ? (type as StringLiteralType).value :
             type.flags & TypeFlags.NumberLiteral ? "" + (type as NumberLiteralType).value :
-            type.flags & TypeFlags.BigIntLiteral ? pseudoBigIntToString((type as BigIntLiteralType).value) :
-            type.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) ? (type as IntrinsicType).intrinsicName :
-            undefined;
+                type.flags & TypeFlags.BigIntLiteral ? pseudoBigIntToString((type as BigIntLiteralType).value) :
+                    type.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) ? (type as IntrinsicType).intrinsicName :
+                        undefined;
     }
 
     function createTemplateLiteralType(texts: readonly string[], types: readonly Type[]) {
@@ -17232,13 +17234,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getStringMappingType(symbol: Symbol, type: Type): Type {
         return type.flags & (TypeFlags.Union | TypeFlags.Never) ? mapType(type, t => getStringMappingType(symbol, t)) :
             type.flags & TypeFlags.StringLiteral ? getStringLiteralType(applyStringMapping(symbol, (type as StringLiteralType).value)) :
-            type.flags & TypeFlags.TemplateLiteral ? getTemplateLiteralType(...applyTemplateStringMapping(symbol, (type as TemplateLiteralType).texts, (type as TemplateLiteralType).types)) :
-            // Mapping<Mapping<T>> === Mapping<T>
-            type.flags & TypeFlags.StringMapping && symbol === type.symbol ? type :
-            type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type) :
-            // This handles Mapping<`${number}`> and Mapping<`${bigint}`>
-            isPatternLiteralPlaceholderType(type) ? getStringMappingTypeForGenericType(symbol, getTemplateLiteralType(["", ""], [type])) :
-            type;
+                type.flags & TypeFlags.TemplateLiteral ? getTemplateLiteralType(...applyTemplateStringMapping(symbol, (type as TemplateLiteralType).texts, (type as TemplateLiteralType).types)) :
+                    // Mapping<Mapping<T>> === Mapping<T>
+                    type.flags & TypeFlags.StringMapping && symbol === type.symbol ? type :
+                        type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type) :
+                            // This handles Mapping<`${number}`> and Mapping<`${bigint}`>
+                            isPatternLiteralPlaceholderType(type) ? getStringMappingTypeForGenericType(symbol, getTemplateLiteralType(["", ""], [type])) :
+                                type;
     }
 
     function applyStringMapping(symbol: Symbol, str: string) {
@@ -17318,10 +17320,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getPropertyNameFromIndex(indexType: Type, accessNode: StringLiteral | Identifier | PrivateIdentifier | ObjectBindingPattern | ArrayBindingPattern | ComputedPropertyName | NumericLiteral | IndexedAccessTypeNode | ElementAccessExpression | SyntheticExpression | undefined) {
         return isTypeUsableAsPropertyName(indexType) ?
             getPropertyNameFromType(indexType) :
-                accessNode && isPropertyName(accessNode) ?
-                    // late bound names are handled in the first branch, so here we only need to handle normal names
-                    getPropertyNameForPropertyNameNode(accessNode) :
-                    undefined;
+            accessNode && isPropertyName(accessNode) ?
+                // late bound names are handled in the first branch, so here we only need to handle normal names
+                getPropertyNameForPropertyNameNode(accessNode) :
+                undefined;
     }
 
     function isUncalledFunctionReference(node: Node, symbol: Symbol) {
@@ -17365,7 +17367,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const propType = getTypeOfSymbol(prop);
                 return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ? getFlowTypeOfReference(accessExpression, propType) :
                     accessNode && isIndexedAccessTypeNode(accessNode) && containsMissingType(propType) ? getUnionType([propType, undefinedType]) :
-                    propType;
+                        propType;
             }
             if (everyType(objectType, isTupleType) && isNumericLiteralName(propName)) {
                 const index = +propName;
@@ -17419,8 +17421,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     !(objectType.symbol &&
                         objectType.symbol.flags & (SymbolFlags.RegularEnum | SymbolFlags.ConstEnum) &&
                         (indexType.symbol &&
-                        indexType.flags & TypeFlags.EnumLiteral &&
-                        getParentOfSymbol(indexType.symbol) === objectType.symbol))) {
+                            indexType.flags & TypeFlags.EnumLiteral &&
+                            getParentOfSymbol(indexType.symbol) === objectType.symbol))) {
                     return getUnionType([indexInfo.type, missingType]);
                 }
                 return indexInfo.type;
@@ -17529,8 +17531,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getIndexNodeForAccessExpression(accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression) {
         return accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode.argumentExpression :
             accessNode.kind === SyntaxKind.IndexedAccessType ? accessNode.indexType :
-            accessNode.kind === SyntaxKind.ComputedPropertyName ? accessNode.expression :
-            accessNode;
+                accessNode.kind === SyntaxKind.ComputedPropertyName ? accessNode.expression :
+                    accessNode;
     }
 
     function isPatternLiteralPlaceholderType(type: Type): boolean {
@@ -17579,7 +17581,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getSimplifiedType(type: Type, writing: boolean): Type {
         return type.flags & TypeFlags.IndexedAccess ? getSimplifiedIndexedAccessType(type as IndexedAccessType, writing) :
             type.flags & TypeFlags.Conditional ? getSimplifiedConditionalType(type as ConditionalType, writing) :
-            type;
+                type;
     }
 
     function distributeIndexOverObjectType(objectType: Type, indexType: Type, writing: boolean) {
@@ -18356,7 +18358,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getRegularTypeOfLiteralType(type: Type): Type {
         return type.flags & TypeFlags.Freshable ? (type as FreshableType).regularType :
             type.flags & TypeFlags.Union ? ((type as UnionType).regularType || ((type as UnionType).regularType = mapType(type, getRegularTypeOfLiteralType) as UnionType)) :
-            type;
+                type;
     }
 
     function isFreshLiteralType(type: Type) {
@@ -18479,7 +18481,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeFromNamedTupleTypeNode(node: NamedTupleMember): Type {
         const links = getNodeLinks(node);
         return links.resolvedType || (links.resolvedType =
-                node.dotDotDotToken ? getTypeFromRestTypeNode(node) :
+            node.dotDotDotToken ? getTypeFromRestTypeNode(node) :
                 addOptionality(getTypeFromTypeNode(node.type), /*isProperty*/ true, !!node.questionToken));
     }
 
@@ -18787,7 +18789,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getObjectTypeInstantiation(type: AnonymousType | DeferredTypeReference, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]) {
         const declaration = type.objectFlags & ObjectFlags.Reference ? (type as TypeReference).node! :
             type.objectFlags & ObjectFlags.InstantiationExpressionType ? (type as InstantiationExpressionType).node :
-            type.symbol.declarations![0];
+                type.symbol.declarations![0];
         const links = getNodeLinks(declaration);
         const target = type.objectFlags & ObjectFlags.Reference ? links.resolvedType! as DeferredTypeReference :
             type.objectFlags & ObjectFlags.Instantiated ? type.target! : type;
@@ -18827,7 +18829,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const newMapper = createTypeMapper(typeParameters, typeArguments);
                 result = target.objectFlags & ObjectFlags.Reference ? createDeferredTypeReference((type as DeferredTypeReference).target, (type as DeferredTypeReference).node, newMapper, newAliasSymbol, newAliasTypeArguments) :
                     target.objectFlags & ObjectFlags.Mapped ? instantiateMappedType(target as MappedType, newMapper, newAliasSymbol, newAliasTypeArguments) :
-                    instantiateAnonymousType(target, newMapper, newAliasSymbol, newAliasTypeArguments);
+                        instantiateAnonymousType(target, newMapper, newAliasSymbol, newAliasTypeArguments);
                 target.instantiations.set(id, result); // Set cached result early in case we recursively invoke instantiation while eagerly computing type variable visibility below
                 const resultObjectFlags = getObjectFlags(result);
                 if (result.flags & TypeFlags.ObjectFlagsType && !(resultObjectFlags & ObjectFlags.CouldContainTypeVariablesComputed)) {
@@ -18886,7 +18888,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const tpDeclaration = tp.symbol.declarations![0]; // There is exactly one declaration, otherwise `containsReference` is not called
                         const tpScope = tpDeclaration.kind === SyntaxKind.TypeParameter ? tpDeclaration.parent : // Type parameter is a regular type parameter, e.g. foo<T>
                             tp.isThisType ? tpDeclaration : // Type parameter is the this type, and its declaration is the class declaration.
-                            undefined; // Type parameter's declaration was unrecognized, e.g. comes from JSDoc annotation.
+                                undefined; // Type parameter's declaration was unrecognized, e.g. comes from JSDoc annotation.
                         if (firstIdentifierSymbol.declarations && tpScope) {
                             return some(firstIdentifierSymbol.declarations, idDecl => isNodeDescendantOf(idDecl, tpScope)) ||
                                 some((node as TypeQueryNode).typeArguments, containsReference);
@@ -18968,7 +18970,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const elementTypes = map(getElementTypes(tupleType), (t, i) => {
             const singleton = elementFlags[i] & ElementFlags.Variadic ? t :
                 elementFlags[i] & ElementFlags.Rest ? createArrayType(t) :
-                createTupleType([t], [elementFlags[i]]);
+                    createTupleType([t], [elementFlags[i]]);
             // avoid infinite recursion, if the singleton is the type variable itself
             // then we'd just get back here with the same arguments from within instantiateMappedType
             if (singleton === typeVariable) {
@@ -18994,7 +18996,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const modifiers = getMappedTypeModifiers(mappedType);
         const newTupleModifiers = modifiers & MappedTypeModifiers.IncludeOptional ? map(elementFlags, f => f & ElementFlags.Required ? ElementFlags.Optional : f) :
             modifiers & MappedTypeModifiers.ExcludeOptional ? map(elementFlags, f => f & ElementFlags.Optional ? ElementFlags.Required : f) :
-            elementFlags;
+                elementFlags;
         const newReadonly = getModifiedReadonlyState(tupleType.target.readonly, modifiers);
         return contains(elementTypes, errorType) ? errorType :
             createTupleType(elementTypes, newTupleModifiers, newReadonly, tupleType.target.labeledElementDeclarations);
@@ -19006,7 +19008,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const modifiers = getMappedTypeModifiers(type);
         return strictNullChecks && modifiers & MappedTypeModifiers.IncludeOptional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true) :
             strictNullChecks && modifiers & MappedTypeModifiers.ExcludeOptional && isOptional ? getTypeWithFacts(propType, TypeFacts.NEUndefined) :
-            propType;
+                propType;
     }
 
     function instantiateAnonymousType(type: AnonymousType, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]): AnonymousType {
@@ -19318,12 +19320,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isTypeDerivedFrom(source: Type, target: Type): boolean {
         return source.flags & TypeFlags.Union ? every((source as UnionType).types, t => isTypeDerivedFrom(t, target)) :
             target.flags & TypeFlags.Union ? some((target as UnionType).types, t => isTypeDerivedFrom(source, t)) :
-            source.flags & TypeFlags.Intersection ? some((source as IntersectionType).types, t => isTypeDerivedFrom(t, target)) :
-            source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target) :
-            isEmptyAnonymousObjectType(target) ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) :
-            target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) && !isEmptyAnonymousObjectType(source) :
-            target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType) :
-            hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
+                source.flags & TypeFlags.Intersection ? some((source as IntersectionType).types, t => isTypeDerivedFrom(t, target)) :
+                    source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target) :
+                        isEmptyAnonymousObjectType(target) ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) :
+                            target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) && !isEmptyAnonymousObjectType(source) :
+                                target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType) :
+                                    hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
     }
 
     /**
@@ -19396,7 +19398,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!isConstAssertion(node)) {
                     break;
                 }
-                // fallthrough
+            // fallthrough
             case SyntaxKind.JsxExpression:
             case SyntaxKind.ParenthesizedExpression:
                 return elaborateError((node as AsExpression | ParenthesizedExpression | JsxExpression).expression, source, target, relation, headMessage, containingMessageChain, errorOutputContainer);
@@ -19667,7 +19669,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
 
-    function *generateJsxAttributes(node: JsxAttributes): ElaborationIterator {
+    function* generateJsxAttributes(node: JsxAttributes): ElaborationIterator {
         if (!length(node.properties)) return;
         for (const prop of node.properties) {
             if (isJsxSpreadAttribute(prop) || isHyphenatedJsxName(getTextOfJsxAttributeName(prop.name))) continue;
@@ -19675,7 +19677,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
     }
 
-    function *generateJsxChildren(node: JsxElement, getInvalidTextDiagnostic: () => DiagnosticMessage): ElaborationIterator {
+    function* generateJsxChildren(node: JsxElement, getInvalidTextDiagnostic: () => DiagnosticMessage): ElaborationIterator {
         if (!length(node.children)) return;
         let memberOffset = 0;
         for (let i = 0; i < node.children.length; i++) {
@@ -19771,7 +19773,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const elem = getElaborationElementForJsxChild(child, childrenNameType, getInvalidTextualChildDiagnostic);
                     if (elem) {
                         result = elaborateElementwise(
-                            (function*() { yield elem; })(),
+                            (function* () { yield elem; })(),
                             source,
                             target,
                             relation,
@@ -19810,7 +19812,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
     }
 
-    function *generateLimitedTupleElements(node: ArrayLiteralExpression, target: Type): ElaborationIterator {
+    function* generateLimitedTupleElements(node: ArrayLiteralExpression, target: Type): ElaborationIterator {
         const len = length(node.elements);
         if (!len) return;
         for (let i = 0; i < len; i++) {
@@ -19846,7 +19848,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return false;
     }
 
-    function *generateObjectLiteralElements(node: ObjectLiteralExpression): ElaborationIterator {
+    function* generateObjectLiteralElements(node: ObjectLiteralExpression): ElaborationIterator {
         if (!length(node.properties)) return;
         for (const prop of node.properties) {
             if (isSpreadAssignment(prop)) continue;
@@ -20023,13 +20025,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // here and just use the `any` type directly
             const targetReturnType = isResolvingReturnTypeOfSignature(target) ? anyType
                 : target.declaration && isJSConstructor(target.declaration) ? getDeclaredTypeOfClassOrInterface(getMergedSymbol(target.declaration.symbol))
-                : getReturnTypeOfSignature(target);
+                    : getReturnTypeOfSignature(target);
             if (targetReturnType === voidType || targetReturnType === anyType) {
                 return result;
             }
             const sourceReturnType = isResolvingReturnTypeOfSignature(source) ? anyType
                 : source.declaration && isJSConstructor(source.declaration) ? getDeclaredTypeOfClassOrInterface(getMergedSymbol(source.declaration.symbol))
-                : getReturnTypeOfSignature(source);
+                    : getReturnTypeOfSignature(source);
 
             // The following block preserves behavior forbidding boolean returning functions from being assignable to type guard returning functions
             const targetTypePredicate = getTypePredicateOfSignature(target);
@@ -20087,7 +20089,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         const related = source.type === target.type ? Ternary.True :
             source.type && target.type ? compareTypes(source.type, target.type, reportErrors) :
-            Ternary.False;
+                Ternary.False;
         if (related === Ternary.False && reportErrors) {
             errorReporter!(Diagnostics.Type_predicate_0_is_not_assignable_to_1, typePredicateToString(source), typePredicateToString(target));
         }
@@ -20122,9 +20124,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isEmptyObjectType(type: Type): boolean {
         return type.flags & TypeFlags.Object ? !isGenericMappedType(type) && isEmptyResolvedType(resolveStructuredTypeMembers(type as ObjectType)) :
             type.flags & TypeFlags.NonPrimitive ? true :
-            type.flags & TypeFlags.Union ? some((type as UnionType).types, isEmptyObjectType) :
-            type.flags & TypeFlags.Intersection ? every((type as UnionType).types, isEmptyObjectType) :
-            false;
+                type.flags & TypeFlags.Union ? some((type as UnionType).types, isEmptyObjectType) :
+                    type.flags & TypeFlags.Intersection ? every((type as UnionType).types, isEmptyObjectType) :
+                        false;
     }
 
     function isEmptyAnonymousObjectType(type: Type) {
@@ -20274,11 +20276,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         while (true) {
             const t = isFreshLiteralType(type) ? (type as FreshableType).regularType :
                 isGenericTupleType(type) ? getNormalizedTupleType(type, writing) :
-                getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) || type :
-                type.flags & TypeFlags.UnionOrIntersection ? getNormalizedUnionOrIntersectionType(type as UnionOrIntersectionType, writing) :
-                type.flags & TypeFlags.Substitution ? writing ? (type as SubstitutionType).baseType : getSubstitutionIntersection(type as SubstitutionType) :
-                type.flags & TypeFlags.Simplifiable ? getSimplifiedType(type, writing) :
-                type;
+                    getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) || type :
+                        type.flags & TypeFlags.UnionOrIntersection ? getNormalizedUnionOrIntersectionType(type as UnionOrIntersectionType, writing) :
+                            type.flags & TypeFlags.Substitution ? writing ? (type as SubstitutionType).baseType : getSubstitutionIntersection(type as SubstitutionType) :
+                                type.flags & TypeFlags.Simplifiable ? getSimplifiedType(type, writing) :
+                                    type;
             if (t === type) return t;
             type = t;
         }
@@ -20479,12 +20481,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         else {
                             const prefix = (msg.code === Diagnostics.Construct_signature_return_types_0_and_1_are_incompatible.code ||
                                 msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
-                                    ? "new "
-                                    : "";
+                                ? "new "
+                                : "";
                             const params = (msg.code === Diagnostics.Call_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code ||
                                 msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
-                                    ? ""
-                                    : "...";
+                                ? ""
+                                : "...";
                             path = `${prefix}${path}(${params})`;
                         }
                         break;
@@ -20553,31 +20555,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 generalizedSourceType = getTypeNameForErrorDisplay(generalizedSource);
             }
 
-                // If `target` is of indexed access type (And `source` it is not), we use the object type of `target` for better error reporting
-                const targetFlags = target.flags & TypeFlags.IndexedAccess && !(source.flags & TypeFlags.IndexedAccess) ?
-                    (target as IndexedAccessType).objectType.flags :
-                    target.flags;
+            // If `target` is of indexed access type (And `source` it is not), we use the object type of `target` for better error reporting
+            const targetFlags = target.flags & TypeFlags.IndexedAccess && !(source.flags & TypeFlags.IndexedAccess) ?
+                (target as IndexedAccessType).objectType.flags :
+                target.flags;
 
-                if (targetFlags & TypeFlags.TypeParameter && target !== markerSuperTypeForCheck && target !== markerSubTypeForCheck) {
-                    const constraint = getBaseConstraintOfType(target);
-                    let needsOriginalSource;
-                    if (constraint && (isTypeAssignableTo(generalizedSource, constraint) || (needsOriginalSource = isTypeAssignableTo(source, constraint)))) {
-                        reportError(
-                            Diagnostics._0_is_assignable_to_the_constraint_of_type_1_but_1_could_be_instantiated_with_a_different_subtype_of_constraint_2,
-                            needsOriginalSource ? sourceType : generalizedSourceType,
-                            targetType,
-                            typeToString(constraint),
-                        );
-                    }
-                    else {
-                        errorInfo = undefined;
-                        reportError(
-                            Diagnostics._0_could_be_instantiated_with_an_arbitrary_type_which_could_be_unrelated_to_1,
-                            targetType,
-                            generalizedSourceType
-                        );
-                    }
+            if (targetFlags & TypeFlags.TypeParameter && target !== markerSuperTypeForCheck && target !== markerSubTypeForCheck) {
+                const constraint = getBaseConstraintOfType(target);
+                let needsOriginalSource;
+                if (constraint && (isTypeAssignableTo(generalizedSource, constraint) || (needsOriginalSource = isTypeAssignableTo(source, constraint)))) {
+                    reportError(
+                        Diagnostics._0_is_assignable_to_the_constraint_of_type_1_but_1_could_be_instantiated_with_a_different_subtype_of_constraint_2,
+                        needsOriginalSource ? sourceType : generalizedSourceType,
+                        targetType,
+                        typeToString(constraint),
+                    );
                 }
+                else {
+                    errorInfo = undefined;
+                    reportError(
+                        Diagnostics._0_could_be_instantiated_with_an_arbitrary_type_which_could_be_unrelated_to_1,
+                        targetType,
+                        generalizedSourceType
+                    );
+                }
+            }
 
             if (!message) {
                 if (relation === comparableRelation) {
@@ -20713,7 +20715,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const types = (target as UnionType).types;
                 const candidate = types.length === 2 && types[0].flags & TypeFlags.Nullable ? types[1] :
                     types.length === 3 && types[0].flags & TypeFlags.Nullable && types[1].flags & TypeFlags.Nullable ? types[2] :
-                    undefined;
+                        undefined;
                 if (candidate && !(candidate.flags & TypeFlags.Nullable)) {
                     target = getNormalizedType(candidate, /*writing*/ true);
                     if (source === target) return Ternary.True;
@@ -21022,8 +21024,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const alternateForm = source === (source as StringLiteralType).regularType ? (source as StringLiteralType).freshType : (source as StringLiteralType).regularType;
                     const primitive = source.flags & TypeFlags.StringLiteral ? stringType :
                         source.flags & TypeFlags.NumberLiteral ? numberType :
-                        source.flags & TypeFlags.BigIntLiteral ? bigintType :
-                        undefined;
+                            source.flags & TypeFlags.BigIntLiteral ? bigintType :
+                                undefined;
                     return primitive && containsType(targetTypes, primitive) || alternateForm && containsType(targetTypes, alternateForm) ? Ternary.True : Ternary.False;
                 }
                 const match = getMatchingUnionConstituentForType(target as UnionType, source);
@@ -21314,7 +21316,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // the type param can be compared with itself in the target (with the influence of its constraint to match other parts)
                 // For example, if `T extends 1 | 2` and `U extends 2 | 3` and we compare `T & U` to `T & U & (1 | 2 | 3)`
                 if (!result && (source.flags & TypeFlags.Intersection || source.flags & TypeFlags.TypeParameter && target.flags & TypeFlags.Union)) {
-                    const constraint = getEffectiveConstraintOfIntersection(source.flags & TypeFlags.Intersection ? (source as IntersectionType).types: [source], !!(target.flags & TypeFlags.Union));
+                    const constraint = getEffectiveConstraintOfIntersection(source.flags & TypeFlags.Intersection ? (source as IntersectionType).types : [source], !!(target.flags & TypeFlags.Union));
                     if (constraint && everyType(constraint, c => c !== source)) { // Skip comparison if expansion contains the source itself
                         // TODO: Stack errors so we get a pyramid for the "normal" comparison above, _and_ a second for this
                         result = isRelatedTo(constraint, target, RecursionFlags.Source, /*reportErrors*/ false, /*headMessage*/ undefined, intersectionState);
@@ -22517,7 +22519,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function signatureRelatedTo(source: Signature, target: Signature, erase: boolean, reportErrors: boolean, intersectionState: IntersectionState, incompatibleReporter: (source: Type, target: Type) => void): Ternary {
             const checkMode = relation === subtypeRelation ? SignatureCheckMode.StrictTopSignature :
                 relation === strictSubtypeRelation ? SignatureCheckMode.StrictTopSignature | SignatureCheckMode.StrictArity :
-                SignatureCheckMode.None;
+                    SignatureCheckMode.None;
             return compareSignaturesRelated(erase ? getErasedSignature(source) : source, erase ? getErasedSignature(target) : target,
                 checkMode, reportErrors, reportError, incompatibleReporter, isRelatedToWorker, reportUnreliableMapper);
             function isRelatedToWorker(source: Type, target: Type, reportErrors?: boolean) {
@@ -22601,7 +22603,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             for (const targetInfo of indexInfos) {
                 const related = relation !== strictSubtypeRelation && !sourceIsPrimitive && targetHasStringIndex && targetInfo.type.flags & TypeFlags.Any ? Ternary.True :
                     isGenericMappedType(source) && targetHasStringIndex ? isRelatedTo(getTemplateTypeFromMappedType(source), targetInfo.type, RecursionFlags.Both, reportErrors) :
-                    typeRelatedToIndexInfo(source, targetInfo, reportErrors, intersectionState);
+                        typeRelatedToIndexInfo(source, targetInfo, reportErrors, intersectionState);
                 if (!related) {
                     return Ternary.False;
                 }
@@ -23192,8 +23194,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function compareTypePredicatesIdentical(source: TypePredicate | undefined, target: TypePredicate | undefined, compareTypes: (s: Type, t: Type) => Ternary): Ternary {
         return !(source && target && typePredicateKindsMatch(source, target)) ? Ternary.False :
             source.type === target.type ? Ternary.True :
-            source.type && target.type ? compareTypes(source.type, target.type) :
-            Ternary.False;
+                source.type && target.type ? compareTypes(source.type, target.type) :
+                    Ternary.False;
     }
 
     function literalTypesWithSameBaseType(types: Type[]): boolean {
@@ -23354,17 +23356,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isLiteralType(type: Type): boolean {
         return type.flags & TypeFlags.Boolean ? true :
             type.flags & TypeFlags.Union ? type.flags & TypeFlags.EnumLiteral ? true : every((type as UnionType).types, isUnitType) :
-            isUnitType(type);
+                isUnitType(type);
     }
 
     function getBaseTypeOfLiteralType(type: Type): Type {
         return type.flags & TypeFlags.EnumLike ? getBaseTypeOfEnumLikeType(type as LiteralType) :
             type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType :
-            type.flags & TypeFlags.NumberLiteral ? numberType :
-            type.flags & TypeFlags.BigIntLiteral ? bigintType :
-            type.flags & TypeFlags.BooleanLiteral ? booleanType :
-            type.flags & TypeFlags.Union ? getBaseTypeOfLiteralTypeUnion(type as UnionType) :
-            type;
+                type.flags & TypeFlags.NumberLiteral ? numberType :
+                    type.flags & TypeFlags.BigIntLiteral ? bigintType :
+                        type.flags & TypeFlags.BooleanLiteral ? booleanType :
+                            type.flags & TypeFlags.Union ? getBaseTypeOfLiteralTypeUnion(type as UnionType) :
+                                type;
     }
 
     function getBaseTypeOfLiteralTypeUnion(type: UnionType) {
@@ -23377,26 +23379,26 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getBaseTypeOfLiteralTypeForComparison(type: Type): Type {
         return type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType :
             type.flags & (TypeFlags.NumberLiteral | TypeFlags.Enum) ? numberType :
-            type.flags & TypeFlags.BigIntLiteral ? bigintType :
-            type.flags & TypeFlags.BooleanLiteral ? booleanType :
-            type.flags & TypeFlags.Union ? mapType(type, getBaseTypeOfLiteralTypeForComparison) :
-            type;
+                type.flags & TypeFlags.BigIntLiteral ? bigintType :
+                    type.flags & TypeFlags.BooleanLiteral ? booleanType :
+                        type.flags & TypeFlags.Union ? mapType(type, getBaseTypeOfLiteralTypeForComparison) :
+                            type;
     }
 
     function getWidenedLiteralType(type: Type): Type {
         return type.flags & TypeFlags.EnumLike && isFreshLiteralType(type) ? getBaseTypeOfEnumLikeType(type as LiteralType) :
             type.flags & TypeFlags.StringLiteral && isFreshLiteralType(type) ? stringType :
-            type.flags & TypeFlags.NumberLiteral && isFreshLiteralType(type) ? numberType :
-            type.flags & TypeFlags.BigIntLiteral && isFreshLiteralType(type) ? bigintType :
-            type.flags & TypeFlags.BooleanLiteral && isFreshLiteralType(type) ? booleanType :
-            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedLiteralType) :
-            type;
+                type.flags & TypeFlags.NumberLiteral && isFreshLiteralType(type) ? numberType :
+                    type.flags & TypeFlags.BigIntLiteral && isFreshLiteralType(type) ? bigintType :
+                        type.flags & TypeFlags.BooleanLiteral && isFreshLiteralType(type) ? booleanType :
+                            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedLiteralType) :
+                                type;
     }
 
     function getWidenedUniqueESSymbolType(type: Type): Type {
         return type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
             type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedUniqueESSymbolType) :
-            type;
+                type;
     }
 
     function getWidenedLiteralLikeTypeForContextualType(type: Type, contextualType: Type | undefined) {
@@ -23410,7 +23412,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (type && isUnitType(type)) {
             const contextualType = !contextualSignatureReturnType ? undefined :
                 isAsync ? getPromisedTypeOfPromise(contextualSignatureReturnType) :
-                contextualSignatureReturnType;
+                    contextualSignatureReturnType;
             type = getWidenedLiteralLikeTypeForContextualType(type, contextualType);
         }
         return type;
@@ -23469,7 +23471,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             every(t1.target.elementFlags, (f, i) => (f & ElementFlags.Variable) === (t2.target.elementFlags[i] & ElementFlags.Variable));
     }
 
-    function isZeroBigInt({value}: BigIntLiteralType) {
+    function isZeroBigInt({ value }: BigIntLiteralType) {
         return value.base10Value === "0";
     }
 
@@ -23484,14 +23486,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getDefinitelyFalsyPartOfType(type: Type): Type {
         return type.flags & TypeFlags.String ? emptyStringType :
             type.flags & TypeFlags.Number ? zeroType :
-            type.flags & TypeFlags.BigInt ? zeroBigIntType :
-            type === regularFalseType ||
-            type === falseType ||
-            type.flags & (TypeFlags.Void | TypeFlags.Undefined | TypeFlags.Null | TypeFlags.AnyOrUnknown) ||
-            type.flags & TypeFlags.StringLiteral && (type as StringLiteralType).value === "" ||
-            type.flags & TypeFlags.NumberLiteral && (type as NumberLiteralType).value === 0 ||
-            type.flags & TypeFlags.BigIntLiteral && isZeroBigInt(type as BigIntLiteralType) ? type :
-            neverType;
+                type.flags & TypeFlags.BigInt ? zeroBigIntType :
+                    type === regularFalseType ||
+                        type === falseType ||
+                        type.flags & (TypeFlags.Void | TypeFlags.Undefined | TypeFlags.Null | TypeFlags.AnyOrUnknown) ||
+                        type.flags & TypeFlags.StringLiteral && (type as StringLiteralType).value === "" ||
+                        type.flags & TypeFlags.NumberLiteral && (type as NumberLiteralType).value === 0 ||
+                        type.flags & TypeFlags.BigIntLiteral && isZeroBigInt(type as BigIntLiteralType) ? type :
+                        neverType;
     }
 
     /**
@@ -23503,8 +23505,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const missing = (flags & ~type.flags) & (TypeFlags.Undefined | TypeFlags.Null);
         return missing === 0 ? type :
             missing === TypeFlags.Undefined ? getUnionType([type, undefinedType]) :
-            missing === TypeFlags.Null ? getUnionType([type, nullType]) :
-            getUnionType([type, undefinedType, nullType]);
+                missing === TypeFlags.Null ? getUnionType([type, nullType]) :
+                    getUnionType([type, undefinedType, nullType]);
     }
 
     function getOptionalType(type: Type, isProperty = false): Type {
@@ -23541,7 +23543,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getOptionalExpressionType(exprType: Type, expression: Expression) {
         return isExpressionOfOptionalChainRoot(expression) ? getNonNullableType(exprType) :
             isOptionalChain(expression) ? removeOptionalTypeMarker(exprType) :
-            exprType;
+                exprType;
     }
 
     function removeMissingType(type: Type, isOptional: boolean) {
@@ -23832,7 +23834,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if ((isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent)) &&
                         param.parent.parameters.indexOf(param) > -1 &&
                         (resolveName(param, param.name.escapedText, SymbolFlags.Type, /*nameNotFoundMessage*/ undefined, param.name.escapedText, /*isUse*/ true) ||
-                        originalKeywordKind && isTypeNodeKind(originalKeywordKind))) {
+                            originalKeywordKind && isTypeNodeKind(originalKeywordKind))) {
                         const newName = "arg" + param.parent.parameters.indexOf(param);
                         const typeName = declarationNameToString(param.name) + (param.dotDotDotToken ? "[]" : "");
                         errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_0_Colon_1, newName, typeName);
@@ -23876,7 +23878,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 diagnostic = !noImplicitAny ? Diagnostics._0_implicitly_has_an_1_return_type_but_a_better_type_may_be_inferred_from_usage :
                     wideningKind === WideningKind.GeneratorYield ? Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_yield_type :
-                    Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type;
+                        Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type;
                 break;
             case SyntaxKind.MappedType:
                 if (noImplicitAny) {
@@ -24231,7 +24233,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeFromInference(inference: InferenceInfo) {
         return inference.candidates ? getUnionType(inference.candidates, UnionReduction.Subtype) :
             inference.contraCandidates ? getIntersectionType(inference.contraCandidates) :
-            undefined;
+                undefined;
     }
 
     function hasSkipDirectInferenceFlag(node: Node) {
@@ -24320,8 +24322,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return source.flags & TypeFlags.StringLiteral ? inferFromLiteralPartsToTemplateLiteral([(source as StringLiteralType).value], emptyArray, target) :
             source.flags & TypeFlags.TemplateLiteral ?
                 arraysEqual((source as TemplateLiteralType).texts, target.texts) ? map((source as TemplateLiteralType).types, getStringLikeTypeForType) :
-                inferFromLiteralPartsToTemplateLiteral((source as TemplateLiteralType).texts, (source as TemplateLiteralType).types, target) :
-            undefined;
+                    inferFromLiteralPartsToTemplateLiteral((source as TemplateLiteralType).texts, (source as TemplateLiteralType).types, target) :
+                undefined;
     }
 
     function isTypeMatchedByTemplateLiteralType(source: Type, target: TemplateLiteralType): boolean {
@@ -24934,20 +24936,20 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 // for each type in the constraint, find the highest priority matching type
                                 const matchingType = reduceLeft(constraintTypes, (left, right) =>
                                     !(right.flags & allTypeFlags) ? left :
-                                    left.flags & TypeFlags.String ? left : right.flags & TypeFlags.String ? source :
-                                    left.flags & TypeFlags.TemplateLiteral ? left : right.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, right as TemplateLiteralType) ? source :
-                                    left.flags & TypeFlags.StringMapping ? left : right.flags & TypeFlags.StringMapping && str === applyStringMapping(right.symbol, str) ? source :
-                                    left.flags & TypeFlags.StringLiteral ? left : right.flags & TypeFlags.StringLiteral && (right as StringLiteralType).value === str ? right :
-                                    left.flags & TypeFlags.Number ? left : right.flags & TypeFlags.Number ? getNumberLiteralType(+str) :
-                                    left.flags & TypeFlags.Enum ? left : right.flags & TypeFlags.Enum ? getNumberLiteralType(+str) :
-                                    left.flags & TypeFlags.NumberLiteral ? left : right.flags & TypeFlags.NumberLiteral && (right as NumberLiteralType).value === +str ? right :
-                                    left.flags & TypeFlags.BigInt ? left : right.flags & TypeFlags.BigInt ? parseBigIntLiteralType(str) :
-                                    left.flags & TypeFlags.BigIntLiteral ? left : right.flags & TypeFlags.BigIntLiteral && pseudoBigIntToString((right as BigIntLiteralType).value) === str ? right :
-                                    left.flags & TypeFlags.Boolean ? left : right.flags & TypeFlags.Boolean ? str === "true" ? trueType : str === "false" ? falseType : booleanType :
-                                    left.flags & TypeFlags.BooleanLiteral ? left : right.flags & TypeFlags.BooleanLiteral && (right as IntrinsicType).intrinsicName === str ? right :
-                                    left.flags & TypeFlags.Undefined ? left : right.flags & TypeFlags.Undefined && (right as IntrinsicType).intrinsicName === str ? right :
-                                    left.flags & TypeFlags.Null ? left : right.flags & TypeFlags.Null && (right as IntrinsicType).intrinsicName === str ? right :
-                                    left,
+                                        left.flags & TypeFlags.String ? left : right.flags & TypeFlags.String ? source :
+                                            left.flags & TypeFlags.TemplateLiteral ? left : right.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, right as TemplateLiteralType) ? source :
+                                                left.flags & TypeFlags.StringMapping ? left : right.flags & TypeFlags.StringMapping && str === applyStringMapping(right.symbol, str) ? source :
+                                                    left.flags & TypeFlags.StringLiteral ? left : right.flags & TypeFlags.StringLiteral && (right as StringLiteralType).value === str ? right :
+                                                        left.flags & TypeFlags.Number ? left : right.flags & TypeFlags.Number ? getNumberLiteralType(+str) :
+                                                            left.flags & TypeFlags.Enum ? left : right.flags & TypeFlags.Enum ? getNumberLiteralType(+str) :
+                                                                left.flags & TypeFlags.NumberLiteral ? left : right.flags & TypeFlags.NumberLiteral && (right as NumberLiteralType).value === +str ? right :
+                                                                    left.flags & TypeFlags.BigInt ? left : right.flags & TypeFlags.BigInt ? parseBigIntLiteralType(str) :
+                                                                        left.flags & TypeFlags.BigIntLiteral ? left : right.flags & TypeFlags.BigIntLiteral && pseudoBigIntToString((right as BigIntLiteralType).value) === str ? right :
+                                                                            left.flags & TypeFlags.Boolean ? left : right.flags & TypeFlags.Boolean ? str === "true" ? trueType : str === "false" ? falseType : booleanType :
+                                                                                left.flags & TypeFlags.BooleanLiteral ? left : right.flags & TypeFlags.BooleanLiteral && (right as IntrinsicType).intrinsicName === str ? right :
+                                                                                    left.flags & TypeFlags.Undefined ? left : right.flags & TypeFlags.Undefined && (right as IntrinsicType).intrinsicName === str ? right :
+                                                                                        left.flags & TypeFlags.Null ? left : right.flags & TypeFlags.Null && (right as IntrinsicType).intrinsicName === str ? right :
+                                                                                            left,
                                     neverType as Type);
 
                                 if (!(matchingType.flags & TypeFlags.Never)) {
@@ -25203,7 +25205,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             (inference.isFixed || !isTypeParameterAtTopLevelInReturnType(signature, inference.typeParameter));
         const baseCandidates = primitiveConstraint ? sameMap(candidates, getRegularTypeOfLiteralType) :
             widenLiteralTypes ? sameMap(candidates, getWidenedLiteralType) :
-            candidates;
+                candidates;
         // If all inferences were made from a position that implies a combined result, infer a union type.
         // Otherwise, infer a common supertype.
         const unwidenedType = inference.priority! & InferencePriority.PriorityImpliesCombination ?
@@ -25331,7 +25333,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isCallExpression(node.parent)) {
                     return Diagnostics.Cannot_find_name_0_Did_you_mean_to_write_this_in_an_async_function;
                 }
-                // falls through
+            // falls through
             default:
                 if (node.parent.kind === SyntaxKind.ShorthandPropertyAssignment) {
                     return Diagnostics.No_value_exists_in_scope_for_the_shorthand_property_0_Either_declare_one_or_provide_an_initializer;
@@ -25382,7 +25384,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const symbol = getResolvedSymbol(node as Identifier);
                     return symbol !== unknownSymbol ? `${flowContainer ? getNodeId(flowContainer) : "-1"}|${getTypeId(declaredType)}|${getTypeId(initialType)}|${getSymbolId(symbol)}` : undefined;
                 }
-                // falls through
+            // falls through
             case SyntaxKind.ThisKeyword:
                 return `0|${flowContainer ? getNodeId(flowContainer) : "-1"}|${getTypeId(declaredType)}|${getTypeId(initialType)}`;
             case SyntaxKind.NonNullExpression:
@@ -25430,8 +25432,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return isThisInTypeQuery(source) ?
                     target.kind === SyntaxKind.ThisKeyword :
                     target.kind === SyntaxKind.Identifier && getResolvedSymbol(source as Identifier) === getResolvedSymbol(target as Identifier) ||
-                        (isVariableDeclaration(target) || isBindingElement(target)) &&
-                        getExportSymbolOfValueSymbolIfExported(getResolvedSymbol(source as Identifier)) === getSymbolOfDeclaration(target);
+                    (isVariableDeclaration(target) || isBindingElement(target)) &&
+                    getExportSymbolOfValueSymbolIfExported(getResolvedSymbol(source as Identifier)) === getSymbolOfDeclaration(target);
             case SyntaxKind.ThisKeyword:
                 return target.kind === SyntaxKind.ThisKeyword;
             case SyntaxKind.SuperKeyword:
@@ -25811,12 +25813,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (strictNullChecks) {
             switch (facts) {
                 case TypeFacts.NEUndefined:
-                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefined ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQNull && !maybeTypeOfKind(reduced, TypeFlags.Null) ? getUnionType([emptyObjectType, nullType]) : emptyObjectType]): t);
+                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefined ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQNull && !maybeTypeOfKind(reduced, TypeFlags.Null) ? getUnionType([emptyObjectType, nullType]) : emptyObjectType]) : t);
                 case TypeFacts.NENull:
-                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQNull ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQUndefined && !maybeTypeOfKind(reduced, TypeFlags.Undefined) ? getUnionType([emptyObjectType, undefinedType]) : emptyObjectType]): t);
+                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQNull ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQUndefined && !maybeTypeOfKind(reduced, TypeFlags.Undefined) ? getUnionType([emptyObjectType, undefinedType]) : emptyObjectType]) : t);
                 case TypeFacts.NEUndefinedOrNull:
                 case TypeFacts.Truthy:
-                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefinedOrNull ? getGlobalNonNullableTypeInstantiation(t): t);
+                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefinedOrNull ? getGlobalNonNullableTypeInstantiation(t) : t);
             }
         }
         return reduced;
@@ -26141,9 +26143,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             maybeTypeOfKind(typeWithLiterals, TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping | TypeFlags.NumberLiteral | TypeFlags.BigIntLiteral)) {
             return mapType(typeWithPrimitives, t =>
                 t.flags & TypeFlags.String ? extractTypesOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) :
-                isPatternLiteralType(t) && !maybeTypeOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? extractTypesOfKind(typeWithLiterals, TypeFlags.StringLiteral) :
-                t.flags & TypeFlags.Number ? extractTypesOfKind(typeWithLiterals, TypeFlags.Number | TypeFlags.NumberLiteral) :
-                t.flags & TypeFlags.BigInt ? extractTypesOfKind(typeWithLiterals, TypeFlags.BigInt | TypeFlags.BigIntLiteral) : t);
+                    isPatternLiteralType(t) && !maybeTypeOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? extractTypesOfKind(typeWithLiterals, TypeFlags.StringLiteral) :
+                        t.flags & TypeFlags.Number ? extractTypesOfKind(typeWithLiterals, TypeFlags.Number | TypeFlags.NumberLiteral) :
+                            t.flags & TypeFlags.BigInt ? extractTypesOfKind(typeWithLiterals, TypeFlags.BigInt | TypeFlags.BigIntLiteral) : t);
         }
         return typeWithPrimitives;
     }
@@ -26338,7 +26340,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const signatures = getSignaturesOfType(funcType && getApparentType(funcType) || unknownType, SignatureKind.Call);
             const candidate = signatures.length === 1 && !signatures[0].typeParameters ? signatures[0] :
                 some(signatures, hasTypePredicateOrNeverReturnType) ? getResolvedSignature(node) :
-                undefined;
+                    undefined;
             signature = links.effectsSignature = candidate && hasTypePredicateOrNeverReturnType(candidate) ? candidate : unknownSignature;
         }
         return signature === unknownSignature ? undefined : signature;
@@ -26728,7 +26730,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const type = finalizeEvolvingArrayType(getTypeFromFlowType(flowType));
                     const narrowedType = predicate.type ? narrowTypeByTypePredicate(type, predicate, flow.node, /*assumeTrue*/ true) :
                         predicate.kind === TypePredicateKind.AssertsIdentifier && predicate.parameterIndex >= 0 && predicate.parameterIndex < flow.node.arguments.length ? narrowTypeByAssertion(type, flow.node.arguments[predicate.parameterIndex]) :
-                        type;
+                            type;
                     return narrowedType === type ? flowType : createFlowType(narrowedType, isIncomplete(flowType));
                 }
                 if (getReturnTypeOfSignature(signature).flags & TypeFlags.Never) {
@@ -27053,7 +27055,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (candidate) {
                         return operator === (assumeTrue ? SyntaxKind.EqualsEqualsEqualsToken : SyntaxKind.ExclamationEqualsEqualsToken) ? candidate :
                             isUnitType(getTypeOfPropertyOfType(candidate, keyPropertyName) || unknownType) ? removeType(type, candidate) :
-                            type;
+                                type;
                     }
                 }
             }
@@ -27335,7 +27337,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const discriminantType = getUnionType(clauseTypes);
             const caseType =
                 discriminantType.flags & TypeFlags.Never ? neverType :
-                replacePrimitivesWithLiterals(filterType(type, t => areTypesComparable(discriminantType, t)), discriminantType);
+                    replacePrimitivesWithLiterals(filterType(type, t => areTypesComparable(discriminantType, t)), discriminantType);
             if (!hasDefaultClause) {
                 return caseType;
             }
@@ -27364,14 +27366,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // as a subtype of `{}`, and we need the type facts check because function types are subtypes of `object`,
                 // but are classified as "function" according to `typeof`.
                 isTypeRelatedTo(t, impliedType, strictSubtypeRelation) ? getTypeFacts(t) & facts ? t : neverType :
-                // We next check if the consituent is a supertype of the implied type. If so, we substitute the implied
-                // type. This handles top types like `unknown` and `{}`, and supertypes like `{ toString(): string }`.
-                isTypeSubtypeOf(impliedType, t) ? impliedType :
-                // Neither the constituent nor the implied type is a subtype of the other, however their domains may still
-                // overlap. For example, an unconstrained type parameter and type `string`. If the type facts indicate
-                // possible overlap, we form an intersection. Otherwise, we eliminate the constituent.
-                getTypeFacts(t) & facts ? getIntersectionType([t, impliedType]) :
-                neverType);
+                    // We next check if the consituent is a supertype of the implied type. If so, we substitute the implied
+                    // type. This handles top types like `unknown` and `{}`, and supertypes like `{ toString(): string }`.
+                    isTypeSubtypeOf(impliedType, t) ? impliedType :
+                        // Neither the constituent nor the implied type is a subtype of the other, however their domains may still
+                        // overlap. For example, an unconstrained type parameter and type `string`. If the type facts indicate
+                        // possible overlap, we form an intersection. Otherwise, we eliminate the constituent.
+                        getTypeFacts(t) & facts ? getIntersectionType([t, impliedType]) :
+                            neverType);
         }
 
         function narrowTypeBySwitchOnTypeOf(type: Type, switchStatement: SwitchStatement, clauseStart: number, clauseEnd: number): Type {
@@ -27523,9 +27525,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // based on assignability, or as a last resort produce an intersection.
             return !(narrowedType.flags & TypeFlags.Never) ? narrowedType :
                 isTypeSubtypeOf(candidate, type) ? candidate :
-                isTypeAssignableTo(type, candidate) ? type :
-                isTypeAssignableTo(candidate, type) ? candidate :
-                getIntersectionType([type, candidate]);
+                    isTypeAssignableTo(type, candidate) ? type :
+                        isTypeAssignableTo(candidate, type) ? candidate :
+                            getIntersectionType([type, candidate]);
         }
 
         function narrowTypeByCallExpression(type: Type, callExpression: CallExpression, assumeTrue: boolean): Type {
@@ -27594,7 +27596,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             }
                         }
                     }
-                    // falls through
+                // falls through
                 case SyntaxKind.ThisKeyword:
                 case SyntaxKind.SuperKeyword:
                 case SyntaxKind.PropertyAccessExpression:
@@ -27746,7 +27748,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             parent.kind === SyntaxKind.QualifiedName ||
             parent.kind === SyntaxKind.CallExpression && (parent as CallExpression).expression === node ||
             parent.kind === SyntaxKind.ElementAccessExpression && (parent as ElementAccessExpression).expression === node &&
-                !(someType(type, isGenericTypeWithoutNullableConstraint) && isGenericIndexType(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression)));
+            !(someType(type, isGenericTypeWithoutNullableConstraint) && isGenericIndexType(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression)));
     }
 
     function isGenericTypeWithUnionConstraint(type: Type): boolean {
@@ -28005,10 +28007,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 !(isInJSFile(node) && localOrExportSymbol.flags & SymbolFlags.ValueModule)) {
                 const assignmentError = localOrExportSymbol.flags & SymbolFlags.Enum ? Diagnostics.Cannot_assign_to_0_because_it_is_an_enum
                     : localOrExportSymbol.flags & SymbolFlags.Class ? Diagnostics.Cannot_assign_to_0_because_it_is_a_class
-                    : localOrExportSymbol.flags & SymbolFlags.Module ? Diagnostics.Cannot_assign_to_0_because_it_is_a_namespace
-                    : localOrExportSymbol.flags & SymbolFlags.Function ? Diagnostics.Cannot_assign_to_0_because_it_is_a_function
-                    : localOrExportSymbol.flags & SymbolFlags.Alias ? Diagnostics.Cannot_assign_to_0_because_it_is_an_import
-                    : Diagnostics.Cannot_assign_to_0_because_it_is_not_a_variable;
+                        : localOrExportSymbol.flags & SymbolFlags.Module ? Diagnostics.Cannot_assign_to_0_because_it_is_a_namespace
+                            : localOrExportSymbol.flags & SymbolFlags.Function ? Diagnostics.Cannot_assign_to_0_because_it_is_a_function
+                                : localOrExportSymbol.flags & SymbolFlags.Alias ? Diagnostics.Cannot_assign_to_0_because_it_is_an_import
+                                    : Diagnostics.Cannot_assign_to_0_because_it_is_not_a_variable;
 
                 error(node, assignmentError, symbolToString(symbol));
                 return errorType;
@@ -28070,13 +28072,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // declaration container are the same).
         const assumeInitialized = isParameter || isAlias || isOuterVariable || isSpreadDestructuringAssignmentTarget || isModuleExports || isSameScopedBindingElement(node, declaration) ||
             type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void)) !== 0 ||
-            isInTypeQuery(node) || isInAmbientOrTypeNode(node) || node.parent.kind === SyntaxKind.ExportSpecifier) ||
+                isInTypeQuery(node) || isInAmbientOrTypeNode(node) || node.parent.kind === SyntaxKind.ExportSpecifier) ||
             node.parent.kind === SyntaxKind.NonNullExpression ||
             declaration.kind === SyntaxKind.VariableDeclaration && (declaration as VariableDeclaration).exclamationToken ||
             declaration.flags & NodeFlags.Ambient;
         const initialType = isAutomaticTypeInNonNull ? undefinedType :
             assumeInitialized ? (isParameter ? removeOptionalityFromDeclaredType(type, declaration as VariableLikeDeclaration) : type) :
-            typeIsAutomatic ? undefinedType : getOptionalType(type);
+                typeIsAutomatic ? undefinedType : getOptionalType(type);
         const flowType = isAutomaticTypeInNonNull ? getNonNullableType(getFlowTypeOfReference(node, type, initialType, flowContainer)) :
             getFlowTypeOfReference(node, type, initialType, flowContainer);
         // A variable is considered uninitialized when it is possible to analyze the entire control flow graph
@@ -28246,7 +28248,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function findFirstSuperCall(node: Node): SuperCall | undefined {
         return isSuperCall(node) ? node :
             isFunctionLike(node) ? undefined :
-            forEachChild(node, findFirstSuperCall);
+                forEachChild(node, findFirstSuperCall);
     }
 
     /**
@@ -28278,7 +28280,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkThisInStaticClassFieldInitializerInDecoratedClass(thisExpression: Node, container: Node) {
         if (isPropertyDeclaration(container) && hasStaticModifier(container) && legacyDecorators &&
             container.initializer && textRangeContainsPositionInclusive(container.initializer, thisExpression.pos) && hasDecorators(container.parent)) {
-                error(thisExpression, Diagnostics.Cannot_use_this_in_a_static_property_initializer_of_a_decorated_class);
+            error(thisExpression, Diagnostics.Cannot_use_this_in_a_static_property_initializer_of_a_decorated_class);
         }
     }
 
@@ -28707,7 +28709,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             func.kind === SyntaxKind.GetAccessor ||
             func.kind === SyntaxKind.SetAccessor) && func.parent.kind === SyntaxKind.ObjectLiteralExpression ? func.parent :
             func.kind === SyntaxKind.FunctionExpression && func.parent.kind === SyntaxKind.PropertyAssignment ? func.parent.parent as ObjectLiteralExpression :
-            undefined;
+                undefined;
     }
 
     function getThisTypeArgument(type: Type): Type | undefined {
@@ -29000,7 +29002,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isImportCall(callTarget)) {
             return argIndex === 0 ? stringType :
                 argIndex === 1 ? getGlobalImportCallOptionsType(/*reportErrors*/ false) :
-                anyType;
+                    anyType;
         }
 
         // If we're already in the process of resolving the given signature, don't resolve again as
@@ -29060,7 +29062,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * Try to find a resolved symbol for an expression without also resolving its type, as
      * getSymbolAtLocation would (as that could be reentrant into contextual typing)
      */
-     function getSymbolForExpression(e: Expression) {
+    function getSymbolForExpression(e: Expression) {
         if (canHaveSymbol(e) && e.symbol) {
             return e.symbol;
         }
@@ -29450,7 +29452,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             );
             return apparentType.flags & TypeFlags.Union && isObjectLiteralExpression(node) ? discriminateContextualTypeByObjectMembers(node, apparentType as UnionType) :
                 apparentType.flags & TypeFlags.Union && isJsxAttributes(node) ? discriminateContextualTypeByJSXAttributes(node, apparentType as UnionType) :
-                apparentType;
+                    apparentType;
         }
     }
 
@@ -29783,8 +29785,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 signatures,
                 (left: Signature | undefined, right) =>
                     left === right || !left ? left
-                    : compareTypeParametersIdentical(left.typeParameters, right!.typeParameters) ? combineSignaturesOfIntersectionMembers(left, right!)
-                    : undefined)
+                        : compareTypeParametersIdentical(left.typeParameters, right!.typeParameters) ? combineSignaturesOfIntersectionMembers(left, right!)
+                            : undefined)
             : undefined;
     }
 
@@ -29825,8 +29827,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const paramName = leftName === rightName ? leftName :
                 !leftName ? rightName :
-                !rightName ? leftName :
-                undefined;
+                    !rightName ? leftName :
+                        undefined;
             const paramSymbol = createSymbol(
                 SymbolFlags.FunctionScopedVariable | (isOptional && !isRestParam ? SymbolFlags.Optional : 0),
                 paramName || `arg${i}` as __String
@@ -30195,7 +30197,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // for error recovery purposes. For example, if a user wrote `{ a = 100 }` instead of `{ a: 100 }`.
                     // we don't want to say "could not find 'a'".
                     memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ? checkExpressionForMutableLocation(!inDestructuringPattern && memberDecl.objectAssignmentInitializer ? memberDecl.objectAssignmentInitializer : memberDecl.name, checkMode) :
-                    checkObjectLiteralMethod(memberDecl, checkMode);
+                        checkObjectLiteralMethod(memberDecl, checkMode);
                 if (isInJavascript) {
                     const jsDocType = getTypeForDeclarationFromJSDocComment(memberDecl);
                     if (jsDocType) {
@@ -30563,7 +30565,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const childrenPropSymbol = createSymbol(SymbolFlags.Property, jsxChildrenPropertyName);
                 childrenPropSymbol.links.type = childrenTypes.length === 1 ? childrenTypes[0] :
                     childrenContextualType && someType(childrenContextualType, isTupleLikeType) ? createTupleType(childrenTypes) :
-                    createArrayType(getUnionType(childrenTypes));
+                        createArrayType(getUnionType(childrenTypes));
                 // Fake up a property declaration for the children
                 childrenPropSymbol.valueDeclaration = factory.createPropertySignature(/*modifiers*/ undefined, unescapeLeadingUnderscores(jsxChildrenPropertyName), /*questionToken*/ undefined, /*type*/ undefined);
                 setParent(childrenPropSymbol.valueDeclaration, attributes);
@@ -30700,8 +30702,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const isClassic = getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Classic;
         const errorMessage = isClassic
-                                ? Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
-                                : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
+            ? Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
+            : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
         const mod = resolveExternalModule(location!, runtimeImportSpecifier, errorMessage, location!);
         const result = mod && mod !== unknownSymbol ? getMergedSymbol(resolveSymbol(mod)) : undefined;
         if (links) {
@@ -31012,7 +31014,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (isNodeOpeningLikeElement) {
-            const jsxOpeningLikeNode = node ;
+            const jsxOpeningLikeNode = node;
             const sig = getResolvedSignature(jsxOpeningLikeNode);
             checkDeprecatedSignature(sig, node);
 
@@ -31123,8 +31125,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         const errorNode = !reportError ? undefined :
             node.kind === SyntaxKind.QualifiedName ? node.right :
-            node.kind === SyntaxKind.ImportType ? node :
-            node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
+                node.kind === SyntaxKind.ImportType ? node :
+                    node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
 
         return checkPropertyAccessibilityAtLocation(node, isSuper, writing, type, prop, errorNode);
     }
@@ -31915,7 +31917,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const properties = getPropertiesOfType(containingType);
         const jsxSpecific = strName === "for" ? find(properties, x => symbolName(x) === "htmlFor")
             : strName === "class" ? find(properties, x => symbolName(x) === "className")
-            : undefined;
+                : undefined;
         return jsxSpecific ?? getSpellingSuggestionForName(strName, properties, SymbolFlags.Value);
     }
 
@@ -32132,8 +32134,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         // A #private property access in an optional chain is an error dealt with by the parser.
-         // The checker does not check for it, so we need to do our own check here.
-         if (property.valueDeclaration && isPrivateIdentifierClassElementDeclaration(property.valueDeclaration)) {
+        // The checker does not check for it, so we need to do our own check here.
+        if (property.valueDeclaration && isPrivateIdentifierClassElementDeclaration(property.valueDeclaration)) {
             const declClass = getContainingClass(property.valueDeclaration);
             return !isOptionalChain(node) && !!findAncestor(node, parent => parent === declClass);
         }
@@ -32465,7 +32467,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const thisArgumentType = checkExpression(thisArgumentNode);
         return isOptionalChainRoot(thisArgumentNode.parent) ? getNonNullableType(thisArgumentType) :
             isOptionalChain(thisArgumentNode.parent) ? removeOptionalTypeMarker(thisArgumentType) :
-            thisArgumentType;
+                thisArgumentType;
     }
 
     function inferTypeArguments(node: CallLikeExpression, signature: Signature, args: readonly Expression[], checkMode: CheckMode, context: InferenceContext): Type[] {
@@ -32564,8 +32566,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getMutableArrayOrTupleType(type: Type) {
         return type.flags & TypeFlags.Union ? mapType(type, getMutableArrayOrTupleType) :
             type.flags & TypeFlags.Any || isMutableArrayOrTuple(getBaseConstraintOfType(type) || type) ? type :
-            isTupleType(type) ? createTupleType(getElementTypes(type), type.target.elementFlags, /*readonly*/ false, type.target.labeledElementDeclarations) :
-            createTupleType([type], [ElementFlags.Variadic]);
+                isTupleType(type) ? createTupleType(getElementTypes(type), type.target.elementFlags, /*readonly*/ false, type.target.labeledElementDeclarations) :
+                    createTupleType([type], [ElementFlags.Variadic]);
     }
 
     function getSpreadArgumentType(args: readonly Expression[], index: number, argCount: number, restType: Type, context: InferenceContext | undefined, checkMode: CheckMode) {
@@ -32824,8 +32826,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const restArgCount = args.length - argCount;
             const errorNode = !reportErrors ? undefined :
                 restArgCount === 0 ? node :
-                restArgCount === 1 ? args[argCount] :
-                setTextRangePosEnd(createSyntheticExpression(node, spreadType), args[argCount].pos, args[args.length - 1].end);
+                    restArgCount === 1 ? args[argCount] :
+                        setTextRangePosEnd(createSyntheticExpression(node, spreadType), args[argCount].pos, args[args.length - 1].end);
             if (!checkTypeRelatedTo(spreadType, restType, relation, errorNode, headMessage, /*containingMessageChain*/ undefined, errorOutputContainer)) {
                 Debug.assert(!reportErrors || !!errorOutputContainer.errors, "rest parameter should have errors when reporting errors");
                 maybeAddMissingAwaitInfo(errorNode, spreadType, restType);
@@ -33040,7 +33042,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const hasRestParameter = some(signatures, hasEffectiveRestParameter);
         const parameterRange = hasRestParameter ? min
             : min < max ? min + "-" + max
-            : min;
+                : min;
         const isVoidPromiseError = !hasRestParameter && parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node);
         if (isVoidPromiseError && isInJSFile(node)) {
             return getDiagnosticForCallNode(node, Diagnostics.Expected_1_argument_but_got_0_new_Promise_needs_a_JSDoc_hint_to_produce_a_resolve_that_can_be_called_without_arguments);
@@ -33048,10 +33050,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const error =
             isDecorator(node) ?
                 hasRestParameter ? Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_at_least_0 :
-                Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0 :
-            hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1 :
-            isVoidPromiseError ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise :
-            Diagnostics.Expected_0_arguments_but_got_1;
+                    Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0 :
+                hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1 :
+                    isVoidPromiseError ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise :
+                        Diagnostics.Expected_0_arguments_but_got_1;
 
         if (min < args.length && args.length < max) {
             // between min and max, but with no matching overload
@@ -33078,7 +33080,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const messageAndArgs: DiagnosticAndArguments =
                     isBindingPattern(parameter.name) ? [Diagnostics.An_argument_matching_this_binding_pattern_was_not_provided]
                         : isRestParameter(parameter) ? [Diagnostics.Arguments_for_the_rest_parameter_0_were_not_provided, idText(getFirstIdentifier(parameter.name))]
-                        : [Diagnostics.An_argument_for_0_was_not_provided, !parameter.name ? args.length : idText(getFirstIdentifier(parameter.name))];
+                            : [Diagnostics.An_argument_for_0_was_not_provided, !parameter.name ? args.length : idText(getFirstIdentifier(parameter.name))];
                 const parameterError = createDiagnosticForNode(parameter, ...messageAndArgs);
                 return addRelatedInfo(diagnostic, parameterError);
             }
@@ -33110,11 +33112,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const min = getMinTypeArgumentCount(sig.typeParameters);
             const max = length(sig.typeParameters);
             if (headMessage) {
-                let chain = chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min , argCount);
+                let chain = chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min, argCount);
                 chain = chainDiagnosticMessages(chain, headMessage);
                 return createDiagnosticForNodeArrayFromMessageChain(getSourceFileOfNode(node), typeArguments, chain);
             }
-            return createDiagnosticForNodeArray(getSourceFileOfNode(node), typeArguments, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min , argCount);
+            return createDiagnosticForNodeArray(getSourceFileOfNode(node), typeArguments, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min, argCount);
         }
         // Overloads exist
         let belowArgCount = -Infinity;
@@ -33599,7 +33601,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const nonOptionalType = getOptionalExpressionType(funcType, node.expression);
             callChainFlags = nonOptionalType === funcType ? SignatureFlags.None :
                 isOutermostOptionalChain(node) ? SignatureFlags.IsOuterCallChain :
-                SignatureFlags.IsInnerCallChain;
+                    SignatureFlags.IsInnerCallChain;
             funcType = nonOptionalType;
         }
         else {
@@ -34200,7 +34202,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const func = isFunctionDeclaration(node) || isFunctionExpression(node) ? node :
             (isVariableDeclaration(node) || isPropertyAssignment(node)) && node.initializer && isFunctionExpression(node.initializer) ? node.initializer :
-            undefined;
+                undefined;
         if (func) {
             // If the node has a @class or @constructor tag, treat it like a constructor.
             if (getJSDocClassTag(node)) return true;
@@ -34462,7 +34464,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (esModuleSymbol) {
                 return createPromiseReturnType(node,
                     getTypeWithSyntheticDefaultOnly(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier) ||
-                        getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier)
+                    getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier)
                 );
             }
         }
@@ -34664,7 +34666,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const exprType = node.kind === SyntaxKind.ExpressionWithTypeArguments ? checkExpression(node.expression) :
             isThisIdentifier(node.exprName) ? checkThisExpression(node.exprName) :
-            checkExpression(node.exprName);
+                checkExpression(node.exprName);
         return getInstantiationExpressionType(exprType, node);
     }
 
@@ -35177,11 +35179,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const nameType = isPrivate ? getStringLiteralType(idText(node.name)) : getLiteralTypeFromPropertyName(node.name);
         const contextType =
             isMethodDeclaration(node) ? createClassMethodDecoratorContextType(thisType, valueType) :
-            isGetAccessorDeclaration(node) ? createClassGetterDecoratorContextType(thisType, valueType) :
-            isSetAccessorDeclaration(node) ? createClassSetterDecoratorContextType(thisType, valueType) :
-            isAutoAccessorPropertyDeclaration(node) ? createClassAccessorDecoratorContextType(thisType, valueType) :
-            isPropertyDeclaration(node) ? createClassFieldDecoratorContextType(thisType, valueType) :
-            Debug.failBadSyntaxKind(node);
+                isGetAccessorDeclaration(node) ? createClassGetterDecoratorContextType(thisType, valueType) :
+                    isSetAccessorDeclaration(node) ? createClassSetterDecoratorContextType(thisType, valueType) :
+                        isAutoAccessorPropertyDeclaration(node) ? createClassAccessorDecoratorContextType(thisType, valueType) :
+                            isPropertyDeclaration(node) ? createClassFieldDecoratorContextType(thisType, valueType) :
+                                Debug.failBadSyntaxKind(node);
         const overrideType = getClassMemberDecoratorContextOverrideType(nameType, isPrivate, isStatic);
         return getIntersectionType([contextType, overrideType]);
 
@@ -35337,7 +35339,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     const valueType =
                         isMethodDeclaration(node) ? getOrCreateTypeFromSignature(getSignatureFromDeclaration(node)) :
-                        getTypeOfNode(node);
+                            getTypeOfNode(node);
 
                     const thisType = hasStaticModifier(node) ?
                         getTypeOfSymbol(getSymbolOfDeclaration(node.parent)) :
@@ -35348,16 +35350,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // methods it is just the input type.
                     const targetType =
                         isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType) :
-                        isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
-                        valueType;
+                            isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
+                                valueType;
 
                     const contextType = createClassMemberDecoratorContextTypeForNode(node, thisType, valueType);
 
                     // We also wrap the "output type", as needed.
                     const returnType =
                         isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType) :
-                        isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
-                        valueType;
+                            isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
+                                valueType;
 
                     links.decoratorSignature = createESDecoratorCallSignature(targetType, contextType, returnType);
                     break;
@@ -35383,7 +35385,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // regular field decorator is always `undefined` as it isn't installed until it is initialized.
                     const targetType =
                         hasAccessorModifier(node) ? createClassAccessorDecoratorTargetType(thisType, valueType) :
-                        undefinedType;
+                            undefinedType;
 
                     const contextType = createClassMemberDecoratorContextTypeForNode(node, thisType, valueType);
 
@@ -35393,7 +35395,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // initializer mutator. For regular fields, we wrap the "output type" in an initializer mutator.
                     const returnType =
                         hasAccessorModifier(node) ? createClassAccessorDecoratorResultType(thisType, valueType) :
-                        createClassFieldDecoratorInitializerMutatorType(thisType, valueType);
+                            createClassFieldDecoratorInitializerMutatorType(thisType, valueType);
 
                     links.decoratorSignature = createESDecoratorCallSignature(targetType, contextType, returnType);
                     break;
@@ -35445,11 +35447,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     const targetType =
                         isConstructorDeclaration(node.parent) ? getTypeOfSymbol(getSymbolOfDeclaration(node.parent.parent)) :
-                        getParentTypeOfClassElement(node.parent);
+                            getParentTypeOfClassElement(node.parent);
 
                     const keyType =
                         isConstructorDeclaration(node.parent) ? undefinedType :
-                        getClassElementPropertyKeyType(node.parent);
+                            getClassElementPropertyKeyType(node.parent);
 
                     const indexType = getNumberLiteralType(index);
 
@@ -35483,7 +35485,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     const returnType =
                         isPropertyDeclaration(node) ? voidType :
-                        createTypedPropertyDescriptorType(getTypeOfNode(node));
+                            createTypedPropertyDescriptorType(getTypeOfNode(node));
 
                     const hasPropDesc = languageVersion !== ScriptTarget.ES3 && (!isPropertyDeclaration(parent) || hasAccessorModifier(parent));
                     if (hasPropDesc) {
@@ -35637,7 +35639,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const contextualSignature = getContextualSignatureForFunctionLikeDeclaration(func);
                 const contextualType = !contextualSignature ? undefined :
                     contextualSignature === getSignatureFromDeclaration(func) ? isGenerator ? undefined : returnType :
-                    instantiateContextualType(getReturnTypeOfSignature(contextualSignature), func, /*contextFlags*/ undefined);
+                        instantiateContextualType(getReturnTypeOfSignature(contextualSignature), func, /*contextFlags*/ undefined);
                 if (isGenerator) {
                     yieldType = getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded(yieldType, contextualType, IterationTypeKind.Yield, isAsync);
                     returnType = getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded(returnType, contextualType, IterationTypeKind.Return, isAsync);
@@ -36234,14 +36236,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 hasError = true;
                                 break;
                             }
-                            // fallthrough
+                        // fallthrough
                         case ModuleKind.ES2022:
                         case ModuleKind.ESNext:
                         case ModuleKind.System:
                             if (languageVersion >= ScriptTarget.ES2017) {
                                 break;
                             }
-                            // fallthrough
+                        // fallthrough
                         default:
                             span ??= getSpanOfTokenAtPosition(sourceFile, node.pos);
                             const message = isAwaitExpression(node) ? Diagnostics.Top_level_await_expressions_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_or_nodenext_and_the_target_option_is_set_to_es2017_or_higher :
@@ -36332,7 +36334,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const facts = getTypeFacts(operandType) & (TypeFacts.Truthy | TypeFacts.Falsy);
                 return facts === TypeFacts.Truthy ? falseType :
                     facts === TypeFacts.Falsy ? trueType :
-                    booleanType;
+                        booleanType;
             case SyntaxKind.PlusPlusToken:
             case SyntaxKind.MinusMinusToken:
                 const ok = checkArithmeticOperandType(node.operand, checkNonNullType(operandType, node.operand),
@@ -36559,7 +36561,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // present (aka the tuple element property). This call also checks that the parentType is in
         // fact an iterable or array (depending on target language).
         const possiblyOutOfBoundsType = checkIteratedTypeOrElementType(IterationUse.Destructuring | IterationUse.PossiblyOutOfBounds, sourceType, undefinedType, node) || errorType;
-        let inBoundsType: Type | undefined = compilerOptions.noUncheckedIndexedAccess ? undefined: possiblyOutOfBoundsType;
+        let inBoundsType: Type | undefined = compilerOptions.noUncheckedIndexedAccess ? undefined : possiblyOutOfBoundsType;
         for (let i = 0; i < elements.length; i++) {
             let type = possiblyOutOfBoundsType;
             if (node.elements[i].kind === SyntaxKind.SpreadElement) {
@@ -36704,7 +36706,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return false;
                 }
                 return isSideEffectFree((node as BinaryExpression).left) &&
-                        isSideEffectFree((node as BinaryExpression).right);
+                    isSideEffectFree((node as BinaryExpression).right);
 
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
@@ -37185,8 +37187,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function checkForDisallowedESSymbolOperand(operator: PunctuationSyntaxKind): boolean {
             const offendingSymbolOperand =
                 maybeTypeOfKindConsideringBaseConstraint(leftType, TypeFlags.ESSymbolLike) ? left :
-                maybeTypeOfKindConsideringBaseConstraint(rightType, TypeFlags.ESSymbolLike) ? right :
-                undefined;
+                    maybeTypeOfKindConsideringBaseConstraint(rightType, TypeFlags.ESSymbolLike) ? right :
+                        undefined;
 
             if (offendingSymbolOperand) {
                 error(offendingSymbolOperand, Diagnostics.The_0_operator_cannot_be_applied_to_type_symbol, tokenToString(operator));
@@ -37235,7 +37237,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (checkReferenceExpression(left,
                     Diagnostics.The_left_hand_side_of_an_assignment_expression_must_be_a_variable_or_a_property_access,
                     Diagnostics.The_left_hand_side_of_an_assignment_expression_may_not_be_an_optional_property_access)
-                    ) {
+                ) {
 
                     let headMessage: DiagnosticMessage | undefined;
                     if (exactOptionalPropertyTypes && isPropertyAccessExpression(left) && maybeTypeOfKind(valueType, TypeFlags.Undefined)) {
@@ -37357,7 +37359,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             effectiveLeft = leftBase;
             effectiveRight = rightBase;
         }
-        return [ effectiveLeft, effectiveRight ];
+        return [effectiveLeft, effectiveRight];
     }
 
     function checkYieldExpression(node: YieldExpression): Type {
@@ -37619,7 +37621,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const type = checkExpression(node, checkMode, forceTuple);
         return isConstContext(node) || isCommonJsExportedExpression(node) ? getRegularTypeOfLiteralType(type) :
             isTypeAssertion(node) ? type :
-            getWidenedLiteralLikeTypeForContextualType(type, instantiateContextualType(getContextualType(node, /*contextFlags*/ undefined), node, /*contextFlags*/ undefined));
+                getWidenedLiteralLikeTypeForContextualType(type, instantiateContextualType(getContextualType(node, /*contextFlags*/ undefined), node, /*contextFlags*/ undefined));
     }
 
     function checkPropertyAssignment(node: PropertyAssignment, checkMode?: CheckMode): Type {
@@ -37983,7 +37985,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if ((node as CallExpression).expression.kind === SyntaxKind.ImportKeyword) {
                     return checkImportCallExpression(node as ImportCall);
                 }
-                // falls through
+            // falls through
             case SyntaxKind.NewExpression:
                 return checkCallExpression(node as CallExpression, checkMode);
             case SyntaxKind.TaggedTemplateExpression:
@@ -38177,7 +38179,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 let hasReportedError = false;
                 for (const { name } of parent.parameters) {
                     if (isBindingPattern(name) &&
-                            checkIfTypePredicateVariableIsDeclaredInBindingPattern(name, parameterName, typePredicate.parameterName)) {
+                        checkIfTypePredicateVariableIsDeclaredInBindingPattern(name, parameterName, typePredicate.parameterName)) {
                         hasReportedError = true;
                         break;
                     }
@@ -38343,8 +38345,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const privateStaticFlags = isPrivate && isStaticMember ? DeclarationMeaning.PrivateStatic : 0;
                 const names =
                     isPrivate ? privateIdentifiers :
-                    isStaticMember ? staticNames :
-                    instanceNames;
+                        isStaticMember ? staticNames :
+                            instanceNames;
 
                 const memberName = name && getPropertyNameForPropertyNameNode(name);
                 if (memberName) {
@@ -38424,7 +38426,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         if (compilerOptions.useDefineForClassFields) {
                             break;
                         }
-                        // fall through
+                    // fall through
                     case "prototype":
                         const message = Diagnostics.Static_property_0_conflicts_with_built_in_property_Function_0_of_constructor_function_1;
                         const className = getNameOfSymbolAsWritten(getSymbolOfDeclaration(node));
@@ -38628,7 +38630,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const superCallShouldBeRootLevel =
                         (getEmitScriptTarget(compilerOptions) !== ScriptTarget.ESNext || !useDefineForClassFields) &&
                         (some((node.parent as ClassDeclaration).members, isInstancePropertyWithInitializerOrPrivateIdentifierProperty) ||
-                        some(node.parameters, p => hasSyntacticModifier(p, ModifierFlags.ParameterPropertyModifier)));
+                            some(node.parameters, p => hasSyntacticModifier(p, ModifierFlags.ParameterPropertyModifier)));
 
                     if (superCallShouldBeRootLevel) {
                         // Until we have better flow analysis, it is an error to place the super call within any kind of block or conditional
@@ -39293,10 +39295,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             forEach(declarations, declaration => {
                 const diagnostic = declaration.kind === SyntaxKind.ClassDeclaration
-                        ? Diagnostics.Class_declaration_cannot_implement_overload_list_for_0
-                        : declaration.kind === SyntaxKind.FunctionDeclaration
-                            ? Diagnostics.Function_with_bodies_can_only_merge_with_classes_that_are_ambient
-                            : undefined;
+                    ? Diagnostics.Class_declaration_cannot_implement_overload_list_for_0
+                    : declaration.kind === SyntaxKind.FunctionDeclaration
+                        ? Diagnostics.Function_with_bodies_can_only_merge_with_classes_that_are_ambient
+                        : undefined;
                 if (diagnostic) {
                     addRelatedInfo(
                         error(getNameOfDeclaration(declaration) || declaration, diagnostic, symbolName(symbol)),
@@ -39449,12 +39451,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.ImportSpecifier: // https://github.com/Microsoft/TypeScript/pull/7591
                 case SyntaxKind.Identifier: // https://github.com/microsoft/TypeScript/issues/36098
-                // Identifiers are used as declarations of assignment declarations whose parents may be
-                // SyntaxKind.CallExpression - `Object.defineProperty(thing, "aField", {value: 42});`
-                // SyntaxKind.ElementAccessExpression - `thing["aField"] = 42;` or `thing["aField"];` (with a doc comment on it)
-                // or SyntaxKind.PropertyAccessExpression - `thing.aField = 42;`
-                // all of which are pretty much always values, or at least imply a value meaning.
-                // It may be apprpriate to treat these as aliases in the future.
+                    // Identifiers are used as declarations of assignment declarations whose parents may be
+                    // SyntaxKind.CallExpression - `Object.defineProperty(thing, "aField", {value: 42});`
+                    // SyntaxKind.ElementAccessExpression - `thing["aField"] = 42;` or `thing["aField"];` (with a doc comment on it)
+                    // or SyntaxKind.PropertyAccessExpression - `thing.aField = 42;`
+                    // all of which are pretty much always values, or at least imply a value meaning.
+                    // It may be apprpriate to treat these as aliases in the future.
                     return DeclarationSpaces.ExportValue;
                 case SyntaxKind.MethodSignature:
                 case SyntaxKind.PropertySignature:
@@ -39604,7 +39606,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function unwrapAwaitedType(type: Type) {
         return type.flags & TypeFlags.Union ? mapType(type, unwrapAwaitedType) :
             isAwaitedTypeInstantiation(type) ? type.aliasTypeArguments[0] :
-            type;
+                type;
     }
 
     function isAwaitedTypeNeeded(type: Type) {
@@ -39935,7 +39937,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     headMessage = Diagnostics.Decorator_function_return_type_0_is_not_assignable_to_type_1;
                     break;
                 }
-                // falls through
+            // falls through
 
             case SyntaxKind.Parameter:
                 headMessage = Diagnostics.Decorator_function_return_type_is_0_but_is_expected_to_be_void_or_any;
@@ -41046,10 +41048,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         if (isBindingElement(node)) {
             if (
-              node.propertyName &&
-              isIdentifier(node.name) &&
-              isParameterDeclaration(node) &&
-              nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)) {
+                node.propertyName &&
+                isIdentifier(node.name) &&
+                isParameterDeclaration(node) &&
+                nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)) {
                 // type F = ({a: string}) => void;
                 //               ^^^^^^
                 // variable renaming in function type notation is confusing,
@@ -41329,7 +41331,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const testedNode = isIdentifier(location) ? location
                 : isPropertyAccessExpression(location) ? location.name
-                : undefined;
+                    : undefined;
             const testedSymbol = testedNode && getSymbolAtLocation(testedNode);
             if (!testedSymbol && !isPromise) {
                 return;
@@ -41613,10 +41615,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (iterationTypes) {
                     const diagnostic =
                         use & IterationUse.ForOfFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_for_of_will_always_send_0 :
-                        use & IterationUse.SpreadFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_always_send_0 :
-                        use & IterationUse.DestructuringFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring_will_always_send_0 :
-                        use & IterationUse.YieldStarFlag ? Diagnostics.Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_containing_generator_will_always_send_0 :
-                        undefined;
+                            use & IterationUse.SpreadFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_always_send_0 :
+                                use & IterationUse.DestructuringFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring_will_always_send_0 :
+                                    use & IterationUse.YieldStarFlag ? Diagnostics.Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_containing_generator_will_always_send_0 :
+                                        undefined;
                     if (diagnostic) {
                         checkTypeAssignableTo(sentType, iterationTypes.nextType, errorNode, diagnostic);
                     }
@@ -42087,7 +42089,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 errorNode.parent.expression === errorNode &&
                 getGlobalAsyncIterableType(/*reportErrors*/ false) !== emptyGenericType &&
                 isTypeAssignableTo(type, getGlobalAsyncIterableType(/*reportErrors*/ false)
-            ));
+                ));
         return errorAndMaybeSuggestAwait(errorNode, suggestAwait, message, typeToString(type));
     }
 
@@ -42432,7 +42434,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         const container = getContainingFunctionOrClassStaticBlock(node);
-        if(container && isClassStaticBlockDeclaration(container)) {
+        if (container && isClassStaticBlockDeclaration(container)) {
             grammarErrorOnFirstToken(node, Diagnostics.A_return_statement_cannot_be_used_inside_a_class_static_block);
             return;
         }
@@ -43412,9 +43414,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     if (!inheritedAbstractMemberNotImplementedError) {
                         inheritedAbstractMemberNotImplementedError = error(
-                                derivedClassDecl,
-                                Diagnostics.Non_abstract_class_0_does_not_implement_all_abstract_members_of_1,
-                                typeToString(type), typeToString(baseType));
+                            derivedClassDecl,
+                            Diagnostics.Non_abstract_class_0_does_not_implement_all_abstract_members_of_1,
+                            typeToString(type), typeToString(baseType));
 
                     }
                     if (derivedClassDecl.kind === SyntaxKind.ClassExpression) {
@@ -43812,7 +43814,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isInfinityOrNaNString((expr as Identifier).escapedText)) {
                     return +((expr as Identifier).escapedText);
                 }
-                // falls through
+            // falls through
             case SyntaxKind.PropertyAccessExpression:
                 if (isEntityNameExpression(expr)) {
                     const symbol = resolveEntityName(expr, SymbolFlags.Value, /*ignoreErrors*/ true);
@@ -44110,7 +44112,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     break;
                 }
-                // falls through
+            // falls through
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.EnumDeclaration:
             case SyntaxKind.FunctionDeclaration:
@@ -44203,8 +44205,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isInJSFile(node) && !(target.flags & SymbolFlags.Value) && !isTypeOnlyImportOrExportDeclaration(node)) {
                 const errorNode =
                     isImportOrExportSpecifier(node) ? node.propertyName || node.name :
-                    isNamedDeclaration(node) ? node.name :
-                    node;
+                        isNamedDeclaration(node) ? node.name :
+                            node;
 
                 Debug.assert(node.kind !== SyntaxKind.NamespaceExport);
                 if (node.kind === SyntaxKind.ExportSpecifier) {
@@ -44694,7 +44696,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Forbid export= in esm implementation files, and esm mode declaration files
             if (moduleKind >= ModuleKind.ES2015 &&
                 ((node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) ||
-                (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))) {
+                    (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))) {
                 // export assignment is not supported in es6 modules
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or_another_module_format_instead);
             }
@@ -44878,7 +44880,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return checkJSDocPropertyTag(node as JSDocPropertyTag);
             case SyntaxKind.JSDocFunctionType:
                 checkJSDocFunctionType(node as JSDocFunctionType);
-                // falls through
+            // falls through
             case SyntaxKind.JSDocNonNullableType:
             case SyntaxKind.JSDocNullableType:
             case SyntaxKind.JSDocAllType:
@@ -45341,7 +45343,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 switch (location.kind) {
                     case SyntaxKind.SourceFile:
                         if (!isExternalModule(location as SourceFile)) break;
-                        // falls through
+                    // falls through
                     case SyntaxKind.ModuleDeclaration:
                         copyLocallyVisibleExportSymbols(getSymbolOfDeclaration(location as ModuleDeclaration | SourceFile).exports!, meaning & SymbolFlags.ModuleMember);
                         break;
@@ -45797,7 +45799,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!isThisInTypeQuery(node)) {
                     return getSymbolOfNameOrPropertyAccessExpression(node as EntityName | PrivateIdentifier | PropertyAccessExpression);
                 }
-                // falls through
+            // falls through
 
             case SyntaxKind.ThisKeyword:
                 const container = getThisContainer(node, /*includeArrowFunctions*/ false, /*includeClassComputedPropertyName*/ false);
@@ -45810,7 +45812,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isInExpressionContext(node)) {
                     return checkExpression(node as Expression).symbol;
                 }
-                // falls through
+            // falls through
 
             case SyntaxKind.ThisType:
                 return getTypeFromThisTypeNode(node as ThisExpression | ThisTypeNode).symbol;
@@ -45842,7 +45844,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isCallExpression(parent) && isBindableObjectDefinePropertyCall(parent) && parent.arguments[1] === node) {
                     return getSymbolOfDeclaration(parent);
                 }
-                // falls through
+            // falls through
 
             case SyntaxKind.NumericLiteral:
                 // index access
@@ -45874,7 +45876,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const symbol = getIntrinsicTagSymbol(node.parent as JsxOpeningLikeElement);
                     return symbol === unknownSymbol ? undefined : symbol;
                 }
-                // falls through
+            // falls through
 
             default:
                 return undefined;
@@ -46076,7 +46078,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const propsByName = createSymbolTable(getPropertiesOfType(type));
         const functionType = getSignaturesOfType(type, SignatureKind.Call).length ? globalCallableFunctionType :
             getSignaturesOfType(type, SignatureKind.Construct).length ? globalNewableFunctionType :
-            undefined;
+                undefined;
         if (functionType) {
             forEach(getPropertiesOfType(functionType), p => {
                 if (!propsByName.has(p.escapedName)) {
@@ -46103,7 +46105,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const { links: { leftSpread, rightSpread, syntheticOrigin } } = symbol as TransientSymbol;
             return leftSpread ? [leftSpread, rightSpread!]
                 : syntheticOrigin ? [syntheticOrigin]
-                : singleElementArray(tryGetTarget(symbol));
+                    : singleElementArray(tryGetTarget(symbol));
         }
         return undefined;
     }
@@ -46126,8 +46128,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const parent = node.parent;
         if (!parent) return false;
         const isPropertyName = ((isPropertyAccessExpression(parent)
-                                 || isPropertyAssignment(parent))
-                                && parent.name === node);
+            || isPropertyAssignment(parent))
+            && parent.name === node);
         return !isPropertyName && getReferencedValueSymbol(node) === argumentsSymbol;
     }
 
@@ -46705,7 +46707,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const literalValue = (type as LiteralType).value;
         return typeof literalValue === "object" ? factory.createBigIntLiteral(literalValue) :
             typeof literalValue === "number" ? factory.createNumericLiteral(literalValue) :
-            factory.createStringLiteral(literalValue);
+                factory.createStringLiteral(literalValue);
     }
 
     function createLiteralConstValue(node: VariableDeclaration | PropertyDeclaration | PropertySignature | ParameterDeclaration, tracker: SymbolTracker) {
@@ -47616,9 +47618,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function findFirstModifierExcept(node: HasModifiers, allowedModifier: SyntaxKind): Modifier | undefined {
-            const modifier = find(node.modifiers, isModifier);
-            return modifier && modifier.kind !== allowedModifier ? modifier : undefined;
-        }
+        const modifier = find(node.modifiers, isModifier);
+        return modifier && modifier.kind !== allowedModifier ? modifier : undefined;
+    }
 
     function findFirstIllegalModifier(node: HasModifiers | HasIllegalModifiers): Modifier | undefined {
         switch (node.kind) {
@@ -48025,7 +48027,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             else if (canHaveIllegalModifiers(prop) && prop.modifiers) {
                 for (const mod of prop.modifiers) {
-                        if (isModifier(mod)) {
+                    if (isModifier(mod)) {
                         grammarErrorOnNode(mod, Diagnostics._0_modifier_cannot_be_used_here, getTextOfNode(mod));
                     }
                 }
@@ -48160,14 +48162,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                     );
                                     break;
                                 }
-                                // fallthrough
+                            // fallthrough
                             case ModuleKind.ES2022:
                             case ModuleKind.ESNext:
                             case ModuleKind.System:
                                 if (languageVersion >= ScriptTarget.ES2017) {
                                     break;
                                 }
-                                // fallthrough
+                            // fallthrough
                             default:
                                 diagnostics.add(
                                     createDiagnosticForNode(forInOrOfStatement.awaitModifier,
@@ -48661,9 +48663,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (blockScopeKind) {
                 const keyword = blockScopeKind === NodeFlags.Let ? "let" :
                     blockScopeKind === NodeFlags.Const ? "const" :
-                    blockScopeKind === NodeFlags.Using ? "using" :
-                    blockScopeKind === NodeFlags.AwaitUsing ? "await using" :
-                    Debug.fail("Unknown BlockScope flag");
+                        blockScopeKind === NodeFlags.Using ? "using" :
+                            blockScopeKind === NodeFlags.AwaitUsing ? "await using" :
+                                Debug.fail("Unknown BlockScope flag");
                 return grammarErrorOnNode(node, Diagnostics._0_declarations_can_only_be_declared_inside_a_block, keyword);
             }
         }
@@ -49125,7 +49127,7 @@ function isNotAccessor(declaration: Declaration): boolean {
 
 function isNotOverload(declaration: Declaration): boolean {
     return (declaration.kind !== SyntaxKind.FunctionDeclaration && declaration.kind !== SyntaxKind.MethodDeclaration) ||
-            !!(declaration as FunctionDeclaration).body;
+        !!(declaration as FunctionDeclaration).body;
 }
 
 /** Like 'isDeclarationName', but returns true for LHS of `import { x as y }` or `export { x as y }`. */

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7440,7 +7440,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 node.typeArguments = factory.createNodeArray(typeArguments);
             }
             if (signature.declaration?.kind === SyntaxKind.JSDocSignature && signature.declaration.parent.kind === SyntaxKind.JSDocOverloadTag) {
-                addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, getTextOfNode(signature.declaration.parent.parent, /*includeTrivia*/ true).slice(2, -2), /*hasTrailingNewLine*/ true);
+                const comment = getTextOfNode(signature.declaration.parent.parent, /*includeTrivia*/ true).slice(2, -2).split(/\r\n|\n|\r/).map(line => line.replace(/^\s+/, " ")).join("\n");
+                addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, comment, /*hasTrailingNewLine*/ true);
             }
 
             cleanup?.();

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7440,8 +7440,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 node.typeArguments = factory.createNodeArray(typeArguments);
             }
             if (signature.declaration?.kind === SyntaxKind.JSDocSignature && signature.declaration.parent.kind === SyntaxKind.JSDocOverloadTag) {
-                const comment = getTextOfNode(signature.declaration.parent.parent, /*includeTrivia*/ true).slice(2, -2).split(/\r\n|\n|\r/).map(line => line.replace(/^\s+/, " ")).join("\n");
-                addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, comment, /*hasTrailingNewLine*/ true);
+                addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, getTextOfNode(signature.declaration.parent.parent, /*includeTrivia*/ true).slice(2, -2), /*hasTrailingNewLine*/ true);
             }
 
             cleanup?.();

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1257,8 +1257,8 @@ export const enum CheckMode {
     IsForSignatureHelp = 1 << 4,                    // Call resolution for purposes of signature help
     IsForStringLiteralArgumentCompletions = 1 << 5, // Do not infer from the argument currently being typed
     RestBindingElement = 1 << 6,                    // Checking a type that is going to be used to determine the type of a rest binding element
-    //   e.g. in `const { a, ...rest } = foo`, when checking the type of `foo` to determine the type of `rest`,
-    //   we need to preserve generic types instead of substituting them for constraints
+                                                    //   e.g. in `const { a, ...rest } = foo`, when checking the type of `foo` to determine the type of `rest`,
+                                                    //   we need to preserve generic types instead of substituting them for constraints
     TypeOnly = 1 << 7,                              // Called from getTypeOfExpression, diagnostics may be omitted
 }
 
@@ -2352,7 +2352,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
     }
     function errorOrSuggestion(isError: boolean, location: Node, message: DiagnosticMessage | DiagnosticMessageChain, ...args: DiagnosticArguments): void {
-        // Pseudo-synthesized input node
+         // Pseudo-synthesized input node
         if (location.pos < 0 || location.end < 0) {
             if (!isError) {
                 return; // Drop suggestions (we have no span to suggest on)
@@ -2534,7 +2534,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const isEitherBlockScoped = !!(target.flags & SymbolFlags.BlockScopedVariable || source.flags & SymbolFlags.BlockScopedVariable);
             const message = isEitherEnum ? Diagnostics.Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations
                 : isEitherBlockScoped ? Diagnostics.Cannot_redeclare_block_scoped_variable_0
-                    : Diagnostics.Duplicate_identifier_0;
+                : Diagnostics.Duplicate_identifier_0;
             const sourceSymbolFile = source.declarations && getSourceFileOfNode(source.declarations[0]);
             const targetSymbolFile = target.declarations && getSourceFileOfNode(target.declarations[0]);
 
@@ -2784,8 +2784,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             else if (isParameterPropertyDeclaration(declaration, declaration.parent)) {
                 // foo = this.bar is illegal in esnext+useDefineForClassFields when bar is a parameter property
                 return !(getEmitScriptTarget(compilerOptions) === ScriptTarget.ESNext && useDefineForClassFields
-                    && getContainingClass(declaration) === getContainingClass(usage)
-                    && isUsedInFunctionOrInstanceProperty(usage, declaration));
+                         && getContainingClass(declaration) === getContainingClass(usage)
+                         && isUsedInFunctionOrInstanceProperty(usage, declaration));
             }
             return true;
         }
@@ -2907,8 +2907,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // even when stopping at any property declaration, they need to come from the same class
                         return stopAtAnyPropertyDeclaration &&
                             (isPropertyDeclaration(declaration) && node.parent === declaration.parent
-                                || isParameterPropertyDeclaration(declaration, declaration.parent) && node.parent === declaration.parent.parent)
-                            ? "quit" : true;
+                             || isParameterPropertyDeclaration(declaration, declaration.parent) && node.parent === declaration.parent.parent)
+                            ? "quit": true;
                     case SyntaxKind.Block:
                         switch (node.parent.kind) {
                             case SyntaxKind.GetAccessor:
@@ -3106,7 +3106,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.SourceFile:
                     if (!isExternalOrCommonJsModule(location as SourceFile)) break;
                     isInExternalModule = true;
-                // falls through
+                    // falls through
                 case SyntaxKind.ModuleDeclaration:
                     const moduleExports = getSymbolOfDeclaration(location as SourceFile | ModuleDeclaration)?.exports || emptySymbols;
                     if (location.kind === SyntaxKind.SourceFile || (isModuleDeclaration(location) && location.flags & NodeFlags.Ambient && !isGlobalScopeAugmentation(location))) {
@@ -3250,7 +3250,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (getEmitScriptTarget(compilerOptions) >= ScriptTarget.ES2015) {
                         break;
                     }
-                // falls through
+                    // falls through
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.Constructor:
                 case SyntaxKind.GetAccessor:
@@ -3355,7 +3355,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             lastLocation = location;
             location = isJSDocTemplateTag(location) ? getEffectiveContainerForJSDocTemplateTag(location) || location.parent :
                 isJSDocParameterTag(location) || isJSDocReturnTag(location) ? getHostSignatureFromJSDoc(location) || location.parent :
-                    location.parent;
+                location.parent;
         }
 
         // We just climbed up parents looking for the name, meaning that we started in a descendant node of `lastLocation`.
@@ -3437,7 +3437,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 const isUncheckedJS = isUncheckedJSSuggestion(originalLocation, suggestion, /*excludeClasses*/ false);
                                 const message = meaning === SymbolFlags.Namespace || nameArg && typeof nameArg !== "string" && nodeIsSynthesized(nameArg) ? Diagnostics.Cannot_find_namespace_0_Did_you_mean_1
                                     : isUncheckedJS ? Diagnostics.Could_not_find_name_0_Did_you_mean_1
-                                        : Diagnostics.Cannot_find_name_0_Did_you_mean_1;
+                                    : Diagnostics.Cannot_find_name_0_Did_you_mean_1;
                                 const diagnostic = createError(errorLocation, message, diagnosticName(nameArg!), suggestionName);
                                 addErrorOrSuggestion(!isUncheckedJS, diagnostic);
                                 if (suggestion.valueDeclaration) {
@@ -3478,7 +3478,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // we want to check for block-scoped
                 if (errorLocation &&
                     (meaning & SymbolFlags.BlockScopedVariable ||
-                        ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))) {
+                     ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))) {
                     const exportOrLocalSymbol = getExportSymbolOfValueSymbolIfExported(result!);
                     if (exportOrLocalSymbol.flags & SymbolFlags.BlockScopedVariable || exportOrLocalSymbol.flags & SymbolFlags.Class || exportOrLocalSymbol.flags & SymbolFlags.Enum) {
                         checkResolvedBlockScopedVariable(exportOrLocalSymbol, errorLocation);
@@ -3655,7 +3655,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isEntityNameExpression((node as ExpressionWithTypeArguments).expression)) {
                     return (node as ExpressionWithTypeArguments).expression as EntityNameExpression;
                 }
-            // falls through
+                // falls through
             default:
                 return undefined;
         }
@@ -3745,7 +3745,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isExtendedByInterface(node: Node): boolean {
         const grandparent = node.parent.parent;
         const parentOfGrandparent = grandparent.parent;
-        if (grandparent && parentOfGrandparent) {
+        if(grandparent && parentOfGrandparent){
             const isExtending = isHeritageClause(grandparent) && grandparent.token === SyntaxKind.ExtendsKeyword;
             const isInterface = isInterfaceDeclaration(parentOfGrandparent);
             return isExtending && isInterface;
@@ -3885,10 +3885,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             || node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(node as ExportAssignment)
             || isBinaryExpression(node) && getAssignmentDeclarationKind(node) === AssignmentDeclarationKind.ModuleExports && exportAssignmentIsAlias(node)
             || isAccessExpression(node)
-            && isBinaryExpression(node.parent)
-            && node.parent.left === node
-            && node.parent.operatorToken.kind === SyntaxKind.EqualsToken
-            && isAliasableOrJsExpression(node.parent.right)
+                && isBinaryExpression(node.parent)
+                && node.parent.left === node
+                && node.parent.operatorToken.kind === SyntaxKind.EqualsToken
+                && isAliasableOrJsExpression(node.parent.right)
             || node.kind === SyntaxKind.ShorthandPropertyAssignment
             || node.kind === SyntaxKind.PropertyAssignment && isAliasableOrJsExpression((node as PropertyAssignment).initializer)
             || node.kind === SyntaxKind.VariableDeclaration && isVariableDeclarationInitializedToBareOrAccessedRequire(node)
@@ -4084,7 +4084,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (exportStar) {
                 const defaultExport = exportStar.declarations?.find(decl => !!(
                     isExportDeclaration(decl) && decl.moduleSpecifier &&
-                    resolveExternalModuleName(decl, decl.moduleSpecifier)?.exports?.has(InternalSymbolName.Default)
+                        resolveExternalModuleName(decl, decl.moduleSpecifier)?.exports?.has(InternalSymbolName.Default)
                 ));
                 if (defaultExport) {
                     addRelatedInfo(diagnostic, createDiagnosticForNode(defaultExport, Diagnostics.export_Asterisk_does_not_re_export_a_default));
@@ -4458,31 +4458,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * combined flags of all alias targets otherwise.
      */
     function getAllSymbolFlags(symbol: Symbol): SymbolFlags {
-        let flags = symbol.flags;
-        let seenSymbols;
-        while (symbol.flags & SymbolFlags.Alias) {
-            const target = resolveAlias(symbol);
-            if (target === unknownSymbol) {
-                return SymbolFlags.All;
-            }
+      let flags = symbol.flags;
+      let seenSymbols;
+      while (symbol.flags & SymbolFlags.Alias) {
+          const target = resolveAlias(symbol);
+          if (target === unknownSymbol) {
+              return SymbolFlags.All;
+          }
 
-            // Optimizations - try to avoid creating or adding to
-            // `seenSymbols` if possible
-            if (target === symbol || seenSymbols?.has(target)) {
-                break;
-            }
-            if (target.flags & SymbolFlags.Alias) {
-                if (seenSymbols) {
-                    seenSymbols.add(target);
-                }
-                else {
-                    seenSymbols = new Set([symbol, target]);
-                }
-            }
-            flags |= target.flags;
-            symbol = target;
-        }
-        return flags;
+          // Optimizations - try to avoid creating or adding to
+          // `seenSymbols` if possible
+          if (target === symbol || seenSymbols?.has(target)) {
+              break;
+          }
+          if (target.flags & SymbolFlags.Alias) {
+              if (seenSymbols) {
+                  seenSymbols.add(target);
+              }
+              else {
+                  seenSymbols = new Set([symbol, target]);
+              }
+          }
+          flags |= target.flags;
+          symbol = target;
+      }
+      return flags;
     }
 
     /**
@@ -4823,7 +4823,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const initializer = isAssignmentDeclaration(decl) ? getAssignedExpandoInitializer(decl) :
             hasOnlyExpressionInitializer(decl) ? getDeclaredExpandoInitializer(decl) :
-                undefined;
+            undefined;
         return initializer || decl;
     }
 
@@ -4849,9 +4849,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function resolveExternalModuleName(location: Node, moduleReferenceExpression: Expression, ignoreErrors?: boolean): Symbol | undefined {
         const isClassic = getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Classic;
-        const errorMessage = isClassic ?
-            Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
-            : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
+        const errorMessage = isClassic?
+                                Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
+                              : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
         return resolveExternalModuleNameWorker(location, moduleReferenceExpression, ignoreErrors ? undefined : errorMessage);
     }
 
@@ -4875,12 +4875,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const currentSourceFile = getSourceFileOfNode(location);
         const contextSpecifier = isStringLiteralLike(location)
             ? location
-            : findAncestor(location, isImportCall)?.arguments[0] ||
-            findAncestor(location, isImportDeclaration)?.moduleSpecifier ||
-            findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression ||
-            findAncestor(location, isExportDeclaration)?.moduleSpecifier ||
-            (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name ||
-            (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal;
+            :   findAncestor(location, isImportCall)?.arguments[0] ||
+                findAncestor(location, isImportDeclaration)?.moduleSpecifier ||
+                findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression ||
+                findAncestor(location, isExportDeclaration)?.moduleSpecifier ||
+                (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name ||
+                (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal;
         const mode = contextSpecifier && isStringLiteralLike(contextSpecifier) ? getModeForUsageLocation(currentSourceFile, contextSpecifier) : currentSourceFile.impliedNodeFormat;
         const moduleResolutionKind = getEmitModuleResolutionKind(compilerOptions);
         const resolvedModule = getResolvedModule(currentSourceFile, moduleReference, mode);
@@ -5058,8 +5058,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const preferTs = isDeclarationFileName(moduleReference) && shouldAllowImportingTsExtension(compilerOptions);
                 const ext =
                     tsExtension === Extension.Mts || tsExtension === Extension.Dmts ? preferTs ? ".mts" : ".mjs" :
-                        tsExtension === Extension.Cts || tsExtension === Extension.Dmts ? preferTs ? ".cts" : ".cjs" :
-                            preferTs ? ".ts" : ".js";
+                    tsExtension === Extension.Cts || tsExtension === Extension.Dmts ? preferTs ? ".cts" : ".cjs" :
+                    preferTs ? ".ts" : ".js";
                 return importSourceWithoutExtension + ext;
             }
             return importSourceWithoutExtension;
@@ -5248,16 +5248,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function shouldTreatPropertiesOfExternalModuleAsExports(resolvedExternalModuleType: Type) {
         return !(resolvedExternalModuleType.flags & TypeFlags.Primitive ||
-            getObjectFlags(resolvedExternalModuleType) & ObjectFlags.Class ||
-            // `isArrayOrTupleLikeType` is too expensive to use in this auto-imports hot path
-            isArrayType(resolvedExternalModuleType) ||
-            isTupleType(resolvedExternalModuleType));
+                getObjectFlags(resolvedExternalModuleType) & ObjectFlags.Class ||
+                // `isArrayOrTupleLikeType` is too expensive to use in this auto-imports hot path
+                isArrayType(resolvedExternalModuleType) ||
+                isTupleType(resolvedExternalModuleType));
     }
 
     function getExportsOfSymbol(symbol: Symbol): SymbolTable {
         return symbol.flags & SymbolFlags.LateBindingContainer ? getResolvedMembersOrExportsOfSymbol(symbol, MembersOrExportsResolutionKind.resolvedExports) :
             symbol.flags & SymbolFlags.Module ? getExportsOfModule(symbol) :
-                symbol.exports || emptySymbols;
+            symbol.exports || emptySymbols;
     }
 
     function getExportsOfModule(moduleSymbol: Symbol): SymbolTable {
@@ -5467,20 +5467,20 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 && container.flags & SymbolFlags.Type
                 && getDeclaredTypeOfSymbol(container).flags & TypeFlags.Object
                 && meaning === SymbolFlags.Value
-                ? forEachSymbolTableInScope(enclosingDeclaration, t => {
-                    return forEachEntry(t, s => {
-                        if (s.flags & getQualifiedLeftMeaning(meaning) && getTypeOfSymbol(s) === getDeclaredTypeOfSymbol(container)) {
-                            return s;
-                        }
-                    });
-                }) : undefined;
+            ? forEachSymbolTableInScope(enclosingDeclaration, t => {
+                return forEachEntry(t, s => {
+                    if (s.flags & getQualifiedLeftMeaning(meaning) && getTypeOfSymbol(s) === getDeclaredTypeOfSymbol(container)) {
+                        return s;
+                    }
+                });
+            }) : undefined;
             let res = firstVariableMatch ? [firstVariableMatch, ...additionalContainers, container] : [...additionalContainers, container];
             res = append(res, objectLiteralContainer);
             res = addRange(res, reexportContainers);
             return res;
         }
         const candidates = mapDefined(symbol.declarations, d => {
-            if (!isAmbientModule(d) && d.parent) {
+            if (!isAmbientModule(d) && d.parent){
                 // direct children of a module
                 if (hasNonGlobalAugmentationExternalModuleSymbol(d.parent)) {
                     return getSymbolOfDeclaration(d.parent as Declaration);
@@ -5702,7 +5702,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (!isExternalOrCommonJsModule(location as SourceFile)) {
                         break;
                     }
-                // falls through
+                    // falls through
                 case SyntaxKind.ModuleDeclaration:
                     const sym = getSymbolOfDeclaration(location as ModuleDeclaration);
                     // `sym` may not have exports if this module declaration is backed by the symbol for a `const` that's being rewritten
@@ -6269,8 +6269,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 const nameType = getSymbolLinks(symbol).nameType;
                 if (nameType && nameType.flags & (TypeFlags.EnumLiteral | TypeFlags.UniqueESSymbol)) {
-                    context.enclosingDeclaration = nameType.symbol.valueDeclaration;
-                    return factory.createComputedPropertyName(symbolToExpression(nameType.symbol, context, meaning));
+                   context.enclosingDeclaration = nameType.symbol.valueDeclaration;
+                   return factory.createComputedPropertyName(symbolToExpression(nameType.symbol, context, meaning));
                 }
             }
             return symbolToExpression(symbol, context, meaning);
@@ -6280,8 +6280,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             Debug.assert(enclosingDeclaration === undefined || (enclosingDeclaration.flags & NodeFlags.Synthesized) === 0);
             const moduleResolverHost =
                 tracker?.trackSymbol ? tracker.moduleResolverHost :
-                    flags! & NodeBuilderFlags.DoNotIncludeSymbolChain ? createBasicNodeBuilderModuleSpecifierResolutionHost(host) :
-                        undefined;
+                flags! & NodeBuilderFlags.DoNotIncludeSymbolChain ? createBasicNodeBuilderModuleSpecifierResolutionHost(host) :
+                undefined;
             const context: NodeBuilderContext = {
                 enclosingDeclaration,
                 flags: flags || NodeBuilderFlags.None,
@@ -6743,8 +6743,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const isConstructorObject = getObjectFlags(type) & ObjectFlags.Anonymous && type.symbol && type.symbol.flags & SymbolFlags.Class;
                 const id = getObjectFlags(type) & ObjectFlags.Reference && (type as TypeReference & T).node ? "N" + getNodeId((type as TypeReference & T).node!) :
                     type.flags & TypeFlags.Conditional ? "N" + getNodeId((type as ConditionalType & T).root.node) :
-                        type.symbol ? (isConstructorObject ? "+" : "") + getSymbolId(type.symbol) :
-                            undefined;
+                    type.symbol ? (isConstructorObject ? "+" : "") + getSymbolId(type.symbol) :
+                    undefined;
                 // Since instantiations of the same anonymous type have the same symbol, tracking symbols instead
                 // of types allows us to catch circular references to instantiations of the same anonymous type
                 if (!context.visitedTypes) {
@@ -6899,14 +6899,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                         factory.createIdentifier(unescapeLeadingUnderscores(getTupleElementLabel(labeledElementDeclaration))),
                                         flags & ElementFlags.Optional ? factory.createToken(SyntaxKind.QuestionToken) : undefined,
                                         flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) :
-                                            tupleConstituentNodes[i]
+                                        tupleConstituentNodes[i]
                                     );
                                 }
                                 else {
                                     tupleConstituentNodes[i] =
                                         flags & ElementFlags.Variable ? factory.createRestTypeNode(flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) : tupleConstituentNodes[i]) :
-                                            flags & ElementFlags.Optional ? factory.createOptionalTypeNode(tupleConstituentNodes[i]) :
-                                                tupleConstituentNodes[i];
+                                        flags & ElementFlags.Optional ? factory.createOptionalTypeNode(tupleConstituentNodes[i]) :
+                                        tupleConstituentNodes[i];
                                 }
                             }
                             const tupleTypeNode = setEmitFlags(factory.createTupleTypeNode(tupleConstituentNodes), EmitFlags.SingleLine);
@@ -7419,6 +7419,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const flags = modifiersToFlags(modifiers);
                 modifiers = factory.createModifiersFromModifierFlags(flags | ModifierFlags.Abstract);
             }
+
             const node =
                 kind === SyntaxKind.CallSignature ? factory.createCallSignature(typeParameters, parameters, returnTypeNode) :
                 kind === SyntaxKind.ConstructSignature ? factory.createConstructSignature(typeParameters, parameters, returnTypeNode) :
@@ -7438,9 +7439,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             if (typeArguments) {
                 node.typeArguments = factory.createNodeArray(typeArguments);
-            }
-            if (signature.declaration?.kind === SyntaxKind.JSDocSignature && signature.declaration.parent.kind === SyntaxKind.JSDocOverloadTag) {
-                addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, getTextOfNode(signature.declaration.parent.parent, /*includeTrivia*/ true).slice(2, -2), /*hasTrailingNewLine*/ true);
             }
 
             cleanup?.();
@@ -7498,8 +7496,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const dotDotDotToken = isRest ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined;
             const name = parameterDeclaration ? parameterDeclaration.name ?
                 parameterDeclaration.name.kind === SyntaxKind.Identifier ? setEmitFlags(factory.cloneNode(parameterDeclaration.name), EmitFlags.NoAsciiEscaping) :
-                    parameterDeclaration.name.kind === SyntaxKind.QualifiedName ? setEmitFlags(factory.cloneNode(parameterDeclaration.name.right), EmitFlags.NoAsciiEscaping) :
-                        cloneBindingName(parameterDeclaration.name) :
+                parameterDeclaration.name.kind === SyntaxKind.QualifiedName ? setEmitFlags(factory.cloneNode(parameterDeclaration.name.right), EmitFlags.NoAsciiEscaping) :
+                cloneBindingName(parameterDeclaration.name) :
                 symbolName(parameterSymbol) :
                 symbolName(parameterSymbol);
             const isOptional = parameterDeclaration && isOptionalParameter(parameterDeclaration) || getCheckFlags(parameterSymbol) & CheckFlags.OptionalParameter;
@@ -7735,7 +7733,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         importModuleSpecifierPreference: isBundle ? "non-relative" : "project-relative",
                         importModuleSpecifierEnding: isBundle ? "minimal"
                             : resolutionMode === ModuleKind.ESNext ? "js"
-                                : undefined,
+                            : undefined,
                     },
                     { overrideImportMode }
                 ));
@@ -8016,7 +8014,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     let expression: Expression | undefined;
                     if (isSingleOrDoubleQuote(firstChar) && !(symbol.flags & SymbolFlags.EnumMember)) {
-                        expression = factory.createStringLiteral(stripQuotes(symbolName).replace(/\\./g, s => s.substring(1)), firstChar === CharacterCodes.singleQuote);
+                       expression = factory.createStringLiteral(stripQuotes(symbolName).replace(/\\./g, s => s.substring(1)), firstChar === CharacterCodes.singleQuote);
                     }
                     else if (("" + +symbolName) === symbolName) {
                         expression = factory.createNumericLiteral(+symbolName);
@@ -8339,7 +8337,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 function getNameForJSDocFunctionParameter(p: ParameterDeclaration, index: number) {
                     return p.name && isIdentifier(p.name) && p.name.escapedText === "this" ? "this"
                         : getEffectiveDotDotDotForParameter(p) ? `args`
-                            : `arg${index}`;
+                        : `arg${index}`;
                 }
 
                 function rewriteModuleSpecifier(parent: ImportTypeNode, lit: StringLiteral) {
@@ -8642,7 +8640,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return; // If we need to emit a private with a keyword name, we're done for, since something else will try to refer to it by that name
                 }
                 let needsPostExportDefault = isDefault && !!(
-                    symbol.flags & SymbolFlags.ExportDoesNotSupportDefaultModifier
+                       symbol.flags & SymbolFlags.ExportDoesNotSupportDefaultModifier
                     || (symbol.flags & SymbolFlags.Function && length(getPropertiesOfType(getTypeOfSymbol(symbol))))
                 ) && !(symbol.flags & SymbolFlags.Alias); // An alias symbol should preclude needing to make an alias ourselves
                 let needsExportDeclaration = !needsPostExportDefault && !isPrivate && isStringANonContextualKeyword(symbolName) && !isDefault;
@@ -8791,7 +8789,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         for (const node of symbol.declarations) {
                             const resolvedModule = resolveExternalModuleName(node, (node as ExportDeclaration).moduleSpecifier!);
                             if (!resolvedModule) continue;
-                            addResult(factory.createExportDeclaration(/*modifiers*/ undefined, /*isTypeOnly*/(node as ExportDeclaration).isTypeOnly, /*exportClause*/ undefined, factory.createStringLiteral(getSpecifierForModuleSymbol(resolvedModule, context))), ModifierFlags.None);
+                            addResult(factory.createExportDeclaration(/*modifiers*/ undefined, /*isTypeOnly*/ (node as ExportDeclaration).isTypeOnly, /*exportClause*/ undefined, factory.createStringLiteral(getSpecifierForModuleSymbol(resolvedModule, context))), ModifierFlags.None);
                         }
                     }
                 }
@@ -8964,7 +8962,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const initializedValue = p.declarations && p.declarations[0] && isEnumMember(p.declarations[0]) ? getConstantValue(p.declarations[0]) : undefined;
                         return factory.createEnumMember(unescapeLeadingUnderscores(p.escapedName), initializedValue === undefined ? undefined :
                             typeof initializedValue === "string" ? factory.createStringLiteral(initializedValue) :
-                                factory.createNumericLiteral(initializedValue));
+                            factory.createNumericLiteral(initializedValue));
                     })
                 ), modifierFlags);
             }
@@ -9259,7 +9257,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             ), modifierFlags);
                             break;
                         }
-                    // else fall through and treat commonjs require just like import=
+                        // else fall through and treat commonjs require just like import=
                     case SyntaxKind.ImportEqualsDeclaration:
                         // This _specifically_ only exists to handle json declarations - where we make aliases, but since
                         // we emit no declarations for the json document, must not refer to it in the declarations
@@ -9461,8 +9459,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // Otherwise, the type itself should be exported.
                         addResult(statement,
                             target && target.flags & SymbolFlags.Property && target.escapedName === InternalSymbolName.ExportEquals ? ModifierFlags.Ambient
-                                : name === varName ? ModifierFlags.Export
-                                    : ModifierFlags.None);
+                            : name === varName ? ModifierFlags.Export
+                            : ModifierFlags.None);
                     }
                     if (isExportAssignmentCompatibleSymbolName) {
                         results.push(factory.createExportAssignment(
@@ -9486,15 +9484,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // whose input is not type annotated (if the input symbol has an annotation we can reuse, we should prefer it)
                 const ctxSrc = getSourceFileOfNode(context.enclosingDeclaration);
                 return getObjectFlags(typeToSerialize) & (ObjectFlags.Anonymous | ObjectFlags.Mapped) &&
-                    !length(getIndexInfosOfType(typeToSerialize)) &&
-                    !isClassInstanceSide(typeToSerialize) && // While a class instance is potentially representable as a NS, prefer printing a reference to the instance type and serializing the class
-                    !!(length(filter(getPropertiesOfType(typeToSerialize), isNamespaceMember)) || length(getSignaturesOfType(typeToSerialize, SignatureKind.Call))) &&
-                    !length(getSignaturesOfType(typeToSerialize, SignatureKind.Construct)) && // TODO: could probably serialize as function + ns + class, now that that's OK
-                    !getDeclarationWithTypeAnnotation(hostSymbol, enclosingDeclaration) &&
-                    !(typeToSerialize.symbol && some(typeToSerialize.symbol.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
-                    !some(getPropertiesOfType(typeToSerialize), p => isLateBoundName(p.escapedName)) &&
-                    !some(getPropertiesOfType(typeToSerialize), p => some(p.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
-                    every(getPropertiesOfType(typeToSerialize), p => isIdentifierText(symbolName(p), languageVersion));
+                !length(getIndexInfosOfType(typeToSerialize)) &&
+                !isClassInstanceSide(typeToSerialize) && // While a class instance is potentially representable as a NS, prefer printing a reference to the instance type and serializing the class
+                !!(length(filter(getPropertiesOfType(typeToSerialize), isNamespaceMember)) || length(getSignaturesOfType(typeToSerialize, SignatureKind.Call))) &&
+                !length(getSignaturesOfType(typeToSerialize, SignatureKind.Construct)) && // TODO: could probably serialize as function + ns + class, now that that's OK
+                !getDeclarationWithTypeAnnotation(hostSymbol, enclosingDeclaration) &&
+                !(typeToSerialize.symbol && some(typeToSerialize.symbol.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
+                !some(getPropertiesOfType(typeToSerialize), p => isLateBoundName(p.escapedName)) &&
+                !some(getPropertiesOfType(typeToSerialize), p => some(p.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
+                every(getPropertiesOfType(typeToSerialize), p => isIdentifierText(symbolName(p), languageVersion));
             }
 
             function makeSerializePropertySymbol<T extends Node>(createProperty: (
@@ -9528,9 +9526,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     if (p.flags & SymbolFlags.Prototype || p.escapedName === "constructor" ||
                         (baseType && getPropertyOfType(baseType, p.escapedName)
-                            && isReadonlySymbol(getPropertyOfType(baseType, p.escapedName)!) === isReadonlySymbol(p)
-                            && (p.flags & SymbolFlags.Optional) === (getPropertyOfType(baseType, p.escapedName)!.flags & SymbolFlags.Optional)
-                            && isTypeIdenticalTo(getTypeOfSymbol(p), getTypeOfPropertyOfType(baseType, p.escapedName)!))) {
+                         && isReadonlySymbol(getPropertyOfType(baseType, p.escapedName)!) === isReadonlySymbol(p)
+                         && (p.flags & SymbolFlags.Optional) === (getPropertyOfType(baseType, p.escapedName)!.flags & SymbolFlags.Optional)
+                         && isTypeIdenticalTo(getTypeOfSymbol(p), getTypeOfPropertyOfType(baseType, p.escapedName)!))) {
                         return [];
                     }
                     const flag = (modifierFlags & ~ModifierFlags.Async) | (isStatic ? ModifierFlags.Static : 0);
@@ -9651,7 +9649,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (privateProtected) {
                         return [setTextRange(factory.createConstructorDeclaration(
                             factory.createModifiersFromModifierFlags(privateProtected),
-                            /*parameters*/[],
+                            /*parameters*/ [],
                             /*body*/ undefined,
                         ), signatures[0].declaration)];
                     }
@@ -9879,10 +9877,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (context && symbol.escapedName === InternalSymbolName.Default && !(context.flags & NodeBuilderFlags.UseAliasDefinedOutsideCurrentScope) &&
             // If it's not the first part of an entity name, it must print as `default`
             (!(context.flags & NodeBuilderFlags.InInitialEntityName) ||
-                // if the symbol is synthesized, it will only be referenced externally it must print as `default`
-                !symbol.declarations ||
-                // if not in the same binding context (source file, module declaration), it must print as `default`
-                (context.enclosingDeclaration && findAncestor(symbol.declarations[0], isDefaultBindingContext) !== findAncestor(context.enclosingDeclaration, isDefaultBindingContext)))) {
+            // if the symbol is synthesized, it will only be referenced externally it must print as `default`
+            !symbol.declarations ||
+            // if not in the same binding context (source file, module declaration), it must print as `default`
+            (context.enclosingDeclaration && findAncestor(symbol.declarations[0], isDefaultBindingContext) !== findAncestor(context.enclosingDeclaration, isDefaultBindingContext)))) {
             return "default";
         }
         if (symbol.declarations && symbol.declarations.length) {
@@ -9951,7 +9949,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // If the binding pattern is empty, this variable declaration is not visible
                         return false;
                     }
-                // falls through
+                    // falls through
                 case SyntaxKind.ModuleDeclaration:
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.InterfaceDeclaration:
@@ -9982,8 +9980,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // Private/protected properties/methods are not visible
                         return false;
                     }
-                // Public properties/methods are visible if its parents are visible, so:
-                // falls through
+                    // Public properties/methods are visible if its parents are visible, so:
+                    // falls through
 
                 case SyntaxKind.Constructor:
                 case SyntaxKind.ConstructSignature:
@@ -10550,14 +10548,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const constructor = findConstructorDeclaration(declaration.parent);
                 const type = constructor ? getFlowTypeInConstructor(declaration.symbol, constructor) :
                     getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :
-                        undefined;
+                    undefined;
                 return type && addOptionality(type, /*isProperty*/ true, isOptional);
             }
             else {
                 const staticBlocks = filter(declaration.parent.members, isClassStaticBlockDeclaration);
                 const type = staticBlocks.length ? getFlowTypeInStaticBlocks(declaration.symbol, staticBlocks) :
                     getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :
-                        undefined;
+                    undefined;
                 return type && addOptionality(type, /*isProperty*/ true, isOptional);
             }
         }
@@ -10705,7 +10703,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 for (const declaration of symbol.declarations) {
                     const expression = (isBinaryExpression(declaration) || isCallExpression(declaration)) ? declaration :
                         isAccessExpression(declaration) ? isBinaryExpression(declaration.parent) ? declaration.parent : declaration :
-                            undefined;
+                        undefined;
                     if (!expression) {
                         continue; // Non-assignment declaration merged in (eg, an Identifier to mark the thing as a namespace) - skip over it and pull type info from elsewhere
                     }
@@ -10833,7 +10831,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const isDirectExport = kind === AssignmentDeclarationKind.ExportsProperty && (isPropertyAccessExpression(expression.left) || isElementAccessExpression(expression.left)) && (isModuleExportsAccessExpression(expression.left.expression) || (isIdentifier(expression.left.expression) && isExportsIdentifier(expression.left.expression)));
         const type = resolvedSymbol ? getTypeOfSymbol(resolvedSymbol)
             : isDirectExport ? getRegularTypeOfLiteralType(checkExpressionCached(expression.right))
-                : getWidenedLiteralType(checkExpressionCached(expression.right));
+            : getWidenedLiteralType(checkExpressionCached(expression.right));
         if (type.flags & TypeFlags.Object &&
             kind === AssignmentDeclarationKind.ModuleExports &&
             symbol.escapedName === InternalSymbolName.ExportEquals) {
@@ -11173,7 +11171,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         else if (
             isBinaryExpression(declaration) ||
             (isInJSFile(declaration) &&
-                (isCallExpression(declaration) || (isPropertyAccessExpression(declaration) || isBindableStaticElementAccessExpression(declaration)) && isBinaryExpression(declaration.parent)))) {
+            (isCallExpression(declaration) || (isPropertyAccessExpression(declaration) || isBindableStaticElementAccessExpression(declaration)) && isBinaryExpression(declaration.parent)))) {
             type = getWidenedTypeForAssignmentDeclaration(symbol);
         }
         else if (isPropertyAccessExpression(declaration)
@@ -11207,11 +11205,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             type = tryGetTypeFromEffectiveTypeNode(declaration) || checkObjectLiteralMethod(declaration, CheckMode.Normal);
         }
         else if (isParameter(declaration)
-            || isPropertyDeclaration(declaration)
-            || isPropertySignature(declaration)
-            || isVariableDeclaration(declaration)
-            || isBindingElement(declaration)
-            || isJSDocPropertyLikeTag(declaration)) {
+                 || isPropertyDeclaration(declaration)
+                 || isPropertySignature(declaration)
+                 || isVariableDeclaration(declaration)
+                 || isBindingElement(declaration)
+                 || isJSDocPropertyLikeTag(declaration)) {
             type = getWidenedTypeForVariableLikeDeclaration(declaration, /*reportErrors*/ true);
         }
         // getTypeOfSymbol dispatches some JS merges incorrectly because their symbol flags are not mutually exclusive.
@@ -11344,7 +11342,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const baseConstructorType = getBaseConstructorTypeOfClass(getDeclaredTypeOfClassOrInterface(symbol));
         return baseConstructorType.flags & TypeFlags.TypeVariable ? baseConstructorType :
             baseConstructorType.flags & TypeFlags.Intersection ? find((baseConstructorType as IntersectionType).types, t => !!(t.flags & TypeFlags.TypeVariable)) :
-                undefined;
+            undefined;
     }
 
     function getTypeOfFuncClassEnumModule(symbol: Symbol): Type {
@@ -11371,8 +11369,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return anyType;
         }
         else if (declaration && (declaration.kind === SyntaxKind.BinaryExpression ||
-            isAccessExpression(declaration) &&
-            declaration.parent.kind === SyntaxKind.BinaryExpression)) {
+                 isAccessExpression(declaration) &&
+                 declaration.parent.kind === SyntaxKind.BinaryExpression)) {
             return getWidenedTypeForAssignmentDeclaration(symbol);
         }
         else if (symbol.flags & SymbolFlags.ValueModule && declaration && isSourceFile(declaration) && declaration.commonJsModuleIndicator) {
@@ -11417,9 +11415,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // up recursively calling getTypeOfAlias, causing a stack overflow.
             links.type = exportSymbol?.declarations && isDuplicatedCommonJSExport(exportSymbol.declarations) && symbol.declarations!.length ? getFlowTypeFromCommonJSExport(exportSymbol)
                 : isDuplicatedCommonJSExport(symbol.declarations) ? autoType
-                    : declaredType ? declaredType
-                        : getAllSymbolFlags(targetSymbol) & SymbolFlags.Value ? getTypeOfSymbol(targetSymbol)
-                            : errorType;
+                : declaredType ? declaredType
+                : getAllSymbolFlags(targetSymbol) & SymbolFlags.Value ? getTypeOfSymbol(targetSymbol)
+                : errorType;
         }
         return links.type;
     }
@@ -12254,10 +12252,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!derived
                 // non-constructor/static-block assignment declarations are ignored here; they're not treated as overrides
                 || derived.valueDeclaration
-                && isBinaryExpression(derived.valueDeclaration)
-                && !isConstructorDeclaredProperty(derived)
-                && !getContainingClassStaticBlock(derived.valueDeclaration)) {
-                symbols.set(base.escapedName, base);
+                    && isBinaryExpression(derived.valueDeclaration)
+                    && !isConstructorDeclaredProperty(derived)
+                    && !getContainingClassStaticBlock(derived.valueDeclaration)) {
+                    symbols.set(base.escapedName, base);
                 symbols.set(base.escapedName, base);
             }
         }
@@ -12361,7 +12359,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!symbol.declarations) {
             symbol.declarations = [member];
         }
-        else if (!member.symbol.isReplaceableByMethod) {
+        else if(!member.symbol.isReplaceableByMethod) {
             symbol.declarations.push(member);
         }
         if (symbolFlags & SymbolFlags.Value) {
@@ -12449,7 +12447,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const isStatic = resolutionKind === MembersOrExportsResolutionKind.resolvedExports;
             const earlySymbols = !isStatic ? symbol.members :
                 symbol.flags & SymbolFlags.Module ? getExportsOfModuleWorker(symbol).exports :
-                    symbol.exports;
+                symbol.exports;
 
             // In the event we recursively resolve the members/exports of the symbol, we
             // set the initial value of resolvedMembers/resolvedExports to the early-bound
@@ -12883,8 +12881,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const paramName = leftName === rightName ? leftName :
                 !leftName ? rightName :
-                    !rightName ? leftName :
-                        undefined;
+                !rightName ? leftName :
+                undefined;
             const paramSymbol = createSymbol(
                 SymbolFlags.FunctionScopedVariable | (isOptional && !isRestParam ? SymbolFlags.Optional : 0),
                 paramName || `arg${i}` as __String
@@ -13295,7 +13293,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             else if (isValidIndexKeyType(propNameType) || propNameType.flags & (TypeFlags.Any | TypeFlags.Enum)) {
                 const indexKeyType = propNameType.flags & (TypeFlags.Any | TypeFlags.String) ? stringType :
                     propNameType.flags & (TypeFlags.Number | TypeFlags.Enum) ? numberType :
-                        propNameType;
+                    propNameType;
                 const propType = instantiateType(templateType, appendTypeMapping(type.mapper, typeParameter, keyType));
                 const indexInfo = createIndexInfo(indexKeyType, propType, !!(templateModifiers & MappedTypeModifiers.IncludeReadonly));
                 indexInfos = appendIndexInfo(indexInfos, indexInfo, /*union*/ true);
@@ -13318,7 +13316,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // mode, if the underlying property is optional we remove 'undefined' from the type.
             let type = strictNullChecks && symbol.flags & SymbolFlags.Optional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true) :
                 symbol.links.checkFlags & CheckFlags.StripOptional ? removeMissingOrUndefinedType(propType) :
-                    propType;
+                propType;
             if (!popTypeResolution()) {
                 error(currentNode, Diagnostics.Type_of_property_0_circularly_references_itself_in_mapped_type_1, symbolToString(symbol), typeToString(mappedType));
                 type = errorType;
@@ -13554,8 +13552,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getConstraintOfType(type: InstantiableType | UnionOrIntersectionType): Type | undefined {
         return type.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(type as TypeParameter) :
             type.flags & TypeFlags.IndexedAccess ? getConstraintOfIndexedAccess(type as IndexedAccessType) :
-                type.flags & TypeFlags.Conditional ? getConstraintOfConditionalType(type as ConditionalType) :
-                    getBaseConstraintOfType(type);
+            type.flags & TypeFlags.Conditional ? getConstraintOfConditionalType(type as ConditionalType) :
+            getBaseConstraintOfType(type);
     }
 
     function getConstraintOfTypeParameter(typeParameter: TypeParameter): Type | undefined {
@@ -13793,7 +13791,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 return t.flags & TypeFlags.Union && baseTypes.length === types.length ? getUnionType(baseTypes) :
                     t.flags & TypeFlags.Intersection && baseTypes.length ? getIntersectionType(baseTypes) :
-                        undefined;
+                    undefined;
             }
             if (t.flags & TypeFlags.Index) {
                 return keyofConstraintType;
@@ -13921,16 +13919,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const objectFlags = getObjectFlags(t);
         return objectFlags & ObjectFlags.Mapped ? getApparentTypeOfMappedType(t as MappedType) :
             objectFlags & ObjectFlags.Reference && t !== type ? getTypeWithThisArgument(t, type) :
-                t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(t as IntersectionType, type) :
-                    t.flags & TypeFlags.StringLike ? globalStringType :
-                        t.flags & TypeFlags.NumberLike ? globalNumberType :
-                            t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType() :
-                                t.flags & TypeFlags.BooleanLike ? globalBooleanType :
-                                    t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType() :
-                                        t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
-                                            t.flags & TypeFlags.Index ? keyofConstraintType :
-                                                t.flags & TypeFlags.Unknown && !strictNullChecks ? emptyObjectType :
-                                                    t;
+            t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(t as IntersectionType, type) :
+            t.flags & TypeFlags.StringLike ? globalStringType :
+            t.flags & TypeFlags.NumberLike ? globalNumberType :
+            t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType() :
+            t.flags & TypeFlags.BooleanLike ? globalBooleanType :
+            t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType() :
+            t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
+            t.flags & TypeFlags.Index ? keyofConstraintType :
+            t.flags & TypeFlags.Unknown && !strictNullChecks ? emptyObjectType :
+            t;
     }
 
     function getReducedApparentType(type: Type): Type {
@@ -14262,8 +14260,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (skipObjectFunctionPropertyAugment) return undefined;
             const functionType = resolved === anyFunctionType ? globalFunctionType :
                 resolved.callSignatures.length ? globalCallableFunctionType :
-                    resolved.constructSignatures.length ? globalNewableFunctionType :
-                        undefined;
+                resolved.constructSignatures.length ? globalNewableFunctionType :
+                undefined;
             if (functionType) {
                 const symbol = getPropertyOfObjectType(functionType, name);
                 if (symbol) {
@@ -14349,10 +14347,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // the intersected key type, we just use unknownType for the key type as nothing actually depends on the
         // keyType property of the returned IndexInfo.
         return applicableInfos ? createIndexInfo(unknownType, getIntersectionType(map(applicableInfos, info => info.type)),
-            reduceLeft(applicableInfos, (isReadonly, info) => isReadonly && info.isReadonly, /*initial*/ true)) :
+                reduceLeft(applicableInfos, (isReadonly, info) => isReadonly && info.isReadonly, /*initial*/ true)) :
             applicableInfo ? applicableInfo :
-                stringIndexInfo && isApplicableIndexType(keyType, stringType) ? stringIndexInfo :
-                    undefined;
+            stringIndexInfo && isApplicableIndexType(keyType, stringType) ? stringIndexInfo :
+            undefined;
     }
 
     function isApplicableIndexType(source: Type, target: Type): boolean {
@@ -14408,7 +14406,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         return result?.length ? result
             : isFunctionDeclaration(declaration) ? getSignatureOfTypeTag(declaration)?.typeParameters
-                : undefined;
+            : undefined;
     }
 
     function symbolsToArray(symbols: SymbolTable): Symbol[] {
@@ -14740,7 +14738,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 (!isFunctionExpressionOrArrowFunction(decl) &&
                     !isObjectLiteralMethod(decl) &&
                     getSignatureOfTypeTag(decl)) ||
-                getSignatureFromDeclaration(decl)
+                    getSignatureFromDeclaration(decl)
             );
         }
         return result;
@@ -14811,8 +14809,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             let type = signature.target ? instantiateType(getReturnTypeOfSignature(signature.target), signature.mapper) :
                 signature.compositeSignatures ? instantiateType(getUnionOrIntersectionType(map(signature.compositeSignatures, getReturnTypeOfSignature), signature.compositeKind, UnionReduction.Subtype), signature.mapper) :
-                    getReturnTypeFromAnnotation(signature.declaration!) ||
-                    (nodeIsMissing((signature.declaration as FunctionLikeDeclaration).body) ? anyType : getReturnTypeFromBody(signature.declaration as FunctionLikeDeclaration));
+                getReturnTypeFromAnnotation(signature.declaration!) ||
+                (nodeIsMissing((signature.declaration as FunctionLikeDeclaration).body) ? anyType : getReturnTypeFromBody(signature.declaration as FunctionLikeDeclaration));
             if (signature.flags & SignatureFlags.IsInnerCallChain) {
                 type = addOptionalTypeMarker(type);
             }
@@ -15242,8 +15240,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const node = type.node;
             const typeArguments = !node ? emptyArray :
                 node.kind === SyntaxKind.TypeReference ? concatenate(type.target.outerTypeParameters, getEffectiveTypeArguments(node, type.target.localTypeParameters!)) :
-                    node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] :
-                        map(node.elements, getTypeFromTypeNode);
+                node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] :
+                map(node.elements, getTypeFromTypeNode);
             if (popTypeResolution()) {
                 type.resolvedTypeArguments = type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
             }
@@ -15410,12 +15408,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getUnresolvedSymbolForEntityName(name: EntityNameOrEntityNameExpression) {
         const identifier = name.kind === SyntaxKind.QualifiedName ? name.right :
             name.kind === SyntaxKind.PropertyAccessExpression ? name.name :
-                name;
+            name;
         const text = identifier.escapedText;
         if (text) {
             const parentSymbol = name.kind === SyntaxKind.QualifiedName ? getUnresolvedSymbolForEntityName(name.left) :
                 name.kind === SyntaxKind.PropertyAccessExpression ? getUnresolvedSymbolForEntityName(name.expression) :
-                    undefined;
+                undefined;
             const path = parentSymbol ? `${getSymbolPath(parentSymbol)}.${text}` : text as string;
             let result = unresolvedSymbols.get(path);
             if (!result) {
@@ -15516,7 +15514,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getImpliedConstraint(type: Type, checkNode: TypeNode, extendsNode: TypeNode): Type | undefined {
         return isUnaryTupleTypeNode(checkNode) && isUnaryTupleTypeNode(extendsNode) ? getImpliedConstraint(type, (checkNode as TupleTypeNode).elements[0], (extendsNode as TupleTypeNode).elements[0]) :
             getActualTypeVariable(getTypeFromTypeNode(checkNode)) === getActualTypeVariable(type) ? getTypeFromTypeNode(extendsNode) :
-                undefined;
+            undefined;
     }
 
     function getConditionalFlowTypeOfType(type: Type, node: Node) {
@@ -15949,7 +15947,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.NamedTupleMember:
                 return (node as NamedTupleMember).questionToken ? ElementFlags.Optional :
                     (node as NamedTupleMember).dotDotDotToken ? getRestTypeElementFlags(node as NamedTupleMember) :
-                        ElementFlags.Required;
+                    ElementFlags.Required;
             default:
                 return ElementFlags.Required;
         }
@@ -15978,8 +15976,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isDeferredTypeReferenceNode(node: TypeReferenceNode | ArrayTypeNode | TupleTypeNode, hasDefaultTypeArguments?: boolean) {
         return !!getAliasSymbolForTypeNode(node) || isResolvedByTypeAlias(node) && (
             node.kind === SyntaxKind.ArrayType ? mayResolveTypeAlias(node.elementType) :
-                node.kind === SyntaxKind.TupleType ? some(node.elements, mayResolveTypeAlias) :
-                    hasDefaultTypeArguments || some(node.typeArguments, mayResolveTypeAlias));
+            node.kind === SyntaxKind.TupleType ? some(node.elements, mayResolveTypeAlias) :
+            hasDefaultTypeArguments || some(node.typeArguments, mayResolveTypeAlias));
     }
 
     // Return true when the given node is transitively contained in type constructs that eagerly
@@ -16064,7 +16062,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const tupleTarget = getTupleTargetType(elementFlags || map(elementTypes, _ => ElementFlags.Required), readonly, namedMemberDeclarations);
         return tupleTarget === emptyGenericType ? emptyObjectType :
             elementTypes.length ? createNormalizedTypeReference(tupleTarget, elementTypes) :
-                tupleTarget;
+            tupleTarget;
     }
 
     function getTupleTargetType(elementFlags: readonly ElementFlags[], readonly: boolean, namedMemberDeclarations: readonly (NamedTupleMember | ParameterDeclaration | undefined)[]): GenericType {
@@ -16220,7 +16218,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const tupleTarget = getTupleTargetType(expandedFlags, target.readonly, expandedDeclarations);
         return tupleTarget === emptyGenericType ? emptyObjectType :
             expandedFlags.length ? createTypeReference(tupleTarget, expandedTypes) :
-                tupleTarget;
+            tupleTarget;
 
         function addElement(type: Type, flags: ElementFlags, declaration: NamedTupleMember | ParameterDeclaration | undefined) {
             if (flags & ElementFlags.Required) {
@@ -16520,7 +16518,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (typeSet.length === 0) {
                 return includes & TypeFlags.Null ? includes & TypeFlags.IncludesNonWideningType ? nullType : nullWideningType :
                     includes & TypeFlags.Undefined ? includes & TypeFlags.IncludesNonWideningType ? undefinedType : undefinedWideningType :
-                        neverType;
+                    neverType;
             }
         }
         if (!origin && includes & TypeFlags.Union) {
@@ -16592,8 +16590,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const typeKey = !origin ? getTypeListId(types) :
             origin.flags & TypeFlags.Union ? `|${getTypeListId((origin as UnionType).types)}` :
-                origin.flags & TypeFlags.Intersection ? `&${getTypeListId((origin as IntersectionType).types)}` :
-                    `#${(origin as IndexType).type.id}|${getTypeListId(types)}`; // origin type id alone is insufficient, as `keyof x` may resolve to multiple WIP values while `x` is still resolving
+            origin.flags & TypeFlags.Intersection ? `&${getTypeListId((origin as IntersectionType).types)}` :
+            `#${(origin as IndexType).type.id}|${getTypeListId(types)}`; // origin type id alone is insufficient, as `keyof x` may resolve to multiple WIP values while `x` is still resolving
         const id = typeKey + getAliasId(aliasSymbol, aliasTypeArguments);
         let type = unionTypes.get(id);
         if (!type) {
@@ -16691,9 +16689,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!containsType(u.types, type)) {
                 const primitive = type.flags & TypeFlags.StringLiteral ? stringType :
                     type.flags & (TypeFlags.Enum | TypeFlags.NumberLiteral) ? numberType :
-                        type.flags & TypeFlags.BigIntLiteral ? bigintType :
-                            type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
-                                undefined;
+                    type.flags & TypeFlags.BigIntLiteral ? bigintType :
+                    type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
+                    undefined;
                 if (!primitive || !containsType(u.types, primitive)) {
                     return false;
                 }
@@ -16926,7 +16924,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getConstituentCount(type: Type): number {
         return !(type.flags & TypeFlags.UnionOrIntersection) || type.aliasSymbol ? 1 :
             type.flags & TypeFlags.Union && (type as UnionType).origin ? getConstituentCount((type as UnionType).origin!) :
-                getConstituentCountOfTypes((type as UnionOrIntersectionType).types);
+            getConstituentCountOfTypes((type as UnionOrIntersectionType).types);
     }
 
     function getConstituentCountOfTypes(types: Type[]): number {
@@ -17008,7 +17006,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // we had to pick apart the constraintType to potentially map/filter it - compare the final resulting list with the original constraintType,
         // so we can return the union that preserves aliases/origin data if possible
         const result = indexFlags & IndexFlags.NoIndexSignatures ? filterType(getUnionType(keyTypes), t => !(t.flags & (TypeFlags.Any | TypeFlags.String))) : getUnionType(keyTypes);
-        if (result.flags & TypeFlags.Union && constraintType.flags & TypeFlags.Union && getTypeListId((result as UnionType).types) === getTypeListId((constraintType as UnionType).types)) {
+        if (result.flags & TypeFlags.Union && constraintType.flags & TypeFlags.Union && getTypeListId((result as UnionType).types) === getTypeListId((constraintType as UnionType).types)){
             return constraintType;
         }
         return result;
@@ -17032,11 +17030,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function isDistributive(type: Type): boolean {
             return type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Primitive | TypeFlags.Never | TypeFlags.TypeParameter | TypeFlags.Object | TypeFlags.NonPrimitive) ? true :
                 type.flags & TypeFlags.Conditional ? (type as ConditionalType).root.isDistributive && (type as ConditionalType).checkType === typeVariable :
-                    type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral) ? every((type as UnionOrIntersectionType | TemplateLiteralType).types, isDistributive) :
-                        type.flags & TypeFlags.IndexedAccess ? isDistributive((type as IndexedAccessType).objectType) && isDistributive((type as IndexedAccessType).indexType) :
-                            type.flags & TypeFlags.Substitution ? isDistributive((type as SubstitutionType).baseType) && isDistributive((type as SubstitutionType).constraint) :
-                                type.flags & TypeFlags.StringMapping ? isDistributive((type as StringMappingType).type) :
-                                    false;
+                type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral) ? every((type as UnionOrIntersectionType | TemplateLiteralType).types, isDistributive) :
+                type.flags & TypeFlags.IndexedAccess ? isDistributive((type as IndexedAccessType).objectType) && isDistributive((type as IndexedAccessType).indexType) :
+                type.flags & TypeFlags.Substitution ? isDistributive((type as SubstitutionType).baseType) && isDistributive((type as SubstitutionType).constraint):
+                type.flags & TypeFlags.StringMapping ? isDistributive((type as StringMappingType).type) :
+                false;
         }
     }
 
@@ -17100,13 +17098,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         type = getReducedType(type);
         return shouldDeferIndexType(type, indexFlags) ? getIndexTypeForGenericType(type as InstantiableType | UnionOrIntersectionType, indexFlags) :
             type.flags & TypeFlags.Union ? getIntersectionType(map((type as UnionType).types, t => getIndexType(t, indexFlags))) :
-                type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags))) :
-                    getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags) :
-                        type === wildcardType ? wildcardType :
-                            type.flags & TypeFlags.Unknown ? neverType :
-                                type.flags & (TypeFlags.Any | TypeFlags.Never) ? keyofConstraintType :
-                                    getLiteralTypeFromProperties(type, (indexFlags & IndexFlags.NoIndexSignatures ? TypeFlags.StringLiteral : TypeFlags.StringLike) | (indexFlags & IndexFlags.StringsOnly ? 0 : TypeFlags.NumberLike | TypeFlags.ESSymbolLike),
-                                        indexFlags === defaultIndexFlags);
+            type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags))) :
+            getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags) :
+            type === wildcardType ? wildcardType :
+            type.flags & TypeFlags.Unknown ? neverType :
+            type.flags & (TypeFlags.Any | TypeFlags.Never) ? keyofConstraintType :
+            getLiteralTypeFromProperties(type, (indexFlags & IndexFlags.NoIndexSignatures ? TypeFlags.StringLiteral : TypeFlags.StringLike) | (indexFlags & IndexFlags.StringsOnly ? 0 : TypeFlags.NumberLike | TypeFlags.ESSymbolLike),
+                indexFlags === defaultIndexFlags);
     }
 
     function getExtractStringType(type: Type) {
@@ -17218,9 +17216,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTemplateStringForType(type: Type) {
         return type.flags & TypeFlags.StringLiteral ? (type as StringLiteralType).value :
             type.flags & TypeFlags.NumberLiteral ? "" + (type as NumberLiteralType).value :
-                type.flags & TypeFlags.BigIntLiteral ? pseudoBigIntToString((type as BigIntLiteralType).value) :
-                    type.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) ? (type as IntrinsicType).intrinsicName :
-                        undefined;
+            type.flags & TypeFlags.BigIntLiteral ? pseudoBigIntToString((type as BigIntLiteralType).value) :
+            type.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) ? (type as IntrinsicType).intrinsicName :
+            undefined;
     }
 
     function createTemplateLiteralType(texts: readonly string[], types: readonly Type[]) {
@@ -17234,13 +17232,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getStringMappingType(symbol: Symbol, type: Type): Type {
         return type.flags & (TypeFlags.Union | TypeFlags.Never) ? mapType(type, t => getStringMappingType(symbol, t)) :
             type.flags & TypeFlags.StringLiteral ? getStringLiteralType(applyStringMapping(symbol, (type as StringLiteralType).value)) :
-                type.flags & TypeFlags.TemplateLiteral ? getTemplateLiteralType(...applyTemplateStringMapping(symbol, (type as TemplateLiteralType).texts, (type as TemplateLiteralType).types)) :
-                    // Mapping<Mapping<T>> === Mapping<T>
-                    type.flags & TypeFlags.StringMapping && symbol === type.symbol ? type :
-                        type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type) :
-                            // This handles Mapping<`${number}`> and Mapping<`${bigint}`>
-                            isPatternLiteralPlaceholderType(type) ? getStringMappingTypeForGenericType(symbol, getTemplateLiteralType(["", ""], [type])) :
-                                type;
+            type.flags & TypeFlags.TemplateLiteral ? getTemplateLiteralType(...applyTemplateStringMapping(symbol, (type as TemplateLiteralType).texts, (type as TemplateLiteralType).types)) :
+            // Mapping<Mapping<T>> === Mapping<T>
+            type.flags & TypeFlags.StringMapping && symbol === type.symbol ? type :
+            type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type) :
+            // This handles Mapping<`${number}`> and Mapping<`${bigint}`>
+            isPatternLiteralPlaceholderType(type) ? getStringMappingTypeForGenericType(symbol, getTemplateLiteralType(["", ""], [type])) :
+            type;
     }
 
     function applyStringMapping(symbol: Symbol, str: string) {
@@ -17320,10 +17318,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getPropertyNameFromIndex(indexType: Type, accessNode: StringLiteral | Identifier | PrivateIdentifier | ObjectBindingPattern | ArrayBindingPattern | ComputedPropertyName | NumericLiteral | IndexedAccessTypeNode | ElementAccessExpression | SyntheticExpression | undefined) {
         return isTypeUsableAsPropertyName(indexType) ?
             getPropertyNameFromType(indexType) :
-            accessNode && isPropertyName(accessNode) ?
-                // late bound names are handled in the first branch, so here we only need to handle normal names
-                getPropertyNameForPropertyNameNode(accessNode) :
-                undefined;
+                accessNode && isPropertyName(accessNode) ?
+                    // late bound names are handled in the first branch, so here we only need to handle normal names
+                    getPropertyNameForPropertyNameNode(accessNode) :
+                    undefined;
     }
 
     function isUncalledFunctionReference(node: Node, symbol: Symbol) {
@@ -17367,7 +17365,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const propType = getTypeOfSymbol(prop);
                 return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ? getFlowTypeOfReference(accessExpression, propType) :
                     accessNode && isIndexedAccessTypeNode(accessNode) && containsMissingType(propType) ? getUnionType([propType, undefinedType]) :
-                        propType;
+                    propType;
             }
             if (everyType(objectType, isTupleType) && isNumericLiteralName(propName)) {
                 const index = +propName;
@@ -17421,8 +17419,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     !(objectType.symbol &&
                         objectType.symbol.flags & (SymbolFlags.RegularEnum | SymbolFlags.ConstEnum) &&
                         (indexType.symbol &&
-                            indexType.flags & TypeFlags.EnumLiteral &&
-                            getParentOfSymbol(indexType.symbol) === objectType.symbol))) {
+                        indexType.flags & TypeFlags.EnumLiteral &&
+                        getParentOfSymbol(indexType.symbol) === objectType.symbol))) {
                     return getUnionType([indexInfo.type, missingType]);
                 }
                 return indexInfo.type;
@@ -17531,8 +17529,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getIndexNodeForAccessExpression(accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression) {
         return accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode.argumentExpression :
             accessNode.kind === SyntaxKind.IndexedAccessType ? accessNode.indexType :
-                accessNode.kind === SyntaxKind.ComputedPropertyName ? accessNode.expression :
-                    accessNode;
+            accessNode.kind === SyntaxKind.ComputedPropertyName ? accessNode.expression :
+            accessNode;
     }
 
     function isPatternLiteralPlaceholderType(type: Type): boolean {
@@ -17581,7 +17579,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getSimplifiedType(type: Type, writing: boolean): Type {
         return type.flags & TypeFlags.IndexedAccess ? getSimplifiedIndexedAccessType(type as IndexedAccessType, writing) :
             type.flags & TypeFlags.Conditional ? getSimplifiedConditionalType(type as ConditionalType, writing) :
-                type;
+            type;
     }
 
     function distributeIndexOverObjectType(objectType: Type, indexType: Type, writing: boolean) {
@@ -18358,7 +18356,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getRegularTypeOfLiteralType(type: Type): Type {
         return type.flags & TypeFlags.Freshable ? (type as FreshableType).regularType :
             type.flags & TypeFlags.Union ? ((type as UnionType).regularType || ((type as UnionType).regularType = mapType(type, getRegularTypeOfLiteralType) as UnionType)) :
-                type;
+            type;
     }
 
     function isFreshLiteralType(type: Type) {
@@ -18481,7 +18479,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeFromNamedTupleTypeNode(node: NamedTupleMember): Type {
         const links = getNodeLinks(node);
         return links.resolvedType || (links.resolvedType =
-            node.dotDotDotToken ? getTypeFromRestTypeNode(node) :
+                node.dotDotDotToken ? getTypeFromRestTypeNode(node) :
                 addOptionality(getTypeFromTypeNode(node.type), /*isProperty*/ true, !!node.questionToken));
     }
 
@@ -18789,7 +18787,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getObjectTypeInstantiation(type: AnonymousType | DeferredTypeReference, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]) {
         const declaration = type.objectFlags & ObjectFlags.Reference ? (type as TypeReference).node! :
             type.objectFlags & ObjectFlags.InstantiationExpressionType ? (type as InstantiationExpressionType).node :
-                type.symbol.declarations![0];
+            type.symbol.declarations![0];
         const links = getNodeLinks(declaration);
         const target = type.objectFlags & ObjectFlags.Reference ? links.resolvedType! as DeferredTypeReference :
             type.objectFlags & ObjectFlags.Instantiated ? type.target! : type;
@@ -18829,7 +18827,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const newMapper = createTypeMapper(typeParameters, typeArguments);
                 result = target.objectFlags & ObjectFlags.Reference ? createDeferredTypeReference((type as DeferredTypeReference).target, (type as DeferredTypeReference).node, newMapper, newAliasSymbol, newAliasTypeArguments) :
                     target.objectFlags & ObjectFlags.Mapped ? instantiateMappedType(target as MappedType, newMapper, newAliasSymbol, newAliasTypeArguments) :
-                        instantiateAnonymousType(target, newMapper, newAliasSymbol, newAliasTypeArguments);
+                    instantiateAnonymousType(target, newMapper, newAliasSymbol, newAliasTypeArguments);
                 target.instantiations.set(id, result); // Set cached result early in case we recursively invoke instantiation while eagerly computing type variable visibility below
                 const resultObjectFlags = getObjectFlags(result);
                 if (result.flags & TypeFlags.ObjectFlagsType && !(resultObjectFlags & ObjectFlags.CouldContainTypeVariablesComputed)) {
@@ -18888,7 +18886,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const tpDeclaration = tp.symbol.declarations![0]; // There is exactly one declaration, otherwise `containsReference` is not called
                         const tpScope = tpDeclaration.kind === SyntaxKind.TypeParameter ? tpDeclaration.parent : // Type parameter is a regular type parameter, e.g. foo<T>
                             tp.isThisType ? tpDeclaration : // Type parameter is the this type, and its declaration is the class declaration.
-                                undefined; // Type parameter's declaration was unrecognized, e.g. comes from JSDoc annotation.
+                            undefined; // Type parameter's declaration was unrecognized, e.g. comes from JSDoc annotation.
                         if (firstIdentifierSymbol.declarations && tpScope) {
                             return some(firstIdentifierSymbol.declarations, idDecl => isNodeDescendantOf(idDecl, tpScope)) ||
                                 some((node as TypeQueryNode).typeArguments, containsReference);
@@ -18970,7 +18968,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const elementTypes = map(getElementTypes(tupleType), (t, i) => {
             const singleton = elementFlags[i] & ElementFlags.Variadic ? t :
                 elementFlags[i] & ElementFlags.Rest ? createArrayType(t) :
-                    createTupleType([t], [elementFlags[i]]);
+                createTupleType([t], [elementFlags[i]]);
             // avoid infinite recursion, if the singleton is the type variable itself
             // then we'd just get back here with the same arguments from within instantiateMappedType
             if (singleton === typeVariable) {
@@ -18996,7 +18994,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const modifiers = getMappedTypeModifiers(mappedType);
         const newTupleModifiers = modifiers & MappedTypeModifiers.IncludeOptional ? map(elementFlags, f => f & ElementFlags.Required ? ElementFlags.Optional : f) :
             modifiers & MappedTypeModifiers.ExcludeOptional ? map(elementFlags, f => f & ElementFlags.Optional ? ElementFlags.Required : f) :
-                elementFlags;
+            elementFlags;
         const newReadonly = getModifiedReadonlyState(tupleType.target.readonly, modifiers);
         return contains(elementTypes, errorType) ? errorType :
             createTupleType(elementTypes, newTupleModifiers, newReadonly, tupleType.target.labeledElementDeclarations);
@@ -19008,7 +19006,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const modifiers = getMappedTypeModifiers(type);
         return strictNullChecks && modifiers & MappedTypeModifiers.IncludeOptional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true) :
             strictNullChecks && modifiers & MappedTypeModifiers.ExcludeOptional && isOptional ? getTypeWithFacts(propType, TypeFacts.NEUndefined) :
-                propType;
+            propType;
     }
 
     function instantiateAnonymousType(type: AnonymousType, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]): AnonymousType {
@@ -19320,12 +19318,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isTypeDerivedFrom(source: Type, target: Type): boolean {
         return source.flags & TypeFlags.Union ? every((source as UnionType).types, t => isTypeDerivedFrom(t, target)) :
             target.flags & TypeFlags.Union ? some((target as UnionType).types, t => isTypeDerivedFrom(source, t)) :
-                source.flags & TypeFlags.Intersection ? some((source as IntersectionType).types, t => isTypeDerivedFrom(t, target)) :
-                    source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target) :
-                        isEmptyAnonymousObjectType(target) ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) :
-                            target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) && !isEmptyAnonymousObjectType(source) :
-                                target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType) :
-                                    hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
+            source.flags & TypeFlags.Intersection ? some((source as IntersectionType).types, t => isTypeDerivedFrom(t, target)) :
+            source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target) :
+            isEmptyAnonymousObjectType(target) ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) :
+            target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) && !isEmptyAnonymousObjectType(source) :
+            target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType) :
+            hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
     }
 
     /**
@@ -19398,7 +19396,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!isConstAssertion(node)) {
                     break;
                 }
-            // fallthrough
+                // fallthrough
             case SyntaxKind.JsxExpression:
             case SyntaxKind.ParenthesizedExpression:
                 return elaborateError((node as AsExpression | ParenthesizedExpression | JsxExpression).expression, source, target, relation, headMessage, containingMessageChain, errorOutputContainer);
@@ -19669,7 +19667,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
 
-    function* generateJsxAttributes(node: JsxAttributes): ElaborationIterator {
+    function *generateJsxAttributes(node: JsxAttributes): ElaborationIterator {
         if (!length(node.properties)) return;
         for (const prop of node.properties) {
             if (isJsxSpreadAttribute(prop) || isHyphenatedJsxName(getTextOfJsxAttributeName(prop.name))) continue;
@@ -19677,7 +19675,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
     }
 
-    function* generateJsxChildren(node: JsxElement, getInvalidTextDiagnostic: () => DiagnosticMessage): ElaborationIterator {
+    function *generateJsxChildren(node: JsxElement, getInvalidTextDiagnostic: () => DiagnosticMessage): ElaborationIterator {
         if (!length(node.children)) return;
         let memberOffset = 0;
         for (let i = 0; i < node.children.length; i++) {
@@ -19773,7 +19771,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const elem = getElaborationElementForJsxChild(child, childrenNameType, getInvalidTextualChildDiagnostic);
                     if (elem) {
                         result = elaborateElementwise(
-                            (function* () { yield elem; })(),
+                            (function*() { yield elem; })(),
                             source,
                             target,
                             relation,
@@ -19812,7 +19810,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
     }
 
-    function* generateLimitedTupleElements(node: ArrayLiteralExpression, target: Type): ElaborationIterator {
+    function *generateLimitedTupleElements(node: ArrayLiteralExpression, target: Type): ElaborationIterator {
         const len = length(node.elements);
         if (!len) return;
         for (let i = 0; i < len; i++) {
@@ -19848,7 +19846,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return false;
     }
 
-    function* generateObjectLiteralElements(node: ObjectLiteralExpression): ElaborationIterator {
+    function *generateObjectLiteralElements(node: ObjectLiteralExpression): ElaborationIterator {
         if (!length(node.properties)) return;
         for (const prop of node.properties) {
             if (isSpreadAssignment(prop)) continue;
@@ -20025,13 +20023,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // here and just use the `any` type directly
             const targetReturnType = isResolvingReturnTypeOfSignature(target) ? anyType
                 : target.declaration && isJSConstructor(target.declaration) ? getDeclaredTypeOfClassOrInterface(getMergedSymbol(target.declaration.symbol))
-                    : getReturnTypeOfSignature(target);
+                : getReturnTypeOfSignature(target);
             if (targetReturnType === voidType || targetReturnType === anyType) {
                 return result;
             }
             const sourceReturnType = isResolvingReturnTypeOfSignature(source) ? anyType
                 : source.declaration && isJSConstructor(source.declaration) ? getDeclaredTypeOfClassOrInterface(getMergedSymbol(source.declaration.symbol))
-                    : getReturnTypeOfSignature(source);
+                : getReturnTypeOfSignature(source);
 
             // The following block preserves behavior forbidding boolean returning functions from being assignable to type guard returning functions
             const targetTypePredicate = getTypePredicateOfSignature(target);
@@ -20089,7 +20087,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         const related = source.type === target.type ? Ternary.True :
             source.type && target.type ? compareTypes(source.type, target.type, reportErrors) :
-                Ternary.False;
+            Ternary.False;
         if (related === Ternary.False && reportErrors) {
             errorReporter!(Diagnostics.Type_predicate_0_is_not_assignable_to_1, typePredicateToString(source), typePredicateToString(target));
         }
@@ -20124,9 +20122,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isEmptyObjectType(type: Type): boolean {
         return type.flags & TypeFlags.Object ? !isGenericMappedType(type) && isEmptyResolvedType(resolveStructuredTypeMembers(type as ObjectType)) :
             type.flags & TypeFlags.NonPrimitive ? true :
-                type.flags & TypeFlags.Union ? some((type as UnionType).types, isEmptyObjectType) :
-                    type.flags & TypeFlags.Intersection ? every((type as UnionType).types, isEmptyObjectType) :
-                        false;
+            type.flags & TypeFlags.Union ? some((type as UnionType).types, isEmptyObjectType) :
+            type.flags & TypeFlags.Intersection ? every((type as UnionType).types, isEmptyObjectType) :
+            false;
     }
 
     function isEmptyAnonymousObjectType(type: Type) {
@@ -20276,11 +20274,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         while (true) {
             const t = isFreshLiteralType(type) ? (type as FreshableType).regularType :
                 isGenericTupleType(type) ? getNormalizedTupleType(type, writing) :
-                    getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) || type :
-                        type.flags & TypeFlags.UnionOrIntersection ? getNormalizedUnionOrIntersectionType(type as UnionOrIntersectionType, writing) :
-                            type.flags & TypeFlags.Substitution ? writing ? (type as SubstitutionType).baseType : getSubstitutionIntersection(type as SubstitutionType) :
-                                type.flags & TypeFlags.Simplifiable ? getSimplifiedType(type, writing) :
-                                    type;
+                getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) || type :
+                type.flags & TypeFlags.UnionOrIntersection ? getNormalizedUnionOrIntersectionType(type as UnionOrIntersectionType, writing) :
+                type.flags & TypeFlags.Substitution ? writing ? (type as SubstitutionType).baseType : getSubstitutionIntersection(type as SubstitutionType) :
+                type.flags & TypeFlags.Simplifiable ? getSimplifiedType(type, writing) :
+                type;
             if (t === type) return t;
             type = t;
         }
@@ -20481,12 +20479,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         else {
                             const prefix = (msg.code === Diagnostics.Construct_signature_return_types_0_and_1_are_incompatible.code ||
                                 msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
-                                ? "new "
-                                : "";
+                                    ? "new "
+                                    : "";
                             const params = (msg.code === Diagnostics.Call_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code ||
                                 msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
-                                ? ""
-                                : "...";
+                                    ? ""
+                                    : "...";
                             path = `${prefix}${path}(${params})`;
                         }
                         break;
@@ -20555,31 +20553,31 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 generalizedSourceType = getTypeNameForErrorDisplay(generalizedSource);
             }
 
-            // If `target` is of indexed access type (And `source` it is not), we use the object type of `target` for better error reporting
-            const targetFlags = target.flags & TypeFlags.IndexedAccess && !(source.flags & TypeFlags.IndexedAccess) ?
-                (target as IndexedAccessType).objectType.flags :
-                target.flags;
+                // If `target` is of indexed access type (And `source` it is not), we use the object type of `target` for better error reporting
+                const targetFlags = target.flags & TypeFlags.IndexedAccess && !(source.flags & TypeFlags.IndexedAccess) ?
+                    (target as IndexedAccessType).objectType.flags :
+                    target.flags;
 
-            if (targetFlags & TypeFlags.TypeParameter && target !== markerSuperTypeForCheck && target !== markerSubTypeForCheck) {
-                const constraint = getBaseConstraintOfType(target);
-                let needsOriginalSource;
-                if (constraint && (isTypeAssignableTo(generalizedSource, constraint) || (needsOriginalSource = isTypeAssignableTo(source, constraint)))) {
-                    reportError(
-                        Diagnostics._0_is_assignable_to_the_constraint_of_type_1_but_1_could_be_instantiated_with_a_different_subtype_of_constraint_2,
-                        needsOriginalSource ? sourceType : generalizedSourceType,
-                        targetType,
-                        typeToString(constraint),
-                    );
+                if (targetFlags & TypeFlags.TypeParameter && target !== markerSuperTypeForCheck && target !== markerSubTypeForCheck) {
+                    const constraint = getBaseConstraintOfType(target);
+                    let needsOriginalSource;
+                    if (constraint && (isTypeAssignableTo(generalizedSource, constraint) || (needsOriginalSource = isTypeAssignableTo(source, constraint)))) {
+                        reportError(
+                            Diagnostics._0_is_assignable_to_the_constraint_of_type_1_but_1_could_be_instantiated_with_a_different_subtype_of_constraint_2,
+                            needsOriginalSource ? sourceType : generalizedSourceType,
+                            targetType,
+                            typeToString(constraint),
+                        );
+                    }
+                    else {
+                        errorInfo = undefined;
+                        reportError(
+                            Diagnostics._0_could_be_instantiated_with_an_arbitrary_type_which_could_be_unrelated_to_1,
+                            targetType,
+                            generalizedSourceType
+                        );
+                    }
                 }
-                else {
-                    errorInfo = undefined;
-                    reportError(
-                        Diagnostics._0_could_be_instantiated_with_an_arbitrary_type_which_could_be_unrelated_to_1,
-                        targetType,
-                        generalizedSourceType
-                    );
-                }
-            }
 
             if (!message) {
                 if (relation === comparableRelation) {
@@ -20715,7 +20713,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const types = (target as UnionType).types;
                 const candidate = types.length === 2 && types[0].flags & TypeFlags.Nullable ? types[1] :
                     types.length === 3 && types[0].flags & TypeFlags.Nullable && types[1].flags & TypeFlags.Nullable ? types[2] :
-                        undefined;
+                    undefined;
                 if (candidate && !(candidate.flags & TypeFlags.Nullable)) {
                     target = getNormalizedType(candidate, /*writing*/ true);
                     if (source === target) return Ternary.True;
@@ -21024,8 +21022,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const alternateForm = source === (source as StringLiteralType).regularType ? (source as StringLiteralType).freshType : (source as StringLiteralType).regularType;
                     const primitive = source.flags & TypeFlags.StringLiteral ? stringType :
                         source.flags & TypeFlags.NumberLiteral ? numberType :
-                            source.flags & TypeFlags.BigIntLiteral ? bigintType :
-                                undefined;
+                        source.flags & TypeFlags.BigIntLiteral ? bigintType :
+                        undefined;
                     return primitive && containsType(targetTypes, primitive) || alternateForm && containsType(targetTypes, alternateForm) ? Ternary.True : Ternary.False;
                 }
                 const match = getMatchingUnionConstituentForType(target as UnionType, source);
@@ -21316,7 +21314,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // the type param can be compared with itself in the target (with the influence of its constraint to match other parts)
                 // For example, if `T extends 1 | 2` and `U extends 2 | 3` and we compare `T & U` to `T & U & (1 | 2 | 3)`
                 if (!result && (source.flags & TypeFlags.Intersection || source.flags & TypeFlags.TypeParameter && target.flags & TypeFlags.Union)) {
-                    const constraint = getEffectiveConstraintOfIntersection(source.flags & TypeFlags.Intersection ? (source as IntersectionType).types : [source], !!(target.flags & TypeFlags.Union));
+                    const constraint = getEffectiveConstraintOfIntersection(source.flags & TypeFlags.Intersection ? (source as IntersectionType).types: [source], !!(target.flags & TypeFlags.Union));
                     if (constraint && everyType(constraint, c => c !== source)) { // Skip comparison if expansion contains the source itself
                         // TODO: Stack errors so we get a pyramid for the "normal" comparison above, _and_ a second for this
                         result = isRelatedTo(constraint, target, RecursionFlags.Source, /*reportErrors*/ false, /*headMessage*/ undefined, intersectionState);
@@ -22519,7 +22517,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function signatureRelatedTo(source: Signature, target: Signature, erase: boolean, reportErrors: boolean, intersectionState: IntersectionState, incompatibleReporter: (source: Type, target: Type) => void): Ternary {
             const checkMode = relation === subtypeRelation ? SignatureCheckMode.StrictTopSignature :
                 relation === strictSubtypeRelation ? SignatureCheckMode.StrictTopSignature | SignatureCheckMode.StrictArity :
-                    SignatureCheckMode.None;
+                SignatureCheckMode.None;
             return compareSignaturesRelated(erase ? getErasedSignature(source) : source, erase ? getErasedSignature(target) : target,
                 checkMode, reportErrors, reportError, incompatibleReporter, isRelatedToWorker, reportUnreliableMapper);
             function isRelatedToWorker(source: Type, target: Type, reportErrors?: boolean) {
@@ -22603,7 +22601,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             for (const targetInfo of indexInfos) {
                 const related = relation !== strictSubtypeRelation && !sourceIsPrimitive && targetHasStringIndex && targetInfo.type.flags & TypeFlags.Any ? Ternary.True :
                     isGenericMappedType(source) && targetHasStringIndex ? isRelatedTo(getTemplateTypeFromMappedType(source), targetInfo.type, RecursionFlags.Both, reportErrors) :
-                        typeRelatedToIndexInfo(source, targetInfo, reportErrors, intersectionState);
+                    typeRelatedToIndexInfo(source, targetInfo, reportErrors, intersectionState);
                 if (!related) {
                     return Ternary.False;
                 }
@@ -23194,8 +23192,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function compareTypePredicatesIdentical(source: TypePredicate | undefined, target: TypePredicate | undefined, compareTypes: (s: Type, t: Type) => Ternary): Ternary {
         return !(source && target && typePredicateKindsMatch(source, target)) ? Ternary.False :
             source.type === target.type ? Ternary.True :
-                source.type && target.type ? compareTypes(source.type, target.type) :
-                    Ternary.False;
+            source.type && target.type ? compareTypes(source.type, target.type) :
+            Ternary.False;
     }
 
     function literalTypesWithSameBaseType(types: Type[]): boolean {
@@ -23356,17 +23354,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isLiteralType(type: Type): boolean {
         return type.flags & TypeFlags.Boolean ? true :
             type.flags & TypeFlags.Union ? type.flags & TypeFlags.EnumLiteral ? true : every((type as UnionType).types, isUnitType) :
-                isUnitType(type);
+            isUnitType(type);
     }
 
     function getBaseTypeOfLiteralType(type: Type): Type {
         return type.flags & TypeFlags.EnumLike ? getBaseTypeOfEnumLikeType(type as LiteralType) :
             type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType :
-                type.flags & TypeFlags.NumberLiteral ? numberType :
-                    type.flags & TypeFlags.BigIntLiteral ? bigintType :
-                        type.flags & TypeFlags.BooleanLiteral ? booleanType :
-                            type.flags & TypeFlags.Union ? getBaseTypeOfLiteralTypeUnion(type as UnionType) :
-                                type;
+            type.flags & TypeFlags.NumberLiteral ? numberType :
+            type.flags & TypeFlags.BigIntLiteral ? bigintType :
+            type.flags & TypeFlags.BooleanLiteral ? booleanType :
+            type.flags & TypeFlags.Union ? getBaseTypeOfLiteralTypeUnion(type as UnionType) :
+            type;
     }
 
     function getBaseTypeOfLiteralTypeUnion(type: UnionType) {
@@ -23379,26 +23377,26 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getBaseTypeOfLiteralTypeForComparison(type: Type): Type {
         return type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType :
             type.flags & (TypeFlags.NumberLiteral | TypeFlags.Enum) ? numberType :
-                type.flags & TypeFlags.BigIntLiteral ? bigintType :
-                    type.flags & TypeFlags.BooleanLiteral ? booleanType :
-                        type.flags & TypeFlags.Union ? mapType(type, getBaseTypeOfLiteralTypeForComparison) :
-                            type;
+            type.flags & TypeFlags.BigIntLiteral ? bigintType :
+            type.flags & TypeFlags.BooleanLiteral ? booleanType :
+            type.flags & TypeFlags.Union ? mapType(type, getBaseTypeOfLiteralTypeForComparison) :
+            type;
     }
 
     function getWidenedLiteralType(type: Type): Type {
         return type.flags & TypeFlags.EnumLike && isFreshLiteralType(type) ? getBaseTypeOfEnumLikeType(type as LiteralType) :
             type.flags & TypeFlags.StringLiteral && isFreshLiteralType(type) ? stringType :
-                type.flags & TypeFlags.NumberLiteral && isFreshLiteralType(type) ? numberType :
-                    type.flags & TypeFlags.BigIntLiteral && isFreshLiteralType(type) ? bigintType :
-                        type.flags & TypeFlags.BooleanLiteral && isFreshLiteralType(type) ? booleanType :
-                            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedLiteralType) :
-                                type;
+            type.flags & TypeFlags.NumberLiteral && isFreshLiteralType(type) ? numberType :
+            type.flags & TypeFlags.BigIntLiteral && isFreshLiteralType(type) ? bigintType :
+            type.flags & TypeFlags.BooleanLiteral && isFreshLiteralType(type) ? booleanType :
+            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedLiteralType) :
+            type;
     }
 
     function getWidenedUniqueESSymbolType(type: Type): Type {
         return type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
             type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedUniqueESSymbolType) :
-                type;
+            type;
     }
 
     function getWidenedLiteralLikeTypeForContextualType(type: Type, contextualType: Type | undefined) {
@@ -23412,7 +23410,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (type && isUnitType(type)) {
             const contextualType = !contextualSignatureReturnType ? undefined :
                 isAsync ? getPromisedTypeOfPromise(contextualSignatureReturnType) :
-                    contextualSignatureReturnType;
+                contextualSignatureReturnType;
             type = getWidenedLiteralLikeTypeForContextualType(type, contextualType);
         }
         return type;
@@ -23471,7 +23469,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             every(t1.target.elementFlags, (f, i) => (f & ElementFlags.Variable) === (t2.target.elementFlags[i] & ElementFlags.Variable));
     }
 
-    function isZeroBigInt({ value }: BigIntLiteralType) {
+    function isZeroBigInt({value}: BigIntLiteralType) {
         return value.base10Value === "0";
     }
 
@@ -23486,14 +23484,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getDefinitelyFalsyPartOfType(type: Type): Type {
         return type.flags & TypeFlags.String ? emptyStringType :
             type.flags & TypeFlags.Number ? zeroType :
-                type.flags & TypeFlags.BigInt ? zeroBigIntType :
-                    type === regularFalseType ||
-                        type === falseType ||
-                        type.flags & (TypeFlags.Void | TypeFlags.Undefined | TypeFlags.Null | TypeFlags.AnyOrUnknown) ||
-                        type.flags & TypeFlags.StringLiteral && (type as StringLiteralType).value === "" ||
-                        type.flags & TypeFlags.NumberLiteral && (type as NumberLiteralType).value === 0 ||
-                        type.flags & TypeFlags.BigIntLiteral && isZeroBigInt(type as BigIntLiteralType) ? type :
-                        neverType;
+            type.flags & TypeFlags.BigInt ? zeroBigIntType :
+            type === regularFalseType ||
+            type === falseType ||
+            type.flags & (TypeFlags.Void | TypeFlags.Undefined | TypeFlags.Null | TypeFlags.AnyOrUnknown) ||
+            type.flags & TypeFlags.StringLiteral && (type as StringLiteralType).value === "" ||
+            type.flags & TypeFlags.NumberLiteral && (type as NumberLiteralType).value === 0 ||
+            type.flags & TypeFlags.BigIntLiteral && isZeroBigInt(type as BigIntLiteralType) ? type :
+            neverType;
     }
 
     /**
@@ -23505,8 +23503,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const missing = (flags & ~type.flags) & (TypeFlags.Undefined | TypeFlags.Null);
         return missing === 0 ? type :
             missing === TypeFlags.Undefined ? getUnionType([type, undefinedType]) :
-                missing === TypeFlags.Null ? getUnionType([type, nullType]) :
-                    getUnionType([type, undefinedType, nullType]);
+            missing === TypeFlags.Null ? getUnionType([type, nullType]) :
+            getUnionType([type, undefinedType, nullType]);
     }
 
     function getOptionalType(type: Type, isProperty = false): Type {
@@ -23543,7 +23541,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getOptionalExpressionType(exprType: Type, expression: Expression) {
         return isExpressionOfOptionalChainRoot(expression) ? getNonNullableType(exprType) :
             isOptionalChain(expression) ? removeOptionalTypeMarker(exprType) :
-                exprType;
+            exprType;
     }
 
     function removeMissingType(type: Type, isOptional: boolean) {
@@ -23834,7 +23832,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if ((isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent)) &&
                         param.parent.parameters.indexOf(param) > -1 &&
                         (resolveName(param, param.name.escapedText, SymbolFlags.Type, /*nameNotFoundMessage*/ undefined, param.name.escapedText, /*isUse*/ true) ||
-                            originalKeywordKind && isTypeNodeKind(originalKeywordKind))) {
+                        originalKeywordKind && isTypeNodeKind(originalKeywordKind))) {
                         const newName = "arg" + param.parent.parameters.indexOf(param);
                         const typeName = declarationNameToString(param.name) + (param.dotDotDotToken ? "[]" : "");
                         errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_0_Colon_1, newName, typeName);
@@ -23878,7 +23876,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 diagnostic = !noImplicitAny ? Diagnostics._0_implicitly_has_an_1_return_type_but_a_better_type_may_be_inferred_from_usage :
                     wideningKind === WideningKind.GeneratorYield ? Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_yield_type :
-                        Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type;
+                    Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type;
                 break;
             case SyntaxKind.MappedType:
                 if (noImplicitAny) {
@@ -24233,7 +24231,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTypeFromInference(inference: InferenceInfo) {
         return inference.candidates ? getUnionType(inference.candidates, UnionReduction.Subtype) :
             inference.contraCandidates ? getIntersectionType(inference.contraCandidates) :
-                undefined;
+            undefined;
     }
 
     function hasSkipDirectInferenceFlag(node: Node) {
@@ -24322,8 +24320,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return source.flags & TypeFlags.StringLiteral ? inferFromLiteralPartsToTemplateLiteral([(source as StringLiteralType).value], emptyArray, target) :
             source.flags & TypeFlags.TemplateLiteral ?
                 arraysEqual((source as TemplateLiteralType).texts, target.texts) ? map((source as TemplateLiteralType).types, getStringLikeTypeForType) :
-                    inferFromLiteralPartsToTemplateLiteral((source as TemplateLiteralType).texts, (source as TemplateLiteralType).types, target) :
-                undefined;
+                inferFromLiteralPartsToTemplateLiteral((source as TemplateLiteralType).texts, (source as TemplateLiteralType).types, target) :
+            undefined;
     }
 
     function isTypeMatchedByTemplateLiteralType(source: Type, target: TemplateLiteralType): boolean {
@@ -24936,20 +24934,20 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 // for each type in the constraint, find the highest priority matching type
                                 const matchingType = reduceLeft(constraintTypes, (left, right) =>
                                     !(right.flags & allTypeFlags) ? left :
-                                        left.flags & TypeFlags.String ? left : right.flags & TypeFlags.String ? source :
-                                            left.flags & TypeFlags.TemplateLiteral ? left : right.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, right as TemplateLiteralType) ? source :
-                                                left.flags & TypeFlags.StringMapping ? left : right.flags & TypeFlags.StringMapping && str === applyStringMapping(right.symbol, str) ? source :
-                                                    left.flags & TypeFlags.StringLiteral ? left : right.flags & TypeFlags.StringLiteral && (right as StringLiteralType).value === str ? right :
-                                                        left.flags & TypeFlags.Number ? left : right.flags & TypeFlags.Number ? getNumberLiteralType(+str) :
-                                                            left.flags & TypeFlags.Enum ? left : right.flags & TypeFlags.Enum ? getNumberLiteralType(+str) :
-                                                                left.flags & TypeFlags.NumberLiteral ? left : right.flags & TypeFlags.NumberLiteral && (right as NumberLiteralType).value === +str ? right :
-                                                                    left.flags & TypeFlags.BigInt ? left : right.flags & TypeFlags.BigInt ? parseBigIntLiteralType(str) :
-                                                                        left.flags & TypeFlags.BigIntLiteral ? left : right.flags & TypeFlags.BigIntLiteral && pseudoBigIntToString((right as BigIntLiteralType).value) === str ? right :
-                                                                            left.flags & TypeFlags.Boolean ? left : right.flags & TypeFlags.Boolean ? str === "true" ? trueType : str === "false" ? falseType : booleanType :
-                                                                                left.flags & TypeFlags.BooleanLiteral ? left : right.flags & TypeFlags.BooleanLiteral && (right as IntrinsicType).intrinsicName === str ? right :
-                                                                                    left.flags & TypeFlags.Undefined ? left : right.flags & TypeFlags.Undefined && (right as IntrinsicType).intrinsicName === str ? right :
-                                                                                        left.flags & TypeFlags.Null ? left : right.flags & TypeFlags.Null && (right as IntrinsicType).intrinsicName === str ? right :
-                                                                                            left,
+                                    left.flags & TypeFlags.String ? left : right.flags & TypeFlags.String ? source :
+                                    left.flags & TypeFlags.TemplateLiteral ? left : right.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, right as TemplateLiteralType) ? source :
+                                    left.flags & TypeFlags.StringMapping ? left : right.flags & TypeFlags.StringMapping && str === applyStringMapping(right.symbol, str) ? source :
+                                    left.flags & TypeFlags.StringLiteral ? left : right.flags & TypeFlags.StringLiteral && (right as StringLiteralType).value === str ? right :
+                                    left.flags & TypeFlags.Number ? left : right.flags & TypeFlags.Number ? getNumberLiteralType(+str) :
+                                    left.flags & TypeFlags.Enum ? left : right.flags & TypeFlags.Enum ? getNumberLiteralType(+str) :
+                                    left.flags & TypeFlags.NumberLiteral ? left : right.flags & TypeFlags.NumberLiteral && (right as NumberLiteralType).value === +str ? right :
+                                    left.flags & TypeFlags.BigInt ? left : right.flags & TypeFlags.BigInt ? parseBigIntLiteralType(str) :
+                                    left.flags & TypeFlags.BigIntLiteral ? left : right.flags & TypeFlags.BigIntLiteral && pseudoBigIntToString((right as BigIntLiteralType).value) === str ? right :
+                                    left.flags & TypeFlags.Boolean ? left : right.flags & TypeFlags.Boolean ? str === "true" ? trueType : str === "false" ? falseType : booleanType :
+                                    left.flags & TypeFlags.BooleanLiteral ? left : right.flags & TypeFlags.BooleanLiteral && (right as IntrinsicType).intrinsicName === str ? right :
+                                    left.flags & TypeFlags.Undefined ? left : right.flags & TypeFlags.Undefined && (right as IntrinsicType).intrinsicName === str ? right :
+                                    left.flags & TypeFlags.Null ? left : right.flags & TypeFlags.Null && (right as IntrinsicType).intrinsicName === str ? right :
+                                    left,
                                     neverType as Type);
 
                                 if (!(matchingType.flags & TypeFlags.Never)) {
@@ -25205,7 +25203,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             (inference.isFixed || !isTypeParameterAtTopLevelInReturnType(signature, inference.typeParameter));
         const baseCandidates = primitiveConstraint ? sameMap(candidates, getRegularTypeOfLiteralType) :
             widenLiteralTypes ? sameMap(candidates, getWidenedLiteralType) :
-                candidates;
+            candidates;
         // If all inferences were made from a position that implies a combined result, infer a union type.
         // Otherwise, infer a common supertype.
         const unwidenedType = inference.priority! & InferencePriority.PriorityImpliesCombination ?
@@ -25333,7 +25331,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isCallExpression(node.parent)) {
                     return Diagnostics.Cannot_find_name_0_Did_you_mean_to_write_this_in_an_async_function;
                 }
-            // falls through
+                // falls through
             default:
                 if (node.parent.kind === SyntaxKind.ShorthandPropertyAssignment) {
                     return Diagnostics.No_value_exists_in_scope_for_the_shorthand_property_0_Either_declare_one_or_provide_an_initializer;
@@ -25384,7 +25382,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const symbol = getResolvedSymbol(node as Identifier);
                     return symbol !== unknownSymbol ? `${flowContainer ? getNodeId(flowContainer) : "-1"}|${getTypeId(declaredType)}|${getTypeId(initialType)}|${getSymbolId(symbol)}` : undefined;
                 }
-            // falls through
+                // falls through
             case SyntaxKind.ThisKeyword:
                 return `0|${flowContainer ? getNodeId(flowContainer) : "-1"}|${getTypeId(declaredType)}|${getTypeId(initialType)}`;
             case SyntaxKind.NonNullExpression:
@@ -25432,8 +25430,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return isThisInTypeQuery(source) ?
                     target.kind === SyntaxKind.ThisKeyword :
                     target.kind === SyntaxKind.Identifier && getResolvedSymbol(source as Identifier) === getResolvedSymbol(target as Identifier) ||
-                    (isVariableDeclaration(target) || isBindingElement(target)) &&
-                    getExportSymbolOfValueSymbolIfExported(getResolvedSymbol(source as Identifier)) === getSymbolOfDeclaration(target);
+                        (isVariableDeclaration(target) || isBindingElement(target)) &&
+                        getExportSymbolOfValueSymbolIfExported(getResolvedSymbol(source as Identifier)) === getSymbolOfDeclaration(target);
             case SyntaxKind.ThisKeyword:
                 return target.kind === SyntaxKind.ThisKeyword;
             case SyntaxKind.SuperKeyword:
@@ -25813,12 +25811,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (strictNullChecks) {
             switch (facts) {
                 case TypeFacts.NEUndefined:
-                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefined ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQNull && !maybeTypeOfKind(reduced, TypeFlags.Null) ? getUnionType([emptyObjectType, nullType]) : emptyObjectType]) : t);
+                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefined ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQNull && !maybeTypeOfKind(reduced, TypeFlags.Null) ? getUnionType([emptyObjectType, nullType]) : emptyObjectType]): t);
                 case TypeFacts.NENull:
-                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQNull ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQUndefined && !maybeTypeOfKind(reduced, TypeFlags.Undefined) ? getUnionType([emptyObjectType, undefinedType]) : emptyObjectType]) : t);
+                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQNull ? getIntersectionType([t, getTypeFacts(t) & TypeFacts.EQUndefined && !maybeTypeOfKind(reduced, TypeFlags.Undefined) ? getUnionType([emptyObjectType, undefinedType]) : emptyObjectType]): t);
                 case TypeFacts.NEUndefinedOrNull:
                 case TypeFacts.Truthy:
-                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefinedOrNull ? getGlobalNonNullableTypeInstantiation(t) : t);
+                    return mapType(reduced, t => getTypeFacts(t) & TypeFacts.EQUndefinedOrNull ? getGlobalNonNullableTypeInstantiation(t): t);
             }
         }
         return reduced;
@@ -26143,9 +26141,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             maybeTypeOfKind(typeWithLiterals, TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping | TypeFlags.NumberLiteral | TypeFlags.BigIntLiteral)) {
             return mapType(typeWithPrimitives, t =>
                 t.flags & TypeFlags.String ? extractTypesOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) :
-                    isPatternLiteralType(t) && !maybeTypeOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? extractTypesOfKind(typeWithLiterals, TypeFlags.StringLiteral) :
-                        t.flags & TypeFlags.Number ? extractTypesOfKind(typeWithLiterals, TypeFlags.Number | TypeFlags.NumberLiteral) :
-                            t.flags & TypeFlags.BigInt ? extractTypesOfKind(typeWithLiterals, TypeFlags.BigInt | TypeFlags.BigIntLiteral) : t);
+                isPatternLiteralType(t) && !maybeTypeOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? extractTypesOfKind(typeWithLiterals, TypeFlags.StringLiteral) :
+                t.flags & TypeFlags.Number ? extractTypesOfKind(typeWithLiterals, TypeFlags.Number | TypeFlags.NumberLiteral) :
+                t.flags & TypeFlags.BigInt ? extractTypesOfKind(typeWithLiterals, TypeFlags.BigInt | TypeFlags.BigIntLiteral) : t);
         }
         return typeWithPrimitives;
     }
@@ -26340,7 +26338,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const signatures = getSignaturesOfType(funcType && getApparentType(funcType) || unknownType, SignatureKind.Call);
             const candidate = signatures.length === 1 && !signatures[0].typeParameters ? signatures[0] :
                 some(signatures, hasTypePredicateOrNeverReturnType) ? getResolvedSignature(node) :
-                    undefined;
+                undefined;
             signature = links.effectsSignature = candidate && hasTypePredicateOrNeverReturnType(candidate) ? candidate : unknownSignature;
         }
         return signature === unknownSignature ? undefined : signature;
@@ -26730,7 +26728,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const type = finalizeEvolvingArrayType(getTypeFromFlowType(flowType));
                     const narrowedType = predicate.type ? narrowTypeByTypePredicate(type, predicate, flow.node, /*assumeTrue*/ true) :
                         predicate.kind === TypePredicateKind.AssertsIdentifier && predicate.parameterIndex >= 0 && predicate.parameterIndex < flow.node.arguments.length ? narrowTypeByAssertion(type, flow.node.arguments[predicate.parameterIndex]) :
-                            type;
+                        type;
                     return narrowedType === type ? flowType : createFlowType(narrowedType, isIncomplete(flowType));
                 }
                 if (getReturnTypeOfSignature(signature).flags & TypeFlags.Never) {
@@ -27055,7 +27053,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (candidate) {
                         return operator === (assumeTrue ? SyntaxKind.EqualsEqualsEqualsToken : SyntaxKind.ExclamationEqualsEqualsToken) ? candidate :
                             isUnitType(getTypeOfPropertyOfType(candidate, keyPropertyName) || unknownType) ? removeType(type, candidate) :
-                                type;
+                            type;
                     }
                 }
             }
@@ -27337,7 +27335,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const discriminantType = getUnionType(clauseTypes);
             const caseType =
                 discriminantType.flags & TypeFlags.Never ? neverType :
-                    replacePrimitivesWithLiterals(filterType(type, t => areTypesComparable(discriminantType, t)), discriminantType);
+                replacePrimitivesWithLiterals(filterType(type, t => areTypesComparable(discriminantType, t)), discriminantType);
             if (!hasDefaultClause) {
                 return caseType;
             }
@@ -27366,14 +27364,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // as a subtype of `{}`, and we need the type facts check because function types are subtypes of `object`,
                 // but are classified as "function" according to `typeof`.
                 isTypeRelatedTo(t, impliedType, strictSubtypeRelation) ? getTypeFacts(t) & facts ? t : neverType :
-                    // We next check if the consituent is a supertype of the implied type. If so, we substitute the implied
-                    // type. This handles top types like `unknown` and `{}`, and supertypes like `{ toString(): string }`.
-                    isTypeSubtypeOf(impliedType, t) ? impliedType :
-                        // Neither the constituent nor the implied type is a subtype of the other, however their domains may still
-                        // overlap. For example, an unconstrained type parameter and type `string`. If the type facts indicate
-                        // possible overlap, we form an intersection. Otherwise, we eliminate the constituent.
-                        getTypeFacts(t) & facts ? getIntersectionType([t, impliedType]) :
-                            neverType);
+                // We next check if the consituent is a supertype of the implied type. If so, we substitute the implied
+                // type. This handles top types like `unknown` and `{}`, and supertypes like `{ toString(): string }`.
+                isTypeSubtypeOf(impliedType, t) ? impliedType :
+                // Neither the constituent nor the implied type is a subtype of the other, however their domains may still
+                // overlap. For example, an unconstrained type parameter and type `string`. If the type facts indicate
+                // possible overlap, we form an intersection. Otherwise, we eliminate the constituent.
+                getTypeFacts(t) & facts ? getIntersectionType([t, impliedType]) :
+                neverType);
         }
 
         function narrowTypeBySwitchOnTypeOf(type: Type, switchStatement: SwitchStatement, clauseStart: number, clauseEnd: number): Type {
@@ -27525,9 +27523,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // based on assignability, or as a last resort produce an intersection.
             return !(narrowedType.flags & TypeFlags.Never) ? narrowedType :
                 isTypeSubtypeOf(candidate, type) ? candidate :
-                    isTypeAssignableTo(type, candidate) ? type :
-                        isTypeAssignableTo(candidate, type) ? candidate :
-                            getIntersectionType([type, candidate]);
+                isTypeAssignableTo(type, candidate) ? type :
+                isTypeAssignableTo(candidate, type) ? candidate :
+                getIntersectionType([type, candidate]);
         }
 
         function narrowTypeByCallExpression(type: Type, callExpression: CallExpression, assumeTrue: boolean): Type {
@@ -27596,7 +27594,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             }
                         }
                     }
-                // falls through
+                    // falls through
                 case SyntaxKind.ThisKeyword:
                 case SyntaxKind.SuperKeyword:
                 case SyntaxKind.PropertyAccessExpression:
@@ -27748,7 +27746,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             parent.kind === SyntaxKind.QualifiedName ||
             parent.kind === SyntaxKind.CallExpression && (parent as CallExpression).expression === node ||
             parent.kind === SyntaxKind.ElementAccessExpression && (parent as ElementAccessExpression).expression === node &&
-            !(someType(type, isGenericTypeWithoutNullableConstraint) && isGenericIndexType(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression)));
+                !(someType(type, isGenericTypeWithoutNullableConstraint) && isGenericIndexType(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression)));
     }
 
     function isGenericTypeWithUnionConstraint(type: Type): boolean {
@@ -28007,10 +28005,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 !(isInJSFile(node) && localOrExportSymbol.flags & SymbolFlags.ValueModule)) {
                 const assignmentError = localOrExportSymbol.flags & SymbolFlags.Enum ? Diagnostics.Cannot_assign_to_0_because_it_is_an_enum
                     : localOrExportSymbol.flags & SymbolFlags.Class ? Diagnostics.Cannot_assign_to_0_because_it_is_a_class
-                        : localOrExportSymbol.flags & SymbolFlags.Module ? Diagnostics.Cannot_assign_to_0_because_it_is_a_namespace
-                            : localOrExportSymbol.flags & SymbolFlags.Function ? Diagnostics.Cannot_assign_to_0_because_it_is_a_function
-                                : localOrExportSymbol.flags & SymbolFlags.Alias ? Diagnostics.Cannot_assign_to_0_because_it_is_an_import
-                                    : Diagnostics.Cannot_assign_to_0_because_it_is_not_a_variable;
+                    : localOrExportSymbol.flags & SymbolFlags.Module ? Diagnostics.Cannot_assign_to_0_because_it_is_a_namespace
+                    : localOrExportSymbol.flags & SymbolFlags.Function ? Diagnostics.Cannot_assign_to_0_because_it_is_a_function
+                    : localOrExportSymbol.flags & SymbolFlags.Alias ? Diagnostics.Cannot_assign_to_0_because_it_is_an_import
+                    : Diagnostics.Cannot_assign_to_0_because_it_is_not_a_variable;
 
                 error(node, assignmentError, symbolToString(symbol));
                 return errorType;
@@ -28072,13 +28070,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // declaration container are the same).
         const assumeInitialized = isParameter || isAlias || isOuterVariable || isSpreadDestructuringAssignmentTarget || isModuleExports || isSameScopedBindingElement(node, declaration) ||
             type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void)) !== 0 ||
-                isInTypeQuery(node) || isInAmbientOrTypeNode(node) || node.parent.kind === SyntaxKind.ExportSpecifier) ||
+            isInTypeQuery(node) || isInAmbientOrTypeNode(node) || node.parent.kind === SyntaxKind.ExportSpecifier) ||
             node.parent.kind === SyntaxKind.NonNullExpression ||
             declaration.kind === SyntaxKind.VariableDeclaration && (declaration as VariableDeclaration).exclamationToken ||
             declaration.flags & NodeFlags.Ambient;
         const initialType = isAutomaticTypeInNonNull ? undefinedType :
             assumeInitialized ? (isParameter ? removeOptionalityFromDeclaredType(type, declaration as VariableLikeDeclaration) : type) :
-                typeIsAutomatic ? undefinedType : getOptionalType(type);
+            typeIsAutomatic ? undefinedType : getOptionalType(type);
         const flowType = isAutomaticTypeInNonNull ? getNonNullableType(getFlowTypeOfReference(node, type, initialType, flowContainer)) :
             getFlowTypeOfReference(node, type, initialType, flowContainer);
         // A variable is considered uninitialized when it is possible to analyze the entire control flow graph
@@ -28248,7 +28246,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function findFirstSuperCall(node: Node): SuperCall | undefined {
         return isSuperCall(node) ? node :
             isFunctionLike(node) ? undefined :
-                forEachChild(node, findFirstSuperCall);
+            forEachChild(node, findFirstSuperCall);
     }
 
     /**
@@ -28280,7 +28278,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkThisInStaticClassFieldInitializerInDecoratedClass(thisExpression: Node, container: Node) {
         if (isPropertyDeclaration(container) && hasStaticModifier(container) && legacyDecorators &&
             container.initializer && textRangeContainsPositionInclusive(container.initializer, thisExpression.pos) && hasDecorators(container.parent)) {
-            error(thisExpression, Diagnostics.Cannot_use_this_in_a_static_property_initializer_of_a_decorated_class);
+                error(thisExpression, Diagnostics.Cannot_use_this_in_a_static_property_initializer_of_a_decorated_class);
         }
     }
 
@@ -28709,7 +28707,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             func.kind === SyntaxKind.GetAccessor ||
             func.kind === SyntaxKind.SetAccessor) && func.parent.kind === SyntaxKind.ObjectLiteralExpression ? func.parent :
             func.kind === SyntaxKind.FunctionExpression && func.parent.kind === SyntaxKind.PropertyAssignment ? func.parent.parent as ObjectLiteralExpression :
-                undefined;
+            undefined;
     }
 
     function getThisTypeArgument(type: Type): Type | undefined {
@@ -29002,7 +29000,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isImportCall(callTarget)) {
             return argIndex === 0 ? stringType :
                 argIndex === 1 ? getGlobalImportCallOptionsType(/*reportErrors*/ false) :
-                    anyType;
+                anyType;
         }
 
         // If we're already in the process of resolving the given signature, don't resolve again as
@@ -29062,7 +29060,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * Try to find a resolved symbol for an expression without also resolving its type, as
      * getSymbolAtLocation would (as that could be reentrant into contextual typing)
      */
-    function getSymbolForExpression(e: Expression) {
+     function getSymbolForExpression(e: Expression) {
         if (canHaveSymbol(e) && e.symbol) {
             return e.symbol;
         }
@@ -29452,7 +29450,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             );
             return apparentType.flags & TypeFlags.Union && isObjectLiteralExpression(node) ? discriminateContextualTypeByObjectMembers(node, apparentType as UnionType) :
                 apparentType.flags & TypeFlags.Union && isJsxAttributes(node) ? discriminateContextualTypeByJSXAttributes(node, apparentType as UnionType) :
-                    apparentType;
+                apparentType;
         }
     }
 
@@ -29785,8 +29783,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 signatures,
                 (left: Signature | undefined, right) =>
                     left === right || !left ? left
-                        : compareTypeParametersIdentical(left.typeParameters, right!.typeParameters) ? combineSignaturesOfIntersectionMembers(left, right!)
-                            : undefined)
+                    : compareTypeParametersIdentical(left.typeParameters, right!.typeParameters) ? combineSignaturesOfIntersectionMembers(left, right!)
+                    : undefined)
             : undefined;
     }
 
@@ -29827,8 +29825,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const paramName = leftName === rightName ? leftName :
                 !leftName ? rightName :
-                    !rightName ? leftName :
-                        undefined;
+                !rightName ? leftName :
+                undefined;
             const paramSymbol = createSymbol(
                 SymbolFlags.FunctionScopedVariable | (isOptional && !isRestParam ? SymbolFlags.Optional : 0),
                 paramName || `arg${i}` as __String
@@ -30197,7 +30195,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // for error recovery purposes. For example, if a user wrote `{ a = 100 }` instead of `{ a: 100 }`.
                     // we don't want to say "could not find 'a'".
                     memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ? checkExpressionForMutableLocation(!inDestructuringPattern && memberDecl.objectAssignmentInitializer ? memberDecl.objectAssignmentInitializer : memberDecl.name, checkMode) :
-                        checkObjectLiteralMethod(memberDecl, checkMode);
+                    checkObjectLiteralMethod(memberDecl, checkMode);
                 if (isInJavascript) {
                     const jsDocType = getTypeForDeclarationFromJSDocComment(memberDecl);
                     if (jsDocType) {
@@ -30565,7 +30563,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const childrenPropSymbol = createSymbol(SymbolFlags.Property, jsxChildrenPropertyName);
                 childrenPropSymbol.links.type = childrenTypes.length === 1 ? childrenTypes[0] :
                     childrenContextualType && someType(childrenContextualType, isTupleLikeType) ? createTupleType(childrenTypes) :
-                        createArrayType(getUnionType(childrenTypes));
+                    createArrayType(getUnionType(childrenTypes));
                 // Fake up a property declaration for the children
                 childrenPropSymbol.valueDeclaration = factory.createPropertySignature(/*modifiers*/ undefined, unescapeLeadingUnderscores(jsxChildrenPropertyName), /*questionToken*/ undefined, /*type*/ undefined);
                 setParent(childrenPropSymbol.valueDeclaration, attributes);
@@ -30702,8 +30700,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const isClassic = getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Classic;
         const errorMessage = isClassic
-            ? Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
-            : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
+                                ? Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
+                                : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
         const mod = resolveExternalModule(location!, runtimeImportSpecifier, errorMessage, location!);
         const result = mod && mod !== unknownSymbol ? getMergedSymbol(resolveSymbol(mod)) : undefined;
         if (links) {
@@ -31014,7 +31012,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (isNodeOpeningLikeElement) {
-            const jsxOpeningLikeNode = node;
+            const jsxOpeningLikeNode = node ;
             const sig = getResolvedSignature(jsxOpeningLikeNode);
             checkDeprecatedSignature(sig, node);
 
@@ -31125,8 +31123,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         const errorNode = !reportError ? undefined :
             node.kind === SyntaxKind.QualifiedName ? node.right :
-                node.kind === SyntaxKind.ImportType ? node :
-                    node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
+            node.kind === SyntaxKind.ImportType ? node :
+            node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
 
         return checkPropertyAccessibilityAtLocation(node, isSuper, writing, type, prop, errorNode);
     }
@@ -31917,7 +31915,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const properties = getPropertiesOfType(containingType);
         const jsxSpecific = strName === "for" ? find(properties, x => symbolName(x) === "htmlFor")
             : strName === "class" ? find(properties, x => symbolName(x) === "className")
-                : undefined;
+            : undefined;
         return jsxSpecific ?? getSpellingSuggestionForName(strName, properties, SymbolFlags.Value);
     }
 
@@ -32134,8 +32132,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         // A #private property access in an optional chain is an error dealt with by the parser.
-        // The checker does not check for it, so we need to do our own check here.
-        if (property.valueDeclaration && isPrivateIdentifierClassElementDeclaration(property.valueDeclaration)) {
+         // The checker does not check for it, so we need to do our own check here.
+         if (property.valueDeclaration && isPrivateIdentifierClassElementDeclaration(property.valueDeclaration)) {
             const declClass = getContainingClass(property.valueDeclaration);
             return !isOptionalChain(node) && !!findAncestor(node, parent => parent === declClass);
         }
@@ -32467,7 +32465,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const thisArgumentType = checkExpression(thisArgumentNode);
         return isOptionalChainRoot(thisArgumentNode.parent) ? getNonNullableType(thisArgumentType) :
             isOptionalChain(thisArgumentNode.parent) ? removeOptionalTypeMarker(thisArgumentType) :
-                thisArgumentType;
+            thisArgumentType;
     }
 
     function inferTypeArguments(node: CallLikeExpression, signature: Signature, args: readonly Expression[], checkMode: CheckMode, context: InferenceContext): Type[] {
@@ -32566,8 +32564,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getMutableArrayOrTupleType(type: Type) {
         return type.flags & TypeFlags.Union ? mapType(type, getMutableArrayOrTupleType) :
             type.flags & TypeFlags.Any || isMutableArrayOrTuple(getBaseConstraintOfType(type) || type) ? type :
-                isTupleType(type) ? createTupleType(getElementTypes(type), type.target.elementFlags, /*readonly*/ false, type.target.labeledElementDeclarations) :
-                    createTupleType([type], [ElementFlags.Variadic]);
+            isTupleType(type) ? createTupleType(getElementTypes(type), type.target.elementFlags, /*readonly*/ false, type.target.labeledElementDeclarations) :
+            createTupleType([type], [ElementFlags.Variadic]);
     }
 
     function getSpreadArgumentType(args: readonly Expression[], index: number, argCount: number, restType: Type, context: InferenceContext | undefined, checkMode: CheckMode) {
@@ -32826,8 +32824,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const restArgCount = args.length - argCount;
             const errorNode = !reportErrors ? undefined :
                 restArgCount === 0 ? node :
-                    restArgCount === 1 ? args[argCount] :
-                        setTextRangePosEnd(createSyntheticExpression(node, spreadType), args[argCount].pos, args[args.length - 1].end);
+                restArgCount === 1 ? args[argCount] :
+                setTextRangePosEnd(createSyntheticExpression(node, spreadType), args[argCount].pos, args[args.length - 1].end);
             if (!checkTypeRelatedTo(spreadType, restType, relation, errorNode, headMessage, /*containingMessageChain*/ undefined, errorOutputContainer)) {
                 Debug.assert(!reportErrors || !!errorOutputContainer.errors, "rest parameter should have errors when reporting errors");
                 maybeAddMissingAwaitInfo(errorNode, spreadType, restType);
@@ -33042,7 +33040,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const hasRestParameter = some(signatures, hasEffectiveRestParameter);
         const parameterRange = hasRestParameter ? min
             : min < max ? min + "-" + max
-                : min;
+            : min;
         const isVoidPromiseError = !hasRestParameter && parameterRange === 1 && args.length === 0 && isPromiseResolveArityError(node);
         if (isVoidPromiseError && isInJSFile(node)) {
             return getDiagnosticForCallNode(node, Diagnostics.Expected_1_argument_but_got_0_new_Promise_needs_a_JSDoc_hint_to_produce_a_resolve_that_can_be_called_without_arguments);
@@ -33050,10 +33048,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const error =
             isDecorator(node) ?
                 hasRestParameter ? Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_at_least_0 :
-                    Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0 :
-                hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1 :
-                    isVoidPromiseError ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise :
-                        Diagnostics.Expected_0_arguments_but_got_1;
+                Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0 :
+            hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1 :
+            isVoidPromiseError ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise :
+            Diagnostics.Expected_0_arguments_but_got_1;
 
         if (min < args.length && args.length < max) {
             // between min and max, but with no matching overload
@@ -33080,7 +33078,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const messageAndArgs: DiagnosticAndArguments =
                     isBindingPattern(parameter.name) ? [Diagnostics.An_argument_matching_this_binding_pattern_was_not_provided]
                         : isRestParameter(parameter) ? [Diagnostics.Arguments_for_the_rest_parameter_0_were_not_provided, idText(getFirstIdentifier(parameter.name))]
-                            : [Diagnostics.An_argument_for_0_was_not_provided, !parameter.name ? args.length : idText(getFirstIdentifier(parameter.name))];
+                        : [Diagnostics.An_argument_for_0_was_not_provided, !parameter.name ? args.length : idText(getFirstIdentifier(parameter.name))];
                 const parameterError = createDiagnosticForNode(parameter, ...messageAndArgs);
                 return addRelatedInfo(diagnostic, parameterError);
             }
@@ -33112,11 +33110,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const min = getMinTypeArgumentCount(sig.typeParameters);
             const max = length(sig.typeParameters);
             if (headMessage) {
-                let chain = chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min, argCount);
+                let chain = chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min , argCount);
                 chain = chainDiagnosticMessages(chain, headMessage);
                 return createDiagnosticForNodeArrayFromMessageChain(getSourceFileOfNode(node), typeArguments, chain);
             }
-            return createDiagnosticForNodeArray(getSourceFileOfNode(node), typeArguments, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min, argCount);
+            return createDiagnosticForNodeArray(getSourceFileOfNode(node), typeArguments, Diagnostics.Expected_0_type_arguments_but_got_1, min < max ? min + "-" + max : min , argCount);
         }
         // Overloads exist
         let belowArgCount = -Infinity;
@@ -33601,7 +33599,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const nonOptionalType = getOptionalExpressionType(funcType, node.expression);
             callChainFlags = nonOptionalType === funcType ? SignatureFlags.None :
                 isOutermostOptionalChain(node) ? SignatureFlags.IsOuterCallChain :
-                    SignatureFlags.IsInnerCallChain;
+                SignatureFlags.IsInnerCallChain;
             funcType = nonOptionalType;
         }
         else {
@@ -34202,7 +34200,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const func = isFunctionDeclaration(node) || isFunctionExpression(node) ? node :
             (isVariableDeclaration(node) || isPropertyAssignment(node)) && node.initializer && isFunctionExpression(node.initializer) ? node.initializer :
-                undefined;
+            undefined;
         if (func) {
             // If the node has a @class or @constructor tag, treat it like a constructor.
             if (getJSDocClassTag(node)) return true;
@@ -34464,7 +34462,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (esModuleSymbol) {
                 return createPromiseReturnType(node,
                     getTypeWithSyntheticDefaultOnly(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier) ||
-                    getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier)
+                        getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier)
                 );
             }
         }
@@ -34666,7 +34664,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const exprType = node.kind === SyntaxKind.ExpressionWithTypeArguments ? checkExpression(node.expression) :
             isThisIdentifier(node.exprName) ? checkThisExpression(node.exprName) :
-                checkExpression(node.exprName);
+            checkExpression(node.exprName);
         return getInstantiationExpressionType(exprType, node);
     }
 
@@ -35179,11 +35177,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const nameType = isPrivate ? getStringLiteralType(idText(node.name)) : getLiteralTypeFromPropertyName(node.name);
         const contextType =
             isMethodDeclaration(node) ? createClassMethodDecoratorContextType(thisType, valueType) :
-                isGetAccessorDeclaration(node) ? createClassGetterDecoratorContextType(thisType, valueType) :
-                    isSetAccessorDeclaration(node) ? createClassSetterDecoratorContextType(thisType, valueType) :
-                        isAutoAccessorPropertyDeclaration(node) ? createClassAccessorDecoratorContextType(thisType, valueType) :
-                            isPropertyDeclaration(node) ? createClassFieldDecoratorContextType(thisType, valueType) :
-                                Debug.failBadSyntaxKind(node);
+            isGetAccessorDeclaration(node) ? createClassGetterDecoratorContextType(thisType, valueType) :
+            isSetAccessorDeclaration(node) ? createClassSetterDecoratorContextType(thisType, valueType) :
+            isAutoAccessorPropertyDeclaration(node) ? createClassAccessorDecoratorContextType(thisType, valueType) :
+            isPropertyDeclaration(node) ? createClassFieldDecoratorContextType(thisType, valueType) :
+            Debug.failBadSyntaxKind(node);
         const overrideType = getClassMemberDecoratorContextOverrideType(nameType, isPrivate, isStatic);
         return getIntersectionType([contextType, overrideType]);
 
@@ -35339,7 +35337,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     const valueType =
                         isMethodDeclaration(node) ? getOrCreateTypeFromSignature(getSignatureFromDeclaration(node)) :
-                            getTypeOfNode(node);
+                        getTypeOfNode(node);
 
                     const thisType = hasStaticModifier(node) ?
                         getTypeOfSymbol(getSymbolOfDeclaration(node.parent)) :
@@ -35350,16 +35348,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // methods it is just the input type.
                     const targetType =
                         isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType) :
-                            isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
-                                valueType;
+                        isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
+                        valueType;
 
                     const contextType = createClassMemberDecoratorContextTypeForNode(node, thisType, valueType);
 
                     // We also wrap the "output type", as needed.
                     const returnType =
                         isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType) :
-                            isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
-                                valueType;
+                        isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
+                        valueType;
 
                     links.decoratorSignature = createESDecoratorCallSignature(targetType, contextType, returnType);
                     break;
@@ -35385,7 +35383,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // regular field decorator is always `undefined` as it isn't installed until it is initialized.
                     const targetType =
                         hasAccessorModifier(node) ? createClassAccessorDecoratorTargetType(thisType, valueType) :
-                            undefinedType;
+                        undefinedType;
 
                     const contextType = createClassMemberDecoratorContextTypeForNode(node, thisType, valueType);
 
@@ -35395,7 +35393,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // initializer mutator. For regular fields, we wrap the "output type" in an initializer mutator.
                     const returnType =
                         hasAccessorModifier(node) ? createClassAccessorDecoratorResultType(thisType, valueType) :
-                            createClassFieldDecoratorInitializerMutatorType(thisType, valueType);
+                        createClassFieldDecoratorInitializerMutatorType(thisType, valueType);
 
                     links.decoratorSignature = createESDecoratorCallSignature(targetType, contextType, returnType);
                     break;
@@ -35447,11 +35445,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     const targetType =
                         isConstructorDeclaration(node.parent) ? getTypeOfSymbol(getSymbolOfDeclaration(node.parent.parent)) :
-                            getParentTypeOfClassElement(node.parent);
+                        getParentTypeOfClassElement(node.parent);
 
                     const keyType =
                         isConstructorDeclaration(node.parent) ? undefinedType :
-                            getClassElementPropertyKeyType(node.parent);
+                        getClassElementPropertyKeyType(node.parent);
 
                     const indexType = getNumberLiteralType(index);
 
@@ -35485,7 +35483,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     const returnType =
                         isPropertyDeclaration(node) ? voidType :
-                            createTypedPropertyDescriptorType(getTypeOfNode(node));
+                        createTypedPropertyDescriptorType(getTypeOfNode(node));
 
                     const hasPropDesc = languageVersion !== ScriptTarget.ES3 && (!isPropertyDeclaration(parent) || hasAccessorModifier(parent));
                     if (hasPropDesc) {
@@ -35639,7 +35637,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const contextualSignature = getContextualSignatureForFunctionLikeDeclaration(func);
                 const contextualType = !contextualSignature ? undefined :
                     contextualSignature === getSignatureFromDeclaration(func) ? isGenerator ? undefined : returnType :
-                        instantiateContextualType(getReturnTypeOfSignature(contextualSignature), func, /*contextFlags*/ undefined);
+                    instantiateContextualType(getReturnTypeOfSignature(contextualSignature), func, /*contextFlags*/ undefined);
                 if (isGenerator) {
                     yieldType = getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded(yieldType, contextualType, IterationTypeKind.Yield, isAsync);
                     returnType = getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded(returnType, contextualType, IterationTypeKind.Return, isAsync);
@@ -36236,14 +36234,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 hasError = true;
                                 break;
                             }
-                        // fallthrough
+                            // fallthrough
                         case ModuleKind.ES2022:
                         case ModuleKind.ESNext:
                         case ModuleKind.System:
                             if (languageVersion >= ScriptTarget.ES2017) {
                                 break;
                             }
-                        // fallthrough
+                            // fallthrough
                         default:
                             span ??= getSpanOfTokenAtPosition(sourceFile, node.pos);
                             const message = isAwaitExpression(node) ? Diagnostics.Top_level_await_expressions_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_or_nodenext_and_the_target_option_is_set_to_es2017_or_higher :
@@ -36334,7 +36332,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const facts = getTypeFacts(operandType) & (TypeFacts.Truthy | TypeFacts.Falsy);
                 return facts === TypeFacts.Truthy ? falseType :
                     facts === TypeFacts.Falsy ? trueType :
-                        booleanType;
+                    booleanType;
             case SyntaxKind.PlusPlusToken:
             case SyntaxKind.MinusMinusToken:
                 const ok = checkArithmeticOperandType(node.operand, checkNonNullType(operandType, node.operand),
@@ -36561,7 +36559,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // present (aka the tuple element property). This call also checks that the parentType is in
         // fact an iterable or array (depending on target language).
         const possiblyOutOfBoundsType = checkIteratedTypeOrElementType(IterationUse.Destructuring | IterationUse.PossiblyOutOfBounds, sourceType, undefinedType, node) || errorType;
-        let inBoundsType: Type | undefined = compilerOptions.noUncheckedIndexedAccess ? undefined : possiblyOutOfBoundsType;
+        let inBoundsType: Type | undefined = compilerOptions.noUncheckedIndexedAccess ? undefined: possiblyOutOfBoundsType;
         for (let i = 0; i < elements.length; i++) {
             let type = possiblyOutOfBoundsType;
             if (node.elements[i].kind === SyntaxKind.SpreadElement) {
@@ -36706,7 +36704,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return false;
                 }
                 return isSideEffectFree((node as BinaryExpression).left) &&
-                    isSideEffectFree((node as BinaryExpression).right);
+                        isSideEffectFree((node as BinaryExpression).right);
 
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
@@ -37187,8 +37185,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function checkForDisallowedESSymbolOperand(operator: PunctuationSyntaxKind): boolean {
             const offendingSymbolOperand =
                 maybeTypeOfKindConsideringBaseConstraint(leftType, TypeFlags.ESSymbolLike) ? left :
-                    maybeTypeOfKindConsideringBaseConstraint(rightType, TypeFlags.ESSymbolLike) ? right :
-                        undefined;
+                maybeTypeOfKindConsideringBaseConstraint(rightType, TypeFlags.ESSymbolLike) ? right :
+                undefined;
 
             if (offendingSymbolOperand) {
                 error(offendingSymbolOperand, Diagnostics.The_0_operator_cannot_be_applied_to_type_symbol, tokenToString(operator));
@@ -37237,7 +37235,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (checkReferenceExpression(left,
                     Diagnostics.The_left_hand_side_of_an_assignment_expression_must_be_a_variable_or_a_property_access,
                     Diagnostics.The_left_hand_side_of_an_assignment_expression_may_not_be_an_optional_property_access)
-                ) {
+                    ) {
 
                     let headMessage: DiagnosticMessage | undefined;
                     if (exactOptionalPropertyTypes && isPropertyAccessExpression(left) && maybeTypeOfKind(valueType, TypeFlags.Undefined)) {
@@ -37359,7 +37357,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             effectiveLeft = leftBase;
             effectiveRight = rightBase;
         }
-        return [effectiveLeft, effectiveRight];
+        return [ effectiveLeft, effectiveRight ];
     }
 
     function checkYieldExpression(node: YieldExpression): Type {
@@ -37621,7 +37619,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const type = checkExpression(node, checkMode, forceTuple);
         return isConstContext(node) || isCommonJsExportedExpression(node) ? getRegularTypeOfLiteralType(type) :
             isTypeAssertion(node) ? type :
-                getWidenedLiteralLikeTypeForContextualType(type, instantiateContextualType(getContextualType(node, /*contextFlags*/ undefined), node, /*contextFlags*/ undefined));
+            getWidenedLiteralLikeTypeForContextualType(type, instantiateContextualType(getContextualType(node, /*contextFlags*/ undefined), node, /*contextFlags*/ undefined));
     }
 
     function checkPropertyAssignment(node: PropertyAssignment, checkMode?: CheckMode): Type {
@@ -37985,7 +37983,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if ((node as CallExpression).expression.kind === SyntaxKind.ImportKeyword) {
                     return checkImportCallExpression(node as ImportCall);
                 }
-            // falls through
+                // falls through
             case SyntaxKind.NewExpression:
                 return checkCallExpression(node as CallExpression, checkMode);
             case SyntaxKind.TaggedTemplateExpression:
@@ -38179,7 +38177,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 let hasReportedError = false;
                 for (const { name } of parent.parameters) {
                     if (isBindingPattern(name) &&
-                        checkIfTypePredicateVariableIsDeclaredInBindingPattern(name, parameterName, typePredicate.parameterName)) {
+                            checkIfTypePredicateVariableIsDeclaredInBindingPattern(name, parameterName, typePredicate.parameterName)) {
                         hasReportedError = true;
                         break;
                     }
@@ -38345,8 +38343,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const privateStaticFlags = isPrivate && isStaticMember ? DeclarationMeaning.PrivateStatic : 0;
                 const names =
                     isPrivate ? privateIdentifiers :
-                        isStaticMember ? staticNames :
-                            instanceNames;
+                    isStaticMember ? staticNames :
+                    instanceNames;
 
                 const memberName = name && getPropertyNameForPropertyNameNode(name);
                 if (memberName) {
@@ -38426,7 +38424,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         if (compilerOptions.useDefineForClassFields) {
                             break;
                         }
-                    // fall through
+                        // fall through
                     case "prototype":
                         const message = Diagnostics.Static_property_0_conflicts_with_built_in_property_Function_0_of_constructor_function_1;
                         const className = getNameOfSymbolAsWritten(getSymbolOfDeclaration(node));
@@ -38630,7 +38628,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const superCallShouldBeRootLevel =
                         (getEmitScriptTarget(compilerOptions) !== ScriptTarget.ESNext || !useDefineForClassFields) &&
                         (some((node.parent as ClassDeclaration).members, isInstancePropertyWithInitializerOrPrivateIdentifierProperty) ||
-                            some(node.parameters, p => hasSyntacticModifier(p, ModifierFlags.ParameterPropertyModifier)));
+                        some(node.parameters, p => hasSyntacticModifier(p, ModifierFlags.ParameterPropertyModifier)));
 
                     if (superCallShouldBeRootLevel) {
                         // Until we have better flow analysis, it is an error to place the super call within any kind of block or conditional
@@ -39295,10 +39293,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             forEach(declarations, declaration => {
                 const diagnostic = declaration.kind === SyntaxKind.ClassDeclaration
-                    ? Diagnostics.Class_declaration_cannot_implement_overload_list_for_0
-                    : declaration.kind === SyntaxKind.FunctionDeclaration
-                        ? Diagnostics.Function_with_bodies_can_only_merge_with_classes_that_are_ambient
-                        : undefined;
+                        ? Diagnostics.Class_declaration_cannot_implement_overload_list_for_0
+                        : declaration.kind === SyntaxKind.FunctionDeclaration
+                            ? Diagnostics.Function_with_bodies_can_only_merge_with_classes_that_are_ambient
+                            : undefined;
                 if (diagnostic) {
                     addRelatedInfo(
                         error(getNameOfDeclaration(declaration) || declaration, diagnostic, symbolName(symbol)),
@@ -39451,12 +39449,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.ImportSpecifier: // https://github.com/Microsoft/TypeScript/pull/7591
                 case SyntaxKind.Identifier: // https://github.com/microsoft/TypeScript/issues/36098
-                    // Identifiers are used as declarations of assignment declarations whose parents may be
-                    // SyntaxKind.CallExpression - `Object.defineProperty(thing, "aField", {value: 42});`
-                    // SyntaxKind.ElementAccessExpression - `thing["aField"] = 42;` or `thing["aField"];` (with a doc comment on it)
-                    // or SyntaxKind.PropertyAccessExpression - `thing.aField = 42;`
-                    // all of which are pretty much always values, or at least imply a value meaning.
-                    // It may be apprpriate to treat these as aliases in the future.
+                // Identifiers are used as declarations of assignment declarations whose parents may be
+                // SyntaxKind.CallExpression - `Object.defineProperty(thing, "aField", {value: 42});`
+                // SyntaxKind.ElementAccessExpression - `thing["aField"] = 42;` or `thing["aField"];` (with a doc comment on it)
+                // or SyntaxKind.PropertyAccessExpression - `thing.aField = 42;`
+                // all of which are pretty much always values, or at least imply a value meaning.
+                // It may be apprpriate to treat these as aliases in the future.
                     return DeclarationSpaces.ExportValue;
                 case SyntaxKind.MethodSignature:
                 case SyntaxKind.PropertySignature:
@@ -39606,7 +39604,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function unwrapAwaitedType(type: Type) {
         return type.flags & TypeFlags.Union ? mapType(type, unwrapAwaitedType) :
             isAwaitedTypeInstantiation(type) ? type.aliasTypeArguments[0] :
-                type;
+            type;
     }
 
     function isAwaitedTypeNeeded(type: Type) {
@@ -39937,7 +39935,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     headMessage = Diagnostics.Decorator_function_return_type_0_is_not_assignable_to_type_1;
                     break;
                 }
-            // falls through
+                // falls through
 
             case SyntaxKind.Parameter:
                 headMessage = Diagnostics.Decorator_function_return_type_is_0_but_is_expected_to_be_void_or_any;
@@ -41048,10 +41046,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         if (isBindingElement(node)) {
             if (
-                node.propertyName &&
-                isIdentifier(node.name) &&
-                isParameterDeclaration(node) &&
-                nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)) {
+              node.propertyName &&
+              isIdentifier(node.name) &&
+              isParameterDeclaration(node) &&
+              nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)) {
                 // type F = ({a: string}) => void;
                 //               ^^^^^^
                 // variable renaming in function type notation is confusing,
@@ -41331,7 +41329,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const testedNode = isIdentifier(location) ? location
                 : isPropertyAccessExpression(location) ? location.name
-                    : undefined;
+                : undefined;
             const testedSymbol = testedNode && getSymbolAtLocation(testedNode);
             if (!testedSymbol && !isPromise) {
                 return;
@@ -41615,10 +41613,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (iterationTypes) {
                     const diagnostic =
                         use & IterationUse.ForOfFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_for_of_will_always_send_0 :
-                            use & IterationUse.SpreadFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_always_send_0 :
-                                use & IterationUse.DestructuringFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring_will_always_send_0 :
-                                    use & IterationUse.YieldStarFlag ? Diagnostics.Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_containing_generator_will_always_send_0 :
-                                        undefined;
+                        use & IterationUse.SpreadFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_always_send_0 :
+                        use & IterationUse.DestructuringFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring_will_always_send_0 :
+                        use & IterationUse.YieldStarFlag ? Diagnostics.Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_containing_generator_will_always_send_0 :
+                        undefined;
                     if (diagnostic) {
                         checkTypeAssignableTo(sentType, iterationTypes.nextType, errorNode, diagnostic);
                     }
@@ -42089,7 +42087,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 errorNode.parent.expression === errorNode &&
                 getGlobalAsyncIterableType(/*reportErrors*/ false) !== emptyGenericType &&
                 isTypeAssignableTo(type, getGlobalAsyncIterableType(/*reportErrors*/ false)
-                ));
+            ));
         return errorAndMaybeSuggestAwait(errorNode, suggestAwait, message, typeToString(type));
     }
 
@@ -42434,7 +42432,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         const container = getContainingFunctionOrClassStaticBlock(node);
-        if (container && isClassStaticBlockDeclaration(container)) {
+        if(container && isClassStaticBlockDeclaration(container)) {
             grammarErrorOnFirstToken(node, Diagnostics.A_return_statement_cannot_be_used_inside_a_class_static_block);
             return;
         }
@@ -43414,9 +43412,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     if (!inheritedAbstractMemberNotImplementedError) {
                         inheritedAbstractMemberNotImplementedError = error(
-                            derivedClassDecl,
-                            Diagnostics.Non_abstract_class_0_does_not_implement_all_abstract_members_of_1,
-                            typeToString(type), typeToString(baseType));
+                                derivedClassDecl,
+                                Diagnostics.Non_abstract_class_0_does_not_implement_all_abstract_members_of_1,
+                                typeToString(type), typeToString(baseType));
 
                     }
                     if (derivedClassDecl.kind === SyntaxKind.ClassExpression) {
@@ -43814,7 +43812,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isInfinityOrNaNString((expr as Identifier).escapedText)) {
                     return +((expr as Identifier).escapedText);
                 }
-            // falls through
+                // falls through
             case SyntaxKind.PropertyAccessExpression:
                 if (isEntityNameExpression(expr)) {
                     const symbol = resolveEntityName(expr, SymbolFlags.Value, /*ignoreErrors*/ true);
@@ -44112,7 +44110,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     break;
                 }
-            // falls through
+                // falls through
             case SyntaxKind.ClassDeclaration:
             case SyntaxKind.EnumDeclaration:
             case SyntaxKind.FunctionDeclaration:
@@ -44205,8 +44203,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isInJSFile(node) && !(target.flags & SymbolFlags.Value) && !isTypeOnlyImportOrExportDeclaration(node)) {
                 const errorNode =
                     isImportOrExportSpecifier(node) ? node.propertyName || node.name :
-                        isNamedDeclaration(node) ? node.name :
-                            node;
+                    isNamedDeclaration(node) ? node.name :
+                    node;
 
                 Debug.assert(node.kind !== SyntaxKind.NamespaceExport);
                 if (node.kind === SyntaxKind.ExportSpecifier) {
@@ -44696,7 +44694,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Forbid export= in esm implementation files, and esm mode declaration files
             if (moduleKind >= ModuleKind.ES2015 &&
                 ((node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) ||
-                    (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))) {
+                (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))) {
                 // export assignment is not supported in es6 modules
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or_another_module_format_instead);
             }
@@ -44880,7 +44878,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return checkJSDocPropertyTag(node as JSDocPropertyTag);
             case SyntaxKind.JSDocFunctionType:
                 checkJSDocFunctionType(node as JSDocFunctionType);
-            // falls through
+                // falls through
             case SyntaxKind.JSDocNonNullableType:
             case SyntaxKind.JSDocNullableType:
             case SyntaxKind.JSDocAllType:
@@ -45343,7 +45341,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 switch (location.kind) {
                     case SyntaxKind.SourceFile:
                         if (!isExternalModule(location as SourceFile)) break;
-                    // falls through
+                        // falls through
                     case SyntaxKind.ModuleDeclaration:
                         copyLocallyVisibleExportSymbols(getSymbolOfDeclaration(location as ModuleDeclaration | SourceFile).exports!, meaning & SymbolFlags.ModuleMember);
                         break;
@@ -45799,7 +45797,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!isThisInTypeQuery(node)) {
                     return getSymbolOfNameOrPropertyAccessExpression(node as EntityName | PrivateIdentifier | PropertyAccessExpression);
                 }
-            // falls through
+                // falls through
 
             case SyntaxKind.ThisKeyword:
                 const container = getThisContainer(node, /*includeArrowFunctions*/ false, /*includeClassComputedPropertyName*/ false);
@@ -45812,7 +45810,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isInExpressionContext(node)) {
                     return checkExpression(node as Expression).symbol;
                 }
-            // falls through
+                // falls through
 
             case SyntaxKind.ThisType:
                 return getTypeFromThisTypeNode(node as ThisExpression | ThisTypeNode).symbol;
@@ -45844,7 +45842,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isCallExpression(parent) && isBindableObjectDefinePropertyCall(parent) && parent.arguments[1] === node) {
                     return getSymbolOfDeclaration(parent);
                 }
-            // falls through
+                // falls through
 
             case SyntaxKind.NumericLiteral:
                 // index access
@@ -45876,7 +45874,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const symbol = getIntrinsicTagSymbol(node.parent as JsxOpeningLikeElement);
                     return symbol === unknownSymbol ? undefined : symbol;
                 }
-            // falls through
+                // falls through
 
             default:
                 return undefined;
@@ -46078,7 +46076,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const propsByName = createSymbolTable(getPropertiesOfType(type));
         const functionType = getSignaturesOfType(type, SignatureKind.Call).length ? globalCallableFunctionType :
             getSignaturesOfType(type, SignatureKind.Construct).length ? globalNewableFunctionType :
-                undefined;
+            undefined;
         if (functionType) {
             forEach(getPropertiesOfType(functionType), p => {
                 if (!propsByName.has(p.escapedName)) {
@@ -46105,7 +46103,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const { links: { leftSpread, rightSpread, syntheticOrigin } } = symbol as TransientSymbol;
             return leftSpread ? [leftSpread, rightSpread!]
                 : syntheticOrigin ? [syntheticOrigin]
-                    : singleElementArray(tryGetTarget(symbol));
+                : singleElementArray(tryGetTarget(symbol));
         }
         return undefined;
     }
@@ -46128,8 +46126,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const parent = node.parent;
         if (!parent) return false;
         const isPropertyName = ((isPropertyAccessExpression(parent)
-            || isPropertyAssignment(parent))
-            && parent.name === node);
+                                 || isPropertyAssignment(parent))
+                                && parent.name === node);
         return !isPropertyName && getReferencedValueSymbol(node) === argumentsSymbol;
     }
 
@@ -46707,7 +46705,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const literalValue = (type as LiteralType).value;
         return typeof literalValue === "object" ? factory.createBigIntLiteral(literalValue) :
             typeof literalValue === "number" ? factory.createNumericLiteral(literalValue) :
-                factory.createStringLiteral(literalValue);
+            factory.createStringLiteral(literalValue);
     }
 
     function createLiteralConstValue(node: VariableDeclaration | PropertyDeclaration | PropertySignature | ParameterDeclaration, tracker: SymbolTracker) {
@@ -47618,9 +47616,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function findFirstModifierExcept(node: HasModifiers, allowedModifier: SyntaxKind): Modifier | undefined {
-        const modifier = find(node.modifiers, isModifier);
-        return modifier && modifier.kind !== allowedModifier ? modifier : undefined;
-    }
+            const modifier = find(node.modifiers, isModifier);
+            return modifier && modifier.kind !== allowedModifier ? modifier : undefined;
+        }
 
     function findFirstIllegalModifier(node: HasModifiers | HasIllegalModifiers): Modifier | undefined {
         switch (node.kind) {
@@ -48027,7 +48025,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             else if (canHaveIllegalModifiers(prop) && prop.modifiers) {
                 for (const mod of prop.modifiers) {
-                    if (isModifier(mod)) {
+                        if (isModifier(mod)) {
                         grammarErrorOnNode(mod, Diagnostics._0_modifier_cannot_be_used_here, getTextOfNode(mod));
                     }
                 }
@@ -48162,14 +48160,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                     );
                                     break;
                                 }
-                            // fallthrough
+                                // fallthrough
                             case ModuleKind.ES2022:
                             case ModuleKind.ESNext:
                             case ModuleKind.System:
                                 if (languageVersion >= ScriptTarget.ES2017) {
                                     break;
                                 }
-                            // fallthrough
+                                // fallthrough
                             default:
                                 diagnostics.add(
                                     createDiagnosticForNode(forInOrOfStatement.awaitModifier,
@@ -48663,9 +48661,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (blockScopeKind) {
                 const keyword = blockScopeKind === NodeFlags.Let ? "let" :
                     blockScopeKind === NodeFlags.Const ? "const" :
-                        blockScopeKind === NodeFlags.Using ? "using" :
-                            blockScopeKind === NodeFlags.AwaitUsing ? "await using" :
-                                Debug.fail("Unknown BlockScope flag");
+                    blockScopeKind === NodeFlags.Using ? "using" :
+                    blockScopeKind === NodeFlags.AwaitUsing ? "await using" :
+                    Debug.fail("Unknown BlockScope flag");
                 return grammarErrorOnNode(node, Diagnostics._0_declarations_can_only_be_declared_inside_a_block, keyword);
             }
         }
@@ -49127,7 +49125,7 @@ function isNotAccessor(declaration: Declaration): boolean {
 
 function isNotOverload(declaration: Declaration): boolean {
     return (declaration.kind !== SyntaxKind.FunctionDeclaration && declaration.kind !== SyntaxKind.MethodDeclaration) ||
-        !!(declaration as FunctionDeclaration).body;
+            !!(declaration as FunctionDeclaration).body;
 }
 
 /** Like 'isDeclarationName', but returns true for LHS of `import { x as y }` or `export { x as y }`. */

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7440,6 +7440,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (typeArguments) {
                 node.typeArguments = factory.createNodeArray(typeArguments);
             }
+            if (signature.declaration?.kind === SyntaxKind.JSDocSignature && signature.declaration.parent.kind === SyntaxKind.JSDocOverloadTag) {
+                const comment = getTextOfNode(signature.declaration.parent.parent, /*includeTrivia*/ true).slice(2, -2).split(/\r\n|\n|\r/).map(line => line.replace(/^\s+/, " ")).join("\n");
+                addSyntheticLeadingComment(node, SyntaxKind.MultiLineCommentTrivia, comment, /*hasTrailingNewLine*/ true);
+            }
 
             cleanup?.();
             return node;

--- a/tests/baselines/reference/jsFileFunctionOverloads.js
+++ b/tests/baselines/reference/jsFileFunctionOverloads.js
@@ -120,10 +120,39 @@ function flatMap(array, iterable) {
 
 
 //// [jsFileFunctionOverloads.d.ts]
+/**
+ * @overload
+ * @param {number} x
+ * @returns {'number'}
+ */
 declare function getTypeName(x: number): 'number';
+/**
+ * @overload
+ * @param {string} x
+ * @returns {'string'}
+ */
 declare function getTypeName(x: string): 'string';
+/**
+ * @overload
+ * @param {boolean} x
+ * @returns {'boolean'}
+ */
 declare function getTypeName(x: boolean): 'boolean';
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array
+ * @param {(x: T) => U[]} iterable
+ * @returns {U[]}
+ */
 declare function flatMap<T, U>(array: T[], iterable: (x: T) => U[]): U[];
+/**
+ * @template T
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ */
 declare function flatMap<T>(array: T[][]): T[];
 /**
  * @template T

--- a/tests/baselines/reference/jsFileFunctionOverloads.js
+++ b/tests/baselines/reference/jsFileFunctionOverloads.js
@@ -120,39 +120,10 @@ function flatMap(array, iterable) {
 
 
 //// [jsFileFunctionOverloads.d.ts]
-/**
- * @overload
- * @param {number} x
- * @returns {'number'}
- */
 declare function getTypeName(x: number): 'number';
-/**
- * @overload
- * @param {string} x
- * @returns {'string'}
- */
 declare function getTypeName(x: string): 'string';
-/**
- * @overload
- * @param {boolean} x
- * @returns {'boolean'}
- */
 declare function getTypeName(x: boolean): 'boolean';
-/**
- * @template T
- * @template U
- * @overload
- * @param {T[]} array
- * @param {(x: T) => U[]} iterable
- * @returns {U[]}
- */
 declare function flatMap<T, U>(array: T[], iterable: (x: T) => U[]): U[];
-/**
- * @template T
- * @overload
- * @param {T[][]} array
- * @returns {T[]}
- */
 declare function flatMap<T>(array: T[][]): T[];
 /**
  * @template T

--- a/tests/baselines/reference/jsFileFunctionOverloads2.js
+++ b/tests/baselines/reference/jsFileFunctionOverloads2.js
@@ -110,10 +110,90 @@ function flatMap(array, iterable) {
 
 
 //// [jsFileFunctionOverloads2.d.ts]
+/**
+ * @overload
+ * @param {number} x
+ * @returns {'number'}
+ *
+ * @overload
+ * @param {string} x
+ * @returns {'string'}
+ *
+ * @overload
+ * @param {boolean} x
+ * @returns {'boolean'}
+ *
+ * @param {unknown} x
+ * @returns {string}
+ */
 declare function getTypeName(x: number): 'number';
+/**
+ * @overload
+ * @param {number} x
+ * @returns {'number'}
+ *
+ * @overload
+ * @param {string} x
+ * @returns {'string'}
+ *
+ * @overload
+ * @param {boolean} x
+ * @returns {'boolean'}
+ *
+ * @param {unknown} x
+ * @returns {string}
+ */
 declare function getTypeName(x: string): 'string';
+/**
+ * @overload
+ * @param {number} x
+ * @returns {'number'}
+ *
+ * @overload
+ * @param {string} x
+ * @returns {'string'}
+ *
+ * @overload
+ * @param {boolean} x
+ * @returns {'boolean'}
+ *
+ * @param {unknown} x
+ * @returns {string}
+ */
 declare function getTypeName(x: boolean): 'boolean';
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array
+ * @param {(x: T) => U[]} iterable
+ * @returns {U[]}
+ *
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ *
+ * @param {unknown[]} array
+ * @param {(x: unknown) => unknown} iterable
+ * @returns {unknown[]}
+ */
 declare function flatMap<T, U>(array: T[], iterable: (x: T) => U[]): U[];
+/**
+ * @template T
+ * @template U
+ * @overload
+ * @param {T[]} array
+ * @param {(x: T) => U[]} iterable
+ * @returns {U[]}
+ *
+ * @overload
+ * @param {T[][]} array
+ * @returns {T[]}
+ *
+ * @param {unknown[]} array
+ * @param {(x: unknown) => unknown} iterable
+ * @returns {unknown[]}
+ */
 declare function flatMap<T, U>(array: T[][]): T[];
 /**
  * @template T

--- a/tests/baselines/reference/jsFileFunctionOverloads2.js
+++ b/tests/baselines/reference/jsFileFunctionOverloads2.js
@@ -110,90 +110,10 @@ function flatMap(array, iterable) {
 
 
 //// [jsFileFunctionOverloads2.d.ts]
-/**
- * @overload
- * @param {number} x
- * @returns {'number'}
- *
- * @overload
- * @param {string} x
- * @returns {'string'}
- *
- * @overload
- * @param {boolean} x
- * @returns {'boolean'}
- *
- * @param {unknown} x
- * @returns {string}
- */
 declare function getTypeName(x: number): 'number';
-/**
- * @overload
- * @param {number} x
- * @returns {'number'}
- *
- * @overload
- * @param {string} x
- * @returns {'string'}
- *
- * @overload
- * @param {boolean} x
- * @returns {'boolean'}
- *
- * @param {unknown} x
- * @returns {string}
- */
 declare function getTypeName(x: string): 'string';
-/**
- * @overload
- * @param {number} x
- * @returns {'number'}
- *
- * @overload
- * @param {string} x
- * @returns {'string'}
- *
- * @overload
- * @param {boolean} x
- * @returns {'boolean'}
- *
- * @param {unknown} x
- * @returns {string}
- */
 declare function getTypeName(x: boolean): 'boolean';
-/**
- * @template T
- * @template U
- * @overload
- * @param {T[]} array
- * @param {(x: T) => U[]} iterable
- * @returns {U[]}
- *
- * @overload
- * @param {T[][]} array
- * @returns {T[]}
- *
- * @param {unknown[]} array
- * @param {(x: unknown) => unknown} iterable
- * @returns {unknown[]}
- */
 declare function flatMap<T, U>(array: T[], iterable: (x: T) => U[]): U[];
-/**
- * @template T
- * @template U
- * @overload
- * @param {T[]} array
- * @param {(x: T) => U[]} iterable
- * @returns {U[]}
- *
- * @overload
- * @param {T[][]} array
- * @returns {T[]}
- *
- * @param {unknown[]} array
- * @param {(x: unknown) => unknown} iterable
- * @returns {unknown[]}
- */
 declare function flatMap<T, U>(array: T[][]): T[];
 /**
  * @template T

--- a/tests/baselines/reference/jsFileMethodOverloads.js
+++ b/tests/baselines/reference/jsFileMethodOverloads.js
@@ -107,8 +107,28 @@ declare class Example<T> {
      */
     constructor(value: T);
     value: T;
+    /**
+     * @overload
+     * @param {Example<number>} this
+     * @returns {'number'}
+     */
     getTypeName(this: Example<number>): 'number';
+    /**
+     * @overload
+     * @param {Example<string>} this
+     * @returns {'string'}
+     */
     getTypeName(this: Example<string>): 'string';
+    /**
+     * @template U
+     * @overload
+     * @param {(y: T) => U} fn
+     * @returns {U}
+     */
     transform<U>(fn: (y: T) => U): U;
+    /**
+     * @overload
+     * @returns {T}
+     */
     transform(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads.js
+++ b/tests/baselines/reference/jsFileMethodOverloads.js
@@ -108,27 +108,27 @@ declare class Example<T> {
     constructor(value: T);
     value: T;
     /**
-       * @overload
-       * @param {Example<number>} this
-       * @returns {'number'}
-       */
+     * @overload
+     * @param {Example<number>} this
+     * @returns {'number'}
+     */
     getTypeName(this: Example<number>): 'number';
     /**
-       * @overload
-       * @param {Example<string>} this
-       * @returns {'string'}
-       */
+     * @overload
+     * @param {Example<string>} this
+     * @returns {'string'}
+     */
     getTypeName(this: Example<string>): 'string';
     /**
-       * @template U
-       * @overload
-       * @param {(y: T) => U} fn
-       * @returns {U}
-       */
+     * @template U
+     * @overload
+     * @param {(y: T) => U} fn
+     * @returns {U}
+     */
     transform<U>(fn: (y: T) => U): U;
     /**
-       * @overload
-       * @returns {T}
-       */
+     * @overload
+     * @returns {T}
+     */
     transform(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads.js
+++ b/tests/baselines/reference/jsFileMethodOverloads.js
@@ -107,28 +107,8 @@ declare class Example<T> {
      */
     constructor(value: T);
     value: T;
-    /**
-       * @overload
-       * @param {Example<number>} this
-       * @returns {'number'}
-       */
     getTypeName(this: Example<number>): 'number';
-    /**
-       * @overload
-       * @param {Example<string>} this
-       * @returns {'string'}
-       */
     getTypeName(this: Example<string>): 'string';
-    /**
-       * @template U
-       * @overload
-       * @param {(y: T) => U} fn
-       * @returns {U}
-       */
     transform<U>(fn: (y: T) => U): U;
-    /**
-       * @overload
-       * @returns {T}
-       */
     transform(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads.js
+++ b/tests/baselines/reference/jsFileMethodOverloads.js
@@ -108,27 +108,27 @@ declare class Example<T> {
     constructor(value: T);
     value: T;
     /**
-     * @overload
-     * @param {Example<number>} this
-     * @returns {'number'}
-     */
+       * @overload
+       * @param {Example<number>} this
+       * @returns {'number'}
+       */
     getTypeName(this: Example<number>): 'number';
     /**
-     * @overload
-     * @param {Example<string>} this
-     * @returns {'string'}
-     */
+       * @overload
+       * @param {Example<string>} this
+       * @returns {'string'}
+       */
     getTypeName(this: Example<string>): 'string';
     /**
-     * @template U
-     * @overload
-     * @param {(y: T) => U} fn
-     * @returns {U}
-     */
+       * @template U
+       * @overload
+       * @param {(y: T) => U} fn
+       * @returns {U}
+       */
     transform<U>(fn: (y: T) => U): U;
     /**
-     * @overload
-     * @returns {T}
-     */
+       * @overload
+       * @returns {T}
+       */
     transform(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads.js
+++ b/tests/baselines/reference/jsFileMethodOverloads.js
@@ -107,8 +107,28 @@ declare class Example<T> {
      */
     constructor(value: T);
     value: T;
+    /**
+       * @overload
+       * @param {Example<number>} this
+       * @returns {'number'}
+       */
     getTypeName(this: Example<number>): 'number';
+    /**
+       * @overload
+       * @param {Example<string>} this
+       * @returns {'string'}
+       */
     getTypeName(this: Example<string>): 'string';
+    /**
+       * @template U
+       * @overload
+       * @param {(y: T) => U} fn
+       * @returns {U}
+       */
     transform<U>(fn: (y: T) => U): U;
+    /**
+       * @overload
+       * @returns {T}
+       */
     transform(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads2.js
+++ b/tests/baselines/reference/jsFileMethodOverloads2.js
@@ -101,8 +101,54 @@ declare class Example<T> {
      */
     constructor(value: T);
     value: T;
+    /**
+     * @overload
+     * @param {Example<number>} this
+     * @returns {'number'}
+     *
+     * @overload
+     * @param {Example<string>} this
+     * @returns {'string'}
+     *
+     * @returns {string}
+     */
     getTypeName(this: Example<number>): 'number';
+    /**
+     * @overload
+     * @param {Example<number>} this
+     * @returns {'number'}
+     *
+     * @overload
+     * @param {Example<string>} this
+     * @returns {'string'}
+     *
+     * @returns {string}
+     */
     getTypeName(this: Example<string>): 'string';
+    /**
+     * @template U
+     * @overload
+     * @param {(y: T) => U} fn
+     * @returns {U}
+     *
+     * @overload
+     * @returns {T}
+     *
+     * @param {(y: T) => unknown} [fn]
+     * @returns {unknown}
+     */
     transform<U>(fn: (y: T) => U): U;
+    /**
+     * @template U
+     * @overload
+     * @param {(y: T) => U} fn
+     * @returns {U}
+     *
+     * @overload
+     * @returns {T}
+     *
+     * @param {(y: T) => unknown} [fn]
+     * @returns {unknown}
+     */
     transform<U>(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads2.js
+++ b/tests/baselines/reference/jsFileMethodOverloads2.js
@@ -101,8 +101,54 @@ declare class Example<T> {
      */
     constructor(value: T);
     value: T;
+    /**
+       * @overload
+       * @param {Example<number>} this
+       * @returns {'number'}
+       *
+       * @overload
+       * @param {Example<string>} this
+       * @returns {'string'}
+       *
+       * @returns {string}
+       */
     getTypeName(this: Example<number>): 'number';
+    /**
+       * @overload
+       * @param {Example<number>} this
+       * @returns {'number'}
+       *
+       * @overload
+       * @param {Example<string>} this
+       * @returns {'string'}
+       *
+       * @returns {string}
+       */
     getTypeName(this: Example<string>): 'string';
+    /**
+       * @template U
+       * @overload
+       * @param {(y: T) => U} fn
+       * @returns {U}
+       *
+       * @overload
+       * @returns {T}
+       *
+       * @param {(y: T) => unknown} [fn]
+       * @returns {unknown}
+       */
     transform<U>(fn: (y: T) => U): U;
+    /**
+       * @template U
+       * @overload
+       * @param {(y: T) => U} fn
+       * @returns {U}
+       *
+       * @overload
+       * @returns {T}
+       *
+       * @param {(y: T) => unknown} [fn]
+       * @returns {unknown}
+       */
     transform<U>(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads2.js
+++ b/tests/baselines/reference/jsFileMethodOverloads2.js
@@ -102,53 +102,53 @@ declare class Example<T> {
     constructor(value: T);
     value: T;
     /**
-     * @overload
-     * @param {Example<number>} this
-     * @returns {'number'}
-     *
-     * @overload
-     * @param {Example<string>} this
-     * @returns {'string'}
-     *
-     * @returns {string}
-     */
+       * @overload
+       * @param {Example<number>} this
+       * @returns {'number'}
+       *
+       * @overload
+       * @param {Example<string>} this
+       * @returns {'string'}
+       *
+       * @returns {string}
+       */
     getTypeName(this: Example<number>): 'number';
     /**
-     * @overload
-     * @param {Example<number>} this
-     * @returns {'number'}
-     *
-     * @overload
-     * @param {Example<string>} this
-     * @returns {'string'}
-     *
-     * @returns {string}
-     */
+       * @overload
+       * @param {Example<number>} this
+       * @returns {'number'}
+       *
+       * @overload
+       * @param {Example<string>} this
+       * @returns {'string'}
+       *
+       * @returns {string}
+       */
     getTypeName(this: Example<string>): 'string';
     /**
-     * @template U
-     * @overload
-     * @param {(y: T) => U} fn
-     * @returns {U}
-     *
-     * @overload
-     * @returns {T}
-     *
-     * @param {(y: T) => unknown} [fn]
-     * @returns {unknown}
-     */
+       * @template U
+       * @overload
+       * @param {(y: T) => U} fn
+       * @returns {U}
+       *
+       * @overload
+       * @returns {T}
+       *
+       * @param {(y: T) => unknown} [fn]
+       * @returns {unknown}
+       */
     transform<U>(fn: (y: T) => U): U;
     /**
-     * @template U
-     * @overload
-     * @param {(y: T) => U} fn
-     * @returns {U}
-     *
-     * @overload
-     * @returns {T}
-     *
-     * @param {(y: T) => unknown} [fn]
-     * @returns {unknown}
-     */
+       * @template U
+       * @overload
+       * @param {(y: T) => U} fn
+       * @returns {U}
+       *
+       * @overload
+       * @returns {T}
+       *
+       * @param {(y: T) => unknown} [fn]
+       * @returns {unknown}
+       */
     transform<U>(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads2.js
+++ b/tests/baselines/reference/jsFileMethodOverloads2.js
@@ -101,54 +101,8 @@ declare class Example<T> {
      */
     constructor(value: T);
     value: T;
-    /**
-       * @overload
-       * @param {Example<number>} this
-       * @returns {'number'}
-       *
-       * @overload
-       * @param {Example<string>} this
-       * @returns {'string'}
-       *
-       * @returns {string}
-       */
     getTypeName(this: Example<number>): 'number';
-    /**
-       * @overload
-       * @param {Example<number>} this
-       * @returns {'number'}
-       *
-       * @overload
-       * @param {Example<string>} this
-       * @returns {'string'}
-       *
-       * @returns {string}
-       */
     getTypeName(this: Example<string>): 'string';
-    /**
-       * @template U
-       * @overload
-       * @param {(y: T) => U} fn
-       * @returns {U}
-       *
-       * @overload
-       * @returns {T}
-       *
-       * @param {(y: T) => unknown} [fn]
-       * @returns {unknown}
-       */
     transform<U>(fn: (y: T) => U): U;
-    /**
-       * @template U
-       * @overload
-       * @param {(y: T) => U} fn
-       * @returns {U}
-       *
-       * @overload
-       * @returns {T}
-       *
-       * @param {(y: T) => unknown} [fn]
-       * @returns {unknown}
-       */
     transform<U>(): T;
 }

--- a/tests/baselines/reference/jsFileMethodOverloads2.js
+++ b/tests/baselines/reference/jsFileMethodOverloads2.js
@@ -102,53 +102,53 @@ declare class Example<T> {
     constructor(value: T);
     value: T;
     /**
-       * @overload
-       * @param {Example<number>} this
-       * @returns {'number'}
-       *
-       * @overload
-       * @param {Example<string>} this
-       * @returns {'string'}
-       *
-       * @returns {string}
-       */
+     * @overload
+     * @param {Example<number>} this
+     * @returns {'number'}
+     *
+     * @overload
+     * @param {Example<string>} this
+     * @returns {'string'}
+     *
+     * @returns {string}
+     */
     getTypeName(this: Example<number>): 'number';
     /**
-       * @overload
-       * @param {Example<number>} this
-       * @returns {'number'}
-       *
-       * @overload
-       * @param {Example<string>} this
-       * @returns {'string'}
-       *
-       * @returns {string}
-       */
+     * @overload
+     * @param {Example<number>} this
+     * @returns {'number'}
+     *
+     * @overload
+     * @param {Example<string>} this
+     * @returns {'string'}
+     *
+     * @returns {string}
+     */
     getTypeName(this: Example<string>): 'string';
     /**
-       * @template U
-       * @overload
-       * @param {(y: T) => U} fn
-       * @returns {U}
-       *
-       * @overload
-       * @returns {T}
-       *
-       * @param {(y: T) => unknown} [fn]
-       * @returns {unknown}
-       */
+     * @template U
+     * @overload
+     * @param {(y: T) => U} fn
+     * @returns {U}
+     *
+     * @overload
+     * @returns {T}
+     *
+     * @param {(y: T) => unknown} [fn]
+     * @returns {unknown}
+     */
     transform<U>(fn: (y: T) => U): U;
     /**
-       * @template U
-       * @overload
-       * @param {(y: T) => U} fn
-       * @returns {U}
-       *
-       * @overload
-       * @returns {T}
-       *
-       * @param {(y: T) => unknown} [fn]
-       * @returns {unknown}
-       */
+     * @template U
+     * @overload
+     * @param {(y: T) => U} fn
+     * @returns {U}
+     *
+     * @overload
+     * @returns {T}
+     *
+     * @param {(y: T) => unknown} [fn]
+     * @returns {unknown}
+     */
     transform<U>(): T;
 }

--- a/tests/baselines/reference/overloadTag1.js
+++ b/tests/baselines/reference/overloadTag1.js
@@ -98,7 +98,59 @@ uncheckedInternally("zero", "one");
 
 
 //// [overloadTag1.d.ts]
+/**
+ * @overload
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ *
+ * @overload
+ * @param {string} a
+ * @param {boolean} b
+ * @returns {string}
+ *
+ * @param {string | number} a
+ * @param {string | number} b
+ * @returns {string | number}
+ */
 export function overloaded(a: number, b: number): number;
+/**
+ * @overload
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ *
+ * @overload
+ * @param {string} a
+ * @param {boolean} b
+ * @returns {string}
+ *
+ * @param {string | number} a
+ * @param {string | number} b
+ * @returns {string | number}
+ */
 export function overloaded(a: string, b: boolean): string;
+/**
+ * @overload
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ *
+ * @overload
+ * @param {string} a
+ * @param {boolean} b
+ * @returns {string}
+ */
 export function uncheckedInternally(a: number, b: number): number;
+/**
+ * @overload
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ *
+ * @overload
+ * @param {string} a
+ * @param {boolean} b
+ * @returns {string}
+ */
 export function uncheckedInternally(a: string, b: boolean): string;

--- a/tests/baselines/reference/overloadTag1.js
+++ b/tests/baselines/reference/overloadTag1.js
@@ -98,59 +98,7 @@ uncheckedInternally("zero", "one");
 
 
 //// [overloadTag1.d.ts]
-/**
- * @overload
- * @param {number} a
- * @param {number} b
- * @returns {number}
- *
- * @overload
- * @param {string} a
- * @param {boolean} b
- * @returns {string}
- *
- * @param {string | number} a
- * @param {string | number} b
- * @returns {string | number}
- */
 export function overloaded(a: number, b: number): number;
-/**
- * @overload
- * @param {number} a
- * @param {number} b
- * @returns {number}
- *
- * @overload
- * @param {string} a
- * @param {boolean} b
- * @returns {string}
- *
- * @param {string | number} a
- * @param {string | number} b
- * @returns {string | number}
- */
 export function overloaded(a: string, b: boolean): string;
-/**
- * @overload
- * @param {number} a
- * @param {number} b
- * @returns {number}
- *
- * @overload
- * @param {string} a
- * @param {boolean} b
- * @returns {string}
- */
 export function uncheckedInternally(a: number, b: number): number;
-/**
- * @overload
- * @param {number} a
- * @param {number} b
- * @returns {number}
- *
- * @overload
- * @param {string} a
- * @param {boolean} b
- * @returns {string}
- */
 export function uncheckedInternally(a: string, b: boolean): string;

--- a/tests/baselines/reference/overloadTag2.js
+++ b/tests/baselines/reference/overloadTag2.js
@@ -73,8 +73,25 @@ var d = new Foo('str', 2);
 
 //// [overloadTag2.d.ts]
 export class Foo {
+    /**
+     * Should not have an implicit any error, because constructor's return type is always implicit
+     * @constructor
+     * @overload
+     * @param {string} a
+     * @param {number} b
+     */
     constructor(a: string, b: number);
+    /**
+     * @constructor
+     * @overload
+     * @param {number} a
+     */
     constructor(a: number);
+    /**
+     * @constructor
+     * @overload
+     * @param {string} a
+     */
     constructor(a: string);
     #private;
 }

--- a/tests/baselines/reference/overloadTag2.js
+++ b/tests/baselines/reference/overloadTag2.js
@@ -73,8 +73,25 @@ var d = new Foo('str', 2);
 
 //// [overloadTag2.d.ts]
 export class Foo {
+    /**
+         * Should not have an implicit any error, because constructor's return type is always implicit
+         * @constructor
+         * @overload
+         * @param {string} a
+         * @param {number} b
+         */
     constructor(a: string, b: number);
+    /**
+         * @constructor
+         * @overload
+         * @param {number} a
+         */
     constructor(a: number);
+    /**
+         * @constructor
+         * @overload
+         * @param {string} a
+         */
     constructor(a: string);
     #private;
 }

--- a/tests/baselines/reference/overloadTag2.js
+++ b/tests/baselines/reference/overloadTag2.js
@@ -73,25 +73,8 @@ var d = new Foo('str', 2);
 
 //// [overloadTag2.d.ts]
 export class Foo {
-    /**
-         * Should not have an implicit any error, because constructor's return type is always implicit
-         * @constructor
-         * @overload
-         * @param {string} a
-         * @param {number} b
-         */
     constructor(a: string, b: number);
-    /**
-         * @constructor
-         * @overload
-         * @param {number} a
-         */
     constructor(a: number);
-    /**
-         * @constructor
-         * @overload
-         * @param {string} a
-         */
     constructor(a: string);
     #private;
 }

--- a/tests/baselines/reference/templateInsideCallback.js
+++ b/tests/baselines/reference/templateInsideCallback.js
@@ -114,7 +114,21 @@ function flatMap(array, iterable) {
 
 
 //// [templateInsideCallback.d.ts]
+/**
+ * @overload
+ * @template T
+ * @template U
+ * @param {T[]} array
+ * @param {(x: T) => U[]} iterable
+ * @returns {U[]}
+ */
 declare function flatMap<U>(): any;
+/**
+ * @overload
+ * @template T
+ * @param {T[][]} array
+ * @returns {T[]}
+ */
 declare function flatMap(): any;
 /**
  * @typedef Oops

--- a/tests/baselines/reference/templateInsideCallback.js
+++ b/tests/baselines/reference/templateInsideCallback.js
@@ -114,21 +114,7 @@ function flatMap(array, iterable) {
 
 
 //// [templateInsideCallback.d.ts]
-/**
- * @overload
- * @template T
- * @template U
- * @param {T[]} array
- * @param {(x: T) => U[]} iterable
- * @returns {U[]}
- */
 declare function flatMap<U>(): any;
-/**
- * @overload
- * @template T
- * @param {T[][]} array
- * @returns {T[]}
- */
 declare function flatMap(): any;
 /**
  * @typedef Oops


### PR DESCRIPTION
3 open questions:

1. Is this the right way to do it? It's similar to the way addPropertyToElementList.
2. Is it worthwhile to fix emit for multiple overloads in a single comment? That style only works without `@template` and with explicit `@return` for each signature, so I believe it's rare. I left it unfixed.
3. Is it worthwhile to fix indentation? I copied some text manipulation code from getTextOfNodeFromSourceText, but I don't want to put my new code there without evidence that it's useful for more than just my case.

Fixes #53350
