### PR TITLE
Reorganize eslint config rule ordering

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,10 +30,33 @@
         "/coverage/**"
     ],
     "rules": {
-        "max-statements-per-line": ["error", { "max": 1 }],
-        "simple-import-sort/imports": "error",
-        "simple-import-sort/exports": "error",
+        // eslint
+        "dot-notation": "error",
+        "eqeqeq": "error",
+        "no-caller": "error",
+        "no-eval": "error",
+        "no-extra-bind": "error",
+        "no-new-func": "error",
+        "no-new-wrappers": "error",
+        "no-return-await": "error",
+        "no-restricted-globals": [
+            "error",
+            { "name": "setTimeout" },
+            { "name": "clearTimeout" },
+            { "name": "setInterval" },
+            { "name": "clearInterval" },
+            { "name": "setImmediate" },
+            { "name": "clearImmediate" }
+        ],
+        "no-template-curly-in-string": "error",
+        "no-throw-literal": "error",
+        "no-undef-init": "error",
+        "no-var": "error",
+        "object-shorthand": "error",
+        "prefer-const": "error",
+        "prefer-object-spread": "error",
 
+        // @typescript-eslint/eslint-plugin
         "@typescript-eslint/naming-convention": [
             "error",
             { "selector": "typeLike", "format": ["PascalCase"], "filter": { "regex": "^(__String|[A-Za-z]+_[A-Za-z]+)$", "match": false } },
@@ -47,15 +70,14 @@
             { "selector": "property", "format": null }
         ],
 
-        "@typescript-eslint/brace-style": ["error", "stroustrup", { "allowSingleLine": true }],
-        "@typescript-eslint/no-extra-semi": "error",
-        "@typescript-eslint/quotes": ["error", "double", { "avoidEscape": true, "allowTemplateLiterals": true }],
-        "@typescript-eslint/semi": "error",
-        "@typescript-eslint/space-before-function-paren": ["error", {
-            "asyncArrow": "always",
-            "anonymous": "always",
-            "named": "never"
-        }],
+        // Rules enabled in typescript-eslint configs that are not applicable here
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/class-literal-property-style": "off",
+        "@typescript-eslint/consistent-indexed-object-style": "off",
+        "@typescript-eslint/no-duplicate-enum-values": "off",
+        "@typescript-eslint/no-namespace": "off",
+        "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
+        "@typescript-eslint/no-var-requires": "off",
 
         // Todo: For each of these, investigate whether we want to enable them ✨
         "@typescript-eslint/ban-types": "off",
@@ -77,27 +99,16 @@
         // Pending https://github.com/typescript-eslint/typescript-eslint/issues/4820
         "@typescript-eslint/prefer-optional-chain": "off",
 
-        // Rules enabled in typescript-eslint configs that are not applicable here
-        "@typescript-eslint/ban-ts-comment": "off",
-        "@typescript-eslint/class-literal-property-style": "off",
-        "@typescript-eslint/consistent-indexed-object-style": "off",
-        "@typescript-eslint/no-duplicate-enum-values": "off",
-        "@typescript-eslint/no-namespace": "off",
-        "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
-        "@typescript-eslint/no-var-requires": "off",
-
         // scripts/eslint/rules
-        "local/object-literal-surrounding-space": "error",
-        "local/no-type-assertion-whitespace": "error",
-        "local/type-operator-spacing": "error",
-        "local/only-arrow-functions": ["error", {
-            "allowNamedFunctions": true ,
-            "allowDeclarations": true
-        }],
-        "local/no-double-space": "error",
+        "local/only-arrow-functions": [
+            "error",
+            {
+                "allowNamedFunctions": true ,
+                "allowDeclarations": true
+            }
+        ],
         "local/argument-trivia": "error",
         "local/no-in-operator": "error",
-        "local/simple-indent": "error",
         "local/debug-assert": "error",
         "local/no-keywords": "error",
         "local/jsdoc-format": "error",
@@ -105,37 +116,35 @@
         // eslint-plugin-no-null
         "no-null/no-null": "error",
 
-        // eslint
+        // eslint-plugin-simple-import-sort
+        "simple-import-sort/imports": "error",
+        "simple-import-sort/exports": "error",
+
+        // Formatting rules; remove once a formatter enforces these.
         "curly": ["error", "multi-line"],
-        "dot-notation": "error",
-        "eqeqeq": "error",
         "linebreak-style": ["error", "windows"],
+        "max-statements-per-line": ["error", { "max": 1 }],
         "new-parens": "error",
-        "no-caller": "error",
-        "no-eval": "error",
-        "no-extra-bind": "error",
-        "no-new-func": "error",
-        "no-new-wrappers": "error",
-        "no-return-await": "error",
-        "no-restricted-globals": ["error",
-            { "name": "setTimeout" },
-            { "name": "clearTimeout" },
-            { "name": "setInterval" },
-            { "name": "clearInterval" },
-            { "name": "setImmediate" },
-            { "name": "clearImmediate" }
-        ],
-        "no-template-curly-in-string": "error",
-        "no-throw-literal": "error",
         "no-trailing-spaces": "error",
-        "no-undef-init": "error",
-        "no-var": "error",
-        "object-shorthand": "error",
-        "prefer-const": "error",
-        "prefer-object-spread": "error",
         "quote-props": ["error", "consistent-as-needed"],
         "space-in-parens": "error",
-        "unicode-bom": ["error", "never"]
+        "@typescript-eslint/brace-style": ["error", "stroustrup", { "allowSingleLine": true }],
+        "@typescript-eslint/no-extra-semi": "error",
+        "@typescript-eslint/quotes": ["error", "double", { "avoidEscape": true, "allowTemplateLiterals": true }],
+        "@typescript-eslint/semi": "error",
+        "@typescript-eslint/space-before-function-paren": [
+            "error",
+            {
+                "asyncArrow": "always",
+                "anonymous": "always",
+                "named": "never"
+            }
+        ],
+        "local/object-literal-surrounding-space": "error",
+        "local/no-type-assertion-whitespace": "error",
+        "local/type-operator-spacing": "error",
+        "local/no-double-space": "error",
+        "local/simple-indent": "error"
     },
     "overrides": [
         // By default, the ESLint CLI only looks at .js files. But, it will also look at


### PR DESCRIPTION
I've been wanting to do this to make #54820 easier to deal with; I have to bulk delete the formatting-related rules and ensure they're handled, but it's tricky when I have to fix merge conflicts in the file or accidentally miss ones that are in fact formatting-related.