### PR TITLE
Consider `import.meta` a qualified name/property access

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -387,6 +387,7 @@ import {
     mapDefined,
     MapLike,
     MemberName,
+    MetaProperty,
     MethodDeclaration,
     MethodSignature,
     ModeAwareCache,
@@ -7133,7 +7134,8 @@ export function isPrototypeAccess(node: Node): node is BindableStaticAccessExpre
 /** @internal */
 export function isRightSideOfQualifiedNameOrPropertyAccess(node: Node) {
     return (node.parent.kind === SyntaxKind.QualifiedName && (node.parent as QualifiedName).right === node) ||
-        (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).name === node);
+        (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).name === node) ||
+        (node.parent.kind === SyntaxKind.MetaProperty && (node.parent as MetaProperty).name === node);
 }
 
 /** @internal */

--- a/tests/baselines/reference/importMeta(module=commonjs,target=es5).types
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=es5).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMeta(module=commonjs,target=esnext).types
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=esnext).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMeta(module=es2020,target=es5).types
+++ b/tests/baselines/reference/importMeta(module=es2020,target=es5).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMeta(module=es2020,target=esnext).types
+++ b/tests/baselines/reference/importMeta(module=es2020,target=esnext).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMeta(module=esnext,target=es5).types
+++ b/tests/baselines/reference/importMeta(module=esnext,target=es5).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMeta(module=esnext,target=esnext).types
+++ b/tests/baselines/reference/importMeta(module=esnext,target=esnext).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMeta(module=system,target=es5).types
+++ b/tests/baselines/reference/importMeta(module=system,target=es5).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMeta(module=system,target=esnext).types
+++ b/tests/baselines/reference/importMeta(module=system,target=esnext).types
@@ -19,7 +19,7 @@
 >"../hamsters.jpg" : "../hamsters.jpg"
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 >toString : () => string
 
@@ -38,7 +38,7 @@
 >import.meta.scriptElement.dataset : any
 >import.meta.scriptElement : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >scriptElement : any
 >dataset : any
 >size : any
@@ -86,7 +86,7 @@
 export let x = import.meta;
 >x : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 export let y = import.metal;
 >y : any
@@ -106,7 +106,7 @@ export let z = import.import.import.malkovich;
 let globalA = import.meta;
 >globalA : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 let globalB = import.metal;
 >globalB : any
@@ -128,20 +128,20 @@ export const foo: ImportMeta = import.meta.blah = import.meta.blue = import.meta
 >import.meta.blah = import.meta.blue = import.meta : ImportMeta
 >import.meta.blah : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blah : any
 >import.meta.blue = import.meta : ImportMeta
 >import.meta.blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >blue : any
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 
 import.meta = foo;
 >import.meta = foo : ImportMeta
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : ImportMeta
 
 // @Filename augmentations.ts
@@ -163,6 +163,6 @@ const { a, b, c } = import.meta.wellKnownProperty;
 >c : boolean
 >import.meta.wellKnownProperty : { a: number; b: string; c: boolean; }
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >wellKnownProperty : { a: number; b: string; c: boolean; }
 

--- a/tests/baselines/reference/importMetaNarrowing(module=es2020).types
+++ b/tests/baselines/reference/importMetaNarrowing(module=es2020).types
@@ -8,14 +8,14 @@ declare global { interface ImportMeta {foo?: () => void} };
 if (import.meta.foo) {
 >import.meta.foo : (() => void) | undefined
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : (() => void) | undefined
 
   import.meta.foo();
 >import.meta.foo() : void
 >import.meta.foo : () => void
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : () => void
 }
 

--- a/tests/baselines/reference/importMetaNarrowing(module=esnext).types
+++ b/tests/baselines/reference/importMetaNarrowing(module=esnext).types
@@ -8,14 +8,14 @@ declare global { interface ImportMeta {foo?: () => void} };
 if (import.meta.foo) {
 >import.meta.foo : (() => void) | undefined
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : (() => void) | undefined
 
   import.meta.foo();
 >import.meta.foo() : void
 >import.meta.foo : () => void
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : () => void
 }
 

--- a/tests/baselines/reference/importMetaNarrowing(module=system).types
+++ b/tests/baselines/reference/importMetaNarrowing(module=system).types
@@ -8,14 +8,14 @@ declare global { interface ImportMeta {foo?: () => void} };
 if (import.meta.foo) {
 >import.meta.foo : (() => void) | undefined
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : (() => void) | undefined
 
   import.meta.foo();
 >import.meta.foo() : void
 >import.meta.foo : () => void
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >foo : () => void
 }
 

--- a/tests/baselines/reference/misspelledNewMetaProperty.types
+++ b/tests/baselines/reference/misspelledNewMetaProperty.types
@@ -4,5 +4,5 @@
 function foo(){new.targ}
 >foo : () => void
 >new.targ : () => void
->targ : any
+>targ : () => void
 

--- a/tests/baselines/reference/newTarget.es5.types
+++ b/tests/baselines/reference/newTarget.es5.types
@@ -8,25 +8,25 @@ class A {
         const a = new.target;
 >a : typeof A
 >new.target : typeof A
->target : any
+>target : typeof A
 
         const b = () => new.target;
 >b : () => typeof A
 >() => new.target : () => typeof A
 >new.target : typeof A
->target : any
+>target : typeof A
     }
     static c = function () { return new.target; }
 >c : () => any
 >function () { return new.target; } : () => any
 >new.target : () => any
->target : any
+>target : () => any
 
     d = function () { return new.target; }
 >d : () => any
 >function () { return new.target; } : () => any
 >new.target : () => any
->target : any
+>target : () => any
 }
 
 class B extends A {
@@ -41,13 +41,13 @@ class B extends A {
         const e = new.target;
 >e : typeof B
 >new.target : typeof B
->target : any
+>target : typeof B
 
         const f = () => new.target;
 >f : () => typeof B
 >() => new.target : () => typeof B
 >new.target : typeof B
->target : any
+>target : typeof B
     }
 }
 
@@ -57,13 +57,13 @@ function f1() {
     const g = new.target;
 >g : () => void
 >new.target : () => void
->target : any
+>target : () => void
 
     const h = () => new.target;
 >h : () => () => void
 >() => new.target : () => () => void
 >new.target : () => void
->target : any
+>target : () => void
 }
 
 const f2 = function () {
@@ -73,13 +73,13 @@ const f2 = function () {
     const i = new.target;
 >i : () => void
 >new.target : () => void
->target : any
+>target : () => void
 
     const j = () => new.target;
 >j : () => () => void
 >() => new.target : () => () => void
 >new.target : () => void
->target : any
+>target : () => void
 }
 
 const O = {
@@ -90,7 +90,7 @@ const O = {
 >k : () => any
 >function () { return new.target; } : () => any
 >new.target : () => any
->target : any
+>target : () => any
 
 };
 

--- a/tests/baselines/reference/newTarget.es6.types
+++ b/tests/baselines/reference/newTarget.es6.types
@@ -8,25 +8,25 @@ class A {
         const a = new.target;
 >a : typeof A
 >new.target : typeof A
->target : any
+>target : typeof A
 
         const b = () => new.target;
 >b : () => typeof A
 >() => new.target : () => typeof A
 >new.target : typeof A
->target : any
+>target : typeof A
     }
     static c = function () { return new.target; }
 >c : () => any
 >function () { return new.target; } : () => any
 >new.target : () => any
->target : any
+>target : () => any
 
     d = function () { return new.target; }
 >d : () => any
 >function () { return new.target; } : () => any
 >new.target : () => any
->target : any
+>target : () => any
 }
 
 class B extends A {
@@ -41,13 +41,13 @@ class B extends A {
         const e = new.target;
 >e : typeof B
 >new.target : typeof B
->target : any
+>target : typeof B
 
         const f = () => new.target;
 >f : () => typeof B
 >() => new.target : () => typeof B
 >new.target : typeof B
->target : any
+>target : typeof B
     }
 }
 
@@ -57,13 +57,13 @@ function f1() {
     const g = new.target;
 >g : () => void
 >new.target : () => void
->target : any
+>target : () => void
 
     const h = () => new.target;
 >h : () => () => void
 >() => new.target : () => () => void
 >new.target : () => void
->target : any
+>target : () => void
 }
 
 const f2 = function () {
@@ -73,13 +73,13 @@ const f2 = function () {
     const i = new.target;
 >i : () => void
 >new.target : () => void
->target : any
+>target : () => void
 
     const j = () => new.target;
 >j : () => () => void
 >() => new.target : () => () => void
 >new.target : () => void
->target : any
+>target : () => void
 }
 
 const O = {
@@ -90,7 +90,7 @@ const O = {
 >k : () => any
 >function () { return new.target; } : () => any
 >new.target : () => any
->target : any
+>target : () => any
 
 };
 

--- a/tests/baselines/reference/newTargetNarrowing.types
+++ b/tests/baselines/reference/newTargetNarrowing.types
@@ -13,7 +13,7 @@ function f() {
 >new.target.marked === true : boolean
 >new.target.marked : boolean
 >new.target : typeof f
->target : any
+>target : typeof f
 >marked : boolean
 >true : true
 
@@ -22,7 +22,7 @@ function f() {
 >foo : (x: true) => void
 >new.target.marked : true
 >new.target : typeof f
->target : any
+>target : typeof f
 >marked : true
   }
 }

--- a/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=node16).types
+++ b/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=node16).types
@@ -6,7 +6,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};
@@ -18,7 +18,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};

--- a/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesAllowJsImportMeta(module=nodenext).types
@@ -6,7 +6,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};
@@ -18,7 +18,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};

--- a/tests/baselines/reference/nodeModulesImportMeta(module=node16).types
+++ b/tests/baselines/reference/nodeModulesImportMeta(module=node16).types
@@ -6,7 +6,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};
@@ -18,7 +18,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};

--- a/tests/baselines/reference/nodeModulesImportMeta(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesImportMeta(module=nodenext).types
@@ -6,7 +6,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};
@@ -18,7 +18,7 @@ const x = import.meta.url;
 >x : string
 >import.meta.url : string
 >import.meta : ImportMeta
->meta : any
+>meta : ImportMeta
 >url : string
 
 export {x};

--- a/tests/baselines/reference/plainJSGrammarErrors.types
+++ b/tests/baselines/reference/plainJSGrammarErrors.types
@@ -606,7 +606,7 @@ export let noMeta = import.metal
 function foo() { new.targe }
 >foo : () => void
 >new.targe : () => void
->targe : any
+>targe : () => void
 
 const nullaryDynamicImport = import()
 >nullaryDynamicImport : Promise<any>

--- a/tests/baselines/reference/shadowedReservedCompilerDeclarationsWithNoEmit.types
+++ b/tests/baselines/reference/shadowedReservedCompilerDeclarationsWithNoEmit.types
@@ -64,7 +64,7 @@ class C2 extends Base {
         var t = new.target;
 >t : typeof C2
 >new.target : typeof C2
->target : any
+>target : typeof C2
 
         var y = _newTarget;
 >y : string

--- a/tests/cases/fourslash/importMetaCompletionDetails.ts
+++ b/tests/cases/fourslash/importMetaCompletionDetails.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: index.mts
+// @module: Node16
+// @strict: true
+//// let x = import.meta/**/;
+
+verify.completions({
+    marker: "",
+    includes: [
+        {
+            name: "meta",
+            text: "(property) ImportMetaExpression.meta: ImportMeta",
+        },
+    ]
+})
+verify.noErrors();


### PR DESCRIPTION
Fixes #54590.

`isRightSideOfQualifiedNameOrPropertyAccess` is called by `getTypeOfSymbolAtLocation` to decide if we should consider the location's parent instead, so that if we have a property access/qualified name, e.g. `x.y`, we look up the whole expression, and not just `y`. Because `import.meta` was not considered one of those cases, when `getTypeOfSymbolAtLocation` was called by completions, we'd end up trying to resolve the name `meta`, which doesn't resolve to anything, leading to the error.
