### PR TITLE
Add test for const enum usage with verbatimModuleSyntax

### DIFF
--- a/tests/baselines/reference/verbatimModuleSyntaxConstEnumUsage.js
+++ b/tests/baselines/reference/verbatimModuleSyntaxConstEnumUsage.js
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts] ////
+
+//// [foo.ts]
+export enum Foo {
+    a = 1,
+    b,
+    c,
+}
+
+//// [bar.ts]
+import {Foo} from './foo.js';
+
+export enum Bar {
+    a = Foo.a,
+    c = Foo.c,
+    e = 5,
+}
+
+//// [foo.js]
+export var Foo;
+(function (Foo) {
+    Foo[Foo["a"] = 1] = "a";
+    Foo[Foo["b"] = 2] = "b";
+    Foo[Foo["c"] = 3] = "c";
+})(Foo || (Foo = {}));
+//// [bar.js]
+import { Foo } from './foo.js';
+export var Bar;
+(function (Bar) {
+    Bar[Bar["a"] = 1] = "a";
+    Bar[Bar["c"] = 3] = "c";
+    Bar[Bar["e"] = 5] = "e";
+})(Bar || (Bar = {}));

--- a/tests/baselines/reference/verbatimModuleSyntaxConstEnumUsage.symbols
+++ b/tests/baselines/reference/verbatimModuleSyntaxConstEnumUsage.symbols
@@ -1,0 +1,38 @@
+//// [tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts] ////
+
+=== foo.ts ===
+export enum Foo {
+>Foo : Symbol(Foo, Decl(foo.ts, 0, 0))
+
+    a = 1,
+>a : Symbol(Foo.a, Decl(foo.ts, 0, 17))
+
+    b,
+>b : Symbol(Foo.b, Decl(foo.ts, 1, 10))
+
+    c,
+>c : Symbol(Foo.c, Decl(foo.ts, 2, 6))
+}
+
+=== bar.ts ===
+import {Foo} from './foo.js';
+>Foo : Symbol(Foo, Decl(bar.ts, 0, 8))
+
+export enum Bar {
+>Bar : Symbol(Bar, Decl(bar.ts, 0, 29))
+
+    a = Foo.a,
+>a : Symbol(Bar.a, Decl(bar.ts, 2, 17))
+>Foo.a : Symbol(Foo.a, Decl(foo.ts, 0, 17))
+>Foo : Symbol(Foo, Decl(bar.ts, 0, 8))
+>a : Symbol(Foo.a, Decl(foo.ts, 0, 17))
+
+    c = Foo.c,
+>c : Symbol(Bar.c, Decl(bar.ts, 3, 14))
+>Foo.c : Symbol(Foo.c, Decl(foo.ts, 2, 6))
+>Foo : Symbol(Foo, Decl(bar.ts, 0, 8))
+>c : Symbol(Foo.c, Decl(foo.ts, 2, 6))
+
+    e = 5,
+>e : Symbol(Bar.e, Decl(bar.ts, 4, 14))
+}

--- a/tests/baselines/reference/verbatimModuleSyntaxConstEnumUsage.types
+++ b/tests/baselines/reference/verbatimModuleSyntaxConstEnumUsage.types
@@ -1,0 +1,40 @@
+//// [tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts] ////
+
+=== foo.ts ===
+export enum Foo {
+>Foo : Foo
+
+    a = 1,
+>a : Foo.a
+>1 : 1
+
+    b,
+>b : Foo.b
+
+    c,
+>c : Foo.c
+}
+
+=== bar.ts ===
+import {Foo} from './foo.js';
+>Foo : typeof Foo
+
+export enum Bar {
+>Bar : Bar
+
+    a = Foo.a,
+>a : Bar.a
+>Foo.a : Foo.a
+>Foo : typeof Foo
+>a : Foo.a
+
+    c = Foo.c,
+>c : Bar.c
+>Foo.c : Foo.c
+>Foo : typeof Foo
+>c : Foo.c
+
+    e = 5,
+>e : Bar.e
+>5 : 5
+}

--- a/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
+++ b/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
@@ -1,0 +1,18 @@
+// @module: esnext
+// @verbatimModuleSyntax: true
+
+// @filename: foo.ts
+export enum Foo {
+    a = 1,
+    b,
+    c,
+}
+
+// @filename: bar.ts
+import {Foo} from './foo.js';
+
+export enum Bar {
+    a = Foo.a,
+    c = Foo.c,
+    e = 5,
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Test case for #49974, but with `verbatimModuleSyntax`, not `importsNotUsedAsValues`.
