### PR TITLE
Move @typescript-eslint/no-namespace to disabled list

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,6 +84,7 @@
         "@typescript-eslint/class-literal-property-style": "off",
         "@typescript-eslint/consistent-indexed-object-style": "off",
         "@typescript-eslint/no-duplicate-enum-values": "off",
+        "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-namespace": "off",
         "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
         "@typescript-eslint/no-var-requires": "off",
@@ -106,7 +107,6 @@
         "no-useless-escape": "off",
         "prefer-rest-params": "off",
         "prefer-spread": "off",
-        "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-unused-vars": "off",
 
         // Pending https://github.com/typescript-eslint/typescript-eslint/issues/4820


### PR DESCRIPTION
This rule fires for these:

```
/home/jabaile/work/TypeScript/src/compiler/core.ts
  1882:41  error  Unexpected empty function 'noop'        @typescript-eslint/no-empty-function
  2706:43  error  Unexpected empty function 'assertType'  @typescript-eslint/no-empty-function

/home/jabaile/work/TypeScript/src/compiler/debug.ts
  358:43  error  Unexpected empty function 'type'  @typescript-eslint/no-empty-function

/home/jabaile/work/TypeScript/src/testRunner/unittests/evaluation/esDecorators.ts
   741:65  error  Unexpected empty method 'method'   @typescript-eslint/no-empty-function
   768:44  error  Unexpected empty method 'method'   @typescript-eslint/no-empty-function
   785:76  error  Unexpected empty method '#method'  @typescript-eslint/no-empty-function
  1139:70  error  Unexpected empty arrow function    @typescript-eslint/no-empty-function
  1189:70  error  Unexpected empty arrow function    @typescript-eslint/no-empty-function
  1270:70  error  Unexpected empty arrow function    @typescript-eslint/no-empty-function
  1351:70  error  Unexpected empty arrow function    @typescript-eslint/no-empty-function
  1432:70  error  Unexpected empty arrow function    @typescript-eslint/no-empty-function
  1513:70  error  Unexpected empty arrow function    @typescript-eslint/no-empty-function

✖ 12 problems (12 errors, 0 warnings)
```

The first three are functions which are canonically empty (which we'd exempt). It's possible that we'd always use `noop` when we wanted an empty function, so it would seem like this rule is fine to keep things consistent.

However, the last file's errors are in a test which checks that the shape of things is correct, such that it's not really a problem that they are empty, but there's no way we could use `noop` to achieve the same goals, only throw or something to say "this is intentionally empty".

I'm not sure if this rule gets us much; if anything it'd just be an annoyance in the editor when we are working on the code, similarly to my thoughts on `no-empty-interface`.