### PR TITLE
Support destructuring in for-in

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -41531,10 +41531,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         //   VarDecl must be a variable declaration without a type annotation that declares a variable of type Any,
         //   and Expr must be an expression of type Any, an object type, or a type parameter type.
         if (node.initializer.kind === SyntaxKind.VariableDeclarationList) {
-            const variable = (node.initializer as VariableDeclarationList).declarations[0];
-            if (variable && isBindingPattern(variable.name)) {
-                error(variable.name, Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_a_destructuring_pattern);
-            }
             checkVariableDeclarationList(node.initializer as VariableDeclarationList);
         }
         else {
@@ -41544,8 +41540,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             //   and Expr must be an expression of type Any, an object type, or a type parameter type.
             const varExpr = node.initializer;
             const leftType = checkExpression(varExpr);
-            if (varExpr.kind === SyntaxKind.ArrayLiteralExpression || varExpr.kind === SyntaxKind.ObjectLiteralExpression) {
-                error(varExpr, Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_a_destructuring_pattern);
+            if (isAssignmentPattern(varExpr)) {
+                checkDestructuringAssignment(varExpr, getIndexTypeOrString(rightType));
             }
             else if (!isTypeAssignableTo(getIndexTypeOrString(rightType), leftType)) {
                 error(varExpr, Diagnostics.The_left_hand_side_of_a_for_in_statement_must_be_of_type_string_or_any);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2372,10 +2372,6 @@
         "category": "Error",
         "code": 2490
     },
-    "The left-hand side of a 'for...in' statement cannot be a destructuring pattern.": {
-        "category": "Error",
-        "code": 2491
-    },
     "Cannot redeclare identifier '{0}' in catch clause.": {
         "category": "Error",
         "code": 2492

--- a/src/testRunner/unittests/evaluation/destructuring.ts
+++ b/src/testRunner/unittests/evaluation/destructuring.ts
@@ -65,4 +65,36 @@ describe("unittests:: evaluation:: destructuring", () => {
             assert.deepEqual(result.output, { a: 1, b: { y: 2 } });
         });
     });
+    describe("correct evaluation in for-in with array pattern", () => {
+        it("ES5", () => {
+            const result = evaluator.evaluateTypeScript(`
+                export let output: string;
+                for (const [first] in { test: 1 }) { output = first; }
+            `, { target: ts.ScriptTarget.ES5, downlevelIteration: true });
+            assert.deepEqual(result.output, "t");
+        });
+        it("ESNext", () => {
+            const result = evaluator.evaluateTypeScript(`
+                export let output: string;
+                for (const [first] in { test: 1 }) { output = first; }
+            `, { target: ts.ScriptTarget.ESNext });
+            assert.deepEqual(result.output, "t");
+        });
+    });
+    describe("correct evaluation in for-in with object pattern", () => {
+        it("ES5", () => {
+            const result = evaluator.evaluateTypeScript(`
+                export let output: number;
+                for (const { length } in { test: 1 }) { output = length; }
+            `, { target: ts.ScriptTarget.ES5, downlevelIteration: true });
+            assert.deepEqual(result.output, 4);
+        });
+        it("ESNext", () => {
+            const result = evaluator.evaluateTypeScript(`
+                export let output: number;
+                for (const { length } in { test: 1 }) { output = length; }
+            `, { target: ts.ScriptTarget.ESNext });
+            assert.deepEqual(result.output, 4);
+        });
+    });
 });

--- a/tests/baselines/reference/for-inStatementsDestructuring.errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring.errors.txt
@@ -1,10 +1,7 @@
 for-inStatementsDestructuring.ts(1,10): error TS2461: Type 'string' is not an array type.
-for-inStatementsDestructuring.ts(1,10): error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
 
 
-==== for-inStatementsDestructuring.ts (2 errors) ====
+==== for-inStatementsDestructuring.ts (1 errors) ====
     for (var [a, b] in []) {}
              ~~~~~~
 !!! error TS2461: Type 'string' is not an array type.
-             ~~~~~~
-!!! error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.

--- a/tests/baselines/reference/for-inStatementsDestructuring.js
+++ b/tests/baselines/reference/for-inStatementsDestructuring.js
@@ -4,4 +4,6 @@
 for (var [a, b] in []) {}
 
 //// [for-inStatementsDestructuring.js]
-for (var _a = void 0, a = _a[0], b = _a[1] in []) { }
+for (var key_1 in []) {
+    var a = key_1[0], b = key_1[1];
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring2.errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring2.errors.txt
@@ -1,12 +1,9 @@
-for-inStatementsDestructuring2.ts(1,10): error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
 for-inStatementsDestructuring2.ts(1,11): error TS2339: Property 'a' does not exist on type 'String'.
 for-inStatementsDestructuring2.ts(1,14): error TS2339: Property 'b' does not exist on type 'String'.
 
 
-==== for-inStatementsDestructuring2.ts (3 errors) ====
+==== for-inStatementsDestructuring2.ts (2 errors) ====
     for (var {a, b} in []) {}
-             ~~~~~~
-!!! error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
               ~
 !!! error TS2339: Property 'a' does not exist on type 'String'.
                  ~

--- a/tests/baselines/reference/for-inStatementsDestructuring2.js
+++ b/tests/baselines/reference/for-inStatementsDestructuring2.js
@@ -4,4 +4,6 @@
 for (var {a, b} in []) {}
 
 //// [for-inStatementsDestructuring2.js]
-for (var _a = void 0, a = _a.a, b = _a.b in []) { }
+for (var key_1 in []) {
+    var a = key_1.a, b = key_1.b;
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring3.errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring3.errors.txt
@@ -1,8 +1,8 @@
-for-inStatementsDestructuring3.ts(2,6): error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
+for-inStatementsDestructuring3.ts(2,6): error TS2461: Type '"length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"' is not an array type.
 
 
 ==== for-inStatementsDestructuring3.ts (1 errors) ====
     var a, b;
     for ([a, b] in []) { }
          ~~~~~~
-!!! error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
+!!! error TS2461: Type '"length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"' is not an array type.

--- a/tests/baselines/reference/for-inStatementsDestructuring4.errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring4.errors.txt
@@ -1,8 +1,11 @@
-for-inStatementsDestructuring4.ts(2,6): error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
+for-inStatementsDestructuring4.ts(2,7): error TS2339: Property 'a' does not exist on type '"length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"'.
+for-inStatementsDestructuring4.ts(2,10): error TS2339: Property 'b' does not exist on type '"length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"'.
 
 
-==== for-inStatementsDestructuring4.ts (1 errors) ====
+==== for-inStatementsDestructuring4.ts (2 errors) ====
     var a, b;
     for ({a, b} in []) { }
-         ~~~~~~
-!!! error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
+          ~
+!!! error TS2339: Property 'a' does not exist on type '"length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"'.
+             ~
+!!! error TS2339: Property 'b' does not exist on type '"length" | "toString" | "toLocaleString" | "pop" | "push" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"'.

--- a/tests/baselines/reference/for-inStatementsDestructuring4.js
+++ b/tests/baselines/reference/for-inStatementsDestructuring4.js
@@ -6,4 +6,6 @@ for ({a, b} in []) { }
 
 //// [for-inStatementsDestructuring4.js]
 var a, b;
-for ({ a: a, b: b } in []) { }
+for (var key_1 in []) {
+    a = key_1.a, b = key_1.b;
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).errors.txt
@@ -1,0 +1,11 @@
+for-inStatementsDestructuring5.ts(4,6): error TS2461: Type 'string' is not an array type.
+
+
+==== for-inStatementsDestructuring5.ts (1 errors) ====
+    let a: string;
+    declare let obj: { [s: string]: string };
+    
+    for ([a] in obj) {}
+         ~~~
+!!! error TS2461: Type 'string' is not an array type.
+    

--- a/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).js
+++ b/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).js
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts] ////
+
+//// [for-inStatementsDestructuring5.ts]
+let a: string;
+declare let obj: { [s: string]: string };
+
+for ([a] in obj) {}
+
+
+//// [for-inStatementsDestructuring5.js]
+var a;
+for ([a] in obj) { }

--- a/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).symbols
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts] ////
+
+=== for-inStatementsDestructuring5.ts ===
+let a: string;
+>a : Symbol(a, Decl(for-inStatementsDestructuring5.ts, 0, 3))
+
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring5.ts, 1, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring5.ts, 1, 20))
+
+for ([a] in obj) {}
+>a : Symbol(a, Decl(for-inStatementsDestructuring5.ts, 0, 3))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring5.ts, 1, 11))
+

--- a/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).types
+++ b/tests/baselines/reference/for-inStatementsDestructuring5(target=es5).types
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts] ////
+
+=== for-inStatementsDestructuring5.ts ===
+let a: string;
+>a : string
+
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for ([a] in obj) {}
+>[a] : [string]
+>a : string
+>obj : { [s: string]: string; }
+

--- a/tests/baselines/reference/for-inStatementsDestructuring5(target=esnext).js
+++ b/tests/baselines/reference/for-inStatementsDestructuring5(target=esnext).js
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts] ////
+
+//// [for-inStatementsDestructuring5.ts]
+let a: string;
+declare let obj: { [s: string]: string };
+
+for ([a] in obj) {}
+
+
+//// [for-inStatementsDestructuring5.js]
+let a;
+for ([a] in obj) { }

--- a/tests/baselines/reference/for-inStatementsDestructuring5(target=esnext).symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring5(target=esnext).symbols
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts] ////
+
+=== for-inStatementsDestructuring5.ts ===
+let a: string;
+>a : Symbol(a, Decl(for-inStatementsDestructuring5.ts, 0, 3))
+
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring5.ts, 1, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring5.ts, 1, 20))
+
+for ([a] in obj) {}
+>a : Symbol(a, Decl(for-inStatementsDestructuring5.ts, 0, 3))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring5.ts, 1, 11))
+

--- a/tests/baselines/reference/for-inStatementsDestructuring5(target=esnext).types
+++ b/tests/baselines/reference/for-inStatementsDestructuring5(target=esnext).types
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts] ////
+
+=== for-inStatementsDestructuring5.ts ===
+let a: string;
+>a : string
+
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for ([a] in obj) {}
+>[a] : [string]
+>a : string
+>obj : { [s: string]: string; }
+

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).errors.txt
@@ -1,0 +1,12 @@
+for-inStatementsDestructuring6.ts(5,6): error TS2461: Type 'string' is not an array type.
+
+
+==== for-inStatementsDestructuring6.ts (1 errors) ====
+    let b: number;
+    let c: string[];
+    declare let obj: { [s: string]: string };
+    
+    for ([b, ...c] in obj) {}
+         ~~~~~~~~~
+!!! error TS2461: Type 'string' is not an array type.
+    

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).js
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts] ////
+
+//// [for-inStatementsDestructuring6.ts]
+let b: number;
+let c: string[];
+declare let obj: { [s: string]: string };
+
+for ([b, ...c] in obj) {}
+
+
+//// [for-inStatementsDestructuring6.js]
+var b;
+var c;
+for (var key_1 in obj) {
+    b = key_1[0], c = key_1.slice(1);
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts] ////
+
+=== for-inStatementsDestructuring6.ts ===
+let b: number;
+>b : Symbol(b, Decl(for-inStatementsDestructuring6.ts, 0, 3))
+
+let c: string[];
+>c : Symbol(c, Decl(for-inStatementsDestructuring6.ts, 1, 3))
+
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring6.ts, 2, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring6.ts, 2, 20))
+
+for ([b, ...c] in obj) {}
+>b : Symbol(b, Decl(for-inStatementsDestructuring6.ts, 0, 3))
+>c : Symbol(c, Decl(for-inStatementsDestructuring6.ts, 1, 3))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring6.ts, 2, 11))
+

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).types
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=es5).types
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts] ////
+
+=== for-inStatementsDestructuring6.ts ===
+let b: number;
+>b : number
+
+let c: string[];
+>c : string[]
+
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for ([b, ...c] in obj) {}
+>[b, ...c] : [number, ...string[]]
+>b : number
+>...c : string
+>c : string[]
+>obj : { [s: string]: string; }
+

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).errors.txt
@@ -1,0 +1,12 @@
+for-inStatementsDestructuring6.ts(5,7): error TS2322: Type 'string' is not assignable to type 'number'.
+
+
+==== for-inStatementsDestructuring6.ts (1 errors) ====
+    let b: number;
+    let c: string[];
+    declare let obj: { [s: string]: string };
+    
+    for ([b, ...c] in obj) {}
+          ~
+!!! error TS2322: Type 'string' is not assignable to type 'number'.
+    

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).js
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).js
@@ -1,0 +1,14 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts] ////
+
+//// [for-inStatementsDestructuring6.ts]
+let b: number;
+let c: string[];
+declare let obj: { [s: string]: string };
+
+for ([b, ...c] in obj) {}
+
+
+//// [for-inStatementsDestructuring6.js]
+let b;
+let c;
+for ([b, ...c] in obj) { }

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts] ////
+
+=== for-inStatementsDestructuring6.ts ===
+let b: number;
+>b : Symbol(b, Decl(for-inStatementsDestructuring6.ts, 0, 3))
+
+let c: string[];
+>c : Symbol(c, Decl(for-inStatementsDestructuring6.ts, 1, 3))
+
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring6.ts, 2, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring6.ts, 2, 20))
+
+for ([b, ...c] in obj) {}
+>b : Symbol(b, Decl(for-inStatementsDestructuring6.ts, 0, 3))
+>c : Symbol(c, Decl(for-inStatementsDestructuring6.ts, 1, 3))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring6.ts, 2, 11))
+

--- a/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).types
+++ b/tests/baselines/reference/for-inStatementsDestructuring6(target=esnext).types
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts] ////
+
+=== for-inStatementsDestructuring6.ts ===
+let b: number;
+>b : number
+
+let c: string[];
+>c : string[]
+
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for ([b, ...c] in obj) {}
+>[b, ...c] : [number, ...string[]]
+>b : number
+>...c : string
+>c : string[]
+>obj : { [s: string]: string; }
+

--- a/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).errors.txt
@@ -1,0 +1,13 @@
+for-inStatementsDestructuring7.ts(3,10): error TS2461: Type 'string' is not an array type.
+
+
+==== for-inStatementsDestructuring7.ts (1 errors) ====
+    declare let obj: { [s: string]: string };
+    
+    for (let [b, ...c] in obj) {
+             ~~~~~~~~~
+!!! error TS2461: Type 'string' is not an array type.
+        b;
+        c;
+    }
+    

--- a/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).js
+++ b/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).js
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts] ////
+
+//// [for-inStatementsDestructuring7.ts]
+declare let obj: { [s: string]: string };
+
+for (let [b, ...c] in obj) {
+    b;
+    c;
+}
+
+
+//// [for-inStatementsDestructuring7.js]
+for (var key_1 in obj) {
+    var b = key_1[0], c = key_1.slice(1);
+    b;
+    c;
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts] ////
+
+=== for-inStatementsDestructuring7.ts ===
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring7.ts, 0, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring7.ts, 0, 20))
+
+for (let [b, ...c] in obj) {
+>b : Symbol(b, Decl(for-inStatementsDestructuring7.ts, 2, 10))
+>c : Symbol(c, Decl(for-inStatementsDestructuring7.ts, 2, 12))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring7.ts, 0, 11))
+
+    b;
+>b : Symbol(b, Decl(for-inStatementsDestructuring7.ts, 2, 10))
+
+    c;
+>c : Symbol(c, Decl(for-inStatementsDestructuring7.ts, 2, 12))
+}
+

--- a/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).types
+++ b/tests/baselines/reference/for-inStatementsDestructuring7(target=es5).types
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts] ////
+
+=== for-inStatementsDestructuring7.ts ===
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for (let [b, ...c] in obj) {
+>b : any
+>c : any[]
+>obj : { [s: string]: string; }
+
+    b;
+>b : any
+
+    c;
+>c : any[]
+}
+

--- a/tests/baselines/reference/for-inStatementsDestructuring7(target=esnext).js
+++ b/tests/baselines/reference/for-inStatementsDestructuring7(target=esnext).js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts] ////
+
+//// [for-inStatementsDestructuring7.ts]
+declare let obj: { [s: string]: string };
+
+for (let [b, ...c] in obj) {
+    b;
+    c;
+}
+
+
+//// [for-inStatementsDestructuring7.js]
+for (let [b, ...c] in obj) {
+    b;
+    c;
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring7(target=esnext).symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring7(target=esnext).symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts] ////
+
+=== for-inStatementsDestructuring7.ts ===
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring7.ts, 0, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring7.ts, 0, 20))
+
+for (let [b, ...c] in obj) {
+>b : Symbol(b, Decl(for-inStatementsDestructuring7.ts, 2, 10))
+>c : Symbol(c, Decl(for-inStatementsDestructuring7.ts, 2, 12))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring7.ts, 0, 11))
+
+    b;
+>b : Symbol(b, Decl(for-inStatementsDestructuring7.ts, 2, 10))
+
+    c;
+>c : Symbol(c, Decl(for-inStatementsDestructuring7.ts, 2, 12))
+}
+

--- a/tests/baselines/reference/for-inStatementsDestructuring7(target=esnext).types
+++ b/tests/baselines/reference/for-inStatementsDestructuring7(target=esnext).types
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts] ////
+
+=== for-inStatementsDestructuring7.ts ===
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for (let [b, ...c] in obj) {
+>b : string
+>c : string[]
+>obj : { [s: string]: string; }
+
+    b;
+>b : string
+
+    c;
+>c : string[]
+}
+

--- a/tests/baselines/reference/for-inStatementsDestructuring8.js
+++ b/tests/baselines/reference/for-inStatementsDestructuring8.js
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring8.ts] ////
+
+//// [for-inStatementsDestructuring8.ts]
+declare let obj: { [s: string]: string };
+
+for (let { length: length1 } in obj) {
+    length1
+}
+
+
+//// [for-inStatementsDestructuring8.js]
+for (var key_1 in obj) {
+    var length1 = key_1.length;
+    length1;
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring8.symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring8.symbols
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring8.ts] ////
+
+=== for-inStatementsDestructuring8.ts ===
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring8.ts, 0, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring8.ts, 0, 20))
+
+for (let { length: length1 } in obj) {
+>length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
+>length1 : Symbol(length1, Decl(for-inStatementsDestructuring8.ts, 2, 10))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring8.ts, 0, 11))
+
+    length1
+>length1 : Symbol(length1, Decl(for-inStatementsDestructuring8.ts, 2, 10))
+}
+

--- a/tests/baselines/reference/for-inStatementsDestructuring8.types
+++ b/tests/baselines/reference/for-inStatementsDestructuring8.types
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring8.ts] ////
+
+=== for-inStatementsDestructuring8.ts ===
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for (let { length: length1 } in obj) {
+>length : any
+>length1 : number
+>obj : { [s: string]: string; }
+
+    length1
+>length1 : number
+}
+

--- a/tests/baselines/reference/for-inStatementsDestructuring9.js
+++ b/tests/baselines/reference/for-inStatementsDestructuring9.js
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring9.ts] ////
+
+//// [for-inStatementsDestructuring9.ts]
+let length1: number;
+declare let obj: { [s: string]: string };
+
+for ({ length: length1 } in obj) {}
+
+
+//// [for-inStatementsDestructuring9.js]
+var length1;
+for ({ length: length1 } in obj) { }

--- a/tests/baselines/reference/for-inStatementsDestructuring9.symbols
+++ b/tests/baselines/reference/for-inStatementsDestructuring9.symbols
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring9.ts] ////
+
+=== for-inStatementsDestructuring9.ts ===
+let length1: number;
+>length1 : Symbol(length1, Decl(for-inStatementsDestructuring9.ts, 0, 3))
+
+declare let obj: { [s: string]: string };
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring9.ts, 1, 11))
+>s : Symbol(s, Decl(for-inStatementsDestructuring9.ts, 1, 20))
+
+for ({ length: length1 } in obj) {}
+>length : Symbol(length, Decl(for-inStatementsDestructuring9.ts, 3, 6))
+>length1 : Symbol(length1, Decl(for-inStatementsDestructuring9.ts, 0, 3))
+>obj : Symbol(obj, Decl(for-inStatementsDestructuring9.ts, 1, 11))
+

--- a/tests/baselines/reference/for-inStatementsDestructuring9.types
+++ b/tests/baselines/reference/for-inStatementsDestructuring9.types
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring9.ts] ////
+
+=== for-inStatementsDestructuring9.ts ===
+let length1: number;
+>length1 : number
+
+declare let obj: { [s: string]: string };
+>obj : { [s: string]: string; }
+>s : string
+
+for ({ length: length1 } in obj) {}
+>{ length: length1 } : { length: number; }
+>length : number
+>length1 : number
+>obj : { [s: string]: string; }
+

--- a/tests/baselines/reference/parserForStatement5.errors.txt
+++ b/tests/baselines/reference/parserForStatement5.errors.txt
@@ -1,11 +1,8 @@
-parserForStatement5.ts(1,6): error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
 parserForStatement5.ts(1,12): error TS2304: Cannot find name 'b'.
 
 
-==== parserForStatement5.ts (2 errors) ====
+==== parserForStatement5.ts (1 errors) ====
     for ({} in b) {
-         ~~
-!!! error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
                ~
 !!! error TS2304: Cannot find name 'b'.
     }

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring5.ts
@@ -1,0 +1,6 @@
+// @target: es5, esnext
+
+let a: string;
+declare let obj: { [s: string]: string };
+
+for ([a] in obj) {}

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring6.ts
@@ -1,0 +1,7 @@
+// @target: es5, esnext
+
+let b: number;
+let c: string[];
+declare let obj: { [s: string]: string };
+
+for ([b, ...c] in obj) {}

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring7.ts
@@ -1,0 +1,8 @@
+// @target: es5, esnext
+
+declare let obj: { [s: string]: string };
+
+for (let [b, ...c] in obj) {
+    b;
+    c;
+}

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring8.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring8.ts
@@ -1,0 +1,5 @@
+declare let obj: { [s: string]: string };
+
+for (let { length: length1 } in obj) {
+    length1
+}

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring9.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring9.ts
@@ -1,0 +1,4 @@
+let length1: number;
+declare let obj: { [s: string]: string };
+
+for ({ length: length1 } in obj) {}


### PR DESCRIPTION
Why I'm doing this:
1. destructuring `string` is already supported in different contexts ([TS playground](https://www.typescriptlang.org/play?target=99#code/PTAEAEBcEMCcHMCmkBcpEGcB2iAekAoAYwHssNJQBtAMwEtYKAaUAOnZjoBsBdUAXlABySJkhCC9RoRCgAegH4CnLgVmKCxMhVABvUF0RZ4kABZpDxswEZQAXwHDRFCZZOnrasIqA)) so it should also be allowed here for consistency
2. the current es5 output is **incorrect** and can lead to a runtime crash if somebody ignores the fact that typechecking fails and grabs the emitted output. The current output looks like this: `for (var first = (void 0)[0] in { test: 1 }) { }`. As we can see, we end up with `undefined[0]` here