### PR TITLE
Enable @typescript-eslint/ban-types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,7 +84,9 @@
             {
                 "extendDefaults": true,
                 "types": {
-                    "Symbol": false, // This is theoretically good, but ts-eslint appears to mistake our declaration of Symbol for the global Symbol type.
+                    // This is theoretically good, but ts-eslint appears to mistake our declaration of Symbol for the global Symbol type.
+                    // See: https://github.com/typescript-eslint/typescript-eslint/issues/7306
+                    "Symbol": false,
                     "{}": false // {} is a totally useful and valid type.
                 }
             }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,9 +79,18 @@
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/ban-types": [
+            "error",
+            {
+                "extendDefaults": true,
+                "types": {
+                    "Symbol": false, // This is theoretically good, but ts-eslint appears to mistake our declaration of Symbol for the global Symbol type.
+                    "{}": false // {} is a totally useful and valid type.
+                }
+            }
+        ],
 
         // Todo: For each of these, investigate whether we want to enable them ✨
-        "@typescript-eslint/ban-types": "off",
         "no-case-declarations": "off",
         "no-cond-assign": "off",
         "no-constant-condition": "off",

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1711,7 +1711,7 @@ export let sys: System = (() => {
 
         function bufferFrom(input: string, encoding?: string): Buffer {
             // See https://github.com/Microsoft/TypeScript/issues/25652
-            return Buffer.from && (Buffer.from as Function) !== Int8Array.from
+            return Buffer.from && Buffer.from !== Int8Array.from
                 ? Buffer.from(input, encoding)
                 : new Buffer(input, encoding);
         }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -442,11 +442,11 @@ export class TestState {
             for (const k of keys) {
                 const key = k as keyof typeof ls;
                 if (cacheableMembers.indexOf(key) === -1) {
-                    proxy[key] = (...args: any[]) => (ls[key] as Function)(...args);
+                    proxy[key] = (...args: any[]) => (ls[key] as (...args: any[]) => any)(...args);
                     continue;
                 }
                 const memo = Utils.memoize(
-                    (_version: number, _active: string, _caret: number, _selectEnd: number, _marker: string | undefined, ...args: any[]) => (ls[key] as Function)(...args),
+                    (_version: number, _active: string, _caret: number, _selectEnd: number, _marker: string | undefined, ...args: any[]) => (ls[key] as (...args: any[]) => any)(...args),
                     (...args) => args.map(a => a && typeof a === "object" ? JSON.stringify(a) : a).join("|,|")
                 );
                 proxy[key] = (...args: any[]) => memo(


### PR DESCRIPTION
Follow-up to #54693.

All of the things it catches are harmless, realistically, though I agree that `as Function` was the wrong cast as that'd let us accidentally `new` it or something.

I definitely disagree with the default of banning `{}`; that's a very useful type (especially post #49119, a number I have memorized at this point). Annoyingly, violating the rule that bans `{}` or `Object` says to use `NonNullable<unknown>` which is exactly `{}`.

The fact that `Symbol` is mistaken as the global `Symbol` I believe is a bug in ts-eslint, ~~though I don't think it's reported so I'll do that shortly.~~ https://github.com/typescript-eslint/typescript-eslint/issues/7306

Disabling those two leaves the rule to only ban the uppercase primitive wrapper types (good) and `Object` (probably good), so it seems like this rule is fine to keep enabled.