### PR TITLE
Fix export as default not auto importing

### DIFF
--- a/tests/cases/fourslash/importNameCodeFixExportAsDefault.ts
+++ b/tests/cases/fourslash/importNameCodeFixExportAsDefault.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /foo.ts
+////const foo = 'foo'
+////export { foo as default }
+
+// @Filename: /index.ts
+//// foo/**/
+
+verify.applyCodeActionFromCompletion("", {
+  name: "foo",
+  source: "/foo",
+  description: `Add import from "./foo"`,
+  newFileContent: `import foo from "./foo";\n\nfoo`,
+  preferences: {
+    includeCompletionsForModuleExports: true
+  }
+});

--- a/tests/cases/fourslash/importNameCodeFixExportAsDefaultExistingImport.ts
+++ b/tests/cases/fourslash/importNameCodeFixExportAsDefaultExistingImport.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts" />
+
+//// import [|{ v1, v2, v3 }|] from "./module";
+//// v4/*0*/();
+
+// @Filename: module.ts
+//// const v4 = 5;
+//// export { v4 as default };
+//// export const v1 = 5;
+//// export const v2 = 5;
+//// export const v3 = 5;
+
+verify.importFixAtPosition([`v4, { v1, v2, v3 }`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54839

### This PR is About...
A module exported with `export { foo as default }` is not auto-imported when typing `foo`.

### Details
- Added `aliased as default` export to `getDefaultLikeExportNameFromDeclaration`, so that the name for `export as default` can be the declaration name and passed to `exportInfo` for completion.
- Added test cases for `code fix` and `add import to existing`.
- Modified comments for descriptive explanation.

### Passed ✅
- Tests: `hereby runtests-parallel --light=false`
- Lint: `hereby lint`