### PR TITLE
Fix broken PR issue close command in GHA

### DIFF
--- a/.github/workflows/pr-modified-files.yml
+++ b/.github/workflows/pr-modified-files.yml
@@ -99,7 +99,7 @@ jobs:
             MESSAGE+=" You can [read more here](https://github.com/microsoft/TypeScript/blob/main/CONTRIBUTING.md#contributing-libdts-fixes)."
             MESSAGE+=" For house-keeping purposes, this pull request will be closed."
 
-            gh pr close $issue --repo ${{ github.repository }} --comment "$MESSAGE"
+            gh pr close ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --comment "$MESSAGE"
             exit 1 # Stop the pipeline; we just closed the PR.
           fi
 


### PR DESCRIPTION
This `$issue` was accidentally left behind from a previous revision of this workflow and is causing this step to fail.