### PR TITLE
allow a colon directly after @ts-check/nocheck

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -10466,7 +10466,7 @@ function getNamedArgRegEx(name: string): RegExp {
 }
 
 const tripleSlashXMLCommentStartRegEx = /^\/\/\/\s*<(\S+)\s.*?\/>/im;
-const singleLinePragmaRegEx = /^\/\/\/?\s*@([^\s:]+)[\s:]*(.*)\s*$/im;
+const singleLinePragmaRegEx = /^\/\/\/?\s*@([^\s:]+)(.*)\s*$/im;
 function extractPragmas(pragmas: PragmaPseudoMapEntry[], range: CommentRange, text: string) {
     const tripleSlash = range.kind === SyntaxKind.SingleLineCommentTrivia && tripleSlashXMLCommentStartRegEx.exec(text);
     if (tripleSlash) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -10466,7 +10466,7 @@ function getNamedArgRegEx(name: string): RegExp {
 }
 
 const tripleSlashXMLCommentStartRegEx = /^\/\/\/\s*<(\S+)\s.*?\/>/im;
-const singleLinePragmaRegEx = /^\/\/\/?\s*@(\S+)\s*(.*)\s*$/im;
+const singleLinePragmaRegEx = /^\/\/\/?\s*@([^\s:]+)[\s:]*(.*)\s*$/im;
 function extractPragmas(pragmas: PragmaPseudoMapEntry[], range: CommentRange, text: string) {
     const tripleSlash = range.kind === SyntaxKind.SingleLineCommentTrivia && tripleSlashXMLCommentStartRegEx.exec(text);
     if (tripleSlash) {

--- a/tests/baselines/reference/ts-expect-error.errors.txt
+++ b/tests/baselines/reference/ts-expect-error.errors.txt
@@ -68,3 +68,11 @@ ts-expect-error.ts(40,2): error TS2367: This comparison appears to be unintentio
     (({ a: true } as const).a === false); // error
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types 'true' and 'false' have no overlap.
+    
+    // @ts-expect-error: additional commenting with no whitespace
+    var invalidCommentedFancySingle: number = 'nope';
+    
+    /*
+     @ts-expect-error: additional commenting with no whitespace */
+    var invalidCommentedFancyMulti: number = 'nope';
+    

--- a/tests/baselines/reference/ts-expect-error.js
+++ b/tests/baselines/reference/ts-expect-error.js
@@ -42,6 +42,14 @@ var validPlain: string = 'nope';
 (({ a: true } as const).a === false); // error
 (({ a: true } as const).a === false); // error
 
+// @ts-expect-error: additional commenting with no whitespace
+var invalidCommentedFancySingle: number = 'nope';
+
+/*
+ @ts-expect-error: additional commenting with no whitespace */
+var invalidCommentedFancyMulti: number = 'nope';
+
+
 //// [ts-expect-error.js]
 // @ts-expect-error additional commenting
 var invalidCommentedFancySingle = 'nope';
@@ -71,3 +79,8 @@ var validPlain = 'nope';
 ({ a: true }.a === false); // Should error
 ({ a: true }.a === false); // error
 ({ a: true }.a === false); // error
+// @ts-expect-error: additional commenting with no whitespace
+var invalidCommentedFancySingle = 'nope';
+/*
+ @ts-expect-error: additional commenting with no whitespace */
+var invalidCommentedFancyMulti = 'nope';

--- a/tests/baselines/reference/ts-expect-error.symbols
+++ b/tests/baselines/reference/ts-expect-error.symbols
@@ -3,12 +3,12 @@
 === ts-expect-error.ts ===
 // @ts-expect-error additional commenting
 var invalidCommentedFancySingle: number = 'nope';
->invalidCommentedFancySingle : Symbol(invalidCommentedFancySingle, Decl(ts-expect-error.ts, 1, 3))
+>invalidCommentedFancySingle : Symbol(invalidCommentedFancySingle, Decl(ts-expect-error.ts, 1, 3), Decl(ts-expect-error.ts, 42, 3))
 
 /*
  @ts-expect-error additional commenting */
 var invalidCommentedFancyMulti: number = 'nope';
->invalidCommentedFancyMulti : Symbol(invalidCommentedFancyMulti, Decl(ts-expect-error.ts, 5, 3))
+>invalidCommentedFancyMulti : Symbol(invalidCommentedFancyMulti, Decl(ts-expect-error.ts, 5, 3), Decl(ts-expect-error.ts, 46, 3))
 
 // @ts-expect-error additional commenting
 var validCommentedFancySingle: string = 'nope';
@@ -70,4 +70,13 @@ var validPlain: string = 'nope';
 >a : Symbol(a, Decl(ts-expect-error.ts, 39, 3))
 >const : Symbol(const)
 >a : Symbol(a, Decl(ts-expect-error.ts, 39, 3))
+
+// @ts-expect-error: additional commenting with no whitespace
+var invalidCommentedFancySingle: number = 'nope';
+>invalidCommentedFancySingle : Symbol(invalidCommentedFancySingle, Decl(ts-expect-error.ts, 1, 3), Decl(ts-expect-error.ts, 42, 3))
+
+/*
+ @ts-expect-error: additional commenting with no whitespace */
+var invalidCommentedFancyMulti: number = 'nope';
+>invalidCommentedFancyMulti : Symbol(invalidCommentedFancyMulti, Decl(ts-expect-error.ts, 5, 3), Decl(ts-expect-error.ts, 46, 3))
 

--- a/tests/baselines/reference/ts-expect-error.types
+++ b/tests/baselines/reference/ts-expect-error.types
@@ -106,3 +106,14 @@ var validPlain: string = 'nope';
 >a : true
 >false : false
 
+// @ts-expect-error: additional commenting with no whitespace
+var invalidCommentedFancySingle: number = 'nope';
+>invalidCommentedFancySingle : number
+>'nope' : "nope"
+
+/*
+ @ts-expect-error: additional commenting with no whitespace */
+var invalidCommentedFancyMulti: number = 'nope';
+>invalidCommentedFancyMulti : number
+>'nope' : "nope"
+

--- a/tests/baselines/reference/ts-ignore.errors.txt
+++ b/tests/baselines/reference/ts-ignore.errors.txt
@@ -20,3 +20,9 @@ ts-ignore.ts(13,5): error TS2322: Type 'string' is not assignable to type 'numbe
     
     var validPlain: string = 'nope';
     
+    // @ts-ignore: with additional commenting
+    var invalidCommentedFancy: number = 'nope';
+    
+    // @ts-ignore: with additional commenting
+    var validCommentedFancy: string = 'nope';
+    

--- a/tests/baselines/reference/ts-ignore.js
+++ b/tests/baselines/reference/ts-ignore.js
@@ -17,6 +17,12 @@ var invalidPlain: number = 'nope';
 
 var validPlain: string = 'nope';
 
+// @ts-ignore: with additional commenting
+var invalidCommentedFancy: number = 'nope';
+
+// @ts-ignore: with additional commenting
+var validCommentedFancy: string = 'nope';
+
 
 //// [ts-ignore.js]
 // @ts-ignore with additional commenting
@@ -29,3 +35,7 @@ var invalidCommentedPlain = 'nope';
 var validCommentedPlain = 'nope';
 var invalidPlain = 'nope';
 var validPlain = 'nope';
+// @ts-ignore: with additional commenting
+var invalidCommentedFancy = 'nope';
+// @ts-ignore: with additional commenting
+var validCommentedFancy = 'nope';

--- a/tests/baselines/reference/ts-ignore.symbols
+++ b/tests/baselines/reference/ts-ignore.symbols
@@ -3,11 +3,11 @@
 === ts-ignore.ts ===
 // @ts-ignore with additional commenting
 var invalidCommentedFancy: number = 'nope';
->invalidCommentedFancy : Symbol(invalidCommentedFancy, Decl(ts-ignore.ts, 1, 3))
+>invalidCommentedFancy : Symbol(invalidCommentedFancy, Decl(ts-ignore.ts, 1, 3), Decl(ts-ignore.ts, 17, 3))
 
 // @ts-ignore with additional commenting
 var validCommentedFancy: string = 'nope';
->validCommentedFancy : Symbol(validCommentedFancy, Decl(ts-ignore.ts, 4, 3))
+>validCommentedFancy : Symbol(validCommentedFancy, Decl(ts-ignore.ts, 4, 3), Decl(ts-ignore.ts, 20, 3))
 
 // @ts-ignore
 var invalidCommentedPlain: number = 'nope';
@@ -22,4 +22,12 @@ var invalidPlain: number = 'nope';
 
 var validPlain: string = 'nope';
 >validPlain : Symbol(validPlain, Decl(ts-ignore.ts, 14, 3))
+
+// @ts-ignore: with additional commenting
+var invalidCommentedFancy: number = 'nope';
+>invalidCommentedFancy : Symbol(invalidCommentedFancy, Decl(ts-ignore.ts, 1, 3), Decl(ts-ignore.ts, 17, 3))
+
+// @ts-ignore: with additional commenting
+var validCommentedFancy: string = 'nope';
+>validCommentedFancy : Symbol(validCommentedFancy, Decl(ts-ignore.ts, 4, 3), Decl(ts-ignore.ts, 20, 3))
 

--- a/tests/baselines/reference/ts-ignore.types
+++ b/tests/baselines/reference/ts-ignore.types
@@ -29,3 +29,13 @@ var validPlain: string = 'nope';
 >validPlain : string
 >'nope' : "nope"
 
+// @ts-ignore: with additional commenting
+var invalidCommentedFancy: number = 'nope';
+>invalidCommentedFancy : number
+>'nope' : "nope"
+
+// @ts-ignore: with additional commenting
+var validCommentedFancy: string = 'nope';
+>validCommentedFancy : string
+>'nope' : "nope"
+

--- a/tests/baselines/reference/tsNoCheckForTypescriptComments1.js
+++ b/tests/baselines/reference/tsNoCheckForTypescriptComments1.js
@@ -1,0 +1,60 @@
+//// [tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts] ////
+
+//// [file.ts]
+// @ts-nocheck additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+
+export interface Aleph {
+  q: number;
+}
+
+export class Bet implements Aleph {
+  q: string = 'lol'; // And so will this implements error
+}
+
+
+//// [file.js]
+"use strict";
+// @ts-nocheck additional comments
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Bet = exports.a = void 0;
+exports.a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+var Bet = /** @class */ (function () {
+    function Bet() {
+        this.q = 'lol'; // And so will this implements error
+    }
+    return Bet;
+}());
+exports.Bet = Bet;
+
+
+//// [file.d.ts]
+export declare const a: any;
+export interface Aleph {
+    q: number;
+}
+export declare class Bet implements Aleph {
+    q: string;
+}
+
+
+//// [DtsFileErrors]
+
+
+file.d.ts(6,5): error TS2416: Property 'q' in type 'Bet' is not assignable to the same property in base type 'Aleph'.
+  Type 'string' is not assignable to type 'number'.
+
+
+==== file.d.ts (1 errors) ====
+    export declare const a: any;
+    export interface Aleph {
+        q: number;
+    }
+    export declare class Bet implements Aleph {
+        q: string;
+        ~
+!!! error TS2416: Property 'q' in type 'Bet' is not assignable to the same property in base type 'Aleph'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
+    }
+    

--- a/tests/baselines/reference/tsNoCheckForTypescriptComments1.symbols
+++ b/tests/baselines/reference/tsNoCheckForTypescriptComments1.symbols
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts] ////
+
+=== file.ts ===
+// @ts-nocheck additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+>a : Symbol(a, Decl(file.ts, 2, 12))
+
+export interface Aleph {
+>Aleph : Symbol(Aleph, Decl(file.ts, 2, 24))
+
+  q: number;
+>q : Symbol(Aleph.q, Decl(file.ts, 4, 24))
+}
+
+export class Bet implements Aleph {
+>Bet : Symbol(Bet, Decl(file.ts, 6, 1))
+>Aleph : Symbol(Aleph, Decl(file.ts, 2, 24))
+
+  q: string = 'lol'; // And so will this implements error
+>q : Symbol(Bet.q, Decl(file.ts, 8, 35))
+}
+

--- a/tests/baselines/reference/tsNoCheckForTypescriptComments1.types
+++ b/tests/baselines/reference/tsNoCheckForTypescriptComments1.types
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts] ////
+
+=== file.ts ===
+// @ts-nocheck additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+>a : any
+>1 + {} : any
+>1 : 1
+>{} : {}
+
+export interface Aleph {
+  q: number;
+>q : number
+}
+
+export class Bet implements Aleph {
+>Bet : Bet
+
+  q: string = 'lol'; // And so will this implements error
+>q : string
+>'lol' : "lol"
+}
+

--- a/tests/baselines/reference/tsNoCheckForTypescriptComments2.js
+++ b/tests/baselines/reference/tsNoCheckForTypescriptComments2.js
@@ -1,0 +1,60 @@
+//// [tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts] ////
+
+//// [file.ts]
+// @ts-nocheck: additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+
+export interface Aleph {
+    q: number;
+}
+
+export class Bet implements Aleph {
+    q: string = "lol" // And so will this implements error
+}
+
+
+//// [file.js]
+"use strict";
+// @ts-nocheck: additional comments
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Bet = exports.a = void 0;
+exports.a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+var Bet = /** @class */ (function () {
+    function Bet() {
+        this.q = "lol"; // And so will this implements error
+    }
+    return Bet;
+}());
+exports.Bet = Bet;
+
+
+//// [file.d.ts]
+export declare const a: any;
+export interface Aleph {
+    q: number;
+}
+export declare class Bet implements Aleph {
+    q: string;
+}
+
+
+//// [DtsFileErrors]
+
+
+file.d.ts(6,5): error TS2416: Property 'q' in type 'Bet' is not assignable to the same property in base type 'Aleph'.
+  Type 'string' is not assignable to type 'number'.
+
+
+==== file.d.ts (1 errors) ====
+    export declare const a: any;
+    export interface Aleph {
+        q: number;
+    }
+    export declare class Bet implements Aleph {
+        q: string;
+        ~
+!!! error TS2416: Property 'q' in type 'Bet' is not assignable to the same property in base type 'Aleph'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
+    }
+    

--- a/tests/baselines/reference/tsNoCheckForTypescriptComments2.symbols
+++ b/tests/baselines/reference/tsNoCheckForTypescriptComments2.symbols
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts] ////
+
+=== file.ts ===
+// @ts-nocheck: additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+>a : Symbol(a, Decl(file.ts, 2, 12))
+
+export interface Aleph {
+>Aleph : Symbol(Aleph, Decl(file.ts, 2, 24))
+
+    q: number;
+>q : Symbol(Aleph.q, Decl(file.ts, 4, 24))
+}
+
+export class Bet implements Aleph {
+>Bet : Symbol(Bet, Decl(file.ts, 6, 1))
+>Aleph : Symbol(Aleph, Decl(file.ts, 2, 24))
+
+    q: string = "lol" // And so will this implements error
+>q : Symbol(Bet.q, Decl(file.ts, 8, 35))
+}
+

--- a/tests/baselines/reference/tsNoCheckForTypescriptComments2.types
+++ b/tests/baselines/reference/tsNoCheckForTypescriptComments2.types
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts] ////
+
+=== file.ts ===
+// @ts-nocheck: additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+>a : any
+>1 + {} : any
+>1 : 1
+>{} : {}
+
+export interface Aleph {
+    q: number;
+>q : number
+}
+
+export class Bet implements Aleph {
+>Bet : Bet
+
+    q: string = "lol" // And so will this implements error
+>q : string
+>"lol" : "lol"
+}
+

--- a/tests/cases/conformance/directives/ts-expect-error.ts
+++ b/tests/cases/conformance/directives/ts-expect-error.ts
@@ -38,3 +38,10 @@ var validPlain: string = 'nope';
 
 (({ a: true } as const).a === false); // error
 (({ a: true } as const).a === false); // error
+
+// @ts-expect-error: additional commenting with no whitespace
+var invalidCommentedFancySingle: number = 'nope';
+
+/*
+ @ts-expect-error: additional commenting with no whitespace */
+var invalidCommentedFancyMulti: number = 'nope';

--- a/tests/cases/conformance/directives/ts-ignore.ts
+++ b/tests/cases/conformance/directives/ts-ignore.ts
@@ -13,3 +13,9 @@ var validCommentedPlain: string = 'nope';
 var invalidPlain: number = 'nope';
 
 var validPlain: string = 'nope';
+
+// @ts-ignore: with additional commenting
+var invalidCommentedFancy: number = 'nope';
+
+// @ts-ignore: with additional commenting
+var validCommentedFancy: string = 'nope';

--- a/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts
+++ b/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+// @filename: file.ts
+
+// @ts-nocheck additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+
+export interface Aleph {
+  q: number;
+}
+
+export class Bet implements Aleph {
+  q: string = 'lol'; // And so will this implements error
+}

--- a/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts
+++ b/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+// @filename: file.ts
+
+// @ts-nocheck: additional comments
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+
+export interface Aleph {
+    q: number;
+}
+
+export class Bet implements Aleph {
+    q: string = "lol" // And so will this implements error
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] #54859 There is an associated issue in the `Backlog` milestone (**required**) 
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54859

`// @ts-ignore` and  `// @ts-expect-error` allow any characters after the pragma, which has encouraged people to use a colon between the pragma and any additional text. See the original issue #54859 for some examples.

For consistency, this PR makes `// @ts-check` and  `// @ts-nocheck` also allow a colon immediately after the pragma.

