### PR TITLE
Discriminate contextual types using shorthand properties

### DIFF
--- a/tests/baselines/reference/contextuallyTypedByDiscriminableUnion.js
+++ b/tests/baselines/reference/contextuallyTypedByDiscriminableUnion.js
@@ -26,6 +26,14 @@ invoke({
     }
 });
 
+const kind = "a"
+invoke({
+    kind,
+    method(a) {
+        return +a;
+    }
+})
+
 
 //// [contextuallyTypedByDiscriminableUnion.js]
 function invoke(item) {
@@ -38,6 +46,13 @@ function invoke(item) {
 }
 invoke({
     kind: "a",
+    method: function (a) {
+        return +a;
+    }
+});
+var kind = "a";
+invoke({
+    kind: kind,
     method: function (a) {
         return +a;
     }

--- a/tests/baselines/reference/contextuallyTypedByDiscriminableUnion.symbols
+++ b/tests/baselines/reference/contextuallyTypedByDiscriminableUnion.symbols
@@ -60,3 +60,21 @@ invoke({
     }
 });
 
+const kind = "a"
+>kind : Symbol(kind, Decl(contextuallyTypedByDiscriminableUnion.ts, 25, 5))
+
+invoke({
+>invoke : Symbol(invoke, Decl(contextuallyTypedByDiscriminableUnion.ts, 6, 2))
+
+    kind,
+>kind : Symbol(kind, Decl(contextuallyTypedByDiscriminableUnion.ts, 26, 8))
+
+    method(a) {
+>method : Symbol(method, Decl(contextuallyTypedByDiscriminableUnion.ts, 27, 9))
+>a : Symbol(a, Decl(contextuallyTypedByDiscriminableUnion.ts, 28, 11))
+
+        return +a;
+>a : Symbol(a, Decl(contextuallyTypedByDiscriminableUnion.ts, 28, 11))
+    }
+})
+

--- a/tests/baselines/reference/contextuallyTypedByDiscriminableUnion.types
+++ b/tests/baselines/reference/contextuallyTypedByDiscriminableUnion.types
@@ -69,3 +69,25 @@ invoke({
     }
 });
 
+const kind = "a"
+>kind : "a"
+>"a" : "a"
+
+invoke({
+>invoke({    kind,    method(a) {        return +a;    }}) : void
+>invoke : (item: ADT) => void
+>{    kind,    method(a) {        return +a;    }} : { kind: "a"; method(a: string): number; }
+
+    kind,
+>kind : "a"
+
+    method(a) {
+>method : (a: string) => number
+>a : string
+
+        return +a;
+>+a : number
+>a : string
+    }
+})
+

--- a/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
+++ b/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
@@ -23,3 +23,11 @@ invoke({
         return +a;
     }
 });
+
+const kind = "a"
+invoke({
+    kind,
+    method(a) {
+        return +a;
+    }
+})


### PR DESCRIPTION
It's a bug that I noticed when working on https://github.com/microsoft/TypeScript/pull/55144