### PR TITLE
Remove lib.d.ts line number info from new definition baselines

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -1445,6 +1445,7 @@ export class TestState {
         }: BaselineDocumentSpansWithFileContentsOptions<T>,
         spanToContextId: Map<T, number>,
     ) {
+        const isLibFile = /lib(?:.*)\.d\.ts$/.test(fileName);
         let readableContents = `// === ${fileName} ===`;
         let newContent = "";
         interface Detail {
@@ -1619,12 +1620,12 @@ export class TestState {
                 if (locationLine - posLine > nLines) {
                     if (newContent) {
                         readableContents = readableContents + "\n" + readableJsoncBaseline(newContent + content.slice(pos, lineStarts[posLine + TestState.nLinesContext]) +
-                            `--- (line: ${posLine + TestState.nLinesContext + 1}) skipped ---`);
+                            `--- (line: ${isLibFile ? "--" : posLine + TestState.nLinesContext + 1}) skipped ---`);
                         if (location !== undefined) readableContents += "\n";
                         newContent = "";
                     }
                     if (location !== undefined) {
-                        newContent += `--- (line: ${locationLine - TestState.nLinesContext + 1}) skipped ---\n` +
+                        newContent += `--- (line: ${isLibFile ? "--" : locationLine - TestState.nLinesContext + 1}) skipped ---\n` +
                             content.slice(lineStarts[locationLine - TestState.nLinesContext + 1], location);
                     }
                     return;

--- a/tests/baselines/reference/goToTypeDefinition_Pick.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinition_Pick.baseline.jsonc
@@ -9,7 +9,7 @@
 // user2
 
 // === lib.d.ts ===
-// --- (line: 1588) skipped ---
+// --- (line: --) skipped ---
 // /**
 //  * From T, pick a set of properties whose keys are in the union K
 //  */
@@ -19,7 +19,7 @@
 // 
 // /**
 //  * Construct a type with a set of properties K of type T
-// --- (line: 1598) skipped ---
+// --- (line: --) skipped ---
 
   // === Details ===
   [
@@ -58,7 +58,7 @@
 // /*GOTO TYPE*/user2
 
 // === lib.d.ts ===
-// --- (line: 1588) skipped ---
+// --- (line: --) skipped ---
 // /**
 //  * From T, pick a set of properties whose keys are in the union K
 //  */
@@ -68,7 +68,7 @@
 // 
 // /**
 //  * Construct a type with a set of properties K of type T
-// --- (line: 1598) skipped ---
+// --- (line: --) skipped ---
 
   // === Details ===
   [

--- a/tests/baselines/reference/goToTypeDefinition_arrayType.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinition_arrayType.baseline.jsonc
@@ -9,7 +9,7 @@
 // --- (line: 7) skipped ---
 
 // === lib.d.ts ===
-// --- (line: 1310) skipped ---
+// --- (line: --) skipped ---
 //     slice(start?: number, end?: number): T[];
 // }
 // 
@@ -199,9 +199,9 @@
 // 
 // interface ArrayConstructor {
 //     new(arrayLength?: number): any[];
-// --- (line: 1500) skipped ---
+// --- (line: --) skipped ---
 
-// --- (line: 1505) skipped ---
+// --- (line: --) skipped ---
 //     readonly prototype: any[];
 // }
 // 
@@ -209,7 +209,7 @@
 // 
 // interface TypedPropertyDescriptor<T> {
 //     enumerable?: boolean;
-// --- (line: 1513) skipped ---
+// --- (line: --) skipped ---
 
   // === Details ===
   [
@@ -262,7 +262,7 @@
 // users3
 
 // === lib.d.ts ===
-// --- (line: 1310) skipped ---
+// --- (line: --) skipped ---
 //     slice(start?: number, end?: number): T[];
 // }
 // 
@@ -452,9 +452,9 @@
 // 
 // interface ArrayConstructor {
 //     new(arrayLength?: number): any[];
-// --- (line: 1500) skipped ---
+// --- (line: --) skipped ---
 
-// --- (line: 1505) skipped ---
+// --- (line: --) skipped ---
 //     readonly prototype: any[];
 // }
 // 
@@ -462,7 +462,7 @@
 // 
 // interface TypedPropertyDescriptor<T> {
 //     enumerable?: boolean;
-// --- (line: 1513) skipped ---
+// --- (line: --) skipped ---
 
   // === Details ===
   [

--- a/tests/baselines/reference/goToTypeDefinition_promiseType.baseline.jsonc
+++ b/tests/baselines/reference/goToTypeDefinition_promiseType.baseline.jsonc
@@ -8,7 +8,7 @@
 // export {}
 
 // === lib.d.ts ===
-// --- (line: 1531) skipped ---
+// --- (line: --) skipped ---
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
@@ -31,7 +31,7 @@
 // 
 // /**
 //  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
-// --- (line: 1554) skipped ---
+// --- (line: --) skipped ---
 
   // === Details ===
   [
@@ -69,7 +69,7 @@
 // export {}
 
 // === lib.d.ts ===
-// --- (line: 1531) skipped ---
+// --- (line: --) skipped ---
 // /**
 //  * Represents the completion of an asynchronous operation
 //  */
@@ -92,7 +92,7 @@
 // 
 // /**
 //  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
-// --- (line: 1554) skipped ---
+// --- (line: --) skipped ---
 
   // === Details ===
   [


### PR DESCRIPTION
Similar to #52380 but for the new definition baselines; these baselines are also sensitive to the line number of `lib.d.ts` files, which is currently being hit in #54820 (which reformats `src/lib`) but could happen at any future time on a lib update too.