### PR TITLE
Extend `addPropertyToElementList` to differentiate get/set accessors from properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7176,14 +7176,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     typeElements.push(preserveCommentsOn(getAccessorSignature));
                 }
                 if (propertySymbol.flags & SymbolFlags.SetAccessor) {
+                    const setAccessorDecl = find(propertySymbol.declarations, decl => decl.kind === SyntaxKind.SetAccessor) as SetAccessorDeclaration;
+                    const parameterName = setAccessorDecl?.parameters?.length > 0 ? setAccessorDecl.parameters[0].name : "arg";
                     const setAccessorSignature = factory.createSetAccessorDeclaration(
                         factory.createModifiersFromModifierFlags(flag),
                         propertyName,
                         [factory.createParameterDeclaration(
-                            /*modifiers*/ undefined,
-                            /*dotDotDotToken*/ undefined,
-                            "arg",
-                            /*questionToken*/ undefined,
+                            undefined,
+                            undefined,
+                            parameterName,
+                            undefined,
                             propertyTypeNode
                         )],
                         undefined);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7165,10 +7165,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             if (propertySymbol.flags & SymbolFlags.Accessor) {
                 const modifierFlags = getDeclarationModifierFlagsFromSymbol(propertySymbol);
-                const flag = modifierFlags & ~ModifierFlags.Async;
+                const flags = modifierFlags & ~(ModifierFlags.Async | ModifierFlags.Static | ModifierFlags.Accessor);
                 if (propertySymbol.flags & SymbolFlags.GetAccessor) {
                     const getAccessorSignature = factory.createGetAccessorDeclaration(
-                        factory.createModifiersFromModifierFlags(flag),
+                        factory.createModifiersFromModifierFlags(flags),
                         propertyName,
                         [],
                         propertyTypeNode,
@@ -7179,7 +7179,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const setAccessorDecl = find(propertySymbol.declarations, decl => decl.kind === SyntaxKind.SetAccessor) as SetAccessorDeclaration;
                     const parameterName = setAccessorDecl?.parameters?.length > 0 ? setAccessorDecl.parameters[0].name : "arg";
                     const setAccessorSignature = factory.createSetAccessorDeclaration(
-                        factory.createModifiersFromModifierFlags(flag),
+                        factory.createModifiersFromModifierFlags(flags),
                         propertyName,
                         [factory.createParameterDeclaration(
                             undefined,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7163,17 +7163,37 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
 
-            const modifiers = isReadonlySymbol(propertySymbol) ? [factory.createToken(SyntaxKind.ReadonlyKeyword)] : undefined;
-            if (modifiers) {
-                context.approximateLength += 9;
-            }
-            const propertySignature = factory.createPropertySignature(
-                modifiers,
-                propertyName,
-                optionalToken,
-                propertyTypeNode);
+            if (propertySymbol.flags & (SymbolFlags.GetAccessor | SymbolFlags.SetAccessor)) {
+                if (propertySymbol.flags & SymbolFlags.GetAccessor) {
+                    const getAccessorSignature = factory.createGetAccessorDeclaration(
+                        undefined,
+                        propertyName,
+                        [],
+                        propertyTypeNode,
+                        undefined);
+                    typeElements.push(preserveCommentsOn(getAccessorSignature));
+                }
+                if (propertySymbol.flags & SymbolFlags.SetAccessor) {
+                    const setAccessorSignature = factory.createSetAccessorDeclaration(
+                        undefined,
+                        propertyName,
+                        [],
+                        undefined);
+                    typeElements.push(preserveCommentsOn(setAccessorSignature));
+                }
+            } else {
+                const modifiers = isReadonlySymbol(propertySymbol) ? [factory.createToken(SyntaxKind.ReadonlyKeyword)] : undefined;
+                if (modifiers) {
+                    context.approximateLength += 9;
+                }
+                const propertySignature = factory.createPropertySignature(
+                    modifiers,
+                    propertyName,
+                    optionalToken,
+                    propertyTypeNode);
 
-            typeElements.push(preserveCommentsOn(propertySignature));
+                typeElements.push(preserveCommentsOn(propertySignature));
+            }
 
             function preserveCommentsOn<T extends Node>(node: T) {
                 if (some(propertySymbol.declarations, d => d.kind === SyntaxKind.JSDocPropertyTag)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7163,10 +7163,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
 
-            if (propertySymbol.flags & (SymbolFlags.GetAccessor | SymbolFlags.SetAccessor)) {
+            if (propertySymbol.flags & SymbolFlags.Accessor) {
+                const modifierFlags = getDeclarationModifierFlagsFromSymbol(propertySymbol);
+                const flag = modifierFlags & ~ModifierFlags.Async;
                 if (propertySymbol.flags & SymbolFlags.GetAccessor) {
                     const getAccessorSignature = factory.createGetAccessorDeclaration(
-                        undefined,
+                        factory.createModifiersFromModifierFlags(flag),
                         propertyName,
                         [],
                         propertyTypeNode,
@@ -7175,9 +7177,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 if (propertySymbol.flags & SymbolFlags.SetAccessor) {
                     const setAccessorSignature = factory.createSetAccessorDeclaration(
-                        undefined,
+                        factory.createModifiersFromModifierFlags(flag),
                         propertyName,
-                        [],
+                        [factory.createParameterDeclaration(
+                            /*modifiers*/ undefined,
+                            /*dotDotDotToken*/ undefined,
+                            "arg",
+                            /*questionToken*/ undefined,
+                            propertyTypeNode
+                        )],
                         undefined);
                     typeElements.push(preserveCommentsOn(setAccessorSignature));
                 }

--- a/tests/baselines/reference/YieldExpression17_es6.types
+++ b/tests/baselines/reference/YieldExpression17_es6.types
@@ -2,8 +2,8 @@
 
 === YieldExpression17_es6.ts ===
 var v = { get foo() { yield foo; } }
->v : { readonly foo: void; }
->{ get foo() { yield foo; } } : { readonly foo: void; }
+>v : { get foo(): void; }
+>{ get foo() { yield foo; } } : { get foo(): void; }
 >foo : void
 >yield foo : any
 >foo : any

--- a/tests/baselines/reference/accessorBodyInTypeContext.types
+++ b/tests/baselines/reference/accessorBodyInTypeContext.types
@@ -2,7 +2,7 @@
 
 === accessorBodyInTypeContext.ts ===
 type A = {
->A : { readonly foo: number; }
+>A : { get foo(): number; }
 
     get foo() { return 0 }
 >foo : number
@@ -11,7 +11,7 @@ type A = {
 };
 
 type B = {
->B : { foo: any; }
+>B : { set foo(v: any); }
 
     set foo(v: any) { }
 >foo : any

--- a/tests/baselines/reference/accessorDeclarationEmitJs.types
+++ b/tests/baselines/reference/accessorDeclarationEmitJs.types
@@ -2,8 +2,8 @@
 
 === /a.js ===
 export const t1 = {
->t1 : { p: string; readonly getter: string; }
->{    p: 'value',    get getter() {        return 'value';    },} : { p: string; readonly getter: string; }
+>t1 : { p: string; get getter(): string; }
+>{    p: 'value',    get getter() {        return 'value';    },} : { p: string; get getter(): string; }
 
     p: 'value',
 >p : string
@@ -19,8 +19,8 @@ export const t1 = {
 }
 
 export const t2 = {
->t2 : { v: string; setter: any; }
->{    v: 'value',    set setter(v) {},} : { v: string; setter: any; }
+>t2 : { v: string; set setter(v: any); }
+>{    v: 'value',    set setter(v) {},} : { v: string; set setter(v: any); }
 
     v: 'value',
 >v : string
@@ -32,8 +32,8 @@ export const t2 = {
 }
 
 export const t3 = {
->t3 : { p: string; value: string; }
->{    p: 'value',    get value() {        return 'value';    },    set value(v) {},} : { p: string; value: string; }
+>t3 : { p: string; get value(): string; set value(v: string); }
+>{    p: 'value',    get value() {        return 'value';    },    set value(v) {},} : { p: string; get value(): string; set value(v: string); }
 
     p: 'value',
 >p : string

--- a/tests/baselines/reference/accessorWithES3.types
+++ b/tests/baselines/reference/accessorWithES3.types
@@ -24,8 +24,8 @@ class D {
 }
 
 var x = {
->x : { readonly a: number; }
->{    get a() { return 1 }} : { readonly a: number; }
+>x : { get a(): number; }
+>{    get a() { return 1 }} : { get a(): number; }
 
     get a() { return 1 }
 >a : number
@@ -33,8 +33,8 @@ var x = {
 }
 
 var y = {
->y : { b: any; }
->{    set b(v) { }} : { b: any; }
+>y : { set b(v: any); }
+>{    set b(v) { }} : { set b(v: any); }
 
     set b(v) { }
 >b : any

--- a/tests/baselines/reference/accessorWithES5.types
+++ b/tests/baselines/reference/accessorWithES5.types
@@ -22,8 +22,8 @@ class D {
 }
 
 var x = {
->x : { readonly a: number; }
->{    get a() { return 1 }} : { readonly a: number; }
+>x : { get a(): number; }
+>{    get a() { return 1 }} : { get a(): number; }
 
     get a() { return 1 }
 >a : number
@@ -31,8 +31,8 @@ var x = {
 }
 
 var y = {
->y : { b: any; }
->{    set b(v) { }} : { b: any; }
+>y : { set b(v: any); }
+>{    set b(v) { }} : { set b(v: any); }
 
     set b(v) { }
 >b : any

--- a/tests/baselines/reference/accessorWithoutBody1.types
+++ b/tests/baselines/reference/accessorWithoutBody1.types
@@ -2,7 +2,7 @@
 
 === accessorWithoutBody1.ts ===
 var v = { get foo() }
->v : { readonly foo: any; }
->{ get foo() } : { readonly foo: any; }
+>v : { get foo(): any; }
+>{ get foo() } : { get foo(): any; }
 >foo : any
 

--- a/tests/baselines/reference/accessorWithoutBody2.types
+++ b/tests/baselines/reference/accessorWithoutBody2.types
@@ -2,8 +2,8 @@
 
 === accessorWithoutBody2.ts ===
 var v = { set foo(a) }
->v : { foo: any; }
->{ set foo(a) } : { foo: any; }
+>v : { set foo(a: any); }
+>{ set foo(a) } : { set foo(a: any); }
 >foo : any
 >a : any
 

--- a/tests/baselines/reference/accessorsNotAllowedInES3.types
+++ b/tests/baselines/reference/accessorsNotAllowedInES3.types
@@ -9,8 +9,8 @@ class C {
 >1 : 1
 }
 var y = { get foo() { return 3; } };
->y : { readonly foo: number; }
->{ get foo() { return 3; } } : { readonly foo: number; }
+>y : { get foo(): number; }
+>{ get foo() { return 3; } } : { get foo(): number; }
 >foo : number
 >3 : 3
 

--- a/tests/baselines/reference/accessorsOverrideProperty8.types
+++ b/tests/baselines/reference/accessorsOverrideProperty8.types
@@ -28,10 +28,10 @@ declare function classWithProperties<T extends { [key: string]: Types }, P exten
 };
 
 const Base = classWithProperties({
->Base : { new (): Base & Properties<{ readonly x: "boolean"; y: "string"; }>; prototype: Base & Properties<{ readonly x: "boolean"; y: "string"; }>; }
->classWithProperties({    get x() { return 'boolean' as const },    y: 'string',}, class Base {}) : { new (): Base & Properties<{ readonly x: "boolean"; y: "string"; }>; prototype: Base & Properties<{ readonly x: "boolean"; y: "string"; }>; }
+>Base : { new (): Base & Properties<{ get x(): "boolean"; y: "string"; }>; prototype: Base & Properties<{ get x(): "boolean"; y: "string"; }>; }
+>classWithProperties({    get x() { return 'boolean' as const },    y: 'string',}, class Base {}) : { new (): Base & Properties<{ get x(): "boolean"; y: "string"; }>; prototype: Base & Properties<{ get x(): "boolean"; y: "string"; }>; }
 >classWithProperties : <T extends { [key: string]: Types; }, P extends object>(properties: T, klass: AnyCtor<P>) => { new (): P & Properties<T>; prototype: P & Properties<T>; }
->{    get x() { return 'boolean' as const },    y: 'string',} : { readonly x: "boolean"; y: "string"; }
+>{    get x() { return 'boolean' as const },    y: 'string',} : { get x(): "boolean"; y: "string"; }
 
     get x() { return 'boolean' as const },
 >x : "boolean"
@@ -50,7 +50,7 @@ const Base = classWithProperties({
 
 class MyClass extends Base {
 >MyClass : MyClass
->Base : Base & Properties<{ readonly x: "boolean"; y: "string"; }>
+>Base : Base & Properties<{ get x(): "boolean"; y: "string"; }>
 
     get x() {
 >x : boolean

--- a/tests/baselines/reference/assignmentCompatBug3.types
+++ b/tests/baselines/reference/assignmentCompatBug3.types
@@ -2,12 +2,12 @@
 
 === assignmentCompatBug3.ts ===
 function makePoint(x: number, y: number) {
->makePoint : (x: number, y: number) => { readonly x: number; readonly y: number; dist: () => number; }
+>makePoint : (x: number, y: number) => { get x(): number; get y(): number; dist: () => number; }
 >x : number
 >y : number
 
     return {
->{        get x() { return x;}, // shouldn't be "void"        get y() { return y;}, // shouldn't be "void"        //x: "yo",        //y: "boo",        dist: function () {			return Math.sqrt(x*x+y*y); // shouldn't be picking up "x" and "y" from the object lit		}	} : { readonly x: number; readonly y: number; dist: () => number; }
+>{        get x() { return x;}, // shouldn't be "void"        get y() { return y;}, // shouldn't be "void"        //x: "yo",        //y: "boo",        dist: function () {			return Math.sqrt(x*x+y*y); // shouldn't be picking up "x" and "y" from the object lit		}	} : { get x(): number; get y(): number; dist: () => number; }
 
         get x() { return x;}, // shouldn't be "void"
 >x : number

--- a/tests/baselines/reference/autoAccessor8.js
+++ b/tests/baselines/reference/autoAccessor8.js
@@ -45,7 +45,9 @@ declare class C2 {
 }
 declare function f(): {
     new (): {
-        a: any;
+        get a(): any;
+        set a(arg: any);
     };
-    b: any;
+    get b(): any;
+    set b(arg: any);
 };

--- a/tests/baselines/reference/blockScopedVariablesUseBeforeDef.types
+++ b/tests/baselines/reference/blockScopedVariablesUseBeforeDef.types
@@ -201,8 +201,8 @@ function foo13() {
 >foo13 : () => void
 
     let a = {
->a : { readonly a: any; }
->{        get a() { return x }     } : { readonly a: any; }
+>a : { get a(): any; }
+>{        get a() { return x }     } : { get a(): any; }
 
         get a() { return x } 
 >a : any

--- a/tests/baselines/reference/circularAccessorAnnotations.types
+++ b/tests/baselines/reference/circularAccessorAnnotations.types
@@ -2,28 +2,28 @@
 
 === circularAccessorAnnotations.ts ===
 declare const c1: {
->c1 : { readonly foo: any; }
+>c1 : { get foo(): any; }
 
     get foo(): typeof c1.foo;
 >foo : any
 >c1.foo : any
->c1 : { readonly foo: any; }
+>c1 : { get foo(): any; }
 >foo : any
 }
 
 declare const c2: {
->c2 : { foo: any; }
+>c2 : { set foo(value: any); }
 
     set foo(value: typeof c2.foo);
 >foo : any
 >value : any
 >c2.foo : any
->c2 : { foo: any; }
+>c2 : { set foo(value: any); }
 >foo : any
 }
 
 declare const c3: {
->c3 : { foo: string; }
+>c3 : { get foo(): string; set foo(value: string); }
 
     get foo(): string;
 >foo : string
@@ -32,19 +32,19 @@ declare const c3: {
 >foo : string
 >value : string
 >c3.foo : string
->c3 : { foo: string; }
+>c3 : { get foo(): string; set foo(value: string); }
 >foo : string
 }
 
 type T1 = {
->T1 : { readonly foo: any; }
+>T1 : { get foo(): any; }
 
     get foo(): T1["foo"];
 >foo : any
 }
 
 type T2 = {
->T2 : { foo: any; }
+>T2 : { set foo(value: any); }
 
     set foo(value: T2["foo"]);
 >foo : any
@@ -52,7 +52,7 @@ type T2 = {
 }
 
 type T3 = {
->T3 : { foo: string; }
+>T3 : { get foo(): string; set foo(value: string); }
 
     get foo(): string;
 >foo : string

--- a/tests/baselines/reference/circularObjectLiteralAccessors.types
+++ b/tests/baselines/reference/circularObjectLiteralAccessors.types
@@ -4,19 +4,19 @@
 // Repro from #6000
 
 const a = {
->a : { b: { foo: string; }; foo: string; }
->{    b: {        get foo(): string {            return a.foo;        },        set foo(value: string) {            a.foo = value;        }    },    foo: ''} : { b: { foo: string; }; foo: string; }
+>a : { b: { get foo(): string; set foo(value: string); }; foo: string; }
+>{    b: {        get foo(): string {            return a.foo;        },        set foo(value: string) {            a.foo = value;        }    },    foo: ''} : { b: { get foo(): string; set foo(value: string); }; foo: string; }
 
     b: {
->b : { foo: string; }
->{        get foo(): string {            return a.foo;        },        set foo(value: string) {            a.foo = value;        }    } : { foo: string; }
+>b : { get foo(): string; set foo(value: string); }
+>{        get foo(): string {            return a.foo;        },        set foo(value: string) {            a.foo = value;        }    } : { get foo(): string; set foo(value: string); }
 
         get foo(): string {
 >foo : string
 
             return a.foo;
 >a.foo : string
->a : { b: { foo: string; }; foo: string; }
+>a : { b: { get foo(): string; set foo(value: string); }; foo: string; }
 >foo : string
 
         },
@@ -27,7 +27,7 @@ const a = {
             a.foo = value;
 >a.foo = value : string
 >a.foo : string
->a : { b: { foo: string; }; foo: string; }
+>a : { b: { get foo(): string; set foo(value: string); }; foo: string; }
 >foo : string
 >value : string
         }

--- a/tests/baselines/reference/commentsOnObjectLiteral3.types
+++ b/tests/baselines/reference/commentsOnObjectLiteral3.types
@@ -2,8 +2,8 @@
 
 === commentsOnObjectLiteral3.ts ===
 var v = {
->v : { prop: number; func: () => void; func1(): void; a: any; }
->{ //property prop: 1 /* multiple trailing comments */ /*trailing comments*/, //property func: function () { }, //PropertyName + CallSignature func1() { }, //getter get a() {  return this.prop; } /*trailing 1*/, //setter set a(value) {  this.prop = value; } // trailing 2} : { prop: number; func: () => void; func1(): void; a: any; }
+>v : { prop: number; func: () => void; func1(): void; get a(): any; set a(value: any); }
+>{ //property prop: 1 /* multiple trailing comments */ /*trailing comments*/, //property func: function () { }, //PropertyName + CallSignature func1() { }, //getter get a() {  return this.prop; } /*trailing 1*/, //setter set a(value) {  this.prop = value; } // trailing 2} : { prop: number; func: () => void; func1(): void; get a(): any; set a(value: any); }
 
  //property
  prop: 1 /* multiple trailing comments */ /*trailing comments*/,

--- a/tests/baselines/reference/commentsOnObjectLiteral4.types
+++ b/tests/baselines/reference/commentsOnObjectLiteral4.types
@@ -2,8 +2,8 @@
 
 === commentsOnObjectLiteral4.ts ===
 var v = {
->v : { readonly bar: number; }
->{ /**  * @type {number}  */ get bar(): number {  return 12; }} : { readonly bar: number; }
+>v : { get bar(): number; }
+>{ /**  * @type {number}  */ get bar(): number {  return 12; }} : { get bar(): number; }
 
  /**
   * @type {number}

--- a/tests/baselines/reference/computedPropertyNames11_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames11_ES5.types
@@ -11,8 +11,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: any; [x: number]: any; "": any; readonly 0: number; "hello bye": any; }
->{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; "": any; readonly 0: number; "hello bye": any; }
+>v : { [x: string]: any; [x: number]: any; set ""(v: any); get 0(): number; set "hello bye"(v: any); }
+>{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; set ""(v: any); get 0(): number; set "hello bye"(v: any); }
 
     get [s]() { return 0; },
 >[s] : number

--- a/tests/baselines/reference/computedPropertyNames11_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames11_ES6.types
@@ -11,8 +11,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: any; [x: number]: any; "": any; readonly 0: number; "hello bye": any; }
->{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; "": any; readonly 0: number; "hello bye": any; }
+>v : { [x: string]: any; [x: number]: any; set ""(v: any); get 0(): number; set "hello bye"(v: any); }
+>{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; set ""(v: any); get 0(): number; set "hello bye"(v: any); }
 
     get [s]() { return 0; },
 >[s] : number

--- a/tests/baselines/reference/computedPropertyNames49_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames49_ES5.types
@@ -2,8 +2,8 @@
 
 === computedPropertyNames49_ES5.ts ===
 var x = {
->x : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
->{    p1: 10,    get [1 + 1]() {        throw 10;    },    get [1 + 1]() {        return 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get foo() {        if (1 == 1) {            return 10;        }    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
+>x : { [x: number]: any; p1: number; get foo(): number; p2: number; }
+>{    p1: 10,    get [1 + 1]() {        throw 10;    },    get [1 + 1]() {        return 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get foo() {        if (1 == 1) {            return 10;        }    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; get foo(): number; p2: number; }
 
     p1: 10,
 >p1 : number

--- a/tests/baselines/reference/computedPropertyNames49_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames49_ES6.types
@@ -2,8 +2,8 @@
 
 === computedPropertyNames49_ES6.ts ===
 var x = {
->x : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
->{    p1: 10,    get [1 + 1]() {        throw 10;    },    get [1 + 1]() {        return 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get foo() {        if (1 == 1) {            return 10;        }    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
+>x : { [x: number]: any; p1: number; get foo(): number; p2: number; }
+>{    p1: 10,    get [1 + 1]() {        throw 10;    },    get [1 + 1]() {        return 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get foo() {        if (1 == 1) {            return 10;        }    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; get foo(): number; p2: number; }
 
     p1: 10,
 >p1 : number

--- a/tests/baselines/reference/computedPropertyNames50_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames50_ES5.types
@@ -2,8 +2,8 @@
 
 === computedPropertyNames50_ES5.ts ===
 var x = {
->x : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
->{    p1: 10,    get foo() {        if (1 == 1) {            return 10;        }    },    get [1 + 1]() {        throw 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get [1 + 1]() {        return 10;    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
+>x : { [x: number]: any; p1: number; get foo(): number; p2: number; }
+>{    p1: 10,    get foo() {        if (1 == 1) {            return 10;        }    },    get [1 + 1]() {        throw 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get [1 + 1]() {        return 10;    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; get foo(): number; p2: number; }
 
     p1: 10,
 >p1 : number

--- a/tests/baselines/reference/computedPropertyNames50_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames50_ES6.types
@@ -2,8 +2,8 @@
 
 === computedPropertyNames50_ES6.ts ===
 var x = {
->x : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
->{    p1: 10,    get foo() {        if (1 == 1) {            return 10;        }    },    get [1 + 1]() {        throw 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get [1 + 1]() {        return 10;    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; readonly foo: number; p2: number; }
+>x : { [x: number]: any; p1: number; get foo(): number; p2: number; }
+>{    p1: 10,    get foo() {        if (1 == 1) {            return 10;        }    },    get [1 + 1]() {        throw 10;    },    set [1 + 1]() {        // just throw        throw 10;    },    get [1 + 1]() {        return 10;    },    get foo() {        if (2 == 2) {            return 20;        }    },    p2: 20} : { [x: number]: any; p1: number; get foo(): number; p2: number; }
 
     p1: 10,
 >p1 : number

--- a/tests/baselines/reference/computedPropertyNamesSourceMap2_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesSourceMap2_ES5.types
@@ -2,8 +2,8 @@
 
 === computedPropertyNamesSourceMap2_ES5.ts ===
 var v = {
->v : { hello(): void; readonly goodbye: number; }
->{    ["hello"]() {        debugger;	},    get ["goodbye"]() {		return 0;	}} : { hello(): void; readonly goodbye: number; }
+>v : { hello(): void; get goodbye(): number; }
+>{    ["hello"]() {        debugger;	},    get ["goodbye"]() {		return 0;	}} : { hello(): void; get goodbye(): number; }
 
     ["hello"]() {
 >["hello"] : () => void

--- a/tests/baselines/reference/computedPropertyNamesSourceMap2_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesSourceMap2_ES6.types
@@ -2,8 +2,8 @@
 
 === computedPropertyNamesSourceMap2_ES6.ts ===
 var v = {
->v : { hello(): void; readonly goodbye: number; }
->{    ["hello"]() {        debugger;	},	get ["goodbye"]() {		return 0;	}} : { hello(): void; readonly goodbye: number; }
+>v : { hello(): void; get goodbye(): number; }
+>{    ["hello"]() {        debugger;	},	get ["goodbye"]() {		return 0;	}} : { hello(): void; get goodbye(): number; }
 
     ["hello"]() {
 >["hello"] : () => void

--- a/tests/baselines/reference/constructorNameInObjectLiteralAccessor.types
+++ b/tests/baselines/reference/constructorNameInObjectLiteralAccessor.types
@@ -2,8 +2,8 @@
 
 === constructorNameInObjectLiteralAccessor.ts ===
 const c1 = {
->c1 : { constructor: void; }
->{    get constructor() { return },    set constructor(value) {}} : { constructor: void; }
+>c1 : { get constructor(): void; set constructor(value: void); }
+>{    get constructor() { return },    set constructor(value) {}} : { get constructor(): void; set constructor(value: void); }
 
     get constructor() { return },
 >constructor : void

--- a/tests/baselines/reference/contextualTypingOfAccessors.types
+++ b/tests/baselines/reference/contextualTypingOfAccessors.types
@@ -12,9 +12,9 @@ var x: {
 }
  
 x = {
->x = {   get foo() {      return (n)=>n   },   set foo(x) {}} : { foo: (n: any) => any; }
+>x = {   get foo() {      return (n)=>n   },   set foo(x) {}} : { get foo(): (n: any) => any; set foo(x: (n: any) => any); }
 >x : { foo: (x: number) => number; }
->{   get foo() {      return (n)=>n   },   set foo(x) {}} : { foo: (n: any) => any; }
+>{   get foo() {      return (n)=>n   },   set foo(x) {}} : { get foo(): (n: any) => any; set foo(x: (n: any) => any); }
 
    get foo() {
 >foo : (n: any) => any

--- a/tests/baselines/reference/declFileObjectLiteralWithAccessors.js
+++ b/tests/baselines/reference/declFileObjectLiteralWithAccessors.js
@@ -29,10 +29,12 @@ point. /*3*/x = 30;
 //// [declFileObjectLiteralWithAccessors.d.ts]
 declare function makePoint(x: number): {
     b: number;
-    x: number;
+    get x(): number;
+    set x(a: number);
 };
 declare var /*4*/ point: {
     b: number;
-    x: number;
+    get x(): number;
+    set x(a: number);
 };
 declare var /*2*/ x: number;

--- a/tests/baselines/reference/declFileObjectLiteralWithAccessors.types
+++ b/tests/baselines/reference/declFileObjectLiteralWithAccessors.types
@@ -2,11 +2,11 @@
 
 === declFileObjectLiteralWithAccessors.ts ===
 function /*1*/makePoint(x: number) { 
->makePoint : (x: number) => { b: number; x: number; }
+>makePoint : (x: number) => { b: number; get x(): number; set x(a: number); }
 >x : number
 
     return {
->{        b: 10,        get x() { return x; },        set x(a: number) { this.b = a; }    } : { b: number; x: number; }
+>{        b: 10,        get x() { return x; },        set x(a: number) { this.b = a; }    } : { b: number; get x(): number; set x(a: number); }
 
         b: 10,
 >b : number
@@ -28,21 +28,21 @@ function /*1*/makePoint(x: number) {
     };
 };
 var /*4*/point = makePoint(2);
->point : { b: number; x: number; }
->makePoint(2) : { b: number; x: number; }
->makePoint : (x: number) => { b: number; x: number; }
+>point : { b: number; get x(): number; set x(a: number); }
+>makePoint(2) : { b: number; get x(): number; set x(a: number); }
+>makePoint : (x: number) => { b: number; get x(): number; set x(a: number); }
 >2 : 2
 
 var /*2*/x = point.x;
 >x : number
 >point.x : number
->point : { b: number; x: number; }
+>point : { b: number; get x(): number; set x(a: number); }
 >x : number
 
 point./*3*/x = 30;
 >point./*3*/x = 30 : 30
 >point./*3*/x : number
->point : { b: number; x: number; }
+>point : { b: number; get x(): number; set x(a: number); }
 >x : number
 >30 : 30
 

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlyGetter.js
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlyGetter.js
@@ -23,9 +23,9 @@ var /*2*/ x = point. /*3*/x;
 
 //// [declFileObjectLiteralWithOnlyGetter.d.ts]
 declare function makePoint(x: number): {
-    readonly x: number;
+    get x(): number;
 };
 declare var /*4*/ point: {
-    readonly x: number;
+    get x(): number;
 };
 declare var /*2*/ x: number;

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlyGetter.types
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlyGetter.types
@@ -2,11 +2,11 @@
 
 === declFileObjectLiteralWithOnlyGetter.ts ===
 function /*1*/makePoint(x: number) { 
->makePoint : (x: number) => { readonly x: number; }
+>makePoint : (x: number) => { get x(): number; }
 >x : number
 
     return {
->{        get x() { return x; },    } : { readonly x: number; }
+>{        get x() { return x; },    } : { get x(): number; }
 
         get x() { return x; },
 >x : number
@@ -15,14 +15,14 @@ function /*1*/makePoint(x: number) {
     };
 };
 var /*4*/point = makePoint(2);
->point : { readonly x: number; }
->makePoint(2) : { readonly x: number; }
->makePoint : (x: number) => { readonly x: number; }
+>point : { get x(): number; }
+>makePoint(2) : { get x(): number; }
+>makePoint : (x: number) => { get x(): number; }
 >2 : 2
 
 var /*2*/x = point./*3*/x;
 >x : number
 >point./*3*/x : number
->point : { readonly x: number; }
+>point : { get x(): number; }
 >x : number
 

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.js
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.js
@@ -25,9 +25,9 @@ point. /*2*/x = 30;
 //// [declFileObjectLiteralWithOnlySetter.d.ts]
 declare function makePoint(x: number): {
     b: number;
-    x: number;
+    set x(a: number);
 };
 declare var /*3*/ point: {
     b: number;
-    x: number;
+    set x(a: number);
 };

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.types
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.types
@@ -2,11 +2,11 @@
 
 === declFileObjectLiteralWithOnlySetter.ts ===
 function /*1*/makePoint(x: number) { 
->makePoint : (x: number) => { b: number; x: number; }
+>makePoint : (x: number) => { b: number; set x(a: number); }
 >x : number
 
     return {
->{        b: 10,        set x(a: number) { this.b = a; }    } : { b: number; x: number; }
+>{        b: 10,        set x(a: number) { this.b = a; }    } : { b: number; set x(a: number); }
 
         b: 10,
 >b : number
@@ -24,15 +24,15 @@ function /*1*/makePoint(x: number) {
     };
 };
 var /*3*/point = makePoint(2);
->point : { b: number; x: number; }
->makePoint(2) : { b: number; x: number; }
->makePoint : (x: number) => { b: number; x: number; }
+>point : { b: number; set x(a: number); }
+>makePoint(2) : { b: number; set x(a: number); }
+>makePoint : (x: number) => { b: number; set x(a: number); }
 >2 : 2
 
 point./*2*/x = 30;
 >point./*2*/x = 30 : 30
 >point./*2*/x : number
->point : { b: number; x: number; }
+>point : { b: number; set x(a: number); }
 >x : number
 >30 : 30
 

--- a/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling.js
+++ b/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling.js
@@ -46,6 +46,6 @@ export interface Scalar {
 export declare function scalar(value: string): Scalar;
 //// [spacing.d.ts]
 declare const _default: {
-    readonly xs: import("../lib/operators/scalar").Scalar;
+    get xs(): import("../lib/operators/scalar").Scalar;
 };
 export default _default;

--- a/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling.types
+++ b/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling.types
@@ -19,7 +19,7 @@ import { scalar } from '../lib/operators/scalar';
 >scalar : (value: string) => import("src/lib/operators/scalar").Scalar
 
 export default {
->{	get xs() {		return scalar("14px");	}} : { readonly xs: import("src/lib/operators/scalar").Scalar; }
+>{	get xs() {		return scalar("14px");	}} : { get xs(): import("src/lib/operators/scalar").Scalar; }
 
 	get xs() {
 >xs : import("src/lib/operators/scalar").Scalar

--- a/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling2.js
+++ b/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling2.js
@@ -50,7 +50,7 @@ declare module "lib/operators/scalar" {
 }
 declare module "settings/spacing" {
     const _default: {
-        readonly xs: import("lib/operators/scalar").Scalar;
+        get xs(): import("lib/operators/scalar").Scalar;
     };
     export default _default;
 }

--- a/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling2.types
+++ b/tests/baselines/reference/declarationEmitPrefersPathKindBasedOnBundling2.types
@@ -19,7 +19,7 @@ import { scalar } from '../lib/operators/scalar';
 >scalar : (value: string) => import("src/lib/operators/scalar").Scalar
 
 export default {
->{	get xs() {		return scalar("14px");	}} : { readonly xs: import("src/lib/operators/scalar").Scalar; }
+>{	get xs() {		return scalar("14px");	}} : { get xs(): import("src/lib/operators/scalar").Scalar; }
 
 	get xs() {
 >xs : import("src/lib/operators/scalar").Scalar

--- a/tests/baselines/reference/derivedClassSuperProperties.types
+++ b/tests/baselines/reference/derivedClassSuperProperties.types
@@ -676,8 +676,8 @@ class DerivedWithObjectAccessors extends Base {
 
     constructor() {
         const obj = {
->obj : { prop: boolean; }
->{            get prop() {                return true;            },            set prop(param) {                this._prop = param;            }        } : { prop: boolean; }
+>obj : { get prop(): boolean; set prop(param: boolean); }
+>{            get prop() {                return true;            },            set prop(param) {                this._prop = param;            }        } : { get prop(): boolean; set prop(param: boolean); }
 
             get prop() {
 >prop : boolean
@@ -762,8 +762,8 @@ class DerivedWithObjectAccessorsUsingThisInBodies extends Base {
 
     constructor() {
         const obj = {
->obj : { _prop: string; prop: any; }
->{            _prop: "prop",            get prop() {                return this._prop;            },            set prop(param) {                this._prop = param;            }        } : { _prop: string; prop: any; }
+>obj : { _prop: string; get prop(): any; set prop(param: any); }
+>{            _prop: "prop",            get prop() {                return this._prop;            },            set prop(param) {                this._prop = param;            }        } : { _prop: string; get prop(): any; set prop(param: any); }
 
             _prop: "prop",
 >_prop : string

--- a/tests/baselines/reference/divergentAccessors1.types
+++ b/tests/baselines/reference/divergentAccessors1.types
@@ -33,7 +33,7 @@
 
 {
     type T_HasGetSet = {
->T_HasGetSet : { foo: number; }
+>T_HasGetSet : { get foo(): number; set foo(v: number); }
 
         get foo(): number;
 >foo : number
@@ -44,20 +44,20 @@
     }
     
     const t_hgs: T_HasGetSet = null as any;
->t_hgs : { foo: number; }
+>t_hgs : { get foo(): number; set foo(v: number); }
 >null as any : any
 
     t_hgs.foo = "32";
 >t_hgs.foo = "32" : "32"
 >t_hgs.foo : string | number
->t_hgs : { foo: number; }
+>t_hgs : { get foo(): number; set foo(v: number); }
 >foo : string | number
 >"32" : "32"
 
     let r_t_hgs_foo: number = t_hgs.foo;
 >r_t_hgs_foo : number
 >t_hgs.foo : number
->t_hgs : { foo: number; }
+>t_hgs : { get foo(): number; set foo(v: number); }
 >foo : number
 }
 

--- a/tests/baselines/reference/divergentAccessorsTypes1.types
+++ b/tests/baselines/reference/divergentAccessorsTypes1.types
@@ -50,7 +50,7 @@ interface Test2 {
 }
 
 type Test3 = {
->Test3 : { foo: string; bar: string | number; }
+>Test3 : { get foo(): string; set foo(s: string); get bar(): string | number; set bar(s: string | number); }
 
     get foo(): string;
 >foo : string

--- a/tests/baselines/reference/divergentAccessorsTypes6.types
+++ b/tests/baselines/reference/divergentAccessorsTypes6.types
@@ -53,8 +53,8 @@ interface I1 {
 >value : string
 }
 const o1 = {
->o1 : { x: number; }
->{    get x(): number { return 0; },    set x(value: Fail<string>) {}} : { x: number; }
+>o1 : { get x(): number; set x(value: number); }
+>{    get x(): number { return 0; },    set x(value: Fail<string>) {}} : { get x(): number; set x(value: number); }
 
     get x(): number { return 0; },
 >x : number
@@ -68,8 +68,8 @@ const o1 = {
 // A setter annotation still implies the getter return type.
 
 const o2 = {
->o2 : { p1: string; p2: number; }
->{    get p1() { return 0; }, // error - no annotation means type is implied from the setter annotation    set p1(value: string) {},    get p2(): number { return 0; }, // ok - explicit annotation    set p2(value: string) {},} : { p1: string; p2: number; }
+>o2 : { get p1(): string; set p1(value: string); get p2(): number; set p2(value: number); }
+>{    get p1() { return 0; }, // error - no annotation means type is implied from the setter annotation    set p1(value: string) {},    get p2(): number { return 0; }, // ok - explicit annotation    set p2(value: string) {},} : { get p1(): string; set p1(value: string); get p2(): number; set p2(value: number); }
 
     get p1() { return 0; }, // error - no annotation means type is implied from the setter annotation
 >p1 : string

--- a/tests/baselines/reference/downlevelLetConst18.types
+++ b/tests/baselines/reference/downlevelLetConst18.types
@@ -55,8 +55,8 @@ for (let x; ;) {
 >x : any
 
     ({ get foo() { return x } })
->({ get foo() { return x } }) : { readonly foo: any; }
->{ get foo() { return x } } : { readonly foo: any; }
+>({ get foo() { return x } }) : { get foo(): any; }
+>{ get foo() { return x } } : { get foo(): any; }
 >foo : any
 >x : any
 }
@@ -65,8 +65,8 @@ for (let x; ;) {
 >x : any
 
     ({ set foo(v) { x } })
->({ set foo(v) { x } }) : { foo: any; }
->{ set foo(v) { x } } : { foo: any; }
+>({ set foo(v) { x } }) : { set foo(v: any); }
+>{ set foo(v) { x } } : { set foo(v: any); }
 >foo : any
 >v : any
 >x : any

--- a/tests/baselines/reference/duplicateObjectLiteralProperty.types
+++ b/tests/baselines/reference/duplicateObjectLiteralProperty.types
@@ -37,8 +37,8 @@ var x = {
 
 
 var y = {
->y : { readonly a: number; }
->{    get a() { return 0; },    set a(v: number) { },    get a() { return 0; }} : { readonly a: number; }
+>y : { get a(): number; }
+>{    get a() { return 0; },    set a(v: number) { },    get a() { return 0; }} : { get a(): number; }
 
     get a() { return 0; },
 >a : number

--- a/tests/baselines/reference/dynamicNamesErrors.js
+++ b/tests/baselines/reference/dynamicNamesErrors.js
@@ -118,7 +118,7 @@ export type ObjectTypeVisibility = {
 export declare const ObjectLiteralVisibility: {
     [x]: number;
     [y](): number;
-    readonly [z]: number;
-    [w]: number;
+    get [z](): number;
+    set [w](value: number);
 };
 export {};

--- a/tests/baselines/reference/dynamicNamesErrors.types
+++ b/tests/baselines/reference/dynamicNamesErrors.types
@@ -142,8 +142,8 @@ export type ObjectTypeVisibility = {
 };
 
 export const ObjectLiteralVisibility = {
->ObjectLiteralVisibility : { [x]: number; [y](): number; readonly [z]: number; [w]: number; }
->{    [x]: 0,    [y](): number { return 0; },    get [z](): number { return 0; },    set [w](value: number) { },} : { [x]: number; [y](): number; readonly [z]: number; [w]: number; }
+>ObjectLiteralVisibility : { [x]: number; [y](): number; get [z](): number; set [w](value: number); }
+>{    [x]: 0,    [y](): number { return 0; },    get [z](): number { return 0; },    set [w](value: number) { },} : { [x]: number; [y](): number; get [z](): number; set [w](value: number); }
 
     [x]: 0,
 >[x] : number

--- a/tests/baselines/reference/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.types
+++ b/tests/baselines/reference/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.types
@@ -2,8 +2,8 @@
 
 === emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts ===
 var object = {
->object : { _0: number; 0: number; }
->{    _0: 2,    get 0() {        return this._0;    },    set 0(x: number) {        this._0 = x;    },} : { _0: number; 0: number; }
+>object : { _0: number; get 0(): number; set 0(x: number); }
+>{    _0: 2,    get 0() {        return this._0;    },    set 0(x: number) {        this._0 = x;    },} : { _0: number; get 0(): number; set 0(x: number); }
 
     _0: 2,
 >_0 : number
@@ -34,31 +34,31 @@ var object = {
 object[0] **= object[0];
 >object[0] **= object[0] : number
 >object[0] : number
->object : { _0: number; 0: number; }
+>object : { _0: number; get 0(): number; set 0(x: number); }
 >0 : 0
 >object[0] : number
->object : { _0: number; 0: number; }
+>object : { _0: number; get 0(): number; set 0(x: number); }
 >0 : 0
 
 object[0] **= object[0] **= 2;
 >object[0] **= object[0] **= 2 : number
 >object[0] : number
->object : { _0: number; 0: number; }
+>object : { _0: number; get 0(): number; set 0(x: number); }
 >0 : 0
 >object[0] **= 2 : number
 >object[0] : number
->object : { _0: number; 0: number; }
+>object : { _0: number; get 0(): number; set 0(x: number); }
 >0 : 0
 >2 : 2
 
 object[0] **= object[0] ** 2;
 >object[0] **= object[0] ** 2 : number
 >object[0] : number
->object : { _0: number; 0: number; }
+>object : { _0: number; get 0(): number; set 0(x: number); }
 >0 : 0
 >object[0] ** 2 : number
 >object[0] : number
->object : { _0: number; 0: number; }
+>object : { _0: number; get 0(): number; set 0(x: number); }
 >0 : 0
 >2 : 2
 

--- a/tests/baselines/reference/emitThisInObjectLiteralGetter.types
+++ b/tests/baselines/reference/emitThisInObjectLiteralGetter.types
@@ -2,8 +2,8 @@
 
 === emitThisInObjectLiteralGetter.ts ===
 const example = {
->example : { readonly foo: (item: any) => any; }
->{    get foo() {        return item => this.bar(item);    }} : { readonly foo: (item: any) => any; }
+>example : { get foo(): (item: any) => any; }
+>{    get foo() {        return item => this.bar(item);    }} : { get foo(): (item: any) => any; }
 
     get foo() {
 >foo : (item: any) => any

--- a/tests/baselines/reference/es5SetterparameterDestructuringNotElided.types
+++ b/tests/baselines/reference/es5SetterparameterDestructuringNotElided.types
@@ -2,8 +2,8 @@
 
 === es5SetterparameterDestructuringNotElided.ts ===
 const foo = {
->foo : { foo: [any, any]; }
->{    set foo([start, end]: [any, any]) {        void start;        void end;    },} : { foo: [any, any]; }
+>foo : { set foo([start, end]: [any, any]); }
+>{    set foo([start, end]: [any, any]) {        void start;        void end;    },} : { set foo([start, end]: [any, any]); }
 
     set foo([start, end]: [any, any]) {
 >foo : [any, any]

--- a/tests/baselines/reference/exportsAndImportsWithContextualKeywordNames01.types
+++ b/tests/baselines/reference/exportsAndImportsWithContextualKeywordNames01.types
@@ -2,8 +2,8 @@
 
 === t1.ts ===
 let set = {
->set : { foo: number; }
->{    set foo(x: number) {    }} : { foo: number; }
+>set : { set foo(x: number); }
+>{    set foo(x: number) {    }} : { set foo(x: number); }
 
     set foo(x: number) {
 >foo : number
@@ -15,7 +15,7 @@ let get = 10;
 >10 : 10
 
 export { set, get };
->set : { foo: number; }
+>set : { set foo(x: number); }
 >get : number
 
 === t2.ts ===
@@ -24,8 +24,8 @@ import * as set from "./t1";
 
 === t3.ts ===
 import { set as yield } from "./t1";
->set : { foo: number; }
->yield : { foo: number; }
+>set : { set foo(x: number); }
+>yield : { set foo(x: number); }
 
 === t4.ts ===
 import { get } from "./t1";

--- a/tests/baselines/reference/getSetEnumerable.types
+++ b/tests/baselines/reference/getSetEnumerable.types
@@ -30,8 +30,8 @@ class GetSetEnumerableClassGetSet {
 }
 
 const GetSetEnumerableObjectGet = {
->GetSetEnumerableObjectGet : { readonly prop: boolean; }
->{    get prop() { return true; }} : { readonly prop: boolean; }
+>GetSetEnumerableObjectGet : { get prop(): boolean; }
+>{    get prop() { return true; }} : { get prop(): boolean; }
 
     get prop() { return true; }
 >prop : boolean
@@ -40,8 +40,8 @@ const GetSetEnumerableObjectGet = {
 };
 
 const GetSetEnumerableObjectSet = {
->GetSetEnumerableObjectSet : { prop: boolean; }
->{    set prop(value: boolean) { }} : { prop: boolean; }
+>GetSetEnumerableObjectSet : { set prop(value: boolean); }
+>{    set prop(value: boolean) { }} : { set prop(value: boolean); }
 
     set prop(value: boolean) { }
 >prop : boolean
@@ -50,8 +50,8 @@ const GetSetEnumerableObjectSet = {
 };
 
 const GetSetEnumerableObjectGetSet = {
->GetSetEnumerableObjectGetSet : { prop: boolean; }
->{    get prop() { return true; },    set prop(value: boolean) { }} : { prop: boolean; }
+>GetSetEnumerableObjectGetSet : { get prop(): boolean; set prop(value: boolean); }
+>{    get prop() { return true; },    set prop(value: boolean) { }} : { get prop(): boolean; set prop(value: boolean); }
 
     get prop() { return true; },
 >prop : boolean

--- a/tests/baselines/reference/getsetReturnTypes.types
+++ b/tests/baselines/reference/getsetReturnTypes.types
@@ -2,11 +2,11 @@
 
 === getsetReturnTypes.ts ===
 function makePoint(x: number) { 
->makePoint : (x: number) => { readonly x: number; }
+>makePoint : (x: number) => { get x(): number; }
 >x : number
 
  return { 
->{   get x() { return x; }  } : { readonly x: number; }
+>{   get x() { return x; }  } : { get x(): number; }
 
   get x() { return x; } 
 >x : number
@@ -16,16 +16,16 @@ function makePoint(x: number) {
 var x = makePoint(2).x;
 >x : number
 >makePoint(2).x : number
->makePoint(2) : { readonly x: number; }
->makePoint : (x: number) => { readonly x: number; }
+>makePoint(2) : { get x(): number; }
+>makePoint : (x: number) => { get x(): number; }
 >2 : 2
 >x : number
 
 var y: number = makePoint(2).x;
 >y : number
 >makePoint(2).x : number
->makePoint(2) : { readonly x: number; }
->makePoint : (x: number) => { readonly x: number; }
+>makePoint(2) : { get x(): number; }
+>makePoint : (x: number) => { get x(): number; }
 >2 : 2
 >x : number
 

--- a/tests/baselines/reference/gettersAndSetters.types
+++ b/tests/baselines/reference/gettersAndSetters.types
@@ -104,7 +104,7 @@ c.Baz = "bazv";
 var o : {Foo:number;} = {get Foo() {return 0;}, set Foo(val:number){val}}; // o
 >o : { Foo: number; }
 >Foo : number
->{get Foo() {return 0;}, set Foo(val:number){val}} : { Foo: number; }
+>{get Foo() {return 0;}, set Foo(val:number){val}} : { get Foo(): number; set Foo(val: number); }
 >Foo : number
 >0 : 0
 >Foo : number
@@ -156,8 +156,8 @@ if (typeof x === "string") {
 >"string" : "string"
 
   let obj = {
->obj : { prop: any; method(): string; }
->{    set prop(_: any) { x.toUpperCase(); },    get prop() { return x.toUpperCase() },    method() { return x.toUpperCase() }  } : { prop: any; method(): string; }
+>obj : { get prop(): any; set prop(_: any); method(): string; }
+>{    set prop(_: any) { x.toUpperCase(); },    get prop() { return x.toUpperCase() },    method() { return x.toUpperCase() }  } : { get prop(): any; set prop(_: any); method(): string; }
 
     set prop(_: any) { x.toUpperCase(); },
 >prop : any

--- a/tests/baselines/reference/gettersAndSettersTypesAgree.types
+++ b/tests/baselines/reference/gettersAndSettersTypesAgree.types
@@ -22,16 +22,16 @@ class C {
 }
 
 var o1 = {get Foo(){return 0;}, set Foo(val){}}; // ok - types agree (inference)
->o1 : { Foo: number; }
->{get Foo(){return 0;}, set Foo(val){}} : { Foo: number; }
+>o1 : { get Foo(): number; set Foo(val: number); }
+>{get Foo(){return 0;}, set Foo(val){}} : { get Foo(): number; set Foo(val: number); }
 >Foo : number
 >0 : 0
 >Foo : number
 >val : number
 
 var o2 = {get Foo(){return 0;}, set Foo(val:number){}}; // ok - types agree
->o2 : { Foo: number; }
->{get Foo(){return 0;}, set Foo(val:number){}} : { Foo: number; }
+>o2 : { get Foo(): number; set Foo(val: number); }
+>{get Foo(){return 0;}, set Foo(val:number){}} : { get Foo(): number; set Foo(val: number); }
 >Foo : number
 >0 : 0
 >Foo : number

--- a/tests/baselines/reference/illegalSuperCallsInConstructor.types
+++ b/tests/baselines/reference/illegalSuperCallsInConstructor.types
@@ -32,8 +32,8 @@ class Derived extends Base {
 >super : any
 
         var r5 = {
->r5 : { foo: number; }
->{            get foo() {                super();                return 1;            },            set foo(v: number) {                super();            }        } : { foo: number; }
+>r5 : { get foo(): number; set foo(v: number); }
+>{            get foo() {                super();                return 1;            },            set foo(v: number) {                super();            }        } : { get foo(): number; set foo(v: number); }
 
             get foo() {
 >foo : number

--- a/tests/baselines/reference/intersectionsAndReadonlyProperties.types
+++ b/tests/baselines/reference/intersectionsAndReadonlyProperties.types
@@ -19,7 +19,7 @@ i1.a = 2;
 
 // getter and setter
 type Intersection2 = { get a(): number } & { set a(v: number) };
->Intersection2 : { readonly a: number; } & { a: number; }
+>Intersection2 : { get a(): number; } & { set a(v: number); }
 >a : number
 >a : number
 >v : number
@@ -36,7 +36,7 @@ i2.a = 2;
 
 // assignment to an all read-only property should still be disallowed
 type IntersectionAllReadonly = { readonly a: number } & { get a(): number };
->IntersectionAllReadonly : { readonly a: number; } & { readonly a: number; }
+>IntersectionAllReadonly : { readonly a: number; } & { get a(): number; }
 >a : number
 >a : number
 

--- a/tests/baselines/reference/invalidNewTarget.es5.types
+++ b/tests/baselines/reference/invalidNewTarget.es5.types
@@ -75,8 +75,8 @@ class C {
 }
 
 const O = {
->O : { [x: number]: any; k(): any; readonly l: any; m: any; n: any; }
->{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: number]: undefined; k(): any; readonly l: any; m: any; n: any; }
+>O : { [x: number]: any; k(): any; get l(): any; set m(_: any); n: any; }
+>{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: number]: undefined; k(): any; get l(): any; set m(_: any); n: any; }
 
     [new.target]: undefined,
 >[new.target] : undefined

--- a/tests/baselines/reference/invalidNewTarget.es6.types
+++ b/tests/baselines/reference/invalidNewTarget.es6.types
@@ -75,8 +75,8 @@ class C {
 }
 
 const O = {
->O : { [x: number]: any; k(): any; readonly l: any; m: any; n: any; }
->{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: number]: undefined; k(): any; readonly l: any; m: any; n: any; }
+>O : { [x: number]: any; k(): any; get l(): any; set m(_: any); n: any; }
+>{    [new.target]: undefined,    k() { return new.target; },    get l() { return new.target; },    set m(_) { _ = new.target; },    n: new.target,} : { [x: number]: undefined; k(): any; get l(): any; set m(_: any); n: any; }
 
     [new.target]: undefined,
 >[new.target] : undefined

--- a/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.types
+++ b/tests/baselines/reference/jsDeclarationsFunctionLikeClasses2.types
@@ -177,11 +177,11 @@ export function Point2D(x, y) {
 }
 
 Point2D.prototype = {
->Point2D.prototype = {    __proto__: Vec,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { __proto__: typeof Vec; x: number; y: number; }
->Point2D.prototype : { __proto__: typeof Vec; x: number; y: number; }
+>Point2D.prototype = {    __proto__: Vec,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
+>Point2D.prototype : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
 >Point2D : typeof Point2D
->prototype : { __proto__: typeof Vec; x: number; y: number; }
->{    __proto__: Vec,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { __proto__: typeof Vec; x: number; y: number; }
+>prototype : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
+>{    __proto__: Vec,    get x() {        return this.storage[0];    },    /**     * @param {number} x     */    set x(x) {        this.storage[0] = x;    },    get y() {        return this.storage[1];    },    /**     * @param {number} y     */    set y(y) {        this.storage[1] = y;    }} : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
 
     __proto__: Vec,
 >__proto__ : typeof Vec
@@ -193,7 +193,7 @@ Point2D.prototype = {
         return this.storage[0];
 >this.storage[0] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
 >storage : any
 >0 : 0
 
@@ -209,7 +209,7 @@ Point2D.prototype = {
 >this.storage[0] = x : number
 >this.storage[0] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
 >storage : any
 >0 : 0
 >x : number
@@ -221,7 +221,7 @@ Point2D.prototype = {
         return this.storage[1];
 >this.storage[1] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
 >storage : any
 >1 : 1
 
@@ -237,7 +237,7 @@ Point2D.prototype = {
 >this.storage[1] = y : number
 >this.storage[1] : any
 >this.storage : any
->this : { __proto__: typeof Vec; x: number; y: number; }
+>this : { __proto__: typeof Vec; get x(): number; set x(x: number); get y(): number; set y(y: number); }
 >storage : any
 >1 : 1
 >y : number

--- a/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.types
+++ b/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.types
@@ -170,7 +170,7 @@ var a: {
 var b: { [x: number]: string; } = {
 >b : { [x: number]: string; }
 >x : number
->{    a: '',    b: 1,     c: () => { },     "d": '',     "e": 1,     1.0: '',    2.0: 1,     "3.0": '',     "4.0": 1,     f: <Myn>null,     get X() {         return '';    },    set X(v) { },     foo() {         return '';    }} : { a: string; b: number; c: () => void; d: string; e: number; 1: string; 2: number; "3.0": string; "4.0": number; f: Myn; X: string; foo(): string; }
+>{    a: '',    b: 1,     c: () => { },     "d": '',     "e": 1,     1.0: '',    2.0: 1,     "3.0": '',     "4.0": 1,     f: <Myn>null,     get X() {         return '';    },    set X(v) { },     foo() {         return '';    }} : { a: string; b: number; c: () => void; d: string; e: number; 1: string; 2: number; "3.0": string; "4.0": number; f: Myn; get X(): string; set X(v: string); foo(): string; }
 
     a: '',
 >a : string

--- a/tests/baselines/reference/objectLitPropertyScoping.types
+++ b/tests/baselines/reference/objectLitPropertyScoping.types
@@ -4,12 +4,12 @@
 // Should compile, x and y should not be picked up from the properties
 
 function makePoint(x: number, y: number) {
->makePoint : (x: number, y: number) => { readonly x: number; readonly y: number; dist: () => number; }
+>makePoint : (x: number, y: number) => { get x(): number; get y(): number; dist: () => number; }
 >x : number
 >y : number
 
     return {
->{        get x() {            return x;        },        get y() {            return y;        },        dist: function () {            return Math.sqrt(x * x + y * y);        }    } : { readonly x: number; readonly y: number; dist: () => number; }
+>{        get x() {            return x;        },        get y() {            return y;        },        dist: function () {            return Math.sqrt(x * x + y * y);        }    } : { get x(): number; get y(): number; dist: () => number; }
 
         get x() {
 >x : number

--- a/tests/baselines/reference/objectLiteralErrors.types
+++ b/tests/baselines/reference/objectLiteralErrors.types
@@ -150,144 +150,144 @@ var e17 = { a: 0, b: 1, a: 0 };
 
 // Accessor and property with the same name
 var f1 = { a: 0, get a() { return 0; } };
->f1 : { readonly a: number; }
->{ a: 0, get a() { return 0; } } : { readonly a: number; }
+>f1 : { get a(): number; }
+>{ a: 0, get a() { return 0; } } : { get a(): number; }
 >a : number
 >0 : 0
 >a : number
 >0 : 0
 
 var f2 = { a: '', get a() { return ''; } };
->f2 : { readonly a: string; }
->{ a: '', get a() { return ''; } } : { readonly a: string; }
+>f2 : { get a(): string; }
+>{ a: '', get a() { return ''; } } : { get a(): string; }
 >a : string
 >'' : ""
 >a : string
 >'' : ""
 
 var f3 = { a: 0, get a() { return ''; } };
->f3 : { readonly a: string; }
->{ a: 0, get a() { return ''; } } : { readonly a: string; }
+>f3 : { get a(): string; }
+>{ a: 0, get a() { return ''; } } : { get a(): string; }
 >a : number
 >0 : 0
 >a : string
 >'' : ""
 
 var f4 = { a: true, get a() { return false; } };
->f4 : { readonly a: boolean; }
->{ a: true, get a() { return false; } } : { readonly a: boolean; }
+>f4 : { get a(): boolean; }
+>{ a: true, get a() { return false; } } : { get a(): boolean; }
 >a : boolean
 >true : true
 >a : boolean
 >false : false
 
 var f5 = { a: {}, get a() { return {}; } };
->f5 : { readonly a: {}; }
->{ a: {}, get a() { return {}; } } : { readonly a: {}; }
+>f5 : { get a(): {}; }
+>{ a: {}, get a() { return {}; } } : { get a(): {}; }
 >a : {}
 >{} : {}
 >a : {}
 >{} : {}
 
 var f6 = { a: 0, get 'a'() { return 0; } };
->f6 : { readonly a: number; }
->{ a: 0, get 'a'() { return 0; } } : { readonly a: number; }
+>f6 : { get a(): number; }
+>{ a: 0, get 'a'() { return 0; } } : { get a(): number; }
 >a : number
 >0 : 0
 >'a' : number
 >0 : 0
 
 var f7 = { 'a': 0, get a() { return 0; } };
->f7 : { readonly a: number; }
->{ 'a': 0, get a() { return 0; } } : { readonly a: number; }
+>f7 : { get a(): number; }
+>{ 'a': 0, get a() { return 0; } } : { get a(): number; }
 >'a' : number
 >0 : 0
 >a : number
 >0 : 0
 
 var f8 = { 'a': 0, get "a"() { return 0; } };
->f8 : { readonly a: number; }
->{ 'a': 0, get "a"() { return 0; } } : { readonly a: number; }
+>f8 : { get a(): number; }
+>{ 'a': 0, get "a"() { return 0; } } : { get a(): number; }
 >'a' : number
 >0 : 0
 >"a" : number
 >0 : 0
 
 var f9 = { 'a': 0, get 'a'() { return 0; } };
->f9 : { readonly a: number; }
->{ 'a': 0, get 'a'() { return 0; } } : { readonly a: number; }
+>f9 : { get a(): number; }
+>{ 'a': 0, get 'a'() { return 0; } } : { get a(): number; }
 >'a' : number
 >0 : 0
 >'a' : number
 >0 : 0
 
 var f10 = { "a": 0, get 'a'() { return 0; } };
->f10 : { readonly a: number; }
->{ "a": 0, get 'a'() { return 0; } } : { readonly a: number; }
+>f10 : { get a(): number; }
+>{ "a": 0, get 'a'() { return 0; } } : { get a(): number; }
 >"a" : number
 >0 : 0
 >'a' : number
 >0 : 0
 
 var f11 = { 1.0: 0, get '1'() { return 0; } };
->f11 : { readonly '1': number; }
->{ 1.0: 0, get '1'() { return 0; } } : { readonly '1': number; }
+>f11 : { get '1'(): number; }
+>{ 1.0: 0, get '1'() { return 0; } } : { get '1'(): number; }
 >1.0 : number
 >0 : 0
 >'1' : number
 >0 : 0
 
 var f12 = { 0: 0, get 0() { return 0; } };
->f12 : { readonly 0: number; }
->{ 0: 0, get 0() { return 0; } } : { readonly 0: number; }
+>f12 : { get 0(): number; }
+>{ 0: 0, get 0() { return 0; } } : { get 0(): number; }
 >0 : number
 >0 : 0
 >0 : number
 >0 : 0
 
 var f13 = { 0: 0, get 0() { return 0; } };
->f13 : { readonly 0: number; }
->{ 0: 0, get 0() { return 0; } } : { readonly 0: number; }
+>f13 : { get 0(): number; }
+>{ 0: 0, get 0() { return 0; } } : { get 0(): number; }
 >0 : number
 >0 : 0
 >0 : number
 >0 : 0
 
 var f14 = { 0: 0, get 0x0() { return 0; } };
->f14 : { readonly 0: number; }
->{ 0: 0, get 0x0() { return 0; } } : { readonly 0: number; }
+>f14 : { get 0(): number; }
+>{ 0: 0, get 0x0() { return 0; } } : { get 0(): number; }
 >0 : number
 >0 : 0
 >0x0 : number
 >0 : 0
 
 var f14 = { 0: 0, get 0o0() { return 0; } };
->f14 : { readonly 0: number; }
->{ 0: 0, get 0o0() { return 0; } } : { readonly 0: number; }
+>f14 : { get 0(): number; }
+>{ 0: 0, get 0o0() { return 0; } } : { get 0(): number; }
 >0 : number
 >0 : 0
 >0o0 : number
 >0 : 0
 
 var f15 = { "100": 0, get 1e2() { return 0; } };
->f15 : { readonly 100: number; }
->{ "100": 0, get 1e2() { return 0; } } : { readonly 100: number; }
+>f15 : { get 100(): number; }
+>{ "100": 0, get 1e2() { return 0; } } : { get 100(): number; }
 >"100" : number
 >0 : 0
 >1e2 : number
 >0 : 0
 
 var f16 = { 0x20: 0, get 3.2e1() { return 0; } };
->f16 : { readonly 32: number; }
->{ 0x20: 0, get 3.2e1() { return 0; } } : { readonly 32: number; }
+>f16 : { get 32(): number; }
+>{ 0x20: 0, get 3.2e1() { return 0; } } : { get 32(): number; }
 >0x20 : number
 >0 : 0
 >3.2e1 : number
 >0 : 0
 
 var f17 = { a: 0, get b() { return 1; }, get a() { return 0; } };
->f17 : { readonly a: number; readonly b: number; }
->{ a: 0, get b() { return 1; }, get a() { return 0; } } : { readonly a: number; readonly b: number; }
+>f17 : { get a(): number; get b(): number; }
+>{ a: 0, get b() { return 1; }, get a() { return 0; } } : { get a(): number; get b(): number; }
 >a : number
 >0 : 0
 >b : number
@@ -297,24 +297,24 @@ var f17 = { a: 0, get b() { return 1; }, get a() { return 0; } };
 
 // Get and set accessor with mismatched type annotations (only g2 is an error after #43662 implemented)
 var g1 = { get a(): number { return 4; }, set a(n: string) { } };
->g1 : { a: number; }
->{ get a(): number { return 4; }, set a(n: string) { } } : { a: number; }
+>g1 : { get a(): number; set a(n: number); }
+>{ get a(): number { return 4; }, set a(n: string) { } } : { get a(): number; set a(n: number); }
 >a : number
 >4 : 4
 >a : number
 >n : string
 
 var g2 = { get a() { return 4; }, set a(n: string) { } };
->g2 : { a: string; }
->{ get a() { return 4; }, set a(n: string) { } } : { a: string; }
+>g2 : { get a(): string; set a(n: string); }
+>{ get a() { return 4; }, set a(n: string) { } } : { get a(): string; set a(n: string); }
 >a : string
 >4 : 4
 >a : string
 >n : string
 
 var g3 = { get a(): number { return undefined; }, set a(n: string) { } };
->g3 : { a: number; }
->{ get a(): number { return undefined; }, set a(n: string) { } } : { a: number; }
+>g3 : { get a(): number; set a(n: number); }
+>{ get a(): number { return undefined; }, set a(n: string) { } } : { get a(): number; set a(n: number); }
 >a : number
 >undefined : undefined
 >a : number

--- a/tests/baselines/reference/objectLiteralErrorsES3.types
+++ b/tests/baselines/reference/objectLiteralErrorsES3.types
@@ -2,20 +2,20 @@
 
 === objectLiteralErrorsES3.ts ===
 var e1 = { get a() { return 4; } };
->e1 : { readonly a: number; }
->{ get a() { return 4; } } : { readonly a: number; }
+>e1 : { get a(): number; }
+>{ get a() { return 4; } } : { get a(): number; }
 >a : number
 >4 : 4
 
 var e2 = { set a(n) { } };
->e2 : { a: any; }
->{ set a(n) { } } : { a: any; }
+>e2 : { set a(n: any); }
+>{ set a(n) { } } : { set a(n: any); }
 >a : any
 >n : any
 
 var e3 = { get a() { return ''; }, set a(n) { } };
->e3 : { a: string; }
->{ get a() { return ''; }, set a(n) { } } : { a: string; }
+>e3 : { get a(): string; set a(n: string); }
+>{ get a() { return ''; }, set a(n) { } } : { get a(): string; set a(n: string); }
 >a : string
 >'' : ""
 >a : string

--- a/tests/baselines/reference/objectLiteralGettersAndSetters.types
+++ b/tests/baselines/reference/objectLiteralGettersAndSetters.types
@@ -3,8 +3,8 @@
 === objectLiteralGettersAndSetters.ts ===
 // Get and set accessor with the same name
 var sameName1a = { get 'a'() { return ''; }, set a(n) { var p = n; var p: string; } };
->sameName1a : { a: string; }
->{ get 'a'() { return ''; }, set a(n) { var p = n; var p: string; } } : { a: string; }
+>sameName1a : { get a(): string; set a(n: string); }
+>{ get 'a'() { return ''; }, set a(n) { var p = n; var p: string; } } : { get a(): string; set a(n: string); }
 >'a' : string
 >'' : ""
 >a : string
@@ -14,8 +14,8 @@ var sameName1a = { get 'a'() { return ''; }, set a(n) { var p = n; var p: string
 >p : string
 
 var sameName2a = { get 0.0() { return ''; }, set 0(n) { var p = n; var p: string; } };
->sameName2a : { 0: string; }
->{ get 0.0() { return ''; }, set 0(n) { var p = n; var p: string; } } : { 0: string; }
+>sameName2a : { get 0(): string; set 0(n: string); }
+>{ get 0.0() { return ''; }, set 0(n) { var p = n; var p: string; } } : { get 0(): string; set 0(n: string); }
 >0.0 : string
 >'' : ""
 >0 : string
@@ -25,8 +25,8 @@ var sameName2a = { get 0.0() { return ''; }, set 0(n) { var p = n; var p: string
 >p : string
 
 var sameName3a = { get 0x20() { return ''; }, set 3.2e1(n) { var p = n; var p: string; } };
->sameName3a : { 32: string; }
->{ get 0x20() { return ''; }, set 3.2e1(n) { var p = n; var p: string; } } : { 32: string; }
+>sameName3a : { get 32(): string; set 32(n: string); }
+>{ get 0x20() { return ''; }, set 3.2e1(n) { var p = n; var p: string; } } : { get 32(): string; set 32(n: string); }
 >0x20 : string
 >'' : ""
 >3.2e1 : string
@@ -36,8 +36,8 @@ var sameName3a = { get 0x20() { return ''; }, set 3.2e1(n) { var p = n; var p: s
 >p : string
 
 var sameName4a = { get ''() { return ''; }, set ""(n) { var p = n; var p: string; } };
->sameName4a : { "": string; }
->{ get ''() { return ''; }, set ""(n) { var p = n; var p: string; } } : { "": string; }
+>sameName4a : { get ""(): string; set ""(n: string); }
+>{ get ''() { return ''; }, set ""(n) { var p = n; var p: string; } } : { get ""(): string; set ""(n: string); }
 >'' : string
 >'' : ""
 >"" : string
@@ -47,8 +47,8 @@ var sameName4a = { get ''() { return ''; }, set ""(n) { var p = n; var p: string
 >p : string
 
 var sameName5a = { get '\t'() { return ''; }, set '\t'(n) { var p = n; var p: string; } };
->sameName5a : { '\t': string; }
->{ get '\t'() { return ''; }, set '\t'(n) { var p = n; var p: string; } } : { '\t': string; }
+>sameName5a : { get '\t'(): string; set '\t'(n: string); }
+>{ get '\t'() { return ''; }, set '\t'(n) { var p = n; var p: string; } } : { get '\t'(): string; set '\t'(n: string); }
 >'\t' : string
 >'' : ""
 >'\t' : string
@@ -58,8 +58,8 @@ var sameName5a = { get '\t'() { return ''; }, set '\t'(n) { var p = n; var p: st
 >p : string
 
 var sameName6a = { get 'a'() { return ''; }, set a(n) { var p = n; var p: string; } };
->sameName6a : { a: string; }
->{ get 'a'() { return ''; }, set a(n) { var p = n; var p: string; } } : { a: string; }
+>sameName6a : { get a(): string; set a(n: string); }
+>{ get 'a'() { return ''; }, set a(n) { var p = n; var p: string; } } : { get a(): string; set a(n: string); }
 >'a' : string
 >'' : ""
 >a : string
@@ -109,46 +109,46 @@ var callSig3: { num: (n: number) => string; };
 
 // Get accessor only, type of the property is the annotated return type of the get accessor
 var getter1 = { get x(): string { return undefined; } };
->getter1 : { readonly x: string; }
->{ get x(): string { return undefined; } } : { readonly x: string; }
+>getter1 : { get x(): string; }
+>{ get x(): string { return undefined; } } : { get x(): string; }
 >x : string
 >undefined : undefined
 
 var getter1: { readonly x: string; }
->getter1 : { readonly x: string; }
+>getter1 : { get x(): string; }
 >x : string
 
 // Get accessor only, type of the property is the inferred return type of the get accessor
 var getter2 = { get x() { return ''; } };
->getter2 : { readonly x: string; }
->{ get x() { return ''; } } : { readonly x: string; }
+>getter2 : { get x(): string; }
+>{ get x() { return ''; } } : { get x(): string; }
 >x : string
 >'' : ""
 
 var getter2: { readonly x: string; }
->getter2 : { readonly x: string; }
+>getter2 : { get x(): string; }
 >x : string
 
 // Set accessor only, type of the property is the param type of the set accessor
 var setter1 = { set x(n: number) { } };
->setter1 : { x: number; }
->{ set x(n: number) { } } : { x: number; }
+>setter1 : { set x(n: number); }
+>{ set x(n: number) { } } : { set x(n: number); }
 >x : number
 >n : number
 
 var setter1: { x: number };
->setter1 : { x: number; }
+>setter1 : { set x(n: number); }
 >x : number
 
 // Set accessor only, type of the property is Any for an unannotated set accessor
 var setter2 = { set x(n) { } };
->setter2 : { x: any; }
->{ set x(n) { } } : { x: any; }
+>setter2 : { set x(n: any); }
+>{ set x(n) { } } : { set x(n: any); }
 >x : any
 >n : any
 
 var setter2: { x: any };
->setter2 : { x: any; }
+>setter2 : { set x(n: any); }
 >x : any
 
 var anyVar: any;
@@ -156,24 +156,24 @@ var anyVar: any;
 
 // Get and set accessor with matching type annotations
 var sameType1 = { get x(): string { return undefined; }, set x(n: string) { } };
->sameType1 : { x: string; }
->{ get x(): string { return undefined; }, set x(n: string) { } } : { x: string; }
+>sameType1 : { get x(): string; set x(n: string); }
+>{ get x(): string { return undefined; }, set x(n: string) { } } : { get x(): string; set x(n: string); }
 >x : string
 >undefined : undefined
 >x : string
 >n : string
 
 var sameType2 = { get x(): Array<number> { return undefined; }, set x(n: number[]) { } };
->sameType2 : { x: number[]; }
->{ get x(): Array<number> { return undefined; }, set x(n: number[]) { } } : { x: number[]; }
+>sameType2 : { get x(): number[]; set x(n: number[]); }
+>{ get x(): Array<number> { return undefined; }, set x(n: number[]) { } } : { get x(): number[]; set x(n: number[]); }
 >x : number[]
 >undefined : undefined
 >x : number[]
 >n : number[]
 
 var sameType3 = { get x(): any { return undefined; }, set x(n: typeof anyVar) { } };
->sameType3 : { x: any; }
->{ get x(): any { return undefined; }, set x(n: typeof anyVar) { } } : { x: any; }
+>sameType3 : { get x(): any; set x(n: any); }
+>{ get x(): any { return undefined; }, set x(n: typeof anyVar) { } } : { get x(): any; set x(n: any); }
 >x : any
 >undefined : undefined
 >x : any
@@ -181,8 +181,8 @@ var sameType3 = { get x(): any { return undefined; }, set x(n: typeof anyVar) { 
 >anyVar : any
 
 var sameType4 = { get x(): Date { return undefined; }, set x(n: Date) { } };
->sameType4 : { x: Date; }
->{ get x(): Date { return undefined; }, set x(n: Date) { } } : { x: Date; }
+>sameType4 : { get x(): Date; set x(n: Date); }
+>{ get x(): Date { return undefined; }, set x(n: Date) { } } : { get x(): Date; set x(n: Date); }
 >x : Date
 >undefined : undefined
 >x : Date
@@ -190,8 +190,8 @@ var sameType4 = { get x(): Date { return undefined; }, set x(n: Date) { } };
 
 // Type of unannotated get accessor return type is the type annotation of the set accessor param
 var setParamType1 = {
->setParamType1 : { n: (t: string) => void; }
->{    set n(x: (t: string) => void) { },    get n() { return (t) => {            var p: string;            var p = t;        }    }} : { n: (t: string) => void; }
+>setParamType1 : { get n(): (t: string) => void; set n(x: (t: string) => void); }
+>{    set n(x: (t: string) => void) { },    get n() { return (t) => {            var p: string;            var p = t;        }    }} : { get n(): (t: string) => void; set n(x: (t: string) => void); }
 
     set n(x: (t: string) => void) { },
 >n : (t: string) => void
@@ -213,8 +213,8 @@ var setParamType1 = {
     }
 };
 var setParamType2 = {
->setParamType2 : { n: (t: string) => void; }
->{    get n() { return (t) => {            var p: string;            var p = t;        }    },    set n(x: (t: string) => void) { }} : { n: (t: string) => void; }
+>setParamType2 : { get n(): (t: string) => void; set n(x: (t: string) => void); }
+>{    get n() { return (t) => {            var p: string;            var p = t;        }    },    set n(x: (t: string) => void) { }} : { get n(): (t: string) => void; set n(x: (t: string) => void); }
 
     get n() { return (t) => {
 >n : (t: string) => void
@@ -238,8 +238,8 @@ var setParamType2 = {
 
 // Type of unannotated set accessor parameter is the return type annotation of the get accessor
 var getParamType1 = {
->getParamType1 : { n: string; }
->{    set n(x) {        var y = x;        var y: string;    },    get n() { return ''; }} : { n: string; }
+>getParamType1 : { get n(): string; set n(x: string); }
+>{    set n(x) {        var y = x;        var y: string;    },    get n() { return ''; }} : { get n(): string; set n(x: string); }
 
     set n(x) {
 >n : string
@@ -259,8 +259,8 @@ var getParamType1 = {
 
 };
 var getParamType2 = {
->getParamType2 : { n: string; }
->{    get n() { return ''; },    set n(x) {        var y = x;        var y: string;    }} : { n: string; }
+>getParamType2 : { get n(): string; set n(x: string); }
+>{    get n() { return ''; },    set n(x) {        var y = x;        var y: string;    }} : { get n(): string; set n(x: string); }
 
     get n() { return ''; },
 >n : string
@@ -281,8 +281,8 @@ var getParamType2 = {
 
 // Type of unannotated accessors is the inferred return type of the get accessor
 var getParamType3 = {
->getParamType3 : { n: string; }
->{    get n() { return ''; },    set n(x) {        var y = x;        var y: string;    }} : { n: string; }
+>getParamType3 : { get n(): string; set n(x: string); }
+>{    get n() { return ''; },    set n(x) {        var y = x;        var y: string;    }} : { get n(): string; set n(x: string); }
 
     get n() { return ''; },
 >n : string

--- a/tests/baselines/reference/objectLiteralMemberWithModifiers2.types
+++ b/tests/baselines/reference/objectLiteralMemberWithModifiers2.types
@@ -2,7 +2,7 @@
 
 === objectLiteralMemberWithModifiers2.ts ===
 var v = { public get foo() { } }
->v : { readonly foo: void; }
->{ public get foo() { } } : { readonly foo: void; }
+>v : { get foo(): void; }
+>{ public get foo() { } } : { get foo(): void; }
 >foo : void
 

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.types
@@ -3,8 +3,8 @@
 === objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts ===
 // errors
 var y = {
->y : { stringLiteral: any; 42: any; readonly e: void; f: any; this: any; super: any; var: any; class: any; typeof: any; }
->{    "stringLiteral",    42,    get e,    set f,    this,    super,    var,    class,    typeof} : { stringLiteral: any; 42: any; readonly e: void; f: any; this: any; super: any; var: any; class: any; typeof: any; }
+>y : { stringLiteral: any; 42: any; get e(): void; set f(arg: any); this: any; super: any; var: any; class: any; typeof: any; }
+>{    "stringLiteral",    42,    get e,    set f,    this,    super,    var,    class,    typeof} : { stringLiteral: any; 42: any; get e(): void; set f(arg: any); this: any; super: any; var: any; class: any; typeof: any; }
 
     "stringLiteral",
 >"stringLiteral" : any

--- a/tests/baselines/reference/objectLiteralWithGetAccessorInsideFunction.types
+++ b/tests/baselines/reference/objectLiteralWithGetAccessorInsideFunction.types
@@ -5,8 +5,8 @@ function bar() {
 >bar : () => void
 
     var x = {
->x : { readonly _extraOccluded: number; }
->{        get _extraOccluded() {            var occluded = 0;            return occluded;        },    } : { readonly _extraOccluded: number; }
+>x : { get _extraOccluded(): number; }
+>{        get _extraOccluded() {            var occluded = 0;            return occluded;        },    } : { get _extraOccluded(): number; }
 
         get _extraOccluded() {
 >_extraOccluded : number

--- a/tests/baselines/reference/objectLiteralWithSemicolons5.types
+++ b/tests/baselines/reference/objectLiteralWithSemicolons5.types
@@ -2,8 +2,8 @@
 
 === objectLiteralWithSemicolons5.ts ===
 var v = { foo() { }; a: b; get baz() { }; }
->v : { foo(): void; a: any; readonly baz: void; }
->{ foo() { }; a: b; get baz() { }; } : { foo(): void; a: any; readonly baz: void; }
+>v : { foo(): void; a: any; get baz(): void; }
+>{ foo() { }; a: b; get baz() { }; } : { foo(): void; a: any; get baz(): void; }
 >foo : () => void
 >a : any
 >b : any

--- a/tests/baselines/reference/objectSpread.types
+++ b/tests/baselines/reference/objectSpread.types
@@ -139,8 +139,8 @@ let propertyNested: { a: { a: number, b: string } } =
 // accessors don't copy the descriptor
 // (which means that readonly getters become read/write properties)
 let op = { get a () { return 6 } };
->op : { readonly a: number; }
->{ get a () { return 6 } } : { readonly a: number; }
+>op : { get a(): number; }
+>{ get a () { return 6 } } : { get a(): number; }
 >a : number
 >6 : 6
 
@@ -151,7 +151,7 @@ let getter: { a: number, c: number } =
 
     { ...op, c: 7 }
 >{ ...op, c: 7 } : { c: number; a: number; }
->op : { readonly a: number; }
+>op : { get a(): number; }
 >c : number
 >7 : 7
 

--- a/tests/baselines/reference/objectSpreadNegative.types
+++ b/tests/baselines/reference/objectSpreadNegative.types
@@ -284,7 +284,7 @@ spreadFunc(); // error, no call signature
 let setterOnly = { ...{ set b (bad: number) { } } };
 >setterOnly : { b: undefined; }
 >{ ...{ set b (bad: number) { } } } : { b: undefined; }
->{ set b (bad: number) { } } : { b: number; }
+>{ set b (bad: number) { } } : { set b(bad: number); }
 >b : number
 >bad : number
 

--- a/tests/baselines/reference/objectSpreadSetonlyAccessor.types
+++ b/tests/baselines/reference/objectSpreadSetonlyAccessor.types
@@ -8,7 +8,7 @@ const o1: { foo: number, bar: undefined } = { foo: 1, ... { set bar(_v: number) 
 >{ foo: 1, ... { set bar(_v: number) { } } } : { bar: undefined; foo: number; }
 >foo : number
 >1 : 1
->{ set bar(_v: number) { } } : { bar: number; }
+>{ set bar(_v: number) { } } : { set bar(_v: number); }
 >bar : number
 >_v : number
 
@@ -18,7 +18,7 @@ const o2: { foo: undefined } = { foo: 1, ... { set foo(_v: number) { } } }
 >{ foo: 1, ... { set foo(_v: number) { } } } : { foo: undefined; }
 >foo : number
 >1 : 1
->{ set foo(_v: number) { } } : { foo: number; }
+>{ set foo(_v: number) { } } : { set foo(_v: number); }
 >foo : number
 >_v : number
 

--- a/tests/baselines/reference/parserAccessors10.types
+++ b/tests/baselines/reference/parserAccessors10.types
@@ -2,8 +2,8 @@
 
 === parserAccessors10.ts ===
 var v = {
->v : { readonly foo: void; }
->{  public get foo() { }} : { readonly foo: void; }
+>v : { get foo(): void; }
+>{  public get foo() { }} : { get foo(): void; }
 
   public get foo() { }
 >foo : void

--- a/tests/baselines/reference/parserAccessors3.types
+++ b/tests/baselines/reference/parserAccessors3.types
@@ -2,7 +2,7 @@
 
 === parserAccessors3.ts ===
 var v = { get Foo() { } };
->v : { readonly Foo: void; }
->{ get Foo() { } } : { readonly Foo: void; }
+>v : { get Foo(): void; }
+>{ get Foo() { } } : { get Foo(): void; }
 >Foo : void
 

--- a/tests/baselines/reference/parserAccessors4.types
+++ b/tests/baselines/reference/parserAccessors4.types
@@ -2,8 +2,8 @@
 
 === parserAccessors4.ts ===
 var v = { set Foo(a) { } };
->v : { Foo: any; }
->{ set Foo(a) { } } : { Foo: any; }
+>v : { set Foo(a: any); }
+>{ set Foo(a) { } } : { set Foo(a: any); }
 >Foo : any
 >a : any
 

--- a/tests/baselines/reference/parserAccessors7.types
+++ b/tests/baselines/reference/parserAccessors7.types
@@ -2,8 +2,8 @@
 
 === parserAccessors7.ts ===
 var v = { get foo(v: number) { } };
->v : { readonly foo: void; }
->{ get foo(v: number) { } } : { readonly foo: void; }
+>v : { get foo(): void; }
+>{ get foo(v: number) { } } : { get foo(): void; }
 >foo : void
 >v : number
 

--- a/tests/baselines/reference/parserAccessors8.types
+++ b/tests/baselines/reference/parserAccessors8.types
@@ -2,7 +2,7 @@
 
 === parserAccessors8.ts ===
 var v = { set foo() { } }
->v : { foo: any; }
->{ set foo() { } } : { foo: any; }
+>v : { set foo(arg: any); }
+>{ set foo() { } } : { set foo(arg: any); }
 >foo : any
 

--- a/tests/baselines/reference/parserAccessors9.types
+++ b/tests/baselines/reference/parserAccessors9.types
@@ -2,8 +2,8 @@
 
 === parserAccessors9.ts ===
 var v = { set foo(a, b) { } }
->v : { foo: any; }
->{ set foo(a, b) { } } : { foo: any; }
+>v : { set foo(a: any); }
+>{ set foo(a, b) { } } : { set foo(a: any); }
 >foo : any
 >a : any
 >b : any

--- a/tests/baselines/reference/parserES3Accessors3.types
+++ b/tests/baselines/reference/parserES3Accessors3.types
@@ -2,7 +2,7 @@
 
 === parserES3Accessors3.ts ===
 var v = { get Foo() { } };
->v : { readonly Foo: void; }
->{ get Foo() { } } : { readonly Foo: void; }
+>v : { get Foo(): void; }
+>{ get Foo() { } } : { get Foo(): void; }
 >Foo : void
 

--- a/tests/baselines/reference/parserES3Accessors4.types
+++ b/tests/baselines/reference/parserES3Accessors4.types
@@ -2,8 +2,8 @@
 
 === parserES3Accessors4.ts ===
 var v = { set Foo(a) { } };
->v : { Foo: any; }
->{ set Foo(a) { } } : { Foo: any; }
+>v : { set Foo(a: any); }
+>{ set Foo(a) { } } : { set Foo(a: any); }
 >Foo : any
 >a : any
 

--- a/tests/baselines/reference/parserReturnStatement4.types
+++ b/tests/baselines/reference/parserReturnStatement4.types
@@ -2,7 +2,7 @@
 
 === parserReturnStatement4.ts ===
 var v = { get foo() { return } };
->v : { readonly foo: void; }
->{ get foo() { return } } : { readonly foo: void; }
+>v : { get foo(): void; }
+>{ get foo() { return } } : { get foo(): void; }
 >foo : void
 

--- a/tests/baselines/reference/parserStrictMode12.types
+++ b/tests/baselines/reference/parserStrictMode12.types
@@ -5,8 +5,8 @@
 >"use strict" : "use strict"
 
 var v = { set foo(eval) { } }
->v : { foo: any; }
->{ set foo(eval) { } } : { foo: any; }
+>v : { set foo(eval: any); }
+>{ set foo(eval) { } } : { set foo(eval: any); }
 >foo : any
 >eval : any
 

--- a/tests/baselines/reference/readonlyInDeclarationFile.js
+++ b/tests/baselines/reference/readonlyInDeclarationFile.js
@@ -178,8 +178,9 @@ declare var z: {
     readonly [x: string]: Object;
 };
 declare function f(): {
-    readonly x: number;
-    y: number;
+    get x(): number;
+    get y(): number;
+    set y(value: number);
 };
 declare function g(): {
     readonly [x: string]: Object;

--- a/tests/baselines/reference/readonlyInDeclarationFile.types
+++ b/tests/baselines/reference/readonlyInDeclarationFile.types
@@ -117,10 +117,10 @@ var z: {
 }
 
 function f() {
->f : () => { readonly x: number; y: number; }
+>f : () => { get x(): number; get y(): number; set y(value: number); }
 
     return {
->{        get x() { return 1; },        get y() { return 1; },        set y(value) { }    } : { readonly x: number; y: number; }
+>{        get x() { return 1; },        get y() { return 1; },        set y(value) { }    } : { get x(): number; get y(): number; set y(value: number); }
 
         get x() { return 1; },
 >x : number

--- a/tests/baselines/reference/readonlyMembers.types
+++ b/tests/baselines/reference/readonlyMembers.types
@@ -117,8 +117,8 @@ class C {
 }
 
 var o = {
->o : { readonly a: number; b: number; }
->{    get a() { return 1 },    get b() { return 1 },    set b(value) { }} : { readonly a: number; b: number; }
+>o : { get a(): number; get b(): number; set b(value: number); }
+>{    get a() { return 1 },    get b() { return 1 },    set b(value) { }} : { get a(): number; get b(): number; set b(value: number); }
 
     get a() { return 1 },
 >a : number
@@ -136,14 +136,14 @@ var o = {
 o.a = 1;  // Error
 >o.a = 1 : 1
 >o.a : any
->o : { readonly a: number; b: number; }
+>o : { get a(): number; get b(): number; set b(value: number); }
 >a : any
 >1 : 1
 
 o.b = 1;
 >o.b = 1 : 1
 >o.b : number
->o : { readonly a: number; b: number; }
+>o : { get a(): number; get b(): number; set b(value: number); }
 >b : number
 >1 : 1
 

--- a/tests/baselines/reference/recursiveConditionalTypes.types
+++ b/tests/baselines/reference/recursiveConditionalTypes.types
@@ -223,15 +223,15 @@ unbox(b4);  // { value: { value: typeof b4 }}
 >b4 : { value: { value: { value: any; }; }; }
 
 unbox({ value: { value: { get value() { return this; } }}});  // { readonly value: ... }
->unbox({ value: { value: { get value() { return this; } }}}) : { readonly value: { readonly value: any; }; }
+>unbox({ value: { value: { get value() { return this; } }}}) : { get value(): { get value(): any; }; }
 >unbox : <T>(box: RecBox<T>) => T
->{ value: { value: { get value() { return this; } }}} : { value: { value: { readonly value: { readonly value: any; }; }; }; }
->value : { value: { readonly value: { readonly value: any; }; }; }
->{ value: { get value() { return this; } }} : { value: { readonly value: { readonly value: any; }; }; }
->value : { readonly value: { readonly value: any; }; }
->{ get value() { return this; } } : { readonly value: { readonly value: any; }; }
->value : { readonly value: any; }
->this : { readonly value: any; } | RecBox<{ readonly value: { readonly value: any; }; }>
+>{ value: { value: { get value() { return this; } }}} : { value: { value: { get value(): { get value(): any; }; }; }; }
+>value : { value: { get value(): { get value(): any; }; }; }
+>{ value: { get value() { return this; } }} : { value: { get value(): { get value(): any; }; }; }
+>value : { get value(): { get value(): any; }; }
+>{ get value() { return this; } } : { get value(): { get value(): any; }; }
+>value : { get value(): any; }
+>this : { get value(): any; } | RecBox<{ get value(): { get value(): any; }; }>
 
 // Inference from nested instantiations of same generic types
 

--- a/tests/baselines/reference/recursiveInferenceBug.types
+++ b/tests/baselines/reference/recursiveInferenceBug.types
@@ -17,8 +17,8 @@ function f(x: number) {
 
 
 var zz = {
->zz : { g: () => void; readonly f: string; }
->{    g: () =>{ },    get f() { return "abc"; },} : { g: () => void; readonly f: string; }
+>zz : { g: () => void; get f(): string; }
+>{    g: () =>{ },    get f() { return "abc"; },} : { g: () => void; get f(): string; }
 
     g: () =>{ },
 >g : () => void

--- a/tests/baselines/reference/spreadMethods.types
+++ b/tests/baselines/reference/spreadMethods.types
@@ -76,7 +76,7 @@ ssk.g; // error
 
 let i: I = { p: 12, m() { }, get g() { return 0; } };
 >i : I
->{ p: 12, m() { }, get g() { return 0; } } : { p: number; m(): void; readonly g: number; }
+>{ p: 12, m() { }, get g() { return 0; } } : { p: number; m(): void; get g(): number; }
 >p : number
 >12 : 12
 >m : () => void
@@ -127,8 +127,8 @@ ssi.g; // ok
 >g : number
 
 let o = { p: 12, m() { }, get g() { return 0; } };
->o : { p: number; m(): void; readonly g: number; }
->{ p: 12, m() { }, get g() { return 0; } } : { p: number; m(): void; readonly g: number; }
+>o : { p: number; m(): void; get g(): number; }
+>{ p: 12, m() { }, get g() { return 0; } } : { p: number; m(): void; get g(): number; }
 >p : number
 >12 : 12
 >m : () => void
@@ -138,13 +138,13 @@ let o = { p: 12, m() { }, get g() { return 0; } };
 let so = { ...o };
 >so : { p: number; m(): void; g: number; }
 >{ ...o } : { p: number; m(): void; g: number; }
->o : { p: number; m(): void; readonly g: number; }
+>o : { p: number; m(): void; get g(): number; }
 
 let sso = { ...o, ...o };
 >sso : { p: number; m(): void; g: number; }
 >{ ...o, ...o } : { p: number; m(): void; g: number; }
->o : { p: number; m(): void; readonly g: number; }
->o : { p: number; m(): void; readonly g: number; }
+>o : { p: number; m(): void; get g(): number; }
+>o : { p: number; m(): void; get g(): number; }
 
 so.p;
 >so.p : number

--- a/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations.types
+++ b/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations.types
@@ -170,7 +170,7 @@ var a: {
 var b: { [x: string]: string; } = {
 >b : { [x: string]: string; }
 >x : string
->{    a: '',    b: 1,     c: () => { },     "d": '',     "e": 1,     1.0: '',    2.0: 1,     "3.0": '',     "4.0": 1,     f: <MyString>null,     get X() {         return '';    },    set X(v) { },     foo() {         return '';    }} : { a: string; b: number; c: () => void; d: string; e: number; 1: string; 2: number; "3.0": string; "4.0": number; f: MyString; X: string; foo(): string; }
+>{    a: '',    b: 1,     c: () => { },     "d": '',     "e": 1,     1.0: '',    2.0: 1,     "3.0": '',     "4.0": 1,     f: <MyString>null,     get X() {         return '';    },    set X(v) { },     foo() {         return '';    }} : { a: string; b: number; c: () => void; d: string; e: number; 1: string; 2: number; "3.0": string; "4.0": number; f: MyString; get X(): string; set X(v: string); foo(): string; }
 
     a: '',
 >a : string

--- a/tests/baselines/reference/superInObjectLiterals_ES5.types
+++ b/tests/baselines/reference/superInObjectLiterals_ES5.types
@@ -2,8 +2,8 @@
 
 === superInObjectLiterals_ES5.ts ===
 var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
+>{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
 
     __proto__: {
 >__proto__ : { method(): void; }
@@ -97,8 +97,8 @@ class B extends A {
 >f : () => void
 
         var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
+>{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
 
             __proto__: {
 >__proto__ : { method(): void; }

--- a/tests/baselines/reference/superInObjectLiterals_ES6.types
+++ b/tests/baselines/reference/superInObjectLiterals_ES6.types
@@ -2,8 +2,8 @@
 
 === superInObjectLiterals_ES6.ts ===
 var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
+>{    __proto__: {        method() {        }    },    method() {        super.method();    },    get prop() {        super.method();        return 10;    },    set prop(value) {        super.method();    },    p1: function () {        super.method();    },    p2: function f() {        super.method();    },    p3: () => {        super.method();    }} : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
 
     __proto__: {
 >__proto__ : { method(): void; }
@@ -97,8 +97,8 @@ class B extends A {
 >f : () => void
 
         var obj = {
->obj : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
->{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { __proto__: { method(): void; }; method(): void; prop: number; p1: () => void; p2: () => void; p3: () => void; }
+>obj : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
+>{            __proto__: {                method() {                }            },            method() {                super.method();            },            get prop() {                super.method();                return 10;            },            set prop(value) {                super.method();            },            p1: function () {                super.method();            },            p2: function f() {                super.method();            },            p3: () => {                super.method();            }        } : { __proto__: { method(): void; }; method(): void; get prop(): number; set prop(value: number); p1: () => void; p2: () => void; p3: () => void; }
 
             __proto__: {
 >__proto__ : { method(): void; }

--- a/tests/baselines/reference/super_inside-object-literal-getters-and-setters.types
+++ b/tests/baselines/reference/super_inside-object-literal-getters-and-setters.types
@@ -5,8 +5,8 @@ module ObjectLiteral {
 >ObjectLiteral : typeof ObjectLiteral
 
     var ThisInObjectLiteral = {
->ThisInObjectLiteral : { _foo: string; foo: string; test: () => any; }
->{        _foo: '1',        get foo(): string {            return super._foo;        },        set foo(value: string) {            super._foo = value;        },        test: function () {            return super._foo;        }    } : { _foo: string; foo: string; test: () => any; }
+>ThisInObjectLiteral : { _foo: string; get foo(): string; set foo(value: string); test: () => any; }
+>{        _foo: '1',        get foo(): string {            return super._foo;        },        set foo(value: string) {            super._foo = value;        },        test: function () {            return super._foo;        }    } : { _foo: string; get foo(): string; set foo(value: string); test: () => any; }
 
         _foo: '1',
 >_foo : string
@@ -58,8 +58,8 @@ class SuperObjectTest extends F {
 >testing : () => void
 
         var test = {
->test : { readonly F: any; }
->{            get F() {                return super.test();            }        } : { readonly F: any; }
+>test : { get F(): any; }
+>{            get F() {                return super.test();            }        } : { get F(): any; }
 
             get F() {
 >F : any

--- a/tests/baselines/reference/symbolDeclarationEmit10.js
+++ b/tests/baselines/reference/symbolDeclarationEmit10.js
@@ -15,5 +15,6 @@ var obj = {
 
 //// [symbolDeclarationEmit10.d.ts]
 declare var obj: {
-    [Symbol.isConcatSpreadable]: string;
+    get [Symbol.isConcatSpreadable](): string;
+    set [Symbol.isConcatSpreadable](x: string);
 };

--- a/tests/baselines/reference/symbolDeclarationEmit10.types
+++ b/tests/baselines/reference/symbolDeclarationEmit10.types
@@ -2,8 +2,8 @@
 
 === symbolDeclarationEmit10.ts ===
 var obj = {
->obj : { [Symbol.isConcatSpreadable]: string; }
->{    get [Symbol.isConcatSpreadable]() { return '' },    set [Symbol.isConcatSpreadable](x) { }} : { [Symbol.isConcatSpreadable]: string; }
+>obj : { get [Symbol.isConcatSpreadable](): string; set [Symbol.isConcatSpreadable](x: string); }
+>{    get [Symbol.isConcatSpreadable]() { return '' },    set [Symbol.isConcatSpreadable](x) { }} : { get [Symbol.isConcatSpreadable](): string; set [Symbol.isConcatSpreadable](x: string); }
 
     get [Symbol.isConcatSpreadable]() { return '' },
 >[Symbol.isConcatSpreadable] : string

--- a/tests/baselines/reference/symbolProperty18.types
+++ b/tests/baselines/reference/symbolProperty18.types
@@ -2,8 +2,8 @@
 
 === symbolProperty18.ts ===
 var i = {
->i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
->{    [Symbol.iterator]: 0,    [Symbol.toStringTag]() { return "" },    set [Symbol.toPrimitive](p: boolean) { }} : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
+>i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; set [Symbol.toPrimitive](p: boolean); }
+>{    [Symbol.iterator]: 0,    [Symbol.toStringTag]() { return "" },    set [Symbol.toPrimitive](p: boolean) { }} : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; set [Symbol.toPrimitive](p: boolean); }
 
     [Symbol.iterator]: 0,
 >[Symbol.iterator] : number
@@ -30,7 +30,7 @@ var i = {
 var it = i[Symbol.iterator];
 >it : number
 >i[Symbol.iterator] : number
->i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
+>i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; set [Symbol.toPrimitive](p: boolean); }
 >Symbol.iterator : unique symbol
 >Symbol : SymbolConstructor
 >iterator : unique symbol
@@ -39,7 +39,7 @@ var str = i[Symbol.toStringTag]();
 >str : string
 >i[Symbol.toStringTag]() : string
 >i[Symbol.toStringTag] : () => string
->i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
+>i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; set [Symbol.toPrimitive](p: boolean); }
 >Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
 >toStringTag : unique symbol
@@ -47,7 +47,7 @@ var str = i[Symbol.toStringTag]();
 i[Symbol.toPrimitive] = false;
 >i[Symbol.toPrimitive] = false : false
 >i[Symbol.toPrimitive] : boolean
->i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; [Symbol.toPrimitive]: boolean; }
+>i : { [Symbol.iterator]: number; [Symbol.toStringTag](): string; set [Symbol.toPrimitive](p: boolean); }
 >Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
 >toPrimitive : unique symbol

--- a/tests/baselines/reference/symbolProperty5.types
+++ b/tests/baselines/reference/symbolProperty5.types
@@ -2,8 +2,8 @@
 
 === symbolProperty5.ts ===
 var x = {
->x : { [Symbol.iterator]: number; [Symbol.toPrimitive](): void; readonly [Symbol.toStringTag]: number; }
->{    [Symbol.iterator]: 0,    [Symbol.toPrimitive]() { },    get [Symbol.toStringTag]() {        return 0;    }} : { [Symbol.iterator]: number; [Symbol.toPrimitive](): void; readonly [Symbol.toStringTag]: number; }
+>x : { [Symbol.iterator]: number; [Symbol.toPrimitive](): void; get [Symbol.toStringTag](): number; }
+>{    [Symbol.iterator]: 0,    [Symbol.toPrimitive]() { },    get [Symbol.toStringTag]() {        return 0;    }} : { [Symbol.iterator]: number; [Symbol.toPrimitive](): void; get [Symbol.toStringTag](): number; }
 
     [Symbol.iterator]: 0,
 >[Symbol.iterator] : number

--- a/tests/baselines/reference/thisTypeInAccessors.types
+++ b/tests/baselines/reference/thisTypeInAccessors.types
@@ -10,8 +10,8 @@ interface Foo {
 }
 
 const explicit = {
->explicit : { n: number; x: number; }
->{    n: 12,    get x(this: Foo): number { return this.n; },    set x(this: Foo, n: number) { this.n = n; }} : { n: number; x: number; }
+>explicit : { n: number; get x(): number; set x(this: number); }
+>{    n: 12,    get x(this: Foo): number { return this.n; },    set x(this: Foo, n: number) { this.n = n; }} : { n: number; get x(): number; set x(this: number); }
 
     n: 12,
 >n : number
@@ -35,8 +35,8 @@ const explicit = {
 >n : number
 }
 const copiedFromGetter = {
->copiedFromGetter : { n: number; x: number; }
->{    n: 14,    get x(this: Foo): number { return this.n; },    set x(n) { this.n = n; }} : { n: number; x: number; }
+>copiedFromGetter : { n: number; get x(): number; set x(n: number); }
+>{    n: 14,    get x(this: Foo): number { return this.n; },    set x(n) { this.n = n; }} : { n: number; get x(): number; set x(n: number); }
 
     n: 14,
 >n : number
@@ -59,8 +59,8 @@ const copiedFromGetter = {
 >n : number
 }
 const copiedFromSetter = {
->copiedFromSetter : { n: number; x: number; }
->{    n: 15,    get x() { return this.n },    set x(this: Foo, n: number) { this.n = n; }} : { n: number; x: number; }
+>copiedFromSetter : { n: number; get x(): number; set x(this: number); }
+>{    n: 15,    get x() { return this.n },    set x(this: Foo, n: number) { this.n = n; }} : { n: number; get x(): number; set x(this: number); }
 
     n: 15,
 >n : number
@@ -83,8 +83,8 @@ const copiedFromSetter = {
 >n : number
 }
 const copiedFromGetterUnannotated = {
->copiedFromGetterUnannotated : { n: number; x: number; }
->{    n: 16,    get x(this: Foo) { return this.n },    set x(this, n) { this.n = n; }} : { n: number; x: number; }
+>copiedFromGetterUnannotated : { n: number; get x(): number; set x(this: number); }
+>{    n: 16,    get x(this: Foo) { return this.n },    set x(this, n) { this.n = n; }} : { n: number; get x(): number; set x(this: number); }
 
     n: 16,
 >n : number

--- a/tests/baselines/reference/thisTypeInAccessorsNegative.types
+++ b/tests/baselines/reference/thisTypeInAccessorsNegative.types
@@ -13,8 +13,8 @@ interface Bar {
 >wrong : "place" | "time" | "method" | "technique"
 }
 const mismatch = {
->mismatch : { n: number; x: number; }
->{    n: 13,    get x(this: Foo) { return this.n; },    set x(this: Bar, n) { this.wrong = "method"; }} : { n: number; x: number; }
+>mismatch : { n: number; get x(): number; set x(this: number); }
+>{    n: 13,    get x(this: Foo) { return this.n; },    set x(this: Bar, n) { this.wrong = "method"; }} : { n: number; get x(): number; set x(this: number); }
 
     n: 13,
 >n : number
@@ -39,7 +39,7 @@ const mismatch = {
 }
 const contextual: Foo = {
 >contextual : Foo
->{    n: 16,    get x() { return this.n; }} : { n: number; readonly x: number; }
+>{    n: 16,    get x() { return this.n; }} : { n: number; get x(): number; }
 
     n: 16,
 >n : number

--- a/tests/baselines/reference/thisTypeInObjectLiterals2.js
+++ b/tests/baselines/reference/thisTypeInObjectLiterals2.js
@@ -414,8 +414,9 @@ declare let obj1: {
     c: {
         g(): void;
     };
-    readonly d: number;
-    e: string;
+    get d(): number;
+    get e(): string;
+    set e(value: string);
 };
 type Point = {
     x: number;

--- a/tests/baselines/reference/thisTypeInObjectLiterals2.types
+++ b/tests/baselines/reference/thisTypeInObjectLiterals2.types
@@ -5,8 +5,8 @@
 // of the object literal.
 
 let obj1 = {
->obj1 : { a: number; f(): number; b: string; c: { g(): void; }; readonly d: number; e: string; }
->{    a: 1,    f() {        return this.a;    },    b: "hello",    c: {        g() {            this.g();        }    },    get d() {        return this.a;    },    get e() {        return this.b;    },    set e(value) {        this.b = value;    }} : { a: number; f(): number; b: string; c: { g(): void; }; readonly d: number; e: string; }
+>obj1 : { a: number; f(): number; b: string; c: { g(): void; }; get d(): number; get e(): string; set e(value: string); }
+>{    a: 1,    f() {        return this.a;    },    b: "hello",    c: {        g() {            this.g();        }    },    get d() {        return this.a;    },    get e() {        return this.b;    },    set e(value) {        this.b = value;    }} : { a: number; f(): number; b: string; c: { g(): void; }; get d(): number; get e(): string; set e(value: string); }
 
     a: 1,
 >a : number
@@ -17,7 +17,7 @@ let obj1 = {
 
         return this.a;
 >this.a : number
->this : { a: number; f(): number; b: string; c: { g(): void; }; readonly d: number; e: string; }
+>this : { a: number; f(): number; b: string; c: { g(): void; }; get d(): number; get e(): string; set e(value: string); }
 >a : number
 
     },
@@ -44,7 +44,7 @@ let obj1 = {
 
         return this.a;
 >this.a : number
->this : { a: number; f(): number; b: string; c: { g(): void; }; readonly d: number; e: string; }
+>this : { a: number; f(): number; b: string; c: { g(): void; }; get d(): number; get e(): string; set e(value: string); }
 >a : number
 
     },
@@ -53,7 +53,7 @@ let obj1 = {
 
         return this.b;
 >this.b : string
->this : { a: number; f(): number; b: string; c: { g(): void; }; readonly d: number; e: string; }
+>this : { a: number; f(): number; b: string; c: { g(): void; }; get d(): number; get e(): string; set e(value: string); }
 >b : string
 
     },
@@ -64,7 +64,7 @@ let obj1 = {
         this.b = value;
 >this.b = value : string
 >this.b : string
->this : { a: number; f(): number; b: string; c: { g(): void; }; readonly d: number; e: string; }
+>this : { a: number; f(): number; b: string; c: { g(): void; }; get d(): number; get e(): string; set e(value: string); }
 >b : string
 >value : string
     }

--- a/tests/baselines/reference/this_inside-object-literal-getters-and-setters.types
+++ b/tests/baselines/reference/this_inside-object-literal-getters-and-setters.types
@@ -5,8 +5,8 @@ module ObjectLiteral {
 >ObjectLiteral : typeof ObjectLiteral
 
     var ThisInObjectLiteral = {
->ThisInObjectLiteral : { _foo: string; foo: string; test: () => any; }
->{        _foo: '1',        get foo(): string {            return this._foo;        },        set foo(value: string) {            this._foo = value;        },        test: function () {            return this._foo;        }    } : { _foo: string; foo: string; test: () => any; }
+>ThisInObjectLiteral : { _foo: string; get foo(): string; set foo(value: string); test: () => any; }
+>{        _foo: '1',        get foo(): string {            return this._foo;        },        set foo(value: string) {            this._foo = value;        },        test: function () {            return this._foo;        }    } : { _foo: string; get foo(): string; set foo(value: string); test: () => any; }
 
         _foo: '1',
 >_foo : string

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2015).types
@@ -97,8 +97,8 @@ class C3 {
 
 });
 ({
->({    get await() { return 1 },    set await(value) { }}) : { await: number; }
->{    get await() { return 1 },    set await(value) { }} : { await: number; }
+>({    get await() { return 1 },    set await(value) { }}) : { get await(): number; set await(value: number); }
+>{    get await() { return 1 },    set await(value) { }} : { get await(): number; set await(value: number); }
 
     get await() { return 1 },
 >await : number

--- a/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=es2022,target=es2017).types
@@ -97,8 +97,8 @@ class C3 {
 
 });
 ({
->({    get await() { return 1 },    set await(value) { }}) : { await: number; }
->{    get await() { return 1 },    set await(value) { }} : { await: number; }
+>({    get await() { return 1 },    set await(value) { }}) : { get await(): number; set await(value: number); }
+>{    get await() { return 1 },    set await(value) { }} : { get await(): number; set await(value: number); }
 
     get await() { return 1 },
 >await : number

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2015).types
@@ -97,8 +97,8 @@ class C3 {
 
 });
 ({
->({    get await() { return 1 },    set await(value) { }}) : { await: number; }
->{    get await() { return 1 },    set await(value) { }} : { await: number; }
+>({    get await() { return 1 },    set await(value) { }}) : { get await(): number; set await(value: number); }
+>{    get await() { return 1 },    set await(value) { }} : { get await(): number; set await(value: number); }
 
     get await() { return 1 },
 >await : number

--- a/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=esnext,target=es2017).types
@@ -97,8 +97,8 @@ class C3 {
 
 });
 ({
->({    get await() { return 1 },    set await(value) { }}) : { await: number; }
->{    get await() { return 1 },    set await(value) { }} : { await: number; }
+>({    get await() { return 1 },    set await(value) { }}) : { get await(): number; set await(value: number); }
+>{    get await() { return 1 },    set await(value) { }} : { get await(): number; set await(value: number); }
 
     get await() { return 1 },
 >await : number

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2015).types
@@ -97,8 +97,8 @@ class C3 {
 
 });
 ({
->({    get await() { return 1 },    set await(value) { }}) : { await: number; }
->{    get await() { return 1 },    set await(value) { }} : { await: number; }
+>({    get await() { return 1 },    set await(value) { }}) : { get await(): number; set await(value: number); }
+>{    get await() { return 1 },    set await(value) { }} : { get await(): number; set await(value: number); }
 
     get await() { return 1 },
 >await : number

--- a/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait.1(module=system,target=es2017).types
@@ -97,8 +97,8 @@ class C3 {
 
 });
 ({
->({    get await() { return 1 },    set await(value) { }}) : { await: number; }
->{    get await() { return 1 },    set await(value) { }} : { await: number; }
+>({    get await() { return 1 },    set await(value) { }}) : { get await(): number; set await(value: number); }
+>{    get await() { return 1 },    set await(value) { }} : { get await(): number; set await(value: number); }
 
     get await() { return 1 },
 >await : number

--- a/tests/baselines/reference/twoAccessorsWithSameName.types
+++ b/tests/baselines/reference/twoAccessorsWithSameName.types
@@ -40,8 +40,8 @@ class E {
 }
 
 var x = {
->x : { readonly x: number; }
->{    get x() {        return 1;    },    // error    get x() {        return 1;    }} : { readonly x: number; }
+>x : { get x(): number; }
+>{    get x() {        return 1;    },    // error    get x() {        return 1;    }} : { get x(): number; }
 
     get x() {
 >x : number
@@ -61,8 +61,8 @@ var x = {
 }
 
 var y = {
->y : { x: number; }
->{    get x() {        return 1;    },    set x(v) { }} : { x: number; }
+>y : { get x(): number; set x(v: number); }
+>{    get x() {        return 1;    },    set x(v) { }} : { get x(): number; set x(v: number); }
 
     get x() {
 >x : number

--- a/tests/baselines/reference/typeGuardsObjectMethods.types
+++ b/tests/baselines/reference/typeGuardsObjectMethods.types
@@ -15,8 +15,8 @@ var var1: string | number;
 >var1 : string | number
 
 var obj1 = {
->obj1 : { method(param: string | number): string | number; prop: string | number; }
->{    // Inside method    method(param: string | number) {        // global vars in function declaration        num = typeof var1 === "string" && var1.length; // string        // variables in function declaration        var var2: string | number;        num = typeof var2 === "string" && var2.length; // string        // parameters in function declaration        num = typeof param === "string" && param.length; // string        return strOrNum;    },    get prop() {        // global vars in function declaration        num = typeof var1 === "string" && var1.length; // string        // variables in function declaration        var var2: string | number;        num = typeof var2 === "string" && var2.length; // string        return strOrNum;    },    set prop(param: string | number) {        // global vars in function declaration        num = typeof var1 === "string" && var1.length; // string        // variables in function declaration        var var2: string | number;        num = typeof var2 === "string" && var2.length; // string        // parameters in function declaration        num = typeof param === "string" && param.length; // string    }} : { method(param: string | number): string | number; prop: string | number; }
+>obj1 : { method(param: string | number): string | number; get prop(): string | number; set prop(param: string | number); }
+>{    // Inside method    method(param: string | number) {        // global vars in function declaration        num = typeof var1 === "string" && var1.length; // string        // variables in function declaration        var var2: string | number;        num = typeof var2 === "string" && var2.length; // string        // parameters in function declaration        num = typeof param === "string" && param.length; // string        return strOrNum;    },    get prop() {        // global vars in function declaration        num = typeof var1 === "string" && var1.length; // string        // variables in function declaration        var var2: string | number;        num = typeof var2 === "string" && var2.length; // string        return strOrNum;    },    set prop(param: string | number) {        // global vars in function declaration        num = typeof var1 === "string" && var1.length; // string        // variables in function declaration        var var2: string | number;        num = typeof var2 === "string" && var2.length; // string        // parameters in function declaration        num = typeof param === "string" && param.length; // string    }} : { method(param: string | number): string | number; get prop(): string | number; set prop(param: string | number); }
 
     // Inside method
     method(param: string | number) {
@@ -161,13 +161,13 @@ strOrNum = typeof obj1.method(strOrNum) === "string" && obj1.method(strOrNum);
 >typeof obj1.method(strOrNum) : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
 >obj1.method(strOrNum) : string | number
 >obj1.method : (param: string | number) => string | number
->obj1 : { method(param: string | number): string | number; prop: string | number; }
+>obj1 : { method(param: string | number): string | number; get prop(): string | number; set prop(param: string | number); }
 >method : (param: string | number) => string | number
 >strOrNum : string | number
 >"string" : "string"
 >obj1.method(strOrNum) : string | number
 >obj1.method : (param: string | number) => string | number
->obj1 : { method(param: string | number): string | number; prop: string | number; }
+>obj1 : { method(param: string | number): string | number; get prop(): string | number; set prop(param: string | number); }
 >method : (param: string | number) => string | number
 >strOrNum : string | number
 
@@ -179,10 +179,10 @@ strOrNum = typeof obj1.prop === "string" && obj1.prop;
 >typeof obj1.prop === "string" : boolean
 >typeof obj1.prop : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
 >obj1.prop : string | number
->obj1 : { method(param: string | number): string | number; prop: string | number; }
+>obj1 : { method(param: string | number): string | number; get prop(): string | number; set prop(param: string | number); }
 >prop : string | number
 >"string" : "string"
 >obj1.prop : string
->obj1 : { method(param: string | number): string | number; prop: string | number; }
+>obj1 : { method(param: string | number): string | number; get prop(): string | number; set prop(param: string | number); }
 >prop : string
 

--- a/tests/baselines/reference/typeOfThisInAccessor.types
+++ b/tests/baselines/reference/typeOfThisInAccessor.types
@@ -57,8 +57,8 @@ class D<T> {
 }
 
 var x = {
->x : { readonly a: number; }
->{    get a() {        var r3 = this; // any        return 1;    }} : { readonly a: number; }
+>x : { get a(): number; }
+>{    get a() {        var r3 = this; // any        return 1;    }} : { get a(): number; }
 
     get a() {
 >a : number

--- a/tests/baselines/reference/unusedLocalsAndParameters.types
+++ b/tests/baselines/reference/unusedLocalsAndParameters.types
@@ -66,8 +66,8 @@ var E = class {
 }
 
 var o = {
->o : { method(a: any): void; x: number; }
->{    // Object literal method declaration paramter    method(a) {    },    // Accessor declaration paramter    set x(v: number) {    }} : { method(a: any): void; x: number; }
+>o : { method(a: any): void; set x(v: number); }
+>{    // Object literal method declaration paramter    method(a) {    },    // Accessor declaration paramter    set x(v: number) {    }} : { method(a: any): void; set x(v: number); }
 
     // Object literal method declaration paramter
     method(a) {
@@ -83,12 +83,12 @@ var o = {
 };
 
 o;
->o : { method(a: any): void; x: number; }
+>o : { method(a: any): void; set x(v: number); }
 
 // in a for..in statment
 for (let i in o) {
 >i : string
->o : { method(a: any): void; x: number; }
+>o : { method(a: any): void; set x(v: number); }
 }
 
 // in a for..of statment

--- a/tests/baselines/reference/unusedLocalsAndParametersDeferred.types
+++ b/tests/baselines/reference/unusedLocalsAndParametersDeferred.types
@@ -183,8 +183,8 @@ new E();
 
 
 var o = {
->o : { method(a: any): void; x: number; p: void; }
->{    // Object literal method declaration paramter    method(a) {        defered(() => {            a;        });    },    // Accessor declaration paramter    set x(v: number) {        defered(() => {            v;        });    },    // in a property initalizer    p: defered(() => {        prop1;    })} : { method(a: any): void; x: number; p: void; }
+>o : { method(a: any): void; set x(v: number); p: void; }
+>{    // Object literal method declaration paramter    method(a) {        defered(() => {            a;        });    },    // Accessor declaration paramter    set x(v: number) {        defered(() => {            v;        });    },    // in a property initalizer    p: defered(() => {        prop1;    })} : { method(a: any): void; set x(v: number); p: void; }
 
     // Object literal method declaration paramter
     method(a) {
@@ -230,12 +230,12 @@ var o = {
 };
 
 o;
->o : { method(a: any): void; x: number; p: void; }
+>o : { method(a: any): void; set x(v: number); p: void; }
 
 // in a for..in statment
 for (let i in o) {
 >i : string
->o : { method(a: any): void; x: number; p: void; }
+>o : { method(a: any): void; set x(v: number); p: void; }
 
     defered(() => {
 >defered(() => {        i;    }) : void

--- a/tests/cases/fourslash/quickInfoOnObjectLiteralWithAccessors.ts
+++ b/tests/cases/fourslash/quickInfoOnObjectLiteralWithAccessors.ts
@@ -12,10 +12,10 @@
 ////point./*3*/x = 30;
 
 verify.quickInfos({
-    1: "function makePoint(x: number): {\n    b: number;\n    x: number;\n}",
+    1: "function makePoint(x: number): {\n    b: number;\n    get x(): number;\n    set x(a: number);\n}",
     2: "var x: number",
     3: "(property) x: number",
-    4: "var point: {\n    b: number;\n    x: number;\n}",
+    4: "var point: {\n    b: number;\n    get x(): number;\n    set x(a: number);\n}",
 });
 
 verify.completions({

--- a/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlyGetter.ts
+++ b/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlyGetter.ts
@@ -9,9 +9,9 @@
 ////var /*2*/x = point./*3*/x;
 
 verify.quickInfos({
-    1: "function makePoint(x: number): {\n    readonly x: number;\n}",
+    1: "function makePoint(x: number): {\n    get x(): number;\n}",
     2: "var x: number",
-    4: "var point: {\n    readonly x: number;\n}",
+    4: "var point: {\n    get x(): number;\n}",
 });
 
 verify.completions({ marker: "3", exact: { name: "x", text: "(property) x: number" } });

--- a/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlySetter.ts
+++ b/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlySetter.ts
@@ -18,7 +18,7 @@ verify.completions({
 });
 
 verify.quickInfos({
-    1: "function makePoint(x: number): {\n    b: number;\n    x: number;\n}",
+    1: "function makePoint(x: number): {\n    b: number;\n    set x(a: number);\n}",
     2: "(property) x: number",
-    3: "var point: {\n    b: number;\n    x: number;\n}",
+    3: "var point: {\n    b: number;\n    set x(a: number);\n}",
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #54879 

Please don't be alarmed by the large number of changed files here. The code change is only to the `addPropertyToElementList` function in `checker.ts`. The rest of the changes update the baseline and fourslash files for the large number of cases where the compiler was previously incorrectly (AFAICT) emitting regular properties where it should have emitted get or set accessors.

I've looked at all the baseline changes in detail and I believe them to now be more correct. I hope you will agree!

As I undersand it, prior to TS 3.7 this difference between properties and accessors was mostly moot. But more recently it has become quite important (TS2611 errors), and so this PR makes the compiler emit the accessors in a significant set of cases where it should.

One possibly important thing I noticed while reviewing the baseline changes... `tests/cases/compiler/divergentAccessorsTypes6.ts` has some code that looks like this:

```ts
const o2 = {
    // ...
    get p2(): number { return 0; },
    set p2(value: string) {},
};
```

Before this PR, the type of `o2` was:

`o2 : { p2: number; }`

Now it is:

`o2 : { get p2(): number; set p2(value: number); }`

The original (before this PR) was wrong. It didn't capture the divergent accessor. The version in this PR is wrong, too, in much the same way. But because the accessors are separate now, maybe it's a little more problematic for the setter's type be wrong. Let me know if you think this needs to be fixed as part of this PR.