### PR TITLE
Prevent substitution types from leaking out of non-deferred conditionals

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17335,8 +17335,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return true;
     }
 
-    function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, indexType: Type, fullIndexType: Type, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
+    function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, originalIndexType: Type, fullIndexType: Type, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
         const accessExpression = accessNode && accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode : undefined;
+        const indexType = originalIndexType.flags & TypeFlags.Substitution ?
+            getIntersectionType([(originalIndexType as SubstitutionType).baseType, (originalIndexType as SubstitutionType).constraint]) :
+            originalIndexType;
         const propName = accessNode && isPrivateIdentifier(accessNode) ? undefined : getPropertyNameFromIndex(indexType, accessNode);
 
         if (propName !== undefined) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17335,11 +17335,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return true;
     }
 
-    function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, originalIndexType: Type, fullIndexType: Type, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
+    function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, indexType: Type, fullIndexType: Type, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
         const accessExpression = accessNode && accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode : undefined;
-        const indexType = originalIndexType.flags & TypeFlags.Substitution ?
-            getIntersectionType([(originalIndexType as SubstitutionType).baseType, (originalIndexType as SubstitutionType).constraint]) :
-            originalIndexType;
         const propName = accessNode && isPrivateIdentifier(accessNode) ? undefined : getPropertyNameFromIndex(indexType, accessNode);
 
         if (propName !== undefined) {
@@ -17953,6 +17950,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             result.aliasSymbol = aliasSymbol || root.aliasSymbol;
             result.aliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(root.aliasTypeArguments, mapper!); // TODO: GH#18217
             break;
+        }
+        if (result.flags & TypeFlags.Substitution) {
+            const substitution = result as SubstitutionType;
+            result = getIntersectionType([substitution.baseType, substitution.constraint]);
         }
         return extraTypes ? getUnionType(append(extraTypes, result)) : result;
         // We tail-recurse for generic conditional types that (a) have not already been evaluated and cached, and

--- a/tests/baselines/reference/substitutionTypeUsedAsIndex.symbols
+++ b/tests/baselines/reference/substitutionTypeUsedAsIndex.symbols
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/substitutionTypeUsedAsIndex.ts] ////
+
+=== substitutionTypeUsedAsIndex.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54886
+
+interface Dict_54886 {
+>Dict_54886 : Symbol(Dict_54886, Decl(substitutionTypeUsedAsIndex.ts, 0, 0))
+
+  foo: 1;
+>foo : Symbol(Dict_54886.foo, Decl(substitutionTypeUsedAsIndex.ts, 2, 22))
+
+  bar: 1;
+>bar : Symbol(Dict_54886.bar, Decl(substitutionTypeUsedAsIndex.ts, 3, 9))
+}
+
+type FF_54886 = "foo" extends "foo" | "bar" ? "foo" : never;
+>FF_54886 : Symbol(FF_54886, Decl(substitutionTypeUsedAsIndex.ts, 5, 1))
+
+type C_54886 = Dict_54886[FF_54886]; // ok
+>C_54886 : Symbol(C_54886, Decl(substitutionTypeUsedAsIndex.ts, 7, 60))
+>Dict_54886 : Symbol(Dict_54886, Decl(substitutionTypeUsedAsIndex.ts, 0, 0))
+>FF_54886 : Symbol(FF_54886, Decl(substitutionTypeUsedAsIndex.ts, 5, 1))
+

--- a/tests/baselines/reference/substitutionTypeUsedAsIndex.types
+++ b/tests/baselines/reference/substitutionTypeUsedAsIndex.types
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/substitutionTypeUsedAsIndex.ts] ////
+
+=== substitutionTypeUsedAsIndex.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/54886
+
+interface Dict_54886 {
+  foo: 1;
+>foo : 1
+
+  bar: 1;
+>bar : 1
+}
+
+type FF_54886 = "foo" extends "foo" | "bar" ? "foo" : never;
+>FF_54886 : "foo"
+
+type C_54886 = Dict_54886[FF_54886]; // ok
+>C_54886 : 1
+

--- a/tests/cases/compiler/substitutionTypeUsedAsIndex.ts
+++ b/tests/cases/compiler/substitutionTypeUsedAsIndex.ts
@@ -1,0 +1,12 @@
+// @strict: true
+// @noEmit: true
+
+// repro from https://github.com/microsoft/TypeScript/issues/54886
+
+interface Dict_54886 {
+  foo: 1;
+  bar: 1;
+}
+
+type FF_54886 = "foo" extends "foo" | "bar" ? "foo" : never;
+type C_54886 = Dict_54886[FF_54886]; // ok


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/54886
