### PR TITLE
Replace handle on requestId in cancelAnimationFrame.

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -2511,7 +2511,7 @@ declare var AnimationEvent: {
 };
 
 interface AnimationFrameProvider {
-    cancelAnimationFrame(handle: number): void;
+    cancelAnimationFrame(requestId: number): void;
     requestAnimationFrame(callback: FrameRequestCallback): number;
 }
 
@@ -27414,7 +27414,7 @@ declare function toString(): string;
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent)
  */
 declare function dispatchEvent(event: Event): boolean;
-declare function cancelAnimationFrame(handle: number): void;
+declare function cancelAnimationFrame(requestId: number): void;
 declare function requestAnimationFrame(callback: FrameRequestCallback): number;
 /**
  * Fires when the user aborts the download.

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -977,7 +977,7 @@ interface AbstractWorker {
 }
 
 interface AnimationFrameProvider {
-    cancelAnimationFrame(handle: number): void;
+    cancelAnimationFrame(requestId: number): void;
     requestAnimationFrame(callback: FrameRequestCallback): number;
 }
 
@@ -9168,7 +9168,7 @@ declare function setInterval(handler: TimerHandler, timeout?: number, ...argumen
 declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/structuredClone) */
 declare function structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
-declare function cancelAnimationFrame(handle: number): void;
+declare function cancelAnimationFrame(requestId: number): void;
 declare function requestAnimationFrame(callback: FrameRequestCallback): number;
 declare function addEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(type: K, listener: (this: DedicatedWorkerGlobalScope, ev: DedicatedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
 declare function addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/tests/baselines/reference/multiExtendsSplitInterfaces1.types
+++ b/tests/baselines/reference/multiExtendsSplitInterfaces1.types
@@ -3,8 +3,8 @@
 === multiExtendsSplitInterfaces1.ts ===
 self.cancelAnimationFrame(0);
 >self.cancelAnimationFrame(0) : void
->self.cancelAnimationFrame : ((handle: number) => void) & ((handle: number) => void)
+>self.cancelAnimationFrame : ((requestId: number) => void) & ((requestId: number) => void)
 >self : Window & typeof globalThis
->cancelAnimationFrame : ((handle: number) => void) & ((handle: number) => void)
+>cancelAnimationFrame : ((requestId: number) => void) & ((requestId: number) => void)
 >0 : 0
 

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -16025,7 +16025,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     URL: URL;
     alert(message?: any): void;
     blur(): void;
-    cancelAnimationFrame(handle: number): void;
+    cancelAnimationFrame(requestId: number): void;
     captureEvents(): void;
     close(): void;
     confirm(message?: string): boolean;
@@ -16858,7 +16858,7 @@ declare var window: Window;
 declare var URL: URL;
 declare function alert(message?: any): void;
 declare function blur(): void;
-declare function cancelAnimationFrame(handle: number): void;
+declare function cancelAnimationFrame(requestId: number): void;
 declare function captureEvents(): void;
 declare function close(): void;
 declare function confirm(message?: string): boolean;


### PR DESCRIPTION
"requestId" is more understandable than "handle".
On mdn, it is the "request id" that is used, not the "handle":

> A long integer value, the request id, that uniquely identifies the entry in the callback list.

https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#return_value