### PR TITLE
Add auto-import for the `package.json` `imports` field

### DIFF
--- a/tests/cases/fourslash/autoImportPackageJsonExportsSpecifierEndsInTs.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonExportsSpecifierEndsInTs.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /node_modules/pkg/package.json
+//// {
+////     "name": "pkg",
+////     "version": "1.0.0",
+////     "exports": {
+////       "./something.ts": "./a.js"
+////     }
+////  }
+
+// @Filename: /node_modules/pkg/a.d.ts
+//// export function foo(): void;
+
+// @Filename: /package.json
+//// {
+////     "dependencies": {
+////        "pkg": "*"
+////     }
+////  }
+
+// @Filename: /index.ts
+//// foo/**/
+
+verify.importFixModuleSpecifiers("", ["pkg/something.ts"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsLength1.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsLength1.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*": "./src/*.ts"
+////   }
+//// }
+
+// @Filename: /src/a/b/c/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /src/a/b/c/d.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["./something"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsLength2.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsLength2.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*": "./src/*.ts"
+////   }
+//// }
+
+// @Filename: /src/a/b/c/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#a/b/c/something"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsPattern.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsPattern.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*": "./src/*"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#something.js"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsPattern_js.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsPattern_js.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*": "./src/*.js"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#something"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsPattern_js_ts.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsPattern_js_ts.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*.js": "./src/*.ts"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#something.js"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsPattern_ts.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsPattern_ts.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*": "./src/*.ts"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#something"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsPattern_ts_js.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsPattern_ts_js.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*.ts": "./src/*.js"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#something.ts"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImportsPattern_ts_ts.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImportsPattern_ts_ts.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#*.ts": "./src/*.ts"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#something.ts"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImports_js.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImports_js.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#thing": "./src/something.js"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#thing"]);

--- a/tests/cases/fourslash/autoImportPackageJsonImports_ts.ts
+++ b/tests/cases/fourslash/autoImportPackageJsonImports_ts.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// {
+////   "imports": {
+////     "#thing": "./src/something.ts"
+////   }
+//// }
+
+// @Filename: /src/something.ts
+//// export function something(name: string): any;
+
+// @Filename: /a.ts
+//// something/**/
+
+verify.importFixModuleSpecifiers("", ["#thing"]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #49492

This treats `package.json#imports` as roughly equivalent to `compilerOptions#paths` in terms of deciding which specifier to use, it also prefers `package.json#imports` over `compilerOptions#paths`

While doing this, I found some broken behaviour around extension replacement which was already observable with the `package.json#exports` field auto-import but is more visible with `package.json#imports` so this fixes that as well. `autoImportPackageJsonExportsSpecifierEndsInTs` shows an example of what's fixed for `package.json#exports`. That fix and test is in a seperate commit if that's easier to review