### PR TITLE
fix: appropriate error message for out of scope label

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -48423,6 +48423,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let current: Node = node;
         while (current) {
             if (isFunctionLikeOrClassStaticBlockDeclaration(current)) {
+                if (node.label) {
+                    return grammarErrorOnNode(node, Diagnostics.Cannot_find_label_0, node.label.escapedText.toString())
+                }
                 return grammarErrorOnNode(node, Diagnostics.Jump_target_cannot_cross_function_boundary);
             }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7864,5 +7864,9 @@
     "'await using' statements cannot be used inside a class static block.": {
         "category": "Error",
         "code": 18054
+    },
+    "Cannot find label '{0}'.": {
+        "category": "Error",
+        "code": 18055
     }
 }

--- a/tests/baselines/reference/breakTarget5.errors.txt
+++ b/tests/baselines/reference/breakTarget5.errors.txt
@@ -1,4 +1,4 @@
-breakTarget5.ts(5,7): error TS1107: Jump target cannot cross function boundary.
+breakTarget5.ts(5,7): error TS18055: Cannot find label 'target'.
 
 
 ==== breakTarget5.ts (1 errors) ====
@@ -8,7 +8,7 @@ breakTarget5.ts(5,7): error TS1107: Jump target cannot cross function boundary.
         while (true) {
           break target;
           ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'target'.
         }
       }
     }

--- a/tests/baselines/reference/classStaticBlock8.errors.txt
+++ b/tests/baselines/reference/classStaticBlock8.errors.txt
@@ -1,5 +1,5 @@
-classStaticBlock8.ts(6,21): error TS1107: Jump target cannot cross function boundary.
-classStaticBlock8.ts(9,21): error TS1107: Jump target cannot cross function boundary.
+classStaticBlock8.ts(6,21): error TS18055: Cannot find label 'label'.
+classStaticBlock8.ts(9,21): error TS18055: Cannot find label 'label'.
 classStaticBlock8.ts(12,21): error TS1107: Jump target cannot cross function boundary.
 classStaticBlock8.ts(15,21): error TS1107: Jump target cannot cross function boundary.
 
@@ -12,12 +12,12 @@ classStaticBlock8.ts(15,21): error TS1107: Jump target cannot cross function bou
                     if (v === 1) {
                         break label;
                         ~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'label'.
                     }
                     if (v === 2) {
                         continue label;
                         ~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'label'.
                     }
                     if (v === 3) {
                         break

--- a/tests/baselines/reference/continueNotInIterationStatement4.errors.txt
+++ b/tests/baselines/reference/continueNotInIterationStatement4.errors.txt
@@ -1,4 +1,4 @@
-continueNotInIterationStatement4.ts(4,5): error TS1107: Jump target cannot cross function boundary.
+continueNotInIterationStatement4.ts(4,5): error TS18055: Cannot find label 'TWO'.
 
 
 ==== continueNotInIterationStatement4.ts (1 errors) ====
@@ -7,7 +7,7 @@ continueNotInIterationStatement4.ts(4,5): error TS1107: Jump target cannot cross
       var x = () => {
         continue TWO;
         ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
       }
     }
     

--- a/tests/baselines/reference/continueTarget5.errors.txt
+++ b/tests/baselines/reference/continueTarget5.errors.txt
@@ -1,4 +1,4 @@
-continueTarget5.ts(5,7): error TS1107: Jump target cannot cross function boundary.
+continueTarget5.ts(5,7): error TS18055: Cannot find label 'target'.
 
 
 ==== continueTarget5.ts (1 errors) ====
@@ -8,7 +8,7 @@ continueTarget5.ts(5,7): error TS1107: Jump target cannot cross function boundar
         while (true) {
           continue target;
           ~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'target'.
         }
       }
     }

--- a/tests/baselines/reference/invalidDoWhileBreakStatements.errors.txt
+++ b/tests/baselines/reference/invalidDoWhileBreakStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidDoWhileBreakStatements.ts(4,1): error TS1105: A 'break' statement can only be used within an enclosing iteration or switch statement.
 invalidDoWhileBreakStatements.ts(8,4): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
-invalidDoWhileBreakStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidDoWhileBreakStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidDoWhileBreakStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidDoWhileBreakStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidDoWhileBreakStatements.ts(27,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 invalidDoWhileBreakStatements.ts(37,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 
@@ -26,7 +26,7 @@ invalidDoWhileBreakStatements.ts(37,5): error TS1116: A 'break' statement can on
         var x = () => {
             break TWO;
             ~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }while (true)
     
@@ -35,7 +35,7 @@ invalidDoWhileBreakStatements.ts(37,5): error TS1116: A 'break' statement can on
         var fn = function () {
             break THREE;
             ~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }while (true)
     

--- a/tests/baselines/reference/invalidDoWhileContinueStatements.errors.txt
+++ b/tests/baselines/reference/invalidDoWhileContinueStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidDoWhileContinueStatements.ts(4,1): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
 invalidDoWhileContinueStatements.ts(8,4): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
-invalidDoWhileContinueStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidDoWhileContinueStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidDoWhileContinueStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidDoWhileContinueStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidDoWhileContinueStatements.ts(27,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 invalidDoWhileContinueStatements.ts(37,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 
@@ -26,7 +26,7 @@ invalidDoWhileContinueStatements.ts(37,5): error TS1115: A 'continue' statement 
         var x = () => {
             continue TWO;
             ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }while (true)
     
@@ -35,7 +35,7 @@ invalidDoWhileContinueStatements.ts(37,5): error TS1115: A 'continue' statement 
         var fn = function () {
             continue THREE;
             ~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }while (true)
     

--- a/tests/baselines/reference/invalidForBreakStatements.errors.txt
+++ b/tests/baselines/reference/invalidForBreakStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidForBreakStatements.ts(4,1): error TS1105: A 'break' statement can only be used within an enclosing iteration or switch statement.
 invalidForBreakStatements.ts(8,9): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
-invalidForBreakStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidForBreakStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidForBreakStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidForBreakStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidForBreakStatements.ts(27,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 invalidForBreakStatements.ts(36,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 
@@ -26,7 +26,7 @@ invalidForBreakStatements.ts(36,5): error TS1116: A 'break' statement can only j
         var x = () => {
             break TWO;
             ~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }
     
@@ -35,7 +35,7 @@ invalidForBreakStatements.ts(36,5): error TS1116: A 'break' statement can only j
         var fn = function () {
             break THREE;
             ~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }
     

--- a/tests/baselines/reference/invalidForContinueStatements.errors.txt
+++ b/tests/baselines/reference/invalidForContinueStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidForContinueStatements.ts(4,1): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
 invalidForContinueStatements.ts(8,9): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
-invalidForContinueStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidForContinueStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidForContinueStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidForContinueStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidForContinueStatements.ts(27,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 invalidForContinueStatements.ts(36,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 
@@ -26,7 +26,7 @@ invalidForContinueStatements.ts(36,5): error TS1115: A 'continue' statement can 
         var x = () => {
             continue TWO;
             ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }
     
@@ -35,7 +35,7 @@ invalidForContinueStatements.ts(36,5): error TS1115: A 'continue' statement can 
         var fn = function () {
             continue THREE;
             ~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }
     

--- a/tests/baselines/reference/invalidForInBreakStatements.errors.txt
+++ b/tests/baselines/reference/invalidForInBreakStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidForInBreakStatements.ts(4,1): error TS1105: A 'break' statement can only be used within an enclosing iteration or switch statement.
 invalidForInBreakStatements.ts(8,19): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
-invalidForInBreakStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidForInBreakStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidForInBreakStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidForInBreakStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidForInBreakStatements.ts(27,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 invalidForInBreakStatements.ts(37,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 
@@ -26,7 +26,7 @@ invalidForInBreakStatements.ts(37,5): error TS1116: A 'break' statement can only
         var fn = () => {
             break TWO;
             ~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }
     
@@ -35,7 +35,7 @@ invalidForInBreakStatements.ts(37,5): error TS1116: A 'break' statement can only
         var fn = function () {
             break THREE;
             ~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }
     

--- a/tests/baselines/reference/invalidForInContinueStatements.errors.txt
+++ b/tests/baselines/reference/invalidForInContinueStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidForInContinueStatements.ts(4,1): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
 invalidForInContinueStatements.ts(8,19): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
-invalidForInContinueStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidForInContinueStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidForInContinueStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidForInContinueStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidForInContinueStatements.ts(27,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 invalidForInContinueStatements.ts(37,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 
@@ -26,7 +26,7 @@ invalidForInContinueStatements.ts(37,5): error TS1115: A 'continue' statement ca
         var fn = () => {
             continue TWO;
             ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }
     
@@ -35,7 +35,7 @@ invalidForInContinueStatements.ts(37,5): error TS1115: A 'continue' statement ca
         var fn = function () {
             continue THREE;
             ~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }
     

--- a/tests/baselines/reference/invalidWhileBreakStatements.errors.txt
+++ b/tests/baselines/reference/invalidWhileBreakStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidWhileBreakStatements.ts(4,1): error TS1105: A 'break' statement can only be used within an enclosing iteration or switch statement.
 invalidWhileBreakStatements.ts(8,14): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
-invalidWhileBreakStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidWhileBreakStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidWhileBreakStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidWhileBreakStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidWhileBreakStatements.ts(27,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 invalidWhileBreakStatements.ts(37,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 
@@ -26,7 +26,7 @@ invalidWhileBreakStatements.ts(37,5): error TS1116: A 'break' statement can only
         var x = () => {
             break TWO;
             ~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }
     
@@ -35,7 +35,7 @@ invalidWhileBreakStatements.ts(37,5): error TS1116: A 'break' statement can only
         var fn = function () {
             break THREE;
             ~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }
     

--- a/tests/baselines/reference/invalidWhileContinueStatements.errors.txt
+++ b/tests/baselines/reference/invalidWhileContinueStatements.errors.txt
@@ -1,7 +1,7 @@
 invalidWhileContinueStatements.ts(4,1): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
 invalidWhileContinueStatements.ts(8,14): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
-invalidWhileContinueStatements.ts(14,9): error TS1107: Jump target cannot cross function boundary.
-invalidWhileContinueStatements.ts(21,9): error TS1107: Jump target cannot cross function boundary.
+invalidWhileContinueStatements.ts(14,9): error TS18055: Cannot find label 'TWO'.
+invalidWhileContinueStatements.ts(21,9): error TS18055: Cannot find label 'THREE'.
 invalidWhileContinueStatements.ts(27,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 invalidWhileContinueStatements.ts(37,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 
@@ -26,7 +26,7 @@ invalidWhileContinueStatements.ts(37,5): error TS1115: A 'continue' statement ca
         var x = () => {
             continue TWO;
             ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
         }
     }
     
@@ -35,7 +35,7 @@ invalidWhileContinueStatements.ts(37,5): error TS1115: A 'continue' statement ca
         var fn = function () {
             continue THREE;
             ~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'THREE'.
         }
     }
     

--- a/tests/baselines/reference/parser_breakTarget5.errors.txt
+++ b/tests/baselines/reference/parser_breakTarget5.errors.txt
@@ -1,4 +1,4 @@
-parser_breakTarget5.ts(5,7): error TS1107: Jump target cannot cross function boundary.
+parser_breakTarget5.ts(5,7): error TS18055: Cannot find label 'target'.
 
 
 ==== parser_breakTarget5.ts (1 errors) ====
@@ -8,7 +8,7 @@ parser_breakTarget5.ts(5,7): error TS1107: Jump target cannot cross function bou
         while (true) {
           break target;
           ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'target'.
         }
       }
     }

--- a/tests/baselines/reference/parser_continueNotInIterationStatement4.errors.txt
+++ b/tests/baselines/reference/parser_continueNotInIterationStatement4.errors.txt
@@ -1,4 +1,4 @@
-parser_continueNotInIterationStatement4.ts(4,5): error TS1107: Jump target cannot cross function boundary.
+parser_continueNotInIterationStatement4.ts(4,5): error TS18055: Cannot find label 'TWO'.
 
 
 ==== parser_continueNotInIterationStatement4.ts (1 errors) ====
@@ -7,7 +7,7 @@ parser_continueNotInIterationStatement4.ts(4,5): error TS1107: Jump target canno
       var x = () => {
         continue TWO;
         ~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'TWO'.
       }
     }
     

--- a/tests/baselines/reference/parser_continueTarget5.errors.txt
+++ b/tests/baselines/reference/parser_continueTarget5.errors.txt
@@ -1,4 +1,4 @@
-parser_continueTarget5.ts(5,7): error TS1107: Jump target cannot cross function boundary.
+parser_continueTarget5.ts(5,7): error TS18055: Cannot find label 'target'.
 
 
 ==== parser_continueTarget5.ts (1 errors) ====
@@ -8,7 +8,7 @@ parser_continueTarget5.ts(5,7): error TS1107: Jump target cannot cross function 
         while (true) {
           continue target;
           ~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
+!!! error TS18055: Cannot find label 'target'.
         }
       }
     }

--- a/tests/baselines/reference/plainJSBinderErrors.errors.txt
+++ b/tests/baselines/reference/plainJSBinderErrors.errors.txt
@@ -12,12 +12,11 @@ plainJSBinderErrors.js(22,15): error TS1210: Code contained in a class is evalua
 plainJSBinderErrors.js(23,15): error TS1210: Code contained in a class is evaluated in JavaScript's strict mode which does not allow this use of 'arguments'. For more information, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode.
 plainJSBinderErrors.js(27,9): error TS1101: 'with' statements are not allowed in strict mode.
 plainJSBinderErrors.js(33,13): error TS1344: 'A label is not allowed here.
-plainJSBinderErrors.js(34,13): error TS1107: Jump target cannot cross function boundary.
 plainJSBinderErrors.js(39,7): error TS1215: Invalid use of 'eval'. Modules are automatically in strict mode.
 plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules are automatically in strict mode.
 
 
-==== plainJSBinderErrors.js (17 errors) ====
+==== plainJSBinderErrors.js (16 errors) ====
     export default 12
     ~~~~~~~~~~~~~~~~~
 !!! error TS2528: A module cannot have multiple default exports.
@@ -82,8 +81,6 @@ plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules 
                 ~~~~~
 !!! error TS1344: 'A label is not allowed here.
                 break label
-                ~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
             }
             return x
         }

--- a/tests/baselines/reference/plainJSGrammarErrors.errors.txt
+++ b/tests/baselines/reference/plainJSGrammarErrors.errors.txt
@@ -88,9 +88,7 @@ plainJSGrammarErrors.js(154,5): error TS1113: A 'default' clause cannot appear m
 plainJSGrammarErrors.js(161,11): error TS2492: Cannot redeclare identifier 'e' in catch clause.
 plainJSGrammarErrors.js(167,12): error TS1197: Catch clause variable cannot have an initializer.
 plainJSGrammarErrors.js(170,5): error TS1114: Duplicate label 'label'.
-plainJSGrammarErrors.js(179,13): error TS1107: Jump target cannot cross function boundary.
 plainJSGrammarErrors.js(187,13): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
-plainJSGrammarErrors.js(191,5): error TS1107: Jump target cannot cross function boundary.
 plainJSGrammarErrors.js(194,5): error TS1116: A 'break' statement can only jump to a label of an enclosing statement.
 plainJSGrammarErrors.js(195,5): error TS1115: A 'continue' statement can only jump to a label of an enclosing iteration statement.
 plainJSGrammarErrors.js(197,1): error TS1105: A 'break' statement can only be used within an enclosing iteration or switch statement.
@@ -102,7 +100,7 @@ plainJSGrammarErrors.js(204,30): message TS1450: Dynamic imports can only accept
 plainJSGrammarErrors.js(205,36): error TS1325: Argument of dynamic import cannot be spread element.
 
 
-==== plainJSGrammarErrors.js (102 errors) ====
+==== plainJSGrammarErrors.js (100 errors) ====
     class C {
         // #private mistakes
         q = #unbound
@@ -462,8 +460,6 @@ plainJSGrammarErrors.js(205,36): error TS1325: Argument of dynamic import cannot
         outer: for(;;) {
             function test() {
                 break outer
-                ~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
             }
             test()
         }
@@ -478,8 +474,6 @@ plainJSGrammarErrors.js(205,36): error TS1325: Argument of dynamic import cannot
     }
     function jumpToLabelOnly(x) {
         break jumpToLabelOnly
-        ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1107: Jump target cannot cross function boundary.
     }
     for (;;) {
         break toplevel


### PR DESCRIPTION
I've changed the error message when a label is not found in scope. It's a pretty easy fix, as it just checks if there's a label behind a break/continue statement and if so, give the message that the just used label doesn't exist - all this is checked as soon as the checkGrammarBreakOrContinueStatement hits a function/class like 


Fixes #30408
