### PR TITLE
fix(54982): "Inline variable" causes failure when variable is used as the initializer of a destructured variable declaration

### DIFF
--- a/src/services/refactors/inlineVariable.ts
+++ b/src/services/refactors/inlineVariable.ts
@@ -132,7 +132,7 @@ function getInliningInfo(file: SourceFile, startPosition: number, tryWithReferen
 
     // If triggered in a variable declaration, make sure it's not in a catch clause or for-loop
     // and that it has a value.
-    if (isInitializedVariable(parent) && isVariableDeclarationInVariableStatement(parent)) {
+    if (isInitializedVariable(parent) && isVariableDeclarationInVariableStatement(parent) && isIdentifier(parent.name)) {
         // Don't inline the variable if it has multiple declarations.
         if (checker.getMergedSymbol(parent.symbol).declarations?.length !== 1) {
             return { error: getLocaleSpecificMessage(Diagnostics.Variables_with_multiple_declarations_cannot_be_inlined) };

--- a/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration1.ts
+++ b/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration1.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+////export function Component(props: any) {
+////    const { foo } = /*a*/props/*b*/;
+////}
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Inline variable");

--- a/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration2.ts
+++ b/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration2.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+////export function func(arr: any) {
+////    const [foo] = /*a*/arr/*b*/;
+////}
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Inline variable");

--- a/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration3.ts
+++ b/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration3.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////function f() {
+////    const a = { prop: 123 };
+////    const { prop } = /*a*/a/*b*/;
+////}
+
+goTo.select("a", "b");
+verify.not.refactorAvailable("Inline variable");

--- a/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration4.ts
+++ b/tests/cases/fourslash/inlineVariableDestructuredVariableDeclaration4.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+////function f() {
+////    const a = { prop: 123 };
+////    const { prop } = /*a*/a/*b*/;
+////}
+goTo.select("a", "b");
+verify.refactorAvailableForTriggerReason("invoked", "Inline variable");
+edit.applyRefactor({
+    refactorName: "Inline variable",
+    actionName: "Inline variable",
+    actionDescription: "Inline variable",
+    newContent:
+`function f() {
+    const { prop } = { prop: 123 };
+}`,
+    triggerReason: "invoked"
+});


### PR DESCRIPTION
Fixes #54982