### PR TITLE
Skip @link at start of jsdoc types

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8620,15 +8620,17 @@ namespace Parser {
             let pos = getNodePos();
             const hasBrace = (mayOmitBraces ? parseOptional : parseExpected)(SyntaxKind.OpenBraceToken);
             if (token() === SyntaxKind.AtToken) {
-                    // skip @link since it's a common mistake
-                    if(tokenIsIdentifierOrKeyword(nextTokenJSDoc())) {
-                        const kind = scanner.getTokenValue();
-                        if (isJSDocLinkTag(kind)) {
-                            nextTokenJSDoc();
-                            skipWhitespace();
-                        }
-                        pos = getNodePos();
+                // skip @link since it's a common mistake -- other tags will still error
+                const atStart = scanner.getTokenStart()
+                const atEnd = scanner.getTokenEnd()
+                if (tokenIsIdentifierOrKeyword(nextTokenJSDoc())) {
+                    if (!isJSDocLinkTag(scanner.getTokenValue())) {
+                        parseErrorAt(atStart, atEnd, Diagnostics.Type_expected);
                     }
+                    nextTokenJSDoc();
+                    skipWhitespace();
+                    pos = getNodePos();
+                }
             }
             const type = doInsideOfContext(NodeFlags.JSDoc, parseJSDocType);
             if (!mayOmitBraces || hasBrace) {

--- a/tests/baselines/reference/incorrectJSDocTypeAnnotationSyntax.errors.txt
+++ b/tests/baselines/reference/incorrectJSDocTypeAnnotationSyntax.errors.txt
@@ -1,0 +1,27 @@
+incorrectJSDocTypeAnnotationSyntax.js(5,13): error TS1110: Type expected.
+incorrectJSDocTypeAnnotationSyntax.js(6,13): error TS1110: Type expected.
+incorrectJSDocTypeAnnotationSyntax.js(6,23): error TS1110: Type expected.
+
+
+==== incorrectJSDocTypeAnnotationSyntax.js (3 errors) ====
+    class Bad { message = "doom" }
+    class Worse { message = "doooooom" }
+    /**
+     * @throws {@link Bad} it's real bad
+     * @throws {@type Worse} definitely don't want to see this one!
+                ~
+!!! error TS1110: Type expected.
+     * @throws {@TotalType} didn't even mean to put the @ there
+                ~
+!!! error TS1110: Type expected.
+                          ~
+!!! error TS1110: Type expected.
+     * @return {void}
+     */
+    function can(b) {
+        if (b)
+            throw new Bad()
+        else
+            throw new Worse()
+    }
+    

--- a/tests/baselines/reference/incorrectJSDocTypeAnnotationSyntax.symbols
+++ b/tests/baselines/reference/incorrectJSDocTypeAnnotationSyntax.symbols
@@ -1,0 +1,32 @@
+//// [tests/cases/conformance/jsdoc/incorrectJSDocTypeAnnotationSyntax.ts] ////
+
+=== incorrectJSDocTypeAnnotationSyntax.js ===
+class Bad { message = "doom" }
+>Bad : Symbol(Bad, Decl(incorrectJSDocTypeAnnotationSyntax.js, 0, 0))
+>message : Symbol(Bad.message, Decl(incorrectJSDocTypeAnnotationSyntax.js, 0, 11))
+
+class Worse { message = "doooooom" }
+>Worse : Symbol(Worse, Decl(incorrectJSDocTypeAnnotationSyntax.js, 0, 30))
+>message : Symbol(Worse.message, Decl(incorrectJSDocTypeAnnotationSyntax.js, 1, 13))
+
+/**
+ * @throws {@link Bad} it's real bad
+ * @throws {@type Worse} definitely don't want to see this one!
+ * @throws {@TotalType} didn't even mean to put the @ there
+ * @return {void}
+ */
+function can(b) {
+>can : Symbol(can, Decl(incorrectJSDocTypeAnnotationSyntax.js, 1, 36))
+>b : Symbol(b, Decl(incorrectJSDocTypeAnnotationSyntax.js, 8, 13))
+
+    if (b)
+>b : Symbol(b, Decl(incorrectJSDocTypeAnnotationSyntax.js, 8, 13))
+
+        throw new Bad()
+>Bad : Symbol(Bad, Decl(incorrectJSDocTypeAnnotationSyntax.js, 0, 0))
+
+    else
+        throw new Worse()
+>Worse : Symbol(Worse, Decl(incorrectJSDocTypeAnnotationSyntax.js, 0, 30))
+}
+

--- a/tests/baselines/reference/incorrectJSDocTypeAnnotationSyntax.types
+++ b/tests/baselines/reference/incorrectJSDocTypeAnnotationSyntax.types
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/jsdoc/incorrectJSDocTypeAnnotationSyntax.ts] ////
+
+=== incorrectJSDocTypeAnnotationSyntax.js ===
+class Bad { message = "doom" }
+>Bad : Bad
+>message : string
+>"doom" : "doom"
+
+class Worse { message = "doooooom" }
+>Worse : Worse
+>message : string
+>"doooooom" : "doooooom"
+
+/**
+ * @throws {@link Bad} it's real bad
+ * @throws {@type Worse} definitely don't want to see this one!
+ * @throws {@TotalType} didn't even mean to put the @ there
+ * @return {void}
+ */
+function can(b) {
+>can : (b: any) => void
+>b : any
+
+    if (b)
+>b : any
+
+        throw new Bad()
+>new Bad() : Bad
+>Bad : typeof Bad
+
+    else
+        throw new Worse()
+>new Worse() : Worse
+>Worse : typeof Worse
+}
+

--- a/tests/baselines/reference/jsdocLink6.baseline
+++ b/tests/baselines/reference/jsdocLink6.baseline
@@ -1,0 +1,112 @@
+=== /tests/cases/fourslash/jsdocLink6.ts ===
+// class FooError extends Error {}
+// class BarError extends Error {}
+// /**
+//  * Performs blubber.
+//  * 
+//  * @throws {@link FooError} if foo happens.
+//  * @throws {@link BarError} if bar happens.
+//  */
+// function blubber() {}
+// blubber();
+// ^^^^^^^
+// | ----------------------------------------------------------------------
+// | function blubber(): void
+// | Performs blubber.
+// | @throws {@link FooError} if foo happens.
+// | @throws {@link BarError} if bar happens.
+// | ----------------------------------------------------------------------
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsdocLink6.ts",
+      "position": 214,
+      "name": "3"
+    },
+    "item": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 207,
+        "length": 7
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "blubber",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "Performs blubber.",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "throws",
+          "text": [
+            {
+              "text": "{@link FooError}",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "if foo happens.",
+              "kind": "text"
+            }
+          ]
+        },
+        {
+          "name": "throws",
+          "text": [
+            {
+              "text": "{@link BarError}",
+              "kind": "text"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "if bar happens.",
+              "kind": "text"
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/jsdocLink6.baseline
+++ b/tests/baselines/reference/jsdocLink6.baseline
@@ -13,8 +13,8 @@
 // | ----------------------------------------------------------------------
 // | function blubber(): void
 // | Performs blubber.
-// | @throws {@link FooError} if foo happens.
-// | @throws {@link BarError} if bar happens.
+// | @throws FooError} if foo happens.
+// | @throws BarError} if bar happens.
 // | ----------------------------------------------------------------------
 
 [
@@ -76,7 +76,7 @@
           "name": "throws",
           "text": [
             {
-              "text": "{@link FooError}",
+              "text": "FooError}",
               "kind": "text"
             },
             {
@@ -93,7 +93,7 @@
           "name": "throws",
           "text": [
             {
-              "text": "{@link BarError}",
+              "text": "BarError}",
               "kind": "text"
             },
             {

--- a/tests/baselines/reference/jsdocLink7.baseline.jsonc
+++ b/tests/baselines/reference/jsdocLink7.baseline.jsonc
@@ -1,0 +1,53 @@
+// === goToDefinition ===
+// === /tests/cases/fourslash/jsdocLink7.ts ===
+// <|class [|FooError|] extends Error {}|>
+// class BarError extends Error {}
+// /**
+//  * Performs blubber.
+//  * 
+//  * @throws {@link FooError/*GOTO DEF*/} if foo happens.
+//  * @throws {@link BarError} if bar happens.
+//  */
+// function blubber() {}
+// blubber();
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "FooError",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]
+
+
+
+// === goToDefinition ===
+// === /tests/cases/fourslash/jsdocLink7.ts ===
+// class FooError extends Error {}
+// <|class [|BarError|] extends Error {}|>
+// /**
+//  * Performs blubber.
+//  * 
+//  * @throws {@link FooError} if foo happens.
+//  * @throws {@link BarError/*GOTO DEF*/} if bar happens.
+//  */
+// function blubber() {}
+// blubber();
+
+  // === Details ===
+  [
+   {
+    "kind": "class",
+    "name": "BarError",
+    "containerName": "",
+    "isLocal": false,
+    "isAmbient": false,
+    "unverified": false,
+    "failedAliasResolution": false
+   }
+  ]

--- a/tests/cases/conformance/jsdoc/incorrectJSDocTypeAnnotationSyntax.ts
+++ b/tests/cases/conformance/jsdoc/incorrectJSDocTypeAnnotationSyntax.ts
@@ -1,0 +1,18 @@
+// @filename: incorrectJSDocTypeAnnotationSyntax.js
+// @checkJs: true
+// @noEmit: true
+
+class Bad { message = "doom" }
+class Worse { message = "doooooom" }
+/**
+ * @throws {@link Bad} it's real bad
+ * @throws {@type Worse} definitely don't want to see this one!
+ * @throws {@TotalType} didn't even mean to put the @ there
+ * @return {void}
+ */
+function can(b) {
+    if (b)
+        throw new Bad()
+    else
+        throw new Worse()
+}

--- a/tests/cases/fourslash/jsdocLink6.ts
+++ b/tests/cases/fourslash/jsdocLink6.ts
@@ -10,4 +10,5 @@
 //// function blubber() {}
 //// blubber/*3*/();
 
+verify.noErrors()
 verify.baselineQuickInfo();

--- a/tests/cases/fourslash/jsdocLink6.ts
+++ b/tests/cases/fourslash/jsdocLink6.ts
@@ -1,0 +1,13 @@
+///<reference path="fourslash.ts" />
+//// class FooError extends Error {}
+//// class BarError extends Error {}
+//// /**
+////  * Performs blubber.
+////  * 
+////  * @throws {@link FooError} if foo happens.
+////  * @throws {@link BarError} if bar happens.
+////  */
+//// function blubber() {}
+//// blubber/*3*/();
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/jsdocLink7.ts
+++ b/tests/cases/fourslash/jsdocLink7.ts
@@ -1,0 +1,13 @@
+///<reference path="fourslash.ts" />
+//// class FooError extends Error {}
+//// class BarError extends Error {}
+//// /**
+////  * Performs blubber.
+////  * 
+////  * @throws {@link FooError/*1*/} if foo happens.
+////  * @throws {@link BarError/*2*/} if bar happens.
+////  */
+//// function blubber() {}
+//// blubber();
+
+verify.baselineGoToDefinition("1", "2");


### PR DESCRIPTION
Fixes #54650

Only the code in parseJSDocTypeExpression changes; the other diffs are moves of functions to outer scopes.