### PR TITLE
Fix auto import path mapping when first pattern fails

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -775,7 +775,9 @@ function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<rea
                         validateEnding({ ending, value })
                     ) {
                         const matchedStar = value.substring(prefix.length, value.length - suffix.length);
-                        return pathIsRelative(matchedStar) ? undefined : key.replace("*", matchedStar);
+                        if (!pathIsRelative(matchedStar)) {
+                            return key.replace("*", matchedStar);
+                        }
                     }
                 }
             }

--- a/tests/cases/fourslash/autoImportPaths.ts
+++ b/tests/cases/fourslash/autoImportPaths.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /package1/jsconfig.json
+//// {
+////   "compilerOptions": {
+////     checkJs: true,
+////     "paths": {
+////       "package1/*": ["./*"],
+////       "package2/*": ["../package2/*"]
+////     },
+////     "baseUrl": "."
+////   },
+////   "include": [
+////     ".",
+////     "../package2"
+////   ]
+//// }
+
+// @Filename: /package1/file1.js
+//// bar/**/
+
+// @Filename: /package2/file1.js
+//// export const bar = 0;
+
+verify.importFixModuleSpecifiers("", ["package2/file1"], { importModuleSpecifierPreference: "shortest" });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54324
