### PR TITLE
Fixed some variance measurements in type aliases of generic functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1915,6 +1915,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     var wildcardType = createIntrinsicType(TypeFlags.Any, "any");
     var errorType = createIntrinsicType(TypeFlags.Any, "error");
     var unresolvedType = createIntrinsicType(TypeFlags.Any, "unresolved");
+    var erasedType = createIntrinsicType(TypeFlags.Any, "erased");
     var nonInferrableAnyType = createIntrinsicType(TypeFlags.Any, "any", ObjectFlags.ContainsWideningType);
     var intrinsicMarkerType = createIntrinsicType(TypeFlags.Any, "intrinsic");
     var unknownType = createIntrinsicType(TypeFlags.Unknown, "unknown");
@@ -16288,6 +16289,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function addTypeToUnion(typeSet: Type[], includes: TypeFlags, type: Type) {
+        if (type === erasedType) {
+            return includes;
+        }
         const flags = type.flags;
         // We ignore 'never' types in unions
         if (!(flags & TypeFlags.Never)) {
@@ -16621,6 +16625,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function addTypeToIntersection(typeSet: Map<string, Type>, includes: TypeFlags, type: Type) {
+        if (type === erasedType) {
+            return includes;
+        }
         const flags = type.flags;
         if (flags & TypeFlags.Intersection) {
             return addTypesToIntersection(typeSet, includes, (type as IntersectionType).types);
@@ -18681,7 +18688,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function createTypeEraser(sources: readonly TypeParameter[]): TypeMapper {
-        return createTypeMapper(sources, /*targets*/ undefined);
+        return createTypeMapper(sources, sources.map(() => erasedType));
     }
 
     /**

--- a/tests/baselines/reference/complexRecursiveCollections.errors.txt
+++ b/tests/baselines/reference/complexRecursiveCollections.errors.txt
@@ -1,3 +1,6 @@
+immutable.ts(189,20): error TS2430: Interface 'Stack<T>' incorrectly extends interface 'Indexed<T>'.
+  The types returned by 'concat(...).filter(...)' are incompatible between these types.
+    Type 'Set<any>' is not assignable to type 'Indexed<any>'.
 immutable.ts(341,22): error TS2430: Interface 'Keyed<K, V>' incorrectly extends interface 'Collection<K, V>'.
   The types returned by 'toSeq()' are incompatible between these types.
     Type 'Keyed<K, V>' is not assignable to type 'this'.
@@ -33,7 +36,7 @@ immutable.ts(391,22): error TS2430: Interface 'Set<T>' incorrectly extends inter
         flatMap<M>(mapper: (value: T, key: void, iter: this) => Ara<M>, context?: any): N2<M>;
         toSeq(): N2<T>;
     }
-==== immutable.ts (3 errors) ====
+==== immutable.ts (4 errors) ====
     // Test that complex recursive collections can pass the `extends` assignability check without
     // running out of memory. This bug was exposed in Typescript 2.4 when more generic signatures
     // started being checked.
@@ -223,6 +226,10 @@ immutable.ts(391,22): error TS2430: Interface 'Set<T>' incorrectly extends inter
       export function Stack<T>(): Stack<T>;
       export function Stack<T>(collection: Iterable<T>): Stack<T>;
       export interface Stack<T> extends Collection.Indexed<T> {
+                       ~~~~~
+!!! error TS2430: Interface 'Stack<T>' incorrectly extends interface 'Indexed<T>'.
+!!! error TS2430:   The types returned by 'concat(...).filter(...)' are incompatible between these types.
+!!! error TS2430:     Type 'Set<any>' is not assignable to type 'Indexed<any>'.
         // Reading values
         peek(): T | undefined;
         // Persistent changes

--- a/tests/baselines/reference/complexRecursiveCollections.types
+++ b/tests/baselines/reference/complexRecursiveCollections.types
@@ -1139,7 +1139,7 @@ declare module Immutable {
 >Seq : typeof Seq
 
     function isSeq(maybeSeq: any): maybeSeq is Seq.Indexed<any> | Seq.Keyed<any, any>;
->isSeq : (maybeSeq: any) => maybeSeq is Indexed<any> | Keyed<any, any>
+>isSeq : (maybeSeq: any) => maybeSeq is Keyed<any, any> | Indexed<any>
 >maybeSeq : any
 >Seq : any
 >Seq : any

--- a/tests/baselines/reference/varianceAnnotations.errors.txt
+++ b/tests/baselines/reference/varianceAnnotations.errors.txt
@@ -64,9 +64,21 @@ varianceAnnotations.ts(160,68): error TS2345: Argument of type 'ActionObject<{ t
           Types of property '_storedEvent' are incompatible.
             Type '{ type: "PLAY"; value: number; } | { type: "RESET"; }' is not assignable to type '{ type: "PLAY"; value: number; }'.
               Type '{ type: "RESET"; }' is not assignable to type '{ type: "PLAY"; value: number; }'.
+varianceAnnotations.ts(177,15): error TS2636: Type 'F1_53210<sub-A>' is not assignable to type 'F1_53210<super-A>' as implied by variance annotation.
+  Types of parameters 'v' and 'v' are incompatible.
+    Type 'super-A' is not assignable to type 'sub-A'.
+varianceAnnotations.ts(178,15): error TS2636: Type 'F2_53210<sub-A>' is not assignable to type 'F2_53210<super-A>' as implied by variance annotation.
+  Types of parameters 'v2' and 'v2' are incompatible.
+    Type 'super-A' is not assignable to type 'sub-A'.
+varianceAnnotations.ts(179,15): error TS2636: Type 'F3_53210<sub-A>' is not assignable to type 'F3_53210<super-A>' as implied by variance annotation.
+  Types of parameters 'v2' and 'v2' are incompatible.
+    Type 'super-A' is not assignable to type 'sub-A'.
+varianceAnnotations.ts(180,15): error TS2636: Type 'F4_53210<sub-A>' is not assignable to type 'F4_53210<super-A>' as implied by variance annotation.
+  Types of parameters 'v' and 'v' are incompatible.
+    Type 'super-A' is not assignable to type 'sub-A'.
 
 
-==== varianceAnnotations.ts (31 errors) ====
+==== varianceAnnotations.ts (35 errors) ====
     type Covariant<out T> = {
         x: T;
     }
@@ -339,3 +351,24 @@ varianceAnnotations.ts(160,68): error TS2345: Argument of type 'ActionObject<{ t
         }
     }
     
+    // https://github.com/microsoft/TypeScript/issues/53210#issuecomment-1468551245
+    type F1_53210<out A> = <X>(v: X & A) => unknown;
+                  ~~~~~
+!!! error TS2636: Type 'F1_53210<sub-A>' is not assignable to type 'F1_53210<super-A>' as implied by variance annotation.
+!!! error TS2636:   Types of parameters 'v' and 'v' are incompatible.
+!!! error TS2636:     Type 'super-A' is not assignable to type 'sub-A'.
+    type F2_53210<out A> = <X>(v1: X, v2: A) => unknown;
+                  ~~~~~
+!!! error TS2636: Type 'F2_53210<sub-A>' is not assignable to type 'F2_53210<super-A>' as implied by variance annotation.
+!!! error TS2636:   Types of parameters 'v2' and 'v2' are incompatible.
+!!! error TS2636:     Type 'super-A' is not assignable to type 'sub-A'.
+    type F3_53210<out A> = <X>(v2: A) => X;
+                  ~~~~~
+!!! error TS2636: Type 'F3_53210<sub-A>' is not assignable to type 'F3_53210<super-A>' as implied by variance annotation.
+!!! error TS2636:   Types of parameters 'v2' and 'v2' are incompatible.
+!!! error TS2636:     Type 'super-A' is not assignable to type 'sub-A'.
+    type F4_53210<out A> = <X>(v: X | A) => unknown;
+                  ~~~~~
+!!! error TS2636: Type 'F4_53210<sub-A>' is not assignable to type 'F4_53210<super-A>' as implied by variance annotation.
+!!! error TS2636:   Types of parameters 'v' and 'v' are incompatible.
+!!! error TS2636:     Type 'super-A' is not assignable to type 'sub-A'.

--- a/tests/baselines/reference/varianceAnnotations.js
+++ b/tests/baselines/reference/varianceAnnotations.js
@@ -176,6 +176,11 @@ let OuterC = class C<out T> {
     }
 }
 
+// https://github.com/microsoft/TypeScript/issues/53210#issuecomment-1468551245
+type F1_53210<out A> = <X>(v: X & A) => unknown;
+type F2_53210<out A> = <X>(v1: X, v2: A) => unknown;
+type F3_53210<out A> = <X>(v2: A) => X;
+type F4_53210<out A> = <X>(v: X | A) => unknown;
 
 //// [varianceAnnotations.js]
 "use strict";
@@ -336,3 +341,7 @@ declare let OuterC: {
         foo(): any;
     };
 };
+type F1_53210<out A> = <X>(v: X & A) => unknown;
+type F2_53210<out A> = <X>(v1: X, v2: A) => unknown;
+type F3_53210<out A> = <X>(v2: A) => X;
+type F4_53210<out A> = <X>(v: X | A) => unknown;

--- a/tests/baselines/reference/varianceAnnotations.symbols
+++ b/tests/baselines/reference/varianceAnnotations.symbols
@@ -482,3 +482,37 @@ let OuterC = class C<out T> {
     }
 }
 
+// https://github.com/microsoft/TypeScript/issues/53210#issuecomment-1468551245
+type F1_53210<out A> = <X>(v: X & A) => unknown;
+>F1_53210 : Symbol(F1_53210, Decl(varianceAnnotations.ts, 173, 1))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 176, 14))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 176, 24))
+>v : Symbol(v, Decl(varianceAnnotations.ts, 176, 27))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 176, 24))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 176, 14))
+
+type F2_53210<out A> = <X>(v1: X, v2: A) => unknown;
+>F2_53210 : Symbol(F2_53210, Decl(varianceAnnotations.ts, 176, 48))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 177, 14))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 177, 24))
+>v1 : Symbol(v1, Decl(varianceAnnotations.ts, 177, 27))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 177, 24))
+>v2 : Symbol(v2, Decl(varianceAnnotations.ts, 177, 33))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 177, 14))
+
+type F3_53210<out A> = <X>(v2: A) => X;
+>F3_53210 : Symbol(F3_53210, Decl(varianceAnnotations.ts, 177, 52))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 178, 14))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 178, 24))
+>v2 : Symbol(v2, Decl(varianceAnnotations.ts, 178, 27))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 178, 14))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 178, 24))
+
+type F4_53210<out A> = <X>(v: X | A) => unknown;
+>F4_53210 : Symbol(F4_53210, Decl(varianceAnnotations.ts, 178, 39))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 179, 14))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 179, 24))
+>v : Symbol(v, Decl(varianceAnnotations.ts, 179, 27))
+>X : Symbol(X, Decl(varianceAnnotations.ts, 179, 24))
+>A : Symbol(A, Decl(varianceAnnotations.ts, 179, 14))
+

--- a/tests/baselines/reference/varianceAnnotations.types
+++ b/tests/baselines/reference/varianceAnnotations.types
@@ -371,3 +371,21 @@ let OuterC = class C<out T> {
     }
 }
 
+// https://github.com/microsoft/TypeScript/issues/53210#issuecomment-1468551245
+type F1_53210<out A> = <X>(v: X & A) => unknown;
+>F1_53210 : F1_53210<A>
+>v : X & A
+
+type F2_53210<out A> = <X>(v1: X, v2: A) => unknown;
+>F2_53210 : F2_53210<A>
+>v1 : X
+>v2 : A
+
+type F3_53210<out A> = <X>(v2: A) => X;
+>F3_53210 : F3_53210<A>
+>v2 : A
+
+type F4_53210<out A> = <X>(v: X | A) => unknown;
+>F4_53210 : F4_53210<A>
+>v : A | X
+

--- a/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
+++ b/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
@@ -175,3 +175,9 @@ let OuterC = class C<out T> {
         return this;
     }
 }
+
+// https://github.com/microsoft/TypeScript/issues/53210#issuecomment-1468551245
+type F1_53210<out A> = <X>(v: X & A) => unknown;
+type F2_53210<out A> = <X>(v1: X, v2: A) => unknown;
+type F3_53210<out A> = <X>(v2: A) => X;
+type F4_53210<out A> = <X>(v: X | A) => unknown;


### PR DESCRIPTION
An experiment on how the variance measurement could be improved when intersections and unions are involved in situations like this.

related to the issue found [here](https://github.com/microsoft/TypeScript/issues/53210#issuecomment-1468551245), cc @RyanCavanaugh 