### PR TITLE
Don't emit enum members as evaluated `Infinity`/`NaN` when their values are shadowed

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -46851,6 +46851,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return !sym.exports ? [] : nodeBuilder.symbolTableToDeclarationStatements(sym.exports, node, flags, tracker, bundled);
             },
             isImportRequiredByAugmentation,
+            isNameReferencingGlobalValueAtLocation: (name, location) => {
+                return resolveEntityName(factory.createIdentifier(name), SymbolFlags.Value, /*ignoreErrors*/ true, /*dontResolveAlias*/ undefined, location) === getGlobalSymbol(escapeLeadingUnderscores(name), SymbolFlags.Value, /*diagnostic*/ undefined);
+            }
         };
 
         function isImportRequiredByAugmentation(node: ImportDeclaration) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1175,6 +1175,7 @@ export const notImplementedResolver: EmitResolver = {
     isBindingCapturedByNode: notImplemented,
     getDeclarationStatementsForSourceFile: notImplemented,
     isImportRequiredByAugmentation: notImplemented,
+    isNameReferencingGlobalValueAtLocation: notImplemented,
 };
 
 /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5717,6 +5717,7 @@ export interface EmitResolver {
     isBindingCapturedByNode(node: Node, decl: VariableDeclaration | BindingElement): boolean;
     getDeclarationStatementsForSourceFile(node: SourceFile, flags: NodeBuilderFlags, tracker: SymbolTracker, bundled?: boolean): Statement[] | undefined;
     isImportRequiredByAugmentation(decl: ImportDeclaration): boolean;
+    isNameReferencingGlobalValueAtLocation(name: string, location: Node): boolean;
 }
 
 export const enum SymbolFlags {

--- a/tests/baselines/reference/enumShadowedInfinityNaN2.js
+++ b/tests/baselines/reference/enumShadowedInfinityNaN2.js
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/enums/enumShadowedInfinityNaN2.ts] ////
+
+//// [enumShadowedInfinityNaN2.ts]
+// repro https://github.com/microsoft/TypeScript/issues/55091
+
+let Infinity = 3;
+let NaN = 5;
+
+export enum A {
+    X = 1 / 0,
+    Y = -1 / 0,
+    B = 0 / 0,
+}
+
+
+//// [enumShadowedInfinityNaN2.js]
+"use strict";
+// repro https://github.com/microsoft/TypeScript/issues/55091
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.A = void 0;
+var Infinity = 3;
+var NaN = 5;
+var A;
+(function (A) {
+    A[A["X"] = 1 / 0] = "X";
+    A[A["Y"] = -(1 / 0)] = "Y";
+    A[A["B"] = 0 / 0] = "B";
+})(A || (exports.A = A = {}));

--- a/tests/baselines/reference/enumShadowedInfinityNaN2.symbols
+++ b/tests/baselines/reference/enumShadowedInfinityNaN2.symbols
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/enums/enumShadowedInfinityNaN2.ts] ////
+
+=== enumShadowedInfinityNaN2.ts ===
+// repro https://github.com/microsoft/TypeScript/issues/55091
+
+let Infinity = 3;
+>Infinity : Symbol(Infinity, Decl(enumShadowedInfinityNaN2.ts, 2, 3))
+
+let NaN = 5;
+>NaN : Symbol(NaN, Decl(enumShadowedInfinityNaN2.ts, 3, 3))
+
+export enum A {
+>A : Symbol(A, Decl(enumShadowedInfinityNaN2.ts, 3, 12))
+
+    X = 1 / 0,
+>X : Symbol(A.X, Decl(enumShadowedInfinityNaN2.ts, 5, 15))
+
+    Y = -1 / 0,
+>Y : Symbol(A.Y, Decl(enumShadowedInfinityNaN2.ts, 6, 14))
+
+    B = 0 / 0,
+>B : Symbol(A.B, Decl(enumShadowedInfinityNaN2.ts, 7, 15))
+}
+

--- a/tests/baselines/reference/enumShadowedInfinityNaN2.types
+++ b/tests/baselines/reference/enumShadowedInfinityNaN2.types
@@ -1,0 +1,36 @@
+//// [tests/cases/conformance/enums/enumShadowedInfinityNaN2.ts] ////
+
+=== enumShadowedInfinityNaN2.ts ===
+// repro https://github.com/microsoft/TypeScript/issues/55091
+
+let Infinity = 3;
+>Infinity : number
+>3 : 3
+
+let NaN = 5;
+>NaN : number
+>5 : 5
+
+export enum A {
+>A : A
+
+    X = 1 / 0,
+>X : A.X
+>1 / 0 : number
+>1 : 1
+>0 : 0
+
+    Y = -1 / 0,
+>Y : A.Y
+>-1 / 0 : number
+>-1 : -1
+>1 : 1
+>0 : 0
+
+    B = 0 / 0,
+>B : A.B
+>0 / 0 : number
+>0 : 0
+>0 : 0
+}
+

--- a/tests/cases/conformance/enums/enumShadowedInfinityNaN2.ts
+++ b/tests/cases/conformance/enums/enumShadowedInfinityNaN2.ts
@@ -1,0 +1,10 @@
+// repro https://github.com/microsoft/TypeScript/issues/55091
+
+let Infinity = 3;
+let NaN = 5;
+
+export enum A {
+    X = 1 / 0,
+    Y = -1 / 0,
+    B = 0 / 0,
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/55091