### PR TITLE
Triage and fix some eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,6 +58,7 @@
         "unicode-bom": ["error", "never"],
 
         // Enabled in eslint:recommended, but not applicable here
+        "no-extra-boolean-cast": "off",
         "no-case-declarations": "off",
         "no-cond-assign": "off",
         "no-constant-condition": ["error", { "checkLoops": false }],
@@ -91,7 +92,6 @@
 
         // Todo: For each of these, investigate whether we want to enable them ✨
         "@typescript-eslint/ban-types": "off",
-        "no-extra-boolean-cast": "off",
         "no-useless-escape": "off",
         "prefer-rest-params": "off",
         "prefer-spread": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,13 @@
         "prefer-object-spread": "error",
         "unicode-bom": ["error", "never"],
 
+        // Enabled in eslint:recommended, but not applicable here
+        "no-case-declarations": "off",
+        "no-cond-assign": "off",
+        "no-constant-condition": ["error", { "checkLoops": false }],
+        "no-control-regex": "off",
+        "no-inner-declarations": "off",
+
         // @typescript-eslint/eslint-plugin
         "@typescript-eslint/naming-convention": [
             "error",
@@ -79,22 +86,16 @@
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
         "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/no-empty-interface": "off",
+        "@typescript-eslint/no-explicit-any": "off",
 
         // Todo: For each of these, investigate whether we want to enable them ✨
         "@typescript-eslint/ban-types": "off",
-        "no-case-declarations": "off",
-        "no-cond-assign": "off",
-        "no-constant-condition": "off",
-        "no-control-regex": "off",
-        "no-debugger": "off",
         "no-extra-boolean-cast": "off",
-        "no-inner-declarations": "off",
         "no-useless-escape": "off",
         "prefer-rest-params": "off",
         "prefer-spread": "off",
         "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unused-vars": "off",
 
         // Pending https://github.com/typescript-eslint/typescript-eslint/issues/4820

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,7 @@
         "dot-notation": "error",
         "eqeqeq": "error",
         "no-caller": "error",
+        "no-constant-condition": ["error", { "checkLoops": false }],
         "no-eval": "error",
         "no-extra-bind": "error",
         "no-new-func": "error",
@@ -61,7 +62,6 @@
         "no-extra-boolean-cast": "off",
         "no-case-declarations": "off",
         "no-cond-assign": "off",
-        "no-constant-condition": ["error", { "checkLoops": false }],
         "no-control-regex": "off",
         "no-inner-declarations": "off",
 

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -193,6 +193,7 @@ export namespace Debug {
     }
 
     export function fail(message?: string, stackCrawlMark?: AnyFunction): never {
+        // eslint-disable-next-line no-debugger
         debugger;
         const e = new Error(message ? `Debug Failure. ${message}` : "Debug Failure.");
         if ((Error as any).captureStackTrace) {

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -604,7 +604,6 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
         if (hasChangedCompilerOptions) {
             newLine = updateNewLine();
             if (program && changesAffectModuleResolution(program.getCompilerOptions(), compilerOptions)) {
-                debugger;
                 resolutionCache.onChangesAffectModuleResolution();
             }
         }


### PR DESCRIPTION
Follow-up to #54693.

This PR triages the rules that should "obviously" be disabled or fixed.

This caught a case where I had not noticed a stray `debugger` line in a PR.