### PR TITLE
Allow calls ending with unions of tuples

### DIFF
--- a/tests/baselines/reference/callWithSpread6.errors.txt
+++ b/tests/baselines/reference/callWithSpread6.errors.txt
@@ -1,0 +1,53 @@
+callWithSpread6.ts(15,1): error TS2554: Expected 4 arguments, but got 3.
+callWithSpread6.ts(17,19): error TS2554: Expected 1-4 arguments, but got 5.
+callWithSpread6.ts(18,10): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
+callWithSpread6.ts(20,1): error TS2555: Expected at least 2 arguments, but got 1.
+callWithSpread6.ts(22,3): error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
+callWithSpread6.ts(23,1): error TS2555: Expected at least 3 arguments, but got 1.
+callWithSpread6.ts(24,1): error TS2555: Expected at least 3 arguments, but got 2.
+
+
+==== callWithSpread6.ts (7 errors) ====
+    declare const n: number
+    declare const nntnnnt: [number, number] | [number, number, number]
+    declare const ntnnnt: [number] | [number, number, number]
+    declare const ntnnnut: [number] | [number, number, number?]
+    declare function setHours(a: number, b?: number, c?: number, d?: number): number
+    declare function setHoursStrict(a: number, b: number, c: number, d: number): number
+    declare function f(a: number, b: number, ...c: number[]): number
+    declare function g(a: number, b?: number, ...c: number[]): number
+    declare function h(a: number, b: number, c: number, ...d: number[]): number
+    
+    setHours(...nntnnnt)
+    setHours(...ntnnnt)
+    setHours(...ntnnnut)
+    setHours(n, n, ...nntnnnt)
+    setHoursStrict(n, ...nntnnnt)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2554: Expected 4 arguments, but got 3.
+!!! related TS6210 callWithSpread6.ts:6:66: An argument for 'd' was not provided.
+    setHoursStrict(n, n, ...nntnnnt)
+    setHours(n, n, n, ...nntnnnt)
+                      ~~~~~~~~~~
+!!! error TS2554: Expected 1-4 arguments, but got 5.
+    setHours(...nntnnnt, n)
+             ~~~~~~~~~~
+!!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
+    
+    f(...ntnnnt)
+    ~~~~~~~~~~~~
+!!! error TS2555: Expected at least 2 arguments, but got 1.
+!!! related TS6210 callWithSpread6.ts:7:31: An argument for 'b' was not provided.
+    f(...nntnnnt)
+    f(...nntnnnt, n)
+      ~~~~~~~~~~
+!!! error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
+    h(...ntnnnt)
+    ~~~~~~~~~~~~
+!!! error TS2555: Expected at least 3 arguments, but got 1.
+!!! related TS6210 callWithSpread6.ts:9:31: An argument for 'b' was not provided.
+    h(...nntnnnt)
+    ~~~~~~~~~~~~~
+!!! error TS2555: Expected at least 3 arguments, but got 2.
+!!! related TS6210 callWithSpread6.ts:9:42: An argument for 'c' was not provided.
+    

--- a/tests/baselines/reference/callWithSpread6.js
+++ b/tests/baselines/reference/callWithSpread6.js
@@ -1,0 +1,44 @@
+//// [tests/cases/conformance/expressions/functionCalls/callWithSpread6.ts] ////
+
+//// [callWithSpread6.ts]
+declare const n: number
+declare const nntnnnt: [number, number] | [number, number, number]
+declare const ntnnnt: [number] | [number, number, number]
+declare const ntnnnut: [number] | [number, number, number?]
+declare function setHours(a: number, b?: number, c?: number, d?: number): number
+declare function setHoursStrict(a: number, b: number, c: number, d: number): number
+declare function f(a: number, b: number, ...c: number[]): number
+declare function g(a: number, b?: number, ...c: number[]): number
+declare function h(a: number, b: number, c: number, ...d: number[]): number
+
+setHours(...nntnnnt)
+setHours(...ntnnnt)
+setHours(...ntnnnut)
+setHours(n, n, ...nntnnnt)
+setHoursStrict(n, ...nntnnnt)
+setHoursStrict(n, n, ...nntnnnt)
+setHours(n, n, n, ...nntnnnt)
+setHours(...nntnnnt, n)
+
+f(...ntnnnt)
+f(...nntnnnt)
+f(...nntnnnt, n)
+h(...ntnnnt)
+h(...nntnnnt)
+
+
+//// [callWithSpread6.js]
+"use strict";
+setHours(...nntnnnt);
+setHours(...ntnnnt);
+setHours(...ntnnnut);
+setHours(n, n, ...nntnnnt);
+setHoursStrict(n, ...nntnnnt);
+setHoursStrict(n, n, ...nntnnnt);
+setHours(n, n, n, ...nntnnnt);
+setHours(...nntnnnt, n);
+f(...ntnnnt);
+f(...nntnnnt);
+f(...nntnnnt, n);
+h(...ntnnnt);
+h(...nntnnnt);

--- a/tests/baselines/reference/callWithSpread6.symbols
+++ b/tests/baselines/reference/callWithSpread6.symbols
@@ -1,0 +1,110 @@
+//// [tests/cases/conformance/expressions/functionCalls/callWithSpread6.ts] ////
+
+=== callWithSpread6.ts ===
+declare const n: number
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+
+declare const nntnnnt: [number, number] | [number, number, number]
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+
+declare const ntnnnt: [number] | [number, number, number]
+>ntnnnt : Symbol(ntnnnt, Decl(callWithSpread6.ts, 2, 13))
+
+declare const ntnnnut: [number] | [number, number, number?]
+>ntnnnut : Symbol(ntnnnut, Decl(callWithSpread6.ts, 3, 13))
+
+declare function setHours(a: number, b?: number, c?: number, d?: number): number
+>setHours : Symbol(setHours, Decl(callWithSpread6.ts, 3, 59))
+>a : Symbol(a, Decl(callWithSpread6.ts, 4, 26))
+>b : Symbol(b, Decl(callWithSpread6.ts, 4, 36))
+>c : Symbol(c, Decl(callWithSpread6.ts, 4, 48))
+>d : Symbol(d, Decl(callWithSpread6.ts, 4, 60))
+
+declare function setHoursStrict(a: number, b: number, c: number, d: number): number
+>setHoursStrict : Symbol(setHoursStrict, Decl(callWithSpread6.ts, 4, 80))
+>a : Symbol(a, Decl(callWithSpread6.ts, 5, 32))
+>b : Symbol(b, Decl(callWithSpread6.ts, 5, 42))
+>c : Symbol(c, Decl(callWithSpread6.ts, 5, 53))
+>d : Symbol(d, Decl(callWithSpread6.ts, 5, 64))
+
+declare function f(a: number, b: number, ...c: number[]): number
+>f : Symbol(f, Decl(callWithSpread6.ts, 5, 83))
+>a : Symbol(a, Decl(callWithSpread6.ts, 6, 19))
+>b : Symbol(b, Decl(callWithSpread6.ts, 6, 29))
+>c : Symbol(c, Decl(callWithSpread6.ts, 6, 40))
+
+declare function g(a: number, b?: number, ...c: number[]): number
+>g : Symbol(g, Decl(callWithSpread6.ts, 6, 64))
+>a : Symbol(a, Decl(callWithSpread6.ts, 7, 19))
+>b : Symbol(b, Decl(callWithSpread6.ts, 7, 29))
+>c : Symbol(c, Decl(callWithSpread6.ts, 7, 41))
+
+declare function h(a: number, b: number, c: number, ...d: number[]): number
+>h : Symbol(h, Decl(callWithSpread6.ts, 7, 65))
+>a : Symbol(a, Decl(callWithSpread6.ts, 8, 19))
+>b : Symbol(b, Decl(callWithSpread6.ts, 8, 29))
+>c : Symbol(c, Decl(callWithSpread6.ts, 8, 40))
+>d : Symbol(d, Decl(callWithSpread6.ts, 8, 51))
+
+setHours(...nntnnnt)
+>setHours : Symbol(setHours, Decl(callWithSpread6.ts, 3, 59))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+
+setHours(...ntnnnt)
+>setHours : Symbol(setHours, Decl(callWithSpread6.ts, 3, 59))
+>ntnnnt : Symbol(ntnnnt, Decl(callWithSpread6.ts, 2, 13))
+
+setHours(...ntnnnut)
+>setHours : Symbol(setHours, Decl(callWithSpread6.ts, 3, 59))
+>ntnnnut : Symbol(ntnnnut, Decl(callWithSpread6.ts, 3, 13))
+
+setHours(n, n, ...nntnnnt)
+>setHours : Symbol(setHours, Decl(callWithSpread6.ts, 3, 59))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+
+setHoursStrict(n, ...nntnnnt)
+>setHoursStrict : Symbol(setHoursStrict, Decl(callWithSpread6.ts, 4, 80))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+
+setHoursStrict(n, n, ...nntnnnt)
+>setHoursStrict : Symbol(setHoursStrict, Decl(callWithSpread6.ts, 4, 80))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+
+setHours(n, n, n, ...nntnnnt)
+>setHours : Symbol(setHours, Decl(callWithSpread6.ts, 3, 59))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+
+setHours(...nntnnnt, n)
+>setHours : Symbol(setHours, Decl(callWithSpread6.ts, 3, 59))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+
+f(...ntnnnt)
+>f : Symbol(f, Decl(callWithSpread6.ts, 5, 83))
+>ntnnnt : Symbol(ntnnnt, Decl(callWithSpread6.ts, 2, 13))
+
+f(...nntnnnt)
+>f : Symbol(f, Decl(callWithSpread6.ts, 5, 83))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+
+f(...nntnnnt, n)
+>f : Symbol(f, Decl(callWithSpread6.ts, 5, 83))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+>n : Symbol(n, Decl(callWithSpread6.ts, 0, 13))
+
+h(...ntnnnt)
+>h : Symbol(h, Decl(callWithSpread6.ts, 7, 65))
+>ntnnnt : Symbol(ntnnnt, Decl(callWithSpread6.ts, 2, 13))
+
+h(...nntnnnt)
+>h : Symbol(h, Decl(callWithSpread6.ts, 7, 65))
+>nntnnnt : Symbol(nntnnnt, Decl(callWithSpread6.ts, 1, 13))
+

--- a/tests/baselines/reference/callWithSpread6.types
+++ b/tests/baselines/reference/callWithSpread6.types
@@ -1,0 +1,136 @@
+//// [tests/cases/conformance/expressions/functionCalls/callWithSpread6.ts] ////
+
+=== callWithSpread6.ts ===
+declare const n: number
+>n : number
+
+declare const nntnnnt: [number, number] | [number, number, number]
+>nntnnnt : [number, number] | [number, number, number]
+
+declare const ntnnnt: [number] | [number, number, number]
+>ntnnnt : [number, number, number] | [number]
+
+declare const ntnnnut: [number] | [number, number, number?]
+>ntnnnut : [number] | [number, number, (number | undefined)?]
+
+declare function setHours(a: number, b?: number, c?: number, d?: number): number
+>setHours : (a: number, b?: number, c?: number, d?: number) => number
+>a : number
+>b : number | undefined
+>c : number | undefined
+>d : number | undefined
+
+declare function setHoursStrict(a: number, b: number, c: number, d: number): number
+>setHoursStrict : (a: number, b: number, c: number, d: number) => number
+>a : number
+>b : number
+>c : number
+>d : number
+
+declare function f(a: number, b: number, ...c: number[]): number
+>f : (a: number, b: number, ...c: number[]) => number
+>a : number
+>b : number
+>c : number[]
+
+declare function g(a: number, b?: number, ...c: number[]): number
+>g : (a: number, b?: number, ...c: number[]) => number
+>a : number
+>b : number | undefined
+>c : number[]
+
+declare function h(a: number, b: number, c: number, ...d: number[]): number
+>h : (a: number, b: number, c: number, ...d: number[]) => number
+>a : number
+>b : number
+>c : number
+>d : number[]
+
+setHours(...nntnnnt)
+>setHours(...nntnnnt) : number
+>setHours : (a: number, b?: number | undefined, c?: number | undefined, d?: number | undefined) => number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+
+setHours(...ntnnnt)
+>setHours(...ntnnnt) : number
+>setHours : (a: number, b?: number | undefined, c?: number | undefined, d?: number | undefined) => number
+>...ntnnnt : number
+>ntnnnt : [number, number, number] | [number]
+
+setHours(...ntnnnut)
+>setHours(...ntnnnut) : number
+>setHours : (a: number, b?: number | undefined, c?: number | undefined, d?: number | undefined) => number
+>...ntnnnut : number | undefined
+>ntnnnut : [number] | [number, number, (number | undefined)?]
+
+setHours(n, n, ...nntnnnt)
+>setHours(n, n, ...nntnnnt) : number
+>setHours : (a: number, b?: number | undefined, c?: number | undefined, d?: number | undefined) => number
+>n : number
+>n : number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+
+setHoursStrict(n, ...nntnnnt)
+>setHoursStrict(n, ...nntnnnt) : number
+>setHoursStrict : (a: number, b: number, c: number, d: number) => number
+>n : number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+
+setHoursStrict(n, n, ...nntnnnt)
+>setHoursStrict(n, n, ...nntnnnt) : number
+>setHoursStrict : (a: number, b: number, c: number, d: number) => number
+>n : number
+>n : number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+
+setHours(n, n, n, ...nntnnnt)
+>setHours(n, n, n, ...nntnnnt) : number
+>setHours : (a: number, b?: number | undefined, c?: number | undefined, d?: number | undefined) => number
+>n : number
+>n : number
+>n : number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+
+setHours(...nntnnnt, n)
+>setHours(...nntnnnt, n) : number
+>setHours : (a: number, b?: number | undefined, c?: number | undefined, d?: number | undefined) => number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+>n : number
+
+f(...ntnnnt)
+>f(...ntnnnt) : number
+>f : (a: number, b: number, ...c: number[]) => number
+>...ntnnnt : number
+>ntnnnt : [number, number, number] | [number]
+
+f(...nntnnnt)
+>f(...nntnnnt) : number
+>f : (a: number, b: number, ...c: number[]) => number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+
+f(...nntnnnt, n)
+>f(...nntnnnt, n) : number
+>f : (a: number, b: number, ...c: number[]) => number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+>n : number
+
+h(...ntnnnt)
+>h(...ntnnnt) : number
+>h : (a: number, b: number, c: number, ...d: number[]) => number
+>...ntnnnt : number
+>ntnnnt : [number, number, number] | [number]
+
+h(...nntnnnt)
+>h(...nntnnnt) : number
+>h : (a: number, b: number, c: number, ...d: number[]) => number
+>...nntnnnt : number
+>nntnnnt : [number, number] | [number, number, number]
+

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread6.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread6.ts
@@ -1,0 +1,26 @@
+// @strict: true
+// @target: esnext
+declare const n: number
+declare const nntnnnt: [number, number] | [number, number, number]
+declare const ntnnnt: [number] | [number, number, number]
+declare const ntnnnut: [number] | [number, number, number?]
+declare function setHours(a: number, b?: number, c?: number, d?: number): number
+declare function setHoursStrict(a: number, b: number, c: number, d: number): number
+declare function f(a: number, b: number, ...c: number[]): number
+declare function g(a: number, b?: number, ...c: number[]): number
+declare function h(a: number, b: number, c: number, ...d: number[]): number
+
+setHours(...nntnnnt)
+setHours(...ntnnnt)
+setHours(...ntnnnut)
+setHours(n, n, ...nntnnnt)
+setHoursStrict(n, ...nntnnnt)
+setHoursStrict(n, n, ...nntnnnt)
+setHours(n, n, n, ...nntnnnt)
+setHours(...nntnnnt, n)
+
+f(...ntnnnt)
+f(...nntnnnt)
+f(...nntnnnt, n)
+h(...ntnnnt)
+h(...nntnnnt)


### PR DESCRIPTION
Previously, only calls with tuples were allowed, not unions of tuples. For example, this already works:

```
f(string, ...[number, string], string) ==> f(string, number, string, string)
```

But this does not:

```
f(string, ...([string] | [number, number])) ==> (f, string, string | number, number | undefined)
```

This PR allows union types like these *as the last argument*. It's possible to allow them anywhere, but quite a bit more complicated. And the code is already complicated enough: getEffectiveCallArguments now needs to return the minimum number of arguments as well as the argument list (which is the maximum number of arguments).

Also, this transformation should not happen when the tuple union argument is passed to a tuple union rest parameter: `[number] | [string]` is assignable to `[number] | [string]` but the transformed `number | string` is not. Checking for this requires passing around even more information.

Bottom line: I'm not sure the complexity is worth the new code. However, if this is a good idea, there are 3 things that need to be cleaned up:

1. More precise error messages--maybe. Right now error messages are reported in terms of the maximum number of arguments:
2. Allow tuples with trailing `...T` types. Not done or tested, but straightfoward.
3. Find a more elegant way to return the minimum number of arguments.

Fixes #42508
Supercedes #43882, but does less than half of that PR, in less than half the code.