### PR TITLE
Fixed contextual types of optional properties with `exactOptionalPropertyTypes`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29234,7 +29234,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             else if (t.flags & TypeFlags.StructuredType) {
                 const prop = getPropertyOfType(t, name);
                 if (prop) {
-                    return isCircularMappedProperty(prop) ? undefined : getTypeOfSymbol(prop);
+                    return isCircularMappedProperty(prop) ? undefined : removeMissingType(getTypeOfSymbol(prop), !!(prop && prop.flags & SymbolFlags.Optional));
                 }
                 if (isTupleType(t) && isNumericLiteralName(name) && +name >= 0) {
                     const restType = getElementTypeOfSliceOfTupleType(t, t.target.fixedLength, /*endSkipCount*/ 0, /*writing*/ false, /*noReductions*/ true);
@@ -29311,7 +29311,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // If index is before any spread element and within the fixed part of the contextual tuple type, return
                 // the type of the contextual tuple element.
                 if ((firstSpreadIndex === undefined || index < firstSpreadIndex) && index < t.target.fixedLength) {
-                    return getTypeArguments(t)[index];
+                    return removeMissingType(getTypeArguments(t)[index], !!(t.target.elementFlags[index] && ElementFlags.Optional));
                 }
                 // When the length is known and the index is after all spread elements we compute the offset from the element
                 // to the end and the number of ending fixed elements in the contextual tuple type.

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).errors.txt
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).errors.txt
@@ -1,0 +1,19 @@
+contextuallyTypedOptionalProperty.ts(6,21): error TS18048: 'y' is possibly 'undefined'.
+contextuallyTypedOptionalProperty.ts(9,18): error TS18048: 'y' is possibly 'undefined'.
+
+
+==== contextuallyTypedOptionalProperty.ts (2 errors) ====
+    // repro from https://github.com/microsoft/TypeScript/issues/55164
+    
+    declare function match<T>(cb: (value: T) => boolean): T;
+    
+    declare function foo(pos: { x?: number; y?: number }): boolean;
+    foo({ y: match(y => y > 0) })
+                        ~
+!!! error TS18048: 'y' is possibly 'undefined'.
+    
+    declare function foo2(point: [number?]): boolean;
+    foo2([match(y => y > 0)])
+                     ~
+!!! error TS18048: 'y' is possibly 'undefined'.
+    

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/contextuallyTypedOptionalProperty.ts] ////
+
+=== contextuallyTypedOptionalProperty.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/55164
+
+declare function match<T>(cb: (value: T) => boolean): T;
+>match : Symbol(match, Decl(contextuallyTypedOptionalProperty.ts, 0, 0))
+>T : Symbol(T, Decl(contextuallyTypedOptionalProperty.ts, 2, 23))
+>cb : Symbol(cb, Decl(contextuallyTypedOptionalProperty.ts, 2, 26))
+>value : Symbol(value, Decl(contextuallyTypedOptionalProperty.ts, 2, 31))
+>T : Symbol(T, Decl(contextuallyTypedOptionalProperty.ts, 2, 23))
+>T : Symbol(T, Decl(contextuallyTypedOptionalProperty.ts, 2, 23))
+
+declare function foo(pos: { x?: number; y?: number }): boolean;
+>foo : Symbol(foo, Decl(contextuallyTypedOptionalProperty.ts, 2, 56))
+>pos : Symbol(pos, Decl(contextuallyTypedOptionalProperty.ts, 4, 21))
+>x : Symbol(x, Decl(contextuallyTypedOptionalProperty.ts, 4, 27))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 4, 39))
+
+foo({ y: match(y => y > 0) })
+>foo : Symbol(foo, Decl(contextuallyTypedOptionalProperty.ts, 2, 56))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 5, 5))
+>match : Symbol(match, Decl(contextuallyTypedOptionalProperty.ts, 0, 0))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 5, 15))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 5, 15))
+
+declare function foo2(point: [number?]): boolean;
+>foo2 : Symbol(foo2, Decl(contextuallyTypedOptionalProperty.ts, 5, 29))
+>point : Symbol(point, Decl(contextuallyTypedOptionalProperty.ts, 7, 22))
+
+foo2([match(y => y > 0)])
+>foo2 : Symbol(foo2, Decl(contextuallyTypedOptionalProperty.ts, 5, 29))
+>match : Symbol(match, Decl(contextuallyTypedOptionalProperty.ts, 0, 0))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 8, 12))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 8, 12))
+

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).types
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/contextuallyTypedOptionalProperty.ts] ////
+
+=== contextuallyTypedOptionalProperty.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/55164
+
+declare function match<T>(cb: (value: T) => boolean): T;
+>match : <T>(cb: (value: T) => boolean) => T
+>cb : (value: T) => boolean
+>value : T
+
+declare function foo(pos: { x?: number; y?: number }): boolean;
+>foo : (pos: {    x?: number;    y?: number;}) => boolean
+>pos : { x?: number | undefined; y?: number | undefined; }
+>x : number | undefined
+>y : number | undefined
+
+foo({ y: match(y => y > 0) })
+>foo({ y: match(y => y > 0) }) : boolean
+>foo : (pos: { x?: number | undefined; y?: number | undefined; }) => boolean
+>{ y: match(y => y > 0) } : { y: number | undefined; }
+>y : number | undefined
+>match(y => y > 0) : number | undefined
+>match : <T>(cb: (value: T) => boolean) => T
+>y => y > 0 : (y: number | undefined) => boolean
+>y : number | undefined
+>y > 0 : boolean
+>y : number | undefined
+>0 : 0
+
+declare function foo2(point: [number?]): boolean;
+>foo2 : (point: [number?]) => boolean
+>point : [(number | undefined)?]
+
+foo2([match(y => y > 0)])
+>foo2([match(y => y > 0)]) : boolean
+>foo2 : (point: [(number | undefined)?]) => boolean
+>[match(y => y > 0)] : [number | undefined]
+>match(y => y > 0) : number | undefined
+>match : <T>(cb: (value: T) => boolean) => T
+>y => y > 0 : (y: number | undefined) => boolean
+>y : number | undefined
+>y > 0 : boolean
+>y : number | undefined
+>0 : 0
+

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/contextuallyTypedOptionalProperty.ts] ////
+
+=== contextuallyTypedOptionalProperty.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/55164
+
+declare function match<T>(cb: (value: T) => boolean): T;
+>match : Symbol(match, Decl(contextuallyTypedOptionalProperty.ts, 0, 0))
+>T : Symbol(T, Decl(contextuallyTypedOptionalProperty.ts, 2, 23))
+>cb : Symbol(cb, Decl(contextuallyTypedOptionalProperty.ts, 2, 26))
+>value : Symbol(value, Decl(contextuallyTypedOptionalProperty.ts, 2, 31))
+>T : Symbol(T, Decl(contextuallyTypedOptionalProperty.ts, 2, 23))
+>T : Symbol(T, Decl(contextuallyTypedOptionalProperty.ts, 2, 23))
+
+declare function foo(pos: { x?: number; y?: number }): boolean;
+>foo : Symbol(foo, Decl(contextuallyTypedOptionalProperty.ts, 2, 56))
+>pos : Symbol(pos, Decl(contextuallyTypedOptionalProperty.ts, 4, 21))
+>x : Symbol(x, Decl(contextuallyTypedOptionalProperty.ts, 4, 27))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 4, 39))
+
+foo({ y: match(y => y > 0) })
+>foo : Symbol(foo, Decl(contextuallyTypedOptionalProperty.ts, 2, 56))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 5, 5))
+>match : Symbol(match, Decl(contextuallyTypedOptionalProperty.ts, 0, 0))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 5, 15))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 5, 15))
+
+declare function foo2(point: [number?]): boolean;
+>foo2 : Symbol(foo2, Decl(contextuallyTypedOptionalProperty.ts, 5, 29))
+>point : Symbol(point, Decl(contextuallyTypedOptionalProperty.ts, 7, 22))
+
+foo2([match(y => y > 0)])
+>foo2 : Symbol(foo2, Decl(contextuallyTypedOptionalProperty.ts, 5, 29))
+>match : Symbol(match, Decl(contextuallyTypedOptionalProperty.ts, 0, 0))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 8, 12))
+>y : Symbol(y, Decl(contextuallyTypedOptionalProperty.ts, 8, 12))
+

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=true).types
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/contextuallyTypedOptionalProperty.ts] ////
+
+=== contextuallyTypedOptionalProperty.ts ===
+// repro from https://github.com/microsoft/TypeScript/issues/55164
+
+declare function match<T>(cb: (value: T) => boolean): T;
+>match : <T>(cb: (value: T) => boolean) => T
+>cb : (value: T) => boolean
+>value : T
+
+declare function foo(pos: { x?: number; y?: number }): boolean;
+>foo : (pos: {    x?: number;    y?: number;}) => boolean
+>pos : { x?: number; y?: number; }
+>x : number | undefined
+>y : number | undefined
+
+foo({ y: match(y => y > 0) })
+>foo({ y: match(y => y > 0) }) : boolean
+>foo : (pos: { x?: number; y?: number; }) => boolean
+>{ y: match(y => y > 0) } : { y: number; }
+>y : number
+>match(y => y > 0) : number
+>match : <T>(cb: (value: T) => boolean) => T
+>y => y > 0 : (y: number) => boolean
+>y : number
+>y > 0 : boolean
+>y : number
+>0 : 0
+
+declare function foo2(point: [number?]): boolean;
+>foo2 : (point: [number?]) => boolean
+>point : [number?]
+
+foo2([match(y => y > 0)])
+>foo2([match(y => y > 0)]) : boolean
+>foo2 : (point: [number?]) => boolean
+>[match(y => y > 0)] : [number]
+>match(y => y > 0) : number
+>match : <T>(cb: (value: T) => boolean) => T
+>y => y > 0 : (y: number) => boolean
+>y : number
+>y > 0 : boolean
+>y : number
+>0 : 0
+

--- a/tests/cases/compiler/contextuallyTypedOptionalProperty.ts
+++ b/tests/cases/compiler/contextuallyTypedOptionalProperty.ts
@@ -1,0 +1,13 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true, false
+// @noEmit: true
+
+// repro from https://github.com/microsoft/TypeScript/issues/55164
+
+declare function match<T>(cb: (value: T) => boolean): T;
+
+declare function foo(pos: { x?: number; y?: number }): boolean;
+foo({ y: match(y => y > 0) })
+
+declare function foo2(point: [number?]): boolean;
+foo2([match(y => y > 0)])


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/55164