### PR TITLE
Enable eslint rule no-extra-boolean-cast

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,7 +87,6 @@
         "no-constant-condition": "off",
         "no-control-regex": "off",
         "no-debugger": "off",
-        "no-extra-boolean-cast": "off",
         "no-inner-declarations": "off",
         "no-useless-escape": "off",
         "prefer-rest-params": "off",

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24852,7 +24852,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (constraintType.flags & TypeFlags.TypeParameter) {
                 // We're inferring from some source type S to a mapped type { [P in K]: X }, where K is a type
                 // parameter. First infer from 'keyof S' to K.
-                inferWithPriority(getIndexType(source, /*indexFlags*/ !!source.pattern ? IndexFlags.NoIndexSignatures : IndexFlags.None), constraintType, InferencePriority.MappedTypeConstraint);
+                inferWithPriority(getIndexType(source, /*indexFlags*/ source.pattern ? IndexFlags.NoIndexSignatures : IndexFlags.None), constraintType, InferencePriority.MappedTypeConstraint);
                 // If K is constrained to a type C, also infer to C. Thus, for a mapped type { [P in K]: X },
                 // where K extends keyof T, we make the same inferences as for a homomorphic mapped type
                 // { [P in keyof T]: X }. This enables us to make meaningful inferences when the target is a
@@ -31394,7 +31394,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     // Lookup the private identifier lexically.
     function lookupSymbolForPrivateIdentifierDeclaration(propName: __String, location: Node): Symbol | undefined {
-        for (let containingClass = getContainingClassExcludingClassDecorators(location); !!containingClass; containingClass = getContainingClass(containingClass)) {
+        for (let containingClass = getContainingClassExcludingClassDecorators(location); containingClass; containingClass = getContainingClass(containingClass)) {
             const { symbol } = containingClass;
             const name = getSymbolNameForPrivateIdentifier(symbol, propName);
             const prop = (symbol.members && symbol.members.get(name)) || (symbol.exports && symbol.exports.get(name));
@@ -38551,7 +38551,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function setNodeLinksForPrivateIdentifierScope(node: PropertyDeclaration | PropertySignature | MethodDeclaration | MethodSignature | AccessorDeclaration) {
         if (isPrivateIdentifier(node.name) && languageVersion < ScriptTarget.ESNext) {
-            for (let lexicalScope = getEnclosingBlockScopeContainer(node); !!lexicalScope; lexicalScope = getEnclosingBlockScopeContainer(lexicalScope)) {
+            for (let lexicalScope = getEnclosingBlockScopeContainer(node); lexicalScope; lexicalScope = getEnclosingBlockScopeContainer(lexicalScope)) {
                 getNodeLinks(lexicalScope).flags |= NodeCheckFlags.ContainsClassWithPrivateIdentifiers;
             }
 
@@ -49175,7 +49175,7 @@ export function signatureHasLiteralTypes(s: Signature) {
 
 function createBasicNodeBuilderModuleSpecifierResolutionHost(host: TypeCheckerHost): ModuleSpecifierResolutionHost & { getCommonSourceDirectory(): string } {
     return {
-        getCommonSourceDirectory: !!(host as Program).getCommonSourceDirectory ? () => (host as Program).getCommonSourceDirectory() : () => "",
+        getCommonSourceDirectory: (host as Program).getCommonSourceDirectory ? () => (host as Program).getCommonSourceDirectory() : () => "",
         getCurrentDirectory: () => host.getCurrentDirectory(),
         getSymlinkCache: maybeBind(host, host.getSymlinkCache),
         getPackageJsonInfoCache: () => host.getPackageJsonInfoCache?.(),

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2494,7 +2494,7 @@ export function convertToTSConfig(configParseResult: ParsedCommandLine, configFi
             include: filterSameAsDefaultInclude(configParseResult.options.configFile.configFileSpecs.validatedIncludeSpecs),
             exclude: configParseResult.options.configFile.configFileSpecs.validatedExcludeSpecs
         } : {}),
-        compileOnSave: !!configParseResult.compileOnSave ? true : undefined
+        compileOnSave: configParseResult.compileOnSave ? true : undefined
     };
     return config;
 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1153,7 +1153,7 @@ export function rangeEquals<T>(array1: readonly T[], array2: readonly T[], pos: 
  *
  * @internal
  */
-export const elementAt: <T>(array: readonly T[] | undefined, offset: number) => T | undefined = !!Array.prototype.at
+export const elementAt: <T>(array: readonly T[] | undefined, offset: number) => T | undefined = Array.prototype.at
     ? (array, offset) => array?.at(offset)
     : (array, offset) => {
         if (array) {
@@ -2058,7 +2058,7 @@ export function memoizeCached<A extends any[], T>(callback: (...args: A) => T, c
 export function compose<T>(...args: ((t: T) => T)[]): (t: T) => T;
 /** @internal */
 export function compose<T>(a: (t: T) => T, b: (t: T) => T, c: (t: T) => T, d: (t: T) => T, e: (t: T) => T): (t: T) => T {
-    if (!!e) {
+    if (e) {
         const args: ((t: T) => T)[] = [];
         for (let i = 0; i < arguments.length; i++) {
             args[i] = arguments[i];
@@ -2838,21 +2838,21 @@ export function skipWhile<T, U extends T>(array: readonly T[] | undefined, predi
  *
  * @internal
  */
-export const trimString = !!String.prototype.trim ? ((s: string) => s.trim()) : (s: string) => trimStringEnd(trimStringStart(s));
+export const trimString = String.prototype.trim ? ((s: string) => s.trim()) : (s: string) => trimStringEnd(trimStringStart(s));
 
 /**
  * Returns a copy with trailing whitespace removed.
  *
  * @internal
  */
-export const trimStringEnd = !!String.prototype.trimEnd ? ((s: string) => s.trimEnd()) : trimEndImpl;
+export const trimStringEnd = String.prototype.trimEnd ? ((s: string) => s.trimEnd()) : trimEndImpl;
 
 /**
  * Returns a copy with leading whitespace removed.
  *
  * @internal
  */
-export const trimStringStart = !!String.prototype.trimStart ? ((s: string) => s.trimStart()) : (s: string) => s.replace(/^\s+/g, "");
+export const trimStringStart = String.prototype.trimStart ? ((s: string) => s.trimStart()) : (s: string) => s.replace(/^\s+/g, "");
 
 /**
  * https://jsbench.me/gjkoxld4au/1

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1475,7 +1475,7 @@ export let sys: System = (() => {
 
         const platform: string = _os.platform();
         const useCaseSensitiveFileNames = isFileSystemCaseSensitive();
-        const fsRealpath = !!_fs.realpathSync.native ? process.platform === "win32" ? fsRealPathHandlingLongPath : _fs.realpathSync.native : _fs.realpathSync;
+        const fsRealpath = _fs.realpathSync.native ? process.platform === "win32" ? fsRealPathHandlingLongPath : _fs.realpathSync.native : _fs.realpathSync;
 
         // If our filename is "sys.js", then we are executing unbundled on the raw tsc output.
         // In that case, simulate a faked path in the directory where a bundle would normally

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -136,7 +136,7 @@ export function getExportNeedsImportStarHelper(node: ExportDeclaration): boolean
 
 /** @internal */
 export function getImportNeedsImportStarHelper(node: ImportDeclaration): boolean {
-    if (!!getNamespaceDeclarationNode(node)) {
+    if (getNamespaceDeclarationNode(node)) {
         return true;
     }
     const bindings = node.importClause && node.importClause.namedBindings;

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -2027,7 +2027,7 @@ function updateOutputTimestampsWorker<T extends BuilderProgram>(
         // For incremental projects, only buildinfo needs to be upto date with timestamp check
         // as we dont check output files for up-to-date ness
         if (!skipOutputs?.has(toPath(state, buildInfoPath))) {
-            if (!!state.options.verbose) reportStatus(state, verboseMessage, proj.options.configFilePath!);
+            if (state.options.verbose) reportStatus(state, verboseMessage, proj.options.configFilePath!);
             state.host.setModifiedTime(buildInfoPath, now = getCurrentTime(state.host));
             getBuildInfoCacheEntry(state, buildInfoPath, projectPath)!.modifiedTime = now;
         }

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -169,7 +169,7 @@ function shouldBePretty(sys: System, options: CompilerOptions | BuildOptions) {
 
 function getOptionsForHelp(commandLine: ParsedCommandLine) {
     // Sort our options by their names, (e.g. "--noImplicitAny" comes before "--watch")
-    return !!commandLine.options.all ?
+    return commandLine.options.all ?
         sort(optionDeclarations, (a, b) => compareStringsCaseInsensitive(a.name, b.name)) :
         filter(optionDeclarations.slice(), v => !!v.showInSimplifiedHelpView);
 }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2915,7 +2915,7 @@ export class ConfiguredProject extends Project {
      * @internal
      */
     hasOpenRef() {
-        if (!!this.externalProjectRefCount) {
+        if (this.externalProjectRefCount) {
             return true;
         }
 

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -206,11 +206,11 @@ export class TextStorage {
      * telemetry falsely indicating size 0 would be counter-productive.
      */
     public getTelemetryFileSize(): number {
-        return !!this.fileSize
+        return this.fileSize
             ? this.fileSize
-            : !!this.text // Check text before svc because its length is cheaper
+            : this.text // Check text before svc because its length is cheaper
                 ? this.text.length // Could be wrong if this.pendingReloadFromDisk
-                : !!this.svc
+                : this.svc
                     ? this.svc.getSnapshot().getLength() // Could be wrong if this.pendingReloadFromDisk
                     : this.getSnapshot().getLength(); // Should be strictly correct
     }

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -759,7 +759,7 @@ function transformCallbackArgument(func: Expression, hasContinuation: boolean, c
 
 function getPossiblyAwaitedRightHandSide(checker: TypeChecker, type: Type, expr: Expression): AwaitExpression | Expression {
     const rightHandSide = getSynthesizedDeepClone(expr);
-    return !!checker.getPromisedTypeOfPromise(type) ? factory.createAwaitExpression(rightHandSide) : rightHandSide;
+    return checker.getPromisedTypeOfPromise(type) ? factory.createAwaitExpression(rightHandSide) : rightHandSide;
 }
 
 function getLastCallSignature(type: Type, checker: TypeChecker): Signature | undefined {

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -881,7 +881,7 @@ export function isDeclarationOfSymbol(node: Node, target: Symbol | undefined): b
  */
 function declarationIsWriteAccess(decl: Declaration): boolean {
     // Consider anything in an ambient declaration to be a write access since it may be coming from JS.
-    if (!!(decl.flags & NodeFlags.Ambient)) return true;
+    if (decl.flags & NodeFlags.Ambient) return true;
 
     switch (decl.kind) {
         case SyntaxKind.BinaryExpression:
@@ -2664,7 +2664,7 @@ export namespace Core {
     }
 
     function isImplementation(node: Node): boolean {
-        return !!(node.flags & NodeFlags.Ambient) ? !(isInterfaceDeclaration(node) || isTypeAliasDeclaration(node)) :
+        return node.flags & NodeFlags.Ambient ? !(isInterfaceDeclaration(node) || isTypeAliasDeclaration(node)) :
             (isVariableLike(node) ? hasInitializer(node) :
             isFunctionLikeDeclaration(node) ? !!node.body :
             isClassLike(node) || isModuleOrEnumDeclaration(node));

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1476,7 +1476,7 @@ function extractConstantInScope(
         // If no function signature, maybe there was an error, do nothing
         if (!functionSignature) return { variableType, initializer };
         // If the function signature has generic type parameters we don't attempt to move the parameters
-        if (!!functionSignature.getTypeParameters()) return { variableType, initializer };
+        if (functionSignature.getTypeParameters()) return { variableType, initializer };
 
         // We add parameter types if needed
         const parameters: ParameterDeclaration[] = [];


### PR DESCRIPTION
Follow-up to #54693.

This is probably more for discussion; these extra `!!` are redundant and not obviously wrong, but, it's probably a fine cleanup.