### PR TITLE
Fix class name references

### DIFF
--- a/src/compiler/transformers/legacyDecorators.ts
+++ b/src/compiler/transformers/legacyDecorators.ts
@@ -756,7 +756,7 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
      * double-binding semantics for the class name.
      */
     function getClassAliasIfNeeded(node: ClassDeclaration) {
-        if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.ClassWithConstructorReference) {
+        if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.ContainsConstructorReference) {
             enableSubstitutionForClassAliases();
             const classAlias = factory.createUniqueName(node.name && !isGeneratedIdentifier(node.name) ? idText(node.name) : "default");
             classAliases[getOriginalNodeId(node)] = classAlias;
@@ -805,7 +805,7 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
 
     function trySubstituteClassAlias(node: Identifier): Expression | undefined {
         if (classAliases) {
-            if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.ConstructorReferenceInClass) {
+            if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.ConstructorReference) {
                 // Due to the emit for class decorators, any reference to the class from inside of the class body
                 // must instead be rewritten to point to a temporary variable to avoid issues with the double-bind
                 // behavior of class names in ES6.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6022,12 +6022,10 @@ export const enum NodeCheckFlags {
     ContainsCapturedBlockScopeBinding        = 1 << 13,  // Part of a loop that contains block scoped variable captured in closure
     CapturedBlockScopedBinding               = 1 << 14,  // Block-scoped binding that is captured in some function
     BlockScopedBindingInLoop                 = 1 << 15,  // Block-scoped binding with declaration nested inside iteration statement
-    ClassWithBodyScopedClassBinding          = 1 << 16,  // Decorated class that contains a binding to itself inside of the class body.
-    BodyScopedClassBinding                   = 1 << 17,  // Binding to a decorated class inside of the class's body.
     NeedsLoopOutParameter                    = 1 << 18,  // Block scoped binding whose value should be explicitly copied outside of the converted loop
     AssignmentsMarked                        = 1 << 19,  // Parameter assignments have been marked
-    ClassWithConstructorReference            = 1 << 20,  // Class that contains a binding to its constructor inside of the class body.
-    ConstructorReferenceInClass              = 1 << 21,  // Binding to a class constructor inside of the class's body.
+    ContainsConstructorReference             = 1 << 20,  // Class or class element that contains a binding that references the class constructor.
+    ConstructorReference                     = 1 << 21,  // Binding to a class constructor inside of the class's body.
     ContainsClassWithPrivateIdentifiers      = 1 << 22,  // Marked on all block-scoped containers containing a class with private identifiers.
     ContainsSuperPropertyInStaticInitializer = 1 << 23,  // Marked on all block-scoped containers containing a static initializer with 'super.x' or 'super[x]'.
     InCheckIdentifier                        = 1 << 24,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6022,13 +6022,13 @@ export const enum NodeCheckFlags {
     ContainsCapturedBlockScopeBinding        = 1 << 13,  // Part of a loop that contains block scoped variable captured in closure
     CapturedBlockScopedBinding               = 1 << 14,  // Block-scoped binding that is captured in some function
     BlockScopedBindingInLoop                 = 1 << 15,  // Block-scoped binding with declaration nested inside iteration statement
-    NeedsLoopOutParameter                    = 1 << 18,  // Block scoped binding whose value should be explicitly copied outside of the converted loop
-    AssignmentsMarked                        = 1 << 19,  // Parameter assignments have been marked
-    ContainsConstructorReference             = 1 << 20,  // Class or class element that contains a binding that references the class constructor.
-    ConstructorReference                     = 1 << 21,  // Binding to a class constructor inside of the class's body.
-    ContainsClassWithPrivateIdentifiers      = 1 << 22,  // Marked on all block-scoped containers containing a class with private identifiers.
-    ContainsSuperPropertyInStaticInitializer = 1 << 23,  // Marked on all block-scoped containers containing a static initializer with 'super.x' or 'super[x]'.
-    InCheckIdentifier                        = 1 << 24,
+    NeedsLoopOutParameter                    = 1 << 16,  // Block scoped binding whose value should be explicitly copied outside of the converted loop
+    AssignmentsMarked                        = 1 << 17,  // Parameter assignments have been marked
+    ContainsConstructorReference             = 1 << 18,  // Class or class element that contains a binding that references the class constructor.
+    ConstructorReference                     = 1 << 29,  // Binding to a class constructor inside of the class's body.
+    ContainsClassWithPrivateIdentifiers      = 1 << 20,  // Marked on all block-scoped containers containing a class with private identifiers.
+    ContainsSuperPropertyInStaticInitializer = 1 << 21,  // Marked on all block-scoped containers containing a static initializer with 'super.x' or 'super[x]'.
+    InCheckIdentifier                        = 1 << 22,
 }
 
 /** @internal */

--- a/tests/baselines/reference/classBlockScoping.js
+++ b/tests/baselines/reference/classBlockScoping.js
@@ -44,10 +44,10 @@ function f(b) {
                 function Foo() {
                 }
                 Foo.x = function () {
-                    new Foo();
+                    new _a();
                 };
                 Foo.prototype.m = function () {
-                    new Foo();
+                    new _a();
                 };
                 return Foo;
             }()),

--- a/tests/baselines/reference/classNameReferencesInStaticElements.js
+++ b/tests/baselines/reference/classNameReferencesInStaticElements.js
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/classNameReferencesInStaticElements.ts] ////
+
+//// [classNameReferencesInStaticElements.ts]
+// https://github.com/microsoft/TypeScript/issues/54607
+class Foo {
+    static { console.log(this, Foo) }
+    static x = () => { console.log(this, Foo) }
+    static y = function(this: unknown) { console.log(this, Foo) }
+
+    #x() { console.log(Foo); }
+    x() { this.#x(); }
+}
+
+const oldFoo = Foo;
+(Foo as any) = null;
+oldFoo.x();
+oldFoo.y();
+new oldFoo().x();
+
+//// [classNameReferencesInStaticElements.js]
+var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+};
+var _Foo_instances, _a, _Foo_x;
+// https://github.com/microsoft/TypeScript/issues/54607
+class Foo {
+    constructor() {
+        _Foo_instances.add(this);
+    }
+    x() { __classPrivateFieldGet(this, _Foo_instances, "m", _Foo_x).call(this); }
+}
+_a = Foo, _Foo_instances = new WeakSet(), _Foo_x = function _Foo_x() { console.log(_a); };
+(() => {
+    console.log(_a, _a);
+})();
+Foo.x = () => { console.log(_a, _a); };
+Foo.y = function () { console.log(this, _a); };
+const oldFoo = Foo;
+Foo = null;
+oldFoo.x();
+oldFoo.y();
+new oldFoo().x();

--- a/tests/baselines/reference/classStaticBlock12.js
+++ b/tests/baselines/reference/classStaticBlock12.js
@@ -22,5 +22,5 @@ class C {
 _a = C;
 _C_x = { value: 1 };
 (() => {
-    __classPrivateFieldGet(C, _a, "f", _C_x);
+    __classPrivateFieldGet(_a, _a, "f", _C_x);
 })();

--- a/tests/baselines/reference/classStaticBlock13(target=es2015).js
+++ b/tests/baselines/reference/classStaticBlock13(target=es2015).js
@@ -23,11 +23,11 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var _a, _C_x;
 class C {
     foo() {
-        return __classPrivateFieldGet(C, _a, "f", _C_x);
+        return __classPrivateFieldGet(_a, _a, "f", _C_x);
     }
 }
 _a = C;
 _C_x = { value: 123 };
 (() => {
-    console.log(__classPrivateFieldGet(C, _a, "f", _C_x));
+    console.log(__classPrivateFieldGet(_a, _a, "f", _C_x));
 })();

--- a/tests/baselines/reference/computedPropertyNames52(target=es2015).js
+++ b/tests/baselines/reference/computedPropertyNames52(target=es2015).js
@@ -17,7 +17,7 @@ for (let i = 0; i < 10; ++i) {
     let _b, _c;
     array.push((_c = class C {
             constructor() {
-                this[_b] = () => C;
+                this[_b] = () => _c;
             }
         },
         _b = i,

--- a/tests/baselines/reference/computedPropertyNames52(target=es5).js
+++ b/tests/baselines/reference/computedPropertyNames52(target=es5).js
@@ -17,7 +17,7 @@ var _loop_1 = function (i) {
     var _b = void 0, _c = void 0;
     array.push((_c = /** @class */ (function () {
             function C() {
-                this[_b] = function () { return C; };
+                this[_b] = function () { return _c; };
             }
             return C;
         }()),

--- a/tests/baselines/reference/decoratedClassExportsCommonJS1.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS1.js
@@ -24,5 +24,5 @@ let Testing123 = Testing123_1 = class Testing123 {
 exports.Testing123 = Testing123;
 Testing123.prop1 = Testing123_1.prop0;
 exports.Testing123 = Testing123 = Testing123_1 = __decorate([
-    Something({ v: () => Testing123_1 })
+    Something({ v: () => Testing123 })
 ], Testing123);

--- a/tests/baselines/reference/decoratedClassExportsCommonJS2.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS2.js
@@ -14,12 +14,11 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var Testing123_1;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Testing123 = void 0;
-let Testing123 = Testing123_1 = class Testing123 {
+let Testing123 = class Testing123 {
 };
 exports.Testing123 = Testing123;
-exports.Testing123 = Testing123 = Testing123_1 = __decorate([
-    Something({ v: () => Testing123_1 })
+exports.Testing123 = Testing123 = __decorate([
+    Something({ v: () => Testing123 })
 ], Testing123);

--- a/tests/baselines/reference/decoratedClassExportsSystem1.js
+++ b/tests/baselines/reference/decoratedClassExportsSystem1.js
@@ -28,7 +28,7 @@ System.register([], function (exports_1, context_1) {
             exports_1("Testing123", Testing123);
             Testing123.prop1 = Testing123_1.prop0;
             exports_1("Testing123", Testing123 = Testing123_1 = __decorate([
-                Something({ v: () => Testing123_1 })
+                Something({ v: () => Testing123 })
             ], Testing123));
         }
     };

--- a/tests/baselines/reference/decoratedClassExportsSystem2.js
+++ b/tests/baselines/reference/decoratedClassExportsSystem2.js
@@ -15,16 +15,16 @@ System.register([], function (exports_1, context_1) {
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
-    var Testing123_1, Testing123;
+    var Testing123;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
         execute: function () {
-            Testing123 = Testing123_1 = class Testing123 {
+            Testing123 = class Testing123 {
             };
             exports_1("Testing123", Testing123);
-            exports_1("Testing123", Testing123 = Testing123_1 = __decorate([
-                Something({ v: () => Testing123_1 })
+            exports_1("Testing123", Testing123 = __decorate([
+                Something({ v: () => Testing123 })
             ], Testing123));
         }
     };

--- a/tests/baselines/reference/decoratorOnClassConstructorParameter5.js
+++ b/tests/baselines/reference/decoratorOnClassConstructorParameter5.js
@@ -13,13 +13,14 @@ class BulkEditPreviewProvider {
 }
 
 //// [decoratorOnClassConstructorParameter5.js]
-let BulkEditPreviewProvider = class BulkEditPreviewProvider {
+var BulkEditPreviewProvider_1;
+let BulkEditPreviewProvider = BulkEditPreviewProvider_1 = class BulkEditPreviewProvider {
     constructor(_modeService) {
         this._modeService = _modeService;
     }
 };
 BulkEditPreviewProvider.Schema = 'vscode-bulkeditpreview';
-BulkEditPreviewProvider.emptyPreview = { scheme: BulkEditPreviewProvider.Schema };
-BulkEditPreviewProvider = __decorate([
+BulkEditPreviewProvider.emptyPreview = { scheme: BulkEditPreviewProvider_1.Schema };
+BulkEditPreviewProvider = BulkEditPreviewProvider_1 = __decorate([
     __param(0, IFoo)
 ], BulkEditPreviewProvider);

--- a/tests/baselines/reference/decoratorReferences.js
+++ b/tests/baselines/reference/decoratorReferences.js
@@ -22,16 +22,14 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
 var C = /** @class */ (function () {
     function C() {
     }
-    C_1 = C;
     C.prototype.method = function (x, y) { }; // <-- decorator y should be resolved at the class declaration, not the parameter.
-    var C_1;
     __decorate([
         y(null) // <-- y should resolve to the function declaration, not the parameter; T should resolve to the type parameter of the class
         ,
         __param(0, y)
     ], C.prototype, "method", null);
-    C = C_1 = __decorate([
-        y(1, C_1) // <-- T should be resolved to the type alias, not the type parameter of the class; C should resolve to the class
+    C = __decorate([
+        y(1, C) // <-- T should be resolved to the type alias, not the type parameter of the class; C should resolve to the class
     ], C);
     return C;
 }());

--- a/tests/baselines/reference/privateNameAndObjectRestSpread.js
+++ b/tests/baselines/reference/privateNameAndObjectRestSpread.js
@@ -46,9 +46,9 @@ class C {
         __classPrivateFieldGet(obj, _C_prop, "f");
         const rest = __rest(other, []);
         __classPrivateFieldGet(rest, _C_prop, "f");
-        const statics = Object.assign({}, C);
+        const statics = Object.assign({}, _a);
         __classPrivateFieldGet(statics, _a, "f", _C_propStatic);
-        const sRest = __rest(C, []);
+        const sRest = __rest(_a, []);
         __classPrivateFieldGet(sRest, _a, "f", _C_propStatic);
     }
 }

--- a/tests/baselines/reference/privateNameNestedMethodAccess.js
+++ b/tests/baselines/reference/privateNameNestedMethodAccess.js
@@ -32,21 +32,21 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
     return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
 };
-var _C_instances, _C_foo, _C_bar, _C_baz_get;
+var _C_instances, _a, _C_foo, _C_bar, _C_baz_get;
 class C {
     constructor() {
         _C_instances.add(this);
         _C_foo.set(this, 42);
     }
     m() {
-        var _D_instances, _D_bar, _a;
-        return _a = class D {
+        var _D_instances, _D_bar, _b;
+        return _b = class D {
                 constructor() {
                     _D_instances.add(this);
-                    __classPrivateFieldGet(new C(), _C_foo, "f");
-                    __classPrivateFieldGet(new C(), _D_instances, "m", _D_bar); // Error
-                    __classPrivateFieldGet(new C(), _C_instances, "a", _C_baz_get);
-                    __classPrivateFieldGet(new D(), _D_instances, "m", _D_bar);
+                    __classPrivateFieldGet(new _a(), _C_foo, "f");
+                    __classPrivateFieldGet(new _a(), _D_instances, "m", _D_bar); // Error
+                    __classPrivateFieldGet(new _a(), _C_instances, "a", _C_baz_get);
+                    __classPrivateFieldGet(new _b(), _D_instances, "m", _D_bar);
                 }
                 n(x) {
                     __classPrivateFieldGet(x, _C_foo, "f");
@@ -56,7 +56,7 @@ class C {
             },
             _D_instances = new WeakSet(),
             _D_bar = function _D_bar() { },
-            _a;
+            _b;
     }
 }
-_C_foo = new WeakMap(), _C_instances = new WeakSet(), _C_bar = function _C_bar() { __classPrivateFieldGet(new C(), _C_instances, "a", _C_baz_get); }, _C_baz_get = function _C_baz_get() { return 42; };
+_a = C, _C_foo = new WeakMap(), _C_instances = new WeakSet(), _C_bar = function _C_bar() { __classPrivateFieldGet(new _a(), _C_instances, "a", _C_baz_get); }, _C_baz_get = function _C_baz_get() { return 42; };

--- a/tests/baselines/reference/privateNameStaticAccessors.js
+++ b/tests/baselines/reference/privateNameStaticAccessors.js
@@ -32,10 +32,10 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var _a, _A1_prop_get, _A1_prop_set, _A1_roProp_get;
 class A1 {
     constructor(name) {
-        __classPrivateFieldSet(A1, _a, "", "a", _A1_prop_set);
-        __classPrivateFieldSet(A1, _a, "", "a"); // Error
-        console.log(__classPrivateFieldGet(A1, _a, "a", _A1_prop_get));
-        console.log(__classPrivateFieldGet(A1, _a, "a", _A1_roProp_get));
+        __classPrivateFieldSet(_a, _a, "", "a", _A1_prop_set);
+        __classPrivateFieldSet(_a, _a, "", "a"); // Error
+        console.log(__classPrivateFieldGet(_a, _a, "a", _A1_prop_get));
+        console.log(__classPrivateFieldGet(_a, _a, "a", _A1_roProp_get));
     }
 }
 _a = A1, _A1_prop_get = function _A1_prop_get() { return ""; }, _A1_prop_set = function _A1_prop_set(param) { }, _A1_roProp_get = function _A1_roProp_get() { return ""; };

--- a/tests/baselines/reference/privateNameStaticAccessorsAccess.js
+++ b/tests/baselines/reference/privateNameStaticAccessorsAccess.js
@@ -38,8 +38,8 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var _a, _A2_prop_get, _A2_prop_set;
 class A2 {
     constructor() {
-        console.log(__classPrivateFieldGet(A2, _a, "a", _A2_prop_get));
-        let a = A2;
+        console.log(__classPrivateFieldGet(_a, _a, "a", _A2_prop_get));
+        let a = _a;
         __classPrivateFieldGet(a, _a, "a", _A2_prop_get);
         function foo() {
             __classPrivateFieldGet(a, _a, "a", _A2_prop_get);

--- a/tests/baselines/reference/privateNameStaticAccessorsCallExpression.js
+++ b/tests/baselines/reference/privateNameStaticAccessorsCallExpression.js
@@ -46,7 +46,7 @@ class A {
         const str = __classPrivateFieldGet(this, _a, "a", _A_fieldFunc2_get).bind(this) `head${1}middle${2}tail`;
         __classPrivateFieldGet((_b = this.getClass()), _a, "a", _A_fieldFunc2_get).bind(_b) `test${1}and${2}`;
     }
-    static getClass() { return A; }
+    static getClass() { return _a; }
 }
-_a = A, _A_fieldFunc_get = function _A_fieldFunc_get() { return function () { __classPrivateFieldSet(A, _a, 10, "f", _A_x); }; }, _A_fieldFunc2_get = function _A_fieldFunc2_get() { return function (a, ...b) { }; };
+_a = A, _A_fieldFunc_get = function _A_fieldFunc_get() { return function () { __classPrivateFieldSet(_a, _a, 10, "f", _A_x); }; }, _A_fieldFunc2_get = function _A_fieldFunc2_get() { return function (a, ...b) { }; };
 _A_x = { value: 1 };

--- a/tests/baselines/reference/privateNameStaticEmitHelpers.js
+++ b/tests/baselines/reference/privateNameStaticEmitHelpers.js
@@ -18,5 +18,5 @@ var _a, _S_a, _S_b, _S_c_get;
 import { __classPrivateFieldGet, __classPrivateFieldSet } from "tslib";
 export class S {
 }
-_a = S, _S_b = function _S_b() { __classPrivateFieldSet(this, _a, 42, "f", _S_a); }, _S_c_get = function _S_c_get() { return __classPrivateFieldGet(S, _a, "m", _S_b).call(S); };
+_a = S, _S_b = function _S_b() { __classPrivateFieldSet(this, _a, 42, "f", _S_a); }, _S_c_get = function _S_c_get() { return __classPrivateFieldGet(_a, _a, "m", _S_b).call(_a); };
 _S_a = { value: 1 };

--- a/tests/baselines/reference/privateNameStaticFieldAccess.js
+++ b/tests/baselines/reference/privateNameStaticFieldAccess.js
@@ -19,7 +19,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var _a, _A_myField;
 class A {
     constructor() {
-        console.log(__classPrivateFieldGet(A, _a, "f", _A_myField)); //Ok
+        console.log(__classPrivateFieldGet(_a, _a, "f", _A_myField)); //Ok
         console.log(__classPrivateFieldGet(this, _a, "f", _A_myField)); //Error
     }
 }

--- a/tests/baselines/reference/privateNameStaticFieldAssignment.js
+++ b/tests/baselines/reference/privateNameStaticFieldAssignment.js
@@ -53,35 +53,35 @@ var _a, _A_field;
 class A {
     constructor() {
         var _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0;
-        __classPrivateFieldSet(A, _a, 1, "f", _A_field);
-        __classPrivateFieldSet(_b = A, _a, __classPrivateFieldGet(_b, _a, "f", _A_field) + 2, "f", _A_field);
-        __classPrivateFieldSet(_c = A, _a, __classPrivateFieldGet(_c, _a, "f", _A_field) - 3, "f", _A_field);
-        __classPrivateFieldSet(_d = A, _a, __classPrivateFieldGet(_d, _a, "f", _A_field) / 4, "f", _A_field);
-        __classPrivateFieldSet(_e = A, _a, __classPrivateFieldGet(_e, _a, "f", _A_field) * 5, "f", _A_field);
-        __classPrivateFieldSet(_f = A, _a, Math.pow(__classPrivateFieldGet(_f, _a, "f", _A_field), 6), "f", _A_field);
-        __classPrivateFieldSet(_g = A, _a, __classPrivateFieldGet(_g, _a, "f", _A_field) % 7, "f", _A_field);
-        __classPrivateFieldSet(_h = A, _a, __classPrivateFieldGet(_h, _a, "f", _A_field) << 8, "f", _A_field);
-        __classPrivateFieldSet(_j = A, _a, __classPrivateFieldGet(_j, _a, "f", _A_field) >> 9, "f", _A_field);
-        __classPrivateFieldSet(_k = A, _a, __classPrivateFieldGet(_k, _a, "f", _A_field) >>> 10, "f", _A_field);
-        __classPrivateFieldSet(_l = A, _a, __classPrivateFieldGet(_l, _a, "f", _A_field) & 11, "f", _A_field);
-        __classPrivateFieldSet(_m = A, _a, __classPrivateFieldGet(_m, _a, "f", _A_field) | 12, "f", _A_field);
-        __classPrivateFieldSet(_o = A, _a, __classPrivateFieldGet(_o, _a, "f", _A_field) ^ 13, "f", _A_field);
-        __classPrivateFieldSet(A.getClass(), _a, 1, "f", _A_field);
-        __classPrivateFieldSet(_p = A.getClass(), _a, __classPrivateFieldGet(_p, _a, "f", _A_field) + 2, "f", _A_field);
-        __classPrivateFieldSet(_q = A.getClass(), _a, __classPrivateFieldGet(_q, _a, "f", _A_field) - 3, "f", _A_field);
-        __classPrivateFieldSet(_r = A.getClass(), _a, __classPrivateFieldGet(_r, _a, "f", _A_field) / 4, "f", _A_field);
-        __classPrivateFieldSet(_s = A.getClass(), _a, __classPrivateFieldGet(_s, _a, "f", _A_field) * 5, "f", _A_field);
-        __classPrivateFieldSet(_t = A.getClass(), _a, Math.pow(__classPrivateFieldGet(_t, _a, "f", _A_field), 6), "f", _A_field);
-        __classPrivateFieldSet(_u = A.getClass(), _a, __classPrivateFieldGet(_u, _a, "f", _A_field) % 7, "f", _A_field);
-        __classPrivateFieldSet(_v = A.getClass(), _a, __classPrivateFieldGet(_v, _a, "f", _A_field) << 8, "f", _A_field);
-        __classPrivateFieldSet(_w = A.getClass(), _a, __classPrivateFieldGet(_w, _a, "f", _A_field) >> 9, "f", _A_field);
-        __classPrivateFieldSet(_x = A.getClass(), _a, __classPrivateFieldGet(_x, _a, "f", _A_field) >>> 10, "f", _A_field);
-        __classPrivateFieldSet(_y = A.getClass(), _a, __classPrivateFieldGet(_y, _a, "f", _A_field) & 11, "f", _A_field);
-        __classPrivateFieldSet(_z = A.getClass(), _a, __classPrivateFieldGet(_z, _a, "f", _A_field) | 12, "f", _A_field);
-        __classPrivateFieldSet(_0 = A.getClass(), _a, __classPrivateFieldGet(_0, _a, "f", _A_field) ^ 13, "f", _A_field);
+        __classPrivateFieldSet(_a, _a, 1, "f", _A_field);
+        __classPrivateFieldSet(_b = _a, _a, __classPrivateFieldGet(_b, _a, "f", _A_field) + 2, "f", _A_field);
+        __classPrivateFieldSet(_c = _a, _a, __classPrivateFieldGet(_c, _a, "f", _A_field) - 3, "f", _A_field);
+        __classPrivateFieldSet(_d = _a, _a, __classPrivateFieldGet(_d, _a, "f", _A_field) / 4, "f", _A_field);
+        __classPrivateFieldSet(_e = _a, _a, __classPrivateFieldGet(_e, _a, "f", _A_field) * 5, "f", _A_field);
+        __classPrivateFieldSet(_f = _a, _a, Math.pow(__classPrivateFieldGet(_f, _a, "f", _A_field), 6), "f", _A_field);
+        __classPrivateFieldSet(_g = _a, _a, __classPrivateFieldGet(_g, _a, "f", _A_field) % 7, "f", _A_field);
+        __classPrivateFieldSet(_h = _a, _a, __classPrivateFieldGet(_h, _a, "f", _A_field) << 8, "f", _A_field);
+        __classPrivateFieldSet(_j = _a, _a, __classPrivateFieldGet(_j, _a, "f", _A_field) >> 9, "f", _A_field);
+        __classPrivateFieldSet(_k = _a, _a, __classPrivateFieldGet(_k, _a, "f", _A_field) >>> 10, "f", _A_field);
+        __classPrivateFieldSet(_l = _a, _a, __classPrivateFieldGet(_l, _a, "f", _A_field) & 11, "f", _A_field);
+        __classPrivateFieldSet(_m = _a, _a, __classPrivateFieldGet(_m, _a, "f", _A_field) | 12, "f", _A_field);
+        __classPrivateFieldSet(_o = _a, _a, __classPrivateFieldGet(_o, _a, "f", _A_field) ^ 13, "f", _A_field);
+        __classPrivateFieldSet(_a.getClass(), _a, 1, "f", _A_field);
+        __classPrivateFieldSet(_p = _a.getClass(), _a, __classPrivateFieldGet(_p, _a, "f", _A_field) + 2, "f", _A_field);
+        __classPrivateFieldSet(_q = _a.getClass(), _a, __classPrivateFieldGet(_q, _a, "f", _A_field) - 3, "f", _A_field);
+        __classPrivateFieldSet(_r = _a.getClass(), _a, __classPrivateFieldGet(_r, _a, "f", _A_field) / 4, "f", _A_field);
+        __classPrivateFieldSet(_s = _a.getClass(), _a, __classPrivateFieldGet(_s, _a, "f", _A_field) * 5, "f", _A_field);
+        __classPrivateFieldSet(_t = _a.getClass(), _a, Math.pow(__classPrivateFieldGet(_t, _a, "f", _A_field), 6), "f", _A_field);
+        __classPrivateFieldSet(_u = _a.getClass(), _a, __classPrivateFieldGet(_u, _a, "f", _A_field) % 7, "f", _A_field);
+        __classPrivateFieldSet(_v = _a.getClass(), _a, __classPrivateFieldGet(_v, _a, "f", _A_field) << 8, "f", _A_field);
+        __classPrivateFieldSet(_w = _a.getClass(), _a, __classPrivateFieldGet(_w, _a, "f", _A_field) >> 9, "f", _A_field);
+        __classPrivateFieldSet(_x = _a.getClass(), _a, __classPrivateFieldGet(_x, _a, "f", _A_field) >>> 10, "f", _A_field);
+        __classPrivateFieldSet(_y = _a.getClass(), _a, __classPrivateFieldGet(_y, _a, "f", _A_field) & 11, "f", _A_field);
+        __classPrivateFieldSet(_z = _a.getClass(), _a, __classPrivateFieldGet(_z, _a, "f", _A_field) | 12, "f", _A_field);
+        __classPrivateFieldSet(_0 = _a.getClass(), _a, __classPrivateFieldGet(_0, _a, "f", _A_field) ^ 13, "f", _A_field);
     }
     static getClass() {
-        return A;
+        return _a;
     }
 }
 _a = A;

--- a/tests/baselines/reference/privateNameStaticFieldCallExpression.js
+++ b/tests/baselines/reference/privateNameStaticFieldCallExpression.js
@@ -36,18 +36,18 @@ class A {
     test() {
         var _b;
         var _c;
-        __classPrivateFieldGet(A, _a, "f", _A_fieldFunc).call(A);
-        (_b = __classPrivateFieldGet(A, _a, "f", _A_fieldFunc)) === null || _b === void 0 ? void 0 : _b.call(A);
-        const func = __classPrivateFieldGet(A, _a, "f", _A_fieldFunc);
+        __classPrivateFieldGet(_a, _a, "f", _A_fieldFunc).call(_a);
+        (_b = __classPrivateFieldGet(_a, _a, "f", _A_fieldFunc)) === null || _b === void 0 ? void 0 : _b.call(_a);
+        const func = __classPrivateFieldGet(_a, _a, "f", _A_fieldFunc);
         func();
-        new (__classPrivateFieldGet(A, _a, "f", _A_fieldFunc))();
+        new (__classPrivateFieldGet(_a, _a, "f", _A_fieldFunc))();
         const arr = [1, 2];
-        __classPrivateFieldGet(A, _a, "f", _A_fieldFunc2).call(A, 0, ...arr, 3);
-        const b = new (__classPrivateFieldGet(A, _a, "f", _A_fieldFunc2))(0, ...arr, 3);
-        const str = __classPrivateFieldGet(A, _a, "f", _A_fieldFunc2).bind(A) `head${1}middle${2}tail`;
+        __classPrivateFieldGet(_a, _a, "f", _A_fieldFunc2).call(_a, 0, ...arr, 3);
+        const b = new (__classPrivateFieldGet(_a, _a, "f", _A_fieldFunc2))(0, ...arr, 3);
+        const str = __classPrivateFieldGet(_a, _a, "f", _A_fieldFunc2).bind(_a) `head${1}middle${2}tail`;
         __classPrivateFieldGet((_c = this.getClass()), _a, "f", _A_fieldFunc2).bind(_c) `test${1}and${2}`;
     }
-    getClass() { return A; }
+    getClass() { return _a; }
 }
 _a = A;
 _A_fieldFunc = { value: function () { this.x = 10; } };

--- a/tests/baselines/reference/privateNameStaticFieldClassExpression.js
+++ b/tests/baselines/reference/privateNameStaticFieldClassExpression.js
@@ -37,9 +37,9 @@ var __setFunctionName = (this && this.__setFunctionName) || function (f, name, p
 var _a, _B_foo, _B_foo2, _b, _c;
 class B {
     m() {
-        console.log(__classPrivateFieldGet(B, _a, "f", _B_foo).test);
-        __classPrivateFieldGet(B, _a, "f", _B_foo).test = 10;
-        new (__classPrivateFieldGet(B, _a, "f", _B_foo))().field;
+        console.log(__classPrivateFieldGet(_a, _a, "f", _B_foo).test);
+        __classPrivateFieldGet(_a, _a, "f", _B_foo).test = 10;
+        new (__classPrivateFieldGet(_a, _a, "f", _B_foo))().field;
     }
 }
 _a = B;
@@ -47,7 +47,7 @@ _B_foo = { value: (_b = class {
             constructor() {
                 this.field = 10;
                 console.log("hello");
-                new (__classPrivateFieldGet(B, _a, "f", _B_foo2))();
+                new (__classPrivateFieldGet(_a, _a, "f", _B_foo2))();
             }
         },
         __setFunctionName(_b, "#foo"),

--- a/tests/baselines/reference/privateNameStaticFieldDerivedClasses.js
+++ b/tests/baselines/reference/privateNameStaticFieldDerivedClasses.js
@@ -34,14 +34,14 @@ var _a, _Base_prop, _b, _Derived_derivedProp;
 class Base {
     static method(x) {
         Derived.; // error
-        __classPrivateFieldSet(Base, _a, 10, "f", _Base_prop);
+        __classPrivateFieldSet(_a, _a, 10, "f", _Base_prop);
     }
 }
 _a = Base;
 _Base_prop = { value: 123 };
 class Derived extends Base {
     static method(x) {
-        __classPrivateFieldGet(Derived, _b, "f", _Derived_derivedProp);
+        __classPrivateFieldGet(_b, _b, "f", _Derived_derivedProp);
         Base. = 10; // error
     }
 }

--- a/tests/baselines/reference/privateNameStaticFieldDestructuredBinding(target=es2015).js
+++ b/tests/baselines/reference/privateNameStaticFieldDestructuredBinding(target=es2015).js
@@ -43,14 +43,14 @@ class A {
     }
     constructor() {
         var _c;
-        this.otherClass = A;
+        this.otherClass = _b;
         let y;
-        ({ x: ({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value, y } = this.testObject());
-        ([({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value, y] = this.testArray());
-        ({ a: ({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value, b: [({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value] } = { a: 1, b: [2] });
-        [({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value, [({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value]] = [1, [2]];
-        ({ a: ({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value = 1, b: [({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value = 1] } = { b: [] });
-        [({ set value(_b) { __classPrivateFieldSet(A, _b, _b, "f", _A_field); } }).value = 2] = [];
+        ({ x: ({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value, y } = this.testObject());
+        ([({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value, y] = this.testArray());
+        ({ a: ({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value, b: [({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value] } = { a: 1, b: [2] });
+        [({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value, [({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value]] = [1, [2]];
+        ({ a: ({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value = 1, b: [({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value = 1] } = { b: [] });
+        [({ set value(_b) { __classPrivateFieldSet(_b, _b, _b, "f", _A_field); } }).value = 2] = [];
         _c = this.otherClass, [({ set value(_b) { __classPrivateFieldSet(_c, _b, _b, "f", _A_field); } }).value = 2] = [];
     }
     static test(_a) {

--- a/tests/baselines/reference/privateNameStaticFieldUnaryMutation.js
+++ b/tests/baselines/reference/privateNameStaticFieldUnaryMutation.js
@@ -47,16 +47,16 @@ var _a, _C_test;
 class C {
     constructor() {
         var _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y;
-        __classPrivateFieldSet(_b = C, _a, (_c = __classPrivateFieldGet(_b, _a, "f", _C_test), _c++, _c), "f", _C_test);
-        __classPrivateFieldSet(_d = C, _a, (_e = __classPrivateFieldGet(_d, _a, "f", _C_test), _e--, _e), "f", _C_test);
-        __classPrivateFieldSet(_f = C, _a, (_g = __classPrivateFieldGet(_f, _a, "f", _C_test), ++_g), "f", _C_test);
-        __classPrivateFieldSet(_h = C, _a, (_j = __classPrivateFieldGet(_h, _a, "f", _C_test), --_j), "f", _C_test);
-        const a = (__classPrivateFieldSet(_k = C, _a, (_m = __classPrivateFieldGet(_k, _a, "f", _C_test), _l = _m++, _m), "f", _C_test), _l);
-        const b = (__classPrivateFieldSet(_o = C, _a, (_q = __classPrivateFieldGet(_o, _a, "f", _C_test), _p = _q--, _q), "f", _C_test), _p);
-        const c = __classPrivateFieldSet(_r = C, _a, (_s = __classPrivateFieldGet(_r, _a, "f", _C_test), ++_s), "f", _C_test);
-        const d = __classPrivateFieldSet(_t = C, _a, (_u = __classPrivateFieldGet(_t, _a, "f", _C_test), --_u), "f", _C_test);
-        for (__classPrivateFieldSet(C, _a, 0, "f", _C_test); __classPrivateFieldGet(C, _a, "f", _C_test) < 10; __classPrivateFieldSet(_v = C, _a, (_w = __classPrivateFieldGet(_v, _a, "f", _C_test), ++_w), "f", _C_test)) { }
-        for (__classPrivateFieldSet(C, _a, 0, "f", _C_test); __classPrivateFieldGet(C, _a, "f", _C_test) < 10; __classPrivateFieldSet(_x = C, _a, (_y = __classPrivateFieldGet(_x, _a, "f", _C_test), _y++, _y), "f", _C_test)) { }
+        __classPrivateFieldSet(_b = _a, _a, (_c = __classPrivateFieldGet(_b, _a, "f", _C_test), _c++, _c), "f", _C_test);
+        __classPrivateFieldSet(_d = _a, _a, (_e = __classPrivateFieldGet(_d, _a, "f", _C_test), _e--, _e), "f", _C_test);
+        __classPrivateFieldSet(_f = _a, _a, (_g = __classPrivateFieldGet(_f, _a, "f", _C_test), ++_g), "f", _C_test);
+        __classPrivateFieldSet(_h = _a, _a, (_j = __classPrivateFieldGet(_h, _a, "f", _C_test), --_j), "f", _C_test);
+        const a = (__classPrivateFieldSet(_k = _a, _a, (_m = __classPrivateFieldGet(_k, _a, "f", _C_test), _l = _m++, _m), "f", _C_test), _l);
+        const b = (__classPrivateFieldSet(_o = _a, _a, (_q = __classPrivateFieldGet(_o, _a, "f", _C_test), _p = _q--, _q), "f", _C_test), _p);
+        const c = __classPrivateFieldSet(_r = _a, _a, (_s = __classPrivateFieldGet(_r, _a, "f", _C_test), ++_s), "f", _C_test);
+        const d = __classPrivateFieldSet(_t = _a, _a, (_u = __classPrivateFieldGet(_t, _a, "f", _C_test), --_u), "f", _C_test);
+        for (__classPrivateFieldSet(_a, _a, 0, "f", _C_test); __classPrivateFieldGet(_a, _a, "f", _C_test) < 10; __classPrivateFieldSet(_v = _a, _a, (_w = __classPrivateFieldGet(_v, _a, "f", _C_test), ++_w), "f", _C_test)) { }
+        for (__classPrivateFieldSet(_a, _a, 0, "f", _C_test); __classPrivateFieldGet(_a, _a, "f", _C_test) < 10; __classPrivateFieldSet(_x = _a, _a, (_y = __classPrivateFieldGet(_x, _a, "f", _C_test), _y++, _y), "f", _C_test)) { }
     }
     test() {
         var _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y;
@@ -71,7 +71,7 @@ class C {
         for (__classPrivateFieldSet(this.getClass(), _a, 0, "f", _C_test); __classPrivateFieldGet(this.getClass(), _a, "f", _C_test) < 10; __classPrivateFieldSet(_v = this.getClass(), _a, (_w = __classPrivateFieldGet(_v, _a, "f", _C_test), ++_w), "f", _C_test)) { }
         for (__classPrivateFieldSet(this.getClass(), _a, 0, "f", _C_test); __classPrivateFieldGet(this.getClass(), _a, "f", _C_test) < 10; __classPrivateFieldSet(_x = this.getClass(), _a, (_y = __classPrivateFieldGet(_x, _a, "f", _C_test), _y++, _y), "f", _C_test)) { }
     }
-    getClass() { return C; }
+    getClass() { return _a; }
 }
 _a = C;
 _C_test = { value: 24 };

--- a/tests/baselines/reference/privateNameStaticMethod.js
+++ b/tests/baselines/reference/privateNameStaticMethod.js
@@ -24,9 +24,9 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var _a, _A1_method;
 class A1 {
     constructor() {
-        __classPrivateFieldGet(A1, _a, "m", _A1_method).call(A1, "");
-        __classPrivateFieldGet(A1, _a, "m", _A1_method).call(A1, 1); // Error
-        __classPrivateFieldGet(A1, _a, "m", _A1_method).call(A1); // Error 
+        __classPrivateFieldGet(_a, _a, "m", _A1_method).call(_a, "");
+        __classPrivateFieldGet(_a, _a, "m", _A1_method).call(_a, 1); // Error
+        __classPrivateFieldGet(_a, _a, "m", _A1_method).call(_a); // Error 
     }
 }
 _a = A1, _A1_method = function _A1_method(param) {

--- a/tests/baselines/reference/privateNameStaticMethodAssignment.js
+++ b/tests/baselines/reference/privateNameStaticMethodAssignment.js
@@ -31,11 +31,11 @@ class A3 {
     ;
     constructor(a, b) {
         var _b, _c;
-        __classPrivateFieldSet(A3, _a, () => { }, "m"); // Error, not writable 
+        __classPrivateFieldSet(_a, _a, () => { }, "m"); // Error, not writable 
         __classPrivateFieldSet(a, _a, () => { }, "m"); // Error, not writable 
         __classPrivateFieldSet(b, _a, () => { }, "m"); //Error, not writable 
-        ({ x: ({ set value(_b) { __classPrivateFieldSet(A3, _a, _b, "m"); } }).value } = { x: () => { } }); //Error, not writable 
-        let x = __classPrivateFieldGet(A3, _a, "m", _A3_method);
+        ({ x: ({ set value(_b) { __classPrivateFieldSet(_a, _a, _b, "m"); } }).value } = { x: () => { } }); //Error, not writable 
+        let x = __classPrivateFieldGet(_a, _a, "m", _A3_method);
         __classPrivateFieldSet(_b = b, _a, (_c = __classPrivateFieldGet(_b, _a, "m", _A3_method), _c++, _c), "m"); //Error, not writable 
     }
 }

--- a/tests/baselines/reference/privateNameStaticMethodCallExpression.js
+++ b/tests/baselines/reference/privateNameStaticMethodCallExpression.js
@@ -38,20 +38,20 @@ class AA {
     ;
     test() {
         var _b, _c, _d;
-        __classPrivateFieldGet(AA, _a, "m", _AA_method).call(AA);
-        const func = __classPrivateFieldGet(AA, _a, "m", _AA_method);
+        __classPrivateFieldGet(_a, _a, "m", _AA_method).call(_a);
+        const func = __classPrivateFieldGet(_a, _a, "m", _AA_method);
         func();
-        new (__classPrivateFieldGet(AA, _a, "m", _AA_method))();
+        new (__classPrivateFieldGet(_a, _a, "m", _AA_method))();
         const arr = [1, 2];
-        __classPrivateFieldGet(AA, _a, "m", _AA_method2).call(AA, 0, ...arr, 3);
-        const b = new (__classPrivateFieldGet(AA, _a, "m", _AA_method2))(0, ...arr, 3); //Error 
-        const str = __classPrivateFieldGet(AA, _a, "m", _AA_method2).bind(AA) `head${1}middle${2}tail`;
-        __classPrivateFieldGet((_b = AA.getClass()), _a, "m", _AA_method2).bind(_b) `test${1}and${2}`;
-        __classPrivateFieldGet((_c = AA.getClass()), _a, "m", _AA_method2).call(_c, 0, ...arr, 3);
-        const b2 = new (__classPrivateFieldGet(AA.getClass(), _a, "m", _AA_method2))(0, ...arr, 3); //Error 
-        const str2 = __classPrivateFieldGet((_d = AA.getClass()), _a, "m", _AA_method2).bind(_d) `head${1}middle${2}tail`;
+        __classPrivateFieldGet(_a, _a, "m", _AA_method2).call(_a, 0, ...arr, 3);
+        const b = new (__classPrivateFieldGet(_a, _a, "m", _AA_method2))(0, ...arr, 3); //Error 
+        const str = __classPrivateFieldGet(_a, _a, "m", _AA_method2).bind(_a) `head${1}middle${2}tail`;
+        __classPrivateFieldGet((_b = _a.getClass()), _a, "m", _AA_method2).bind(_b) `test${1}and${2}`;
+        __classPrivateFieldGet((_c = _a.getClass()), _a, "m", _AA_method2).call(_c, 0, ...arr, 3);
+        const b2 = new (__classPrivateFieldGet(_a.getClass(), _a, "m", _AA_method2))(0, ...arr, 3); //Error 
+        const str2 = __classPrivateFieldGet((_d = _a.getClass()), _a, "m", _AA_method2).bind(_d) `head${1}middle${2}tail`;
     }
-    static getClass() { return AA; }
+    static getClass() { return _a; }
 }
 _a = AA, _AA_method = function _AA_method() { this.x = 10; }, _AA_method2 = function _AA_method2(a, ...b) { };
 AA.x = 1;

--- a/tests/baselines/reference/privateNameStaticMethodClassExpression.js
+++ b/tests/baselines/reference/privateNameStaticMethodClassExpression.js
@@ -22,7 +22,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 };
 var _a, _D_field, _D_method;
 const C = (_a = class D {
-        static getClass() { return D; }
+        static getClass() { return _a; }
         static getField() { return __classPrivateFieldGet(C, _a, "f", _D_field); }
         ;
     },

--- a/tests/baselines/reference/privateNameStaticMethodInStaticFieldInit.js
+++ b/tests/baselines/reference/privateNameStaticMethodInStaticFieldInit.js
@@ -19,5 +19,5 @@ var _a, _C_method;
 class C {
 }
 _a = C, _C_method = function _C_method() { return 42; };
-C.s = __classPrivateFieldGet(C, _a, "m", _C_method).call(C);
+C.s = __classPrivateFieldGet(_a, _a, "m", _C_method).call(_a);
 console.log(C.s);

--- a/tests/baselines/reference/privateNameWhenNotUseDefineForClassFieldsInEsNext(target=es2020).js
+++ b/tests/baselines/reference/privateNameWhenNotUseDefineForClassFieldsInEsNext(target=es2020).js
@@ -79,7 +79,7 @@ TestWithStatics["X_ z_ zz"] = (_a = class Inner {
             return class {
                 m() {
                     __classPrivateFieldGet(new TestWithStatics(), _TestWithStatics_prop, "f"); // OK
-                    __classPrivateFieldGet(new Inner(), _Inner_foo, "f"); // OK
+                    __classPrivateFieldGet(new _a(), _Inner_foo, "f"); // OK
                 }
             };
         }
@@ -103,7 +103,7 @@ class TestNonStatics {
                     this.C = class InnerInner {
                         m() {
                             __classPrivateFieldGet(new TestNonStatics(), _TestNonStatics_prop, "f"); // Ok
-                            __classPrivateFieldGet(new Inner(), _Inner_foo_1, "f"); // Ok
+                            __classPrivateFieldGet(new _b(), _Inner_foo_1, "f"); // Ok
                         }
                     };
                 }
@@ -114,7 +114,7 @@ class TestNonStatics {
                     return class {
                         m() {
                             __classPrivateFieldGet(new TestNonStatics(), _TestNonStatics_prop, "f"); // OK
-                            __classPrivateFieldGet(new Inner(), _Inner_foo_1, "f"); // OK
+                            __classPrivateFieldGet(new _b(), _Inner_foo_1, "f"); // OK
                         }
                     };
                 }

--- a/tests/baselines/reference/privateNamesAndStaticFields.js
+++ b/tests/baselines/reference/privateNamesAndStaticFields.js
@@ -40,7 +40,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var _a, _A_foo, _A_bar, _b, _B_foo;
 class A {
     constructor() {
-        __classPrivateFieldSet(A, _a, 3, "f", _A_foo);
+        __classPrivateFieldSet(_a, _a, 3, "f", _A_foo);
         __classPrivateFieldGet(B, _a, "f", _A_foo); // Error
         __classPrivateFieldGet(B, _a, "f", _A_bar); // Error
     }
@@ -51,7 +51,7 @@ _A_bar = { value: void 0 };
 class B extends A {
     constructor() {
         super();
-        __classPrivateFieldSet(B, _b, "some string", "f", _B_foo);
+        __classPrivateFieldSet(_b, _b, "some string", "f", _B_foo);
     }
 }
 _b = B;

--- a/tests/baselines/reference/privateNamesInNestedClasses-2.js
+++ b/tests/baselines/reference/privateNamesInNestedClasses-2.js
@@ -34,7 +34,7 @@ class A {
                 _B_x.set(this, 5);
                 class C {
                     constructor() {
-                        __classPrivateFieldGet(A, _B_x, "f"); // error
+                        __classPrivateFieldGet(_a, _B_x, "f"); // error
                     }
                 }
             }

--- a/tests/baselines/reference/privateStaticNameShadowing.js
+++ b/tests/baselines/reference/privateStaticNameShadowing.js
@@ -24,7 +24,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var _b, _X_f, _X_m;
 class X {
     constructor() {
-        __classPrivateFieldGet(X, _b, "m", _X_m).call(X);
+        __classPrivateFieldGet(_b, _b, "m", _X_m).call(_b);
     }
 }
 _b = X, _X_m = function _X_m() {
@@ -33,4 +33,4 @@ _b = X, _X_m = function _X_m() {
     __classPrivateFieldGet(X, _b, "m", _X_m).call(X); // Should check with X as the receiver with _b as the class constructor 
     return 1;
 };
-_X_f = { value: __classPrivateFieldGet(X, _b, "m", _X_m).call(X) };
+_X_f = { value: __classPrivateFieldGet(_b, _b, "m", _X_m).call(_b) };

--- a/tests/baselines/reference/tslibReExportHelpers2.js
+++ b/tests/baselines/reference/tslibReExportHelpers2.js
@@ -48,7 +48,7 @@ var _a, _Foo_test;
 import { __classPrivateFieldGet } from "tslib";
 export class Foo {
     constructor() {
-        console.log(__classPrivateFieldGet(Foo, _a, "m", _Foo_test).call(Foo));
+        console.log(__classPrivateFieldGet(_a, _a, "m", _Foo_test).call(_a));
     }
 }
 _a = Foo, _Foo_test = function _Foo_test() {

--- a/tests/cases/compiler/classNameReferencesInStaticElements.ts
+++ b/tests/cases/compiler/classNameReferencesInStaticElements.ts
@@ -1,0 +1,17 @@
+// @target: es2017
+// @noTypesAndSymbols: true
+// https://github.com/microsoft/TypeScript/issues/54607
+class Foo {
+    static { console.log(this, Foo) }
+    static x = () => { console.log(this, Foo) }
+    static y = function(this: unknown) { console.log(this, Foo) }
+
+    #x() { console.log(Foo); }
+    x() { this.#x(); }
+}
+
+const oldFoo = Foo;
+(Foo as any) = null;
+oldFoo.x();
+oldFoo.y();
+new oldFoo().x();


### PR DESCRIPTION
This fixes our emit for references to a class name inside of a class body when down-level emit moves the member containing the reference outside of the class body. This is necessary to preserve the "double bind" semantics of class names, where references to a class name inside of a class body are not affected when the reference to the class *outside* of the class body is changed.

We generally emit members outside of a class body when downleveling static fields, class static blocks, and private methods/accessors.

Fixes #54607