### PR TITLE
Downgrade octokit back to v19 to regain node 14/16 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@esfx/canceltoken": "^1.0.0",
-                "@octokit/rest": "latest",
+                "@octokit/rest": "^19.0.13",
                 "@types/chai": "^4.3.4",
                 "@types/fs-extra": "^9.0.13",
                 "@types/glob": "^8.1.0",
@@ -613,58 +613,58 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
             "dev": true,
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
-            "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+            "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.0.0",
-                "@octokit/request": "^8.0.2",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.0.0",
+                "@octokit/auth-token": "^3.0.0",
+                "@octokit/graphql": "^5.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
-            "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+            "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0",
+                "@octokit/types": "^9.0.0",
                 "is-plain-object": "^5.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
-            "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
             "dev": true,
             "dependencies": {
-                "@octokit/request": "^8.0.1",
-                "@octokit/types": "^11.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/types": "^9.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             }
         },
         "node_modules/@octokit/openapi-types": {
@@ -674,96 +674,130 @@
             "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
-            "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+            "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0"
+                "@octokit/tsconfig": "^1.0.2",
+                "@octokit/types": "^9.2.3"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             },
             "peerDependencies": {
-                "@octokit/core": ">=5"
+                "@octokit/core": ">=4"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
-            "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
             "dev": true,
-            "engines": {
-                "node": ">= 18"
-            },
             "peerDependencies": {
-                "@octokit/core": ">=5"
+                "@octokit/core": ">=3"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-9.0.0.tgz",
-            "integrity": "sha512-KquMF/VB1IkKNiVnzJKspY5mFgGyLd7HzdJfVEGTJFzqu9BRFNWt+nwTCMuUiWc72gLQhRWYubTwOkQj+w/1PA==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+            "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0"
+                "@octokit/types": "^10.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             },
             "peerDependencies": {
-                "@octokit/core": ">=5"
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+            "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/openapi-types": "^18.0.0"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.0.tgz",
-            "integrity": "sha512-0gg/NwewU0iXctYBale0VVcCPqOtoW5lsog8cNBJgzV/CyTHa2gicUBOlNnzOk6pJkuwXI34qkq+uRm40PmD4A==",
+            "version": "6.2.8",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+            "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
             "dev": true,
             "dependencies": {
-                "@octokit/endpoint": "^9.0.0",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.1.0",
+                "@octokit/endpoint": "^7.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
                 "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
-            "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
             "dev": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0",
+                "@octokit/types": "^9.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/request/node_modules/node-fetch": {
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+            "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "20.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.1.tgz",
-            "integrity": "sha512-wROV21RwHQIMNb2Dgd4+pY+dVy1Dwmp85pBrgr6YRRDYRBu9Gb+D73f4Bl2EukZSj5hInq2Tui9o7gAQpc2k2Q==",
+            "version": "19.0.13",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
+            "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
             "dev": true,
             "dependencies": {
-                "@octokit/core": "^5.0.0",
-                "@octokit/plugin-paginate-rest": "^8.0.0",
-                "@octokit/plugin-request-log": "^4.0.0",
-                "@octokit/plugin-rest-endpoint-methods": "^9.0.0"
+                "@octokit/core": "^4.2.1",
+                "@octokit/plugin-paginate-rest": "^6.1.2",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 14"
             }
         },
+        "node_modules/@octokit/tsconfig": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+            "dev": true
+        },
         "node_modules/@octokit/types": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
-            "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+            "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
             "dev": true,
             "dependencies": {
                 "@octokit/openapi-types": "^18.0.0"
@@ -4417,6 +4451,12 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -4611,6 +4651,22 @@
             "dev": true,
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -5085,45 +5141,45 @@
             }
         },
         "@octokit/auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
             "dev": true
         },
         "@octokit/core": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
-            "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+            "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
             "dev": true,
             "requires": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.0.0",
-                "@octokit/request": "^8.0.2",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.0.0",
+                "@octokit/auth-token": "^3.0.0",
+                "@octokit/graphql": "^5.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/endpoint": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
-            "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+            "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^11.0.0",
+                "@octokit/types": "^9.0.0",
                 "is-plain-object": "^5.0.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/graphql": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
-            "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
             "dev": true,
             "requires": {
-                "@octokit/request": "^8.0.1",
-                "@octokit/types": "^11.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/types": "^9.0.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
@@ -5134,70 +5190,100 @@
             "dev": true
         },
         "@octokit/plugin-paginate-rest": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-8.0.0.tgz",
-            "integrity": "sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+            "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^11.0.0"
+                "@octokit/tsconfig": "^1.0.2",
+                "@octokit/types": "^9.2.3"
             }
         },
         "@octokit/plugin-request-log": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz",
-            "integrity": "sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
             "dev": true,
             "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-9.0.0.tgz",
-            "integrity": "sha512-KquMF/VB1IkKNiVnzJKspY5mFgGyLd7HzdJfVEGTJFzqu9BRFNWt+nwTCMuUiWc72gLQhRWYubTwOkQj+w/1PA==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+            "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^11.0.0"
+                "@octokit/types": "^10.0.0"
+            },
+            "dependencies": {
+                "@octokit/types": {
+                    "version": "10.0.0",
+                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+                    "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+                    "dev": true,
+                    "requires": {
+                        "@octokit/openapi-types": "^18.0.0"
+                    }
+                }
             }
         },
         "@octokit/request": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.0.tgz",
-            "integrity": "sha512-0gg/NwewU0iXctYBale0VVcCPqOtoW5lsog8cNBJgzV/CyTHa2gicUBOlNnzOk6pJkuwXI34qkq+uRm40PmD4A==",
+            "version": "6.2.8",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+            "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
             "dev": true,
             "requires": {
-                "@octokit/endpoint": "^9.0.0",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.1.0",
+                "@octokit/endpoint": "^7.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
                 "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
                 "universal-user-agent": "^6.0.0"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.12",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+                    "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+                    "dev": true,
+                    "requires": {
+                        "whatwg-url": "^5.0.0"
+                    }
+                }
             }
         },
         "@octokit/request-error": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
-            "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
             "dev": true,
             "requires": {
-                "@octokit/types": "^11.0.0",
+                "@octokit/types": "^9.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             }
         },
         "@octokit/rest": {
-            "version": "20.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.0.1.tgz",
-            "integrity": "sha512-wROV21RwHQIMNb2Dgd4+pY+dVy1Dwmp85pBrgr6YRRDYRBu9Gb+D73f4Bl2EukZSj5hInq2Tui9o7gAQpc2k2Q==",
+            "version": "19.0.13",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
+            "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
             "dev": true,
             "requires": {
-                "@octokit/core": "^5.0.0",
-                "@octokit/plugin-paginate-rest": "^8.0.0",
-                "@octokit/plugin-request-log": "^4.0.0",
-                "@octokit/plugin-rest-endpoint-methods": "^9.0.0"
+                "@octokit/core": "^4.2.1",
+                "@octokit/plugin-paginate-rest": "^6.1.2",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
             }
         },
+        "@octokit/tsconfig": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+            "dev": true
+        },
         "@octokit/types": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
-            "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+            "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
             "dev": true,
             "requires": {
                 "@octokit/openapi-types": "^18.0.0"
@@ -7828,6 +7914,12 @@
                 "is-number": "^7.0.0"
             }
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
+        },
         "tsconfig-paths": {
             "version": "3.14.2",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -7979,6 +8071,22 @@
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
             "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
             "dev": true
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ],
     "devDependencies": {
         "@esfx/canceltoken": "^1.0.0",
-        "@octokit/rest": "latest",
+        "@octokit/rest": "^19.0.13",
         "@types/chai": "^4.3.4",
         "@types/fs-extra": "^9.0.13",
         "@types/glob": "^8.1.0",


### PR DESCRIPTION
This just got bumped in main since we weren't pinning this; v20 drops support for v14 and v16, but we still are using Node 16 in our pipelines for various things (and then we get loads of engine errors everywhere else).

I could go try and find every pipeline which is still using 16 and up it, but there's a lot of them across multiple different repos and pipeline projects, and I'm fairly certain that we're going to be able to drop some or all of these scripts in main anyway.