### PR TITLE
Modify interactive inlay hints API to be more backwards compatible

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -760,21 +760,20 @@ export class SessionClient implements LanguageService {
         const response = this.processResponse<protocol.InlayHintsResponse>(request);
 
         return response.body!.map(item => {
-            const { text, position } = item;
-            const hint = typeof text === "string" ? text : text.map(({ text, span }) => ({
-                text,
-                span: span && {
-                    start: this.lineOffsetToPosition(span.file, span.start),
-                    length: this.lineOffsetToPosition(span.file, span.end) - this.lineOffsetToPosition(span.file, span.start),
-                },
-                file: span && span.file
-            }));
+            const { position, displayParts } = item;
 
             return ({
                 ...item,
                 position: this.lineOffsetToPosition(file, position),
-                text: hint,
-                kind: item.kind as InlayHintKind
+                kind: item.kind as InlayHintKind,
+                displayParts: displayParts?.map(({ text, span }) => ({
+                    text,
+                    span: span && {
+                        start: this.lineOffsetToPosition(span.file, span.start),
+                        length: this.lineOffsetToPosition(span.file, span.end) - this.lineOffsetToPosition(span.file, span.start),
+                    },
+                    file: span && span.file
+                })),
             });
         });
     }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2675,11 +2675,12 @@ export interface InlayHintsRequest extends Request {
 }
 
 export interface InlayHintItem {
-    text: string | InlayHintItemDisplayPart[];
+    text: string;
     position: Location;
     kind: InlayHintKind;
     whitespaceBefore?: boolean;
     whitespaceAfter?: boolean;
+    displayParts?: InlayHintItemDisplayPart[];
 }
 
 export interface InlayHintItemDisplayPart {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2675,6 +2675,7 @@ export interface InlayHintsRequest extends Request {
 }
 
 export interface InlayHintItem {
+    /** This property will be the empty string when displayParts is set. */
     text: string;
     position: Location;
     kind: InlayHintKind;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1845,20 +1845,19 @@ export class Session<TMessage = string> implements EventSender {
         const hints = project.getLanguageService().provideInlayHints(file, args, this.getPreferences(file));
 
         return hints.map(hint => {
-            const { text, position } = hint;
-            const hintText = typeof text === "string" ? text : text.map(({ text, span, file }) => ({
-                text,
-                span: span && {
-                    start: scriptInfo.positionToLineOffset(span.start),
-                    end: scriptInfo.positionToLineOffset(span.start + span.length),
-                    file: file!
-                }
-            }));
+            const { position, displayParts } = hint;
 
             return {
                 ...hint,
                 position: scriptInfo.positionToLineOffset(position),
-                text: hintText
+                displayParts: displayParts?.map(({ text, span, file }) => ({
+                    text,
+                    span: span && {
+                        start: scriptInfo.positionToLineOffset(span.start),
+                        end: scriptInfo.positionToLineOffset(span.start + span.length),
+                        file: file!
+                    }
+                })),
             };
         });
     }

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -159,9 +159,11 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
     }
 
     function addParameterHints(text: string, parameter: Identifier, position: number, isFirstVariadicArgument: boolean, sourceFile: SourceFile | undefined) {
-        let hintText: string | InlayHintDisplayPart[] = `${isFirstVariadicArgument ? "..." : ""}${text}`;
+        let hintText = `${isFirstVariadicArgument ? "..." : ""}${text}`;
+        let displayParts: InlayHintDisplayPart[] | undefined;
         if (shouldUseInteractiveInlayHints(preferences)) {
-            hintText = [getNodeDisplayPart(hintText, parameter, sourceFile!), { text: ":" }];
+            hintText = "";
+            displayParts = [getNodeDisplayPart(hintText, parameter, sourceFile!), { text: ":" }];
         }
         else {
             hintText += ":";
@@ -172,6 +174,7 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
             position,
             kind: InlayHintKind.Parameter,
             whitespaceAfter: true,
+            displayParts,
         });
     }
 

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -162,8 +162,8 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
         let hintText = `${isFirstVariadicArgument ? "..." : ""}${text}`;
         let displayParts: InlayHintDisplayPart[] | undefined;
         if (shouldUseInteractiveInlayHints(preferences)) {
-            hintText = "";
             displayParts = [getNodeDisplayPart(hintText, parameter, sourceFile!), { text: ":" }];
+            hintText = "";
         }
         else {
             hintText += ":";

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -866,11 +866,12 @@ export const enum InlayHintKind {
 }
 
 export interface InlayHint {
-    text: string | InlayHintDisplayPart[];
+    text: string;
     position: number;
     kind: InlayHintKind;
     whitespaceBefore?: boolean;
     whitespaceAfter?: boolean;
+    displayParts?: InlayHintDisplayPart[];
 }
 
 export interface InlayHintDisplayPart {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -866,6 +866,7 @@ export const enum InlayHintKind {
 }
 
 export interface InlayHint {
+    /** This property will be the empty string when displayParts is set. */
     text: string;
     position: number;
     kind: InlayHintKind;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2124,6 +2124,7 @@ declare namespace ts {
                 arguments: InlayHintsRequestArgs;
             }
             interface InlayHintItem {
+                /** This property will be the empty string when displayParts is set. */
                 text: string;
                 position: Location;
                 kind: InlayHintKind;
@@ -10391,6 +10392,7 @@ declare namespace ts {
         Enum = "Enum"
     }
     interface InlayHint {
+        /** This property will be the empty string when displayParts is set. */
         text: string;
         position: number;
         kind: InlayHintKind;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2124,11 +2124,12 @@ declare namespace ts {
                 arguments: InlayHintsRequestArgs;
             }
             interface InlayHintItem {
-                text: string | InlayHintItemDisplayPart[];
+                text: string;
                 position: Location;
                 kind: InlayHintKind;
                 whitespaceBefore?: boolean;
                 whitespaceAfter?: boolean;
+                displayParts?: InlayHintItemDisplayPart[];
             }
             interface InlayHintItemDisplayPart {
                 text: string;
@@ -10390,11 +10391,12 @@ declare namespace ts {
         Enum = "Enum"
     }
     interface InlayHint {
-        text: string | InlayHintDisplayPart[];
+        text: string;
         position: number;
         kind: InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
+        displayParts?: InlayHintDisplayPart[];
     }
     interface InlayHintDisplayPart {
         text: string;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6416,11 +6416,12 @@ declare namespace ts {
         Enum = "Enum"
     }
     interface InlayHint {
-        text: string | InlayHintDisplayPart[];
+        text: string;
         position: number;
         kind: InlayHintKind;
         whitespaceBefore?: boolean;
         whitespaceAfter?: boolean;
+        displayParts?: InlayHintDisplayPart[];
     }
     interface InlayHintDisplayPart {
         text: string;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6416,6 +6416,7 @@ declare namespace ts {
         Enum = "Enum"
     }
     interface InlayHint {
+        /** This property will be the empty string when displayParts is set. */
         text: string;
         position: number;
         kind: InlayHintKind;

--- a/tests/baselines/reference/inlayHintsShouldWork1.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork1.baseline
@@ -1,9 +1,13 @@
 foo(1, 2);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 43,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -13,18 +17,19 @@ foo(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 43,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, 2);
        ^
 {
-  "text": [
+  "text": "",
+  "position": 46,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 25,
         "length": 1
@@ -34,8 +39,5 @@ foo(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 46,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork1.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork1.baseline
@@ -7,7 +7,7 @@ foo(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 14,
         "length": 1
@@ -29,7 +29,7 @@ foo(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 25,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork11.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork11.baseline
@@ -1,9 +1,13 @@
 foo(1)(2);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 87,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 13,
         "length": 1
@@ -13,18 +17,19 @@ foo(1)(2);
     {
       "text": ":"
     }
-  ],
-  "position": 87,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1)(2);
        ^
 {
-  "text": [
+  "text": "",
+  "position": 90,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 38,
         "length": 1
@@ -34,8 +39,5 @@ foo(1)(2);
     {
       "text": ":"
     }
-  ],
-  "position": 90,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork11.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork11.baseline
@@ -7,7 +7,7 @@ foo(1)(2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 13,
         "length": 1
@@ -29,7 +29,7 @@ foo(1)(2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 38,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork12.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork12.baseline
@@ -7,7 +7,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 17,
         "length": 1
@@ -29,7 +29,7 @@ foo((c: number) => c + 1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 13,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork12.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork12.baseline
@@ -1,9 +1,13 @@
     return a(1) + 2
              ^
 {
-  "text": [
+  "text": "",
+  "position": 54,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 17,
         "length": 1
@@ -13,18 +17,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 54,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo((c: number) => c + 1);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 67,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 13,
         "length": 1
@@ -34,8 +39,5 @@ foo((c: number) => c + 1);
     {
       "text": ":"
     }
-  ],
-  "position": 67,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork13.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork13.baseline
@@ -7,7 +7,7 @@ foo(a, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 25,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork13.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork13.baseline
@@ -1,9 +1,13 @@
 foo(a, 2);
        ^
 {
-  "text": [
+  "text": "",
+  "position": 66,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 25,
         "length": 1
@@ -13,8 +17,5 @@ foo(a, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 66,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork2.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork2.baseline
@@ -1,9 +1,13 @@
 foo(1, { c: 1 });
     ^
 {
-  "text": [
+  "text": "",
+  "position": 44,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -13,8 +17,5 @@ foo(1, { c: 1 });
     {
       "text": ":"
     }
-  ],
-  "position": 44,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork2.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork2.baseline
@@ -7,7 +7,7 @@ foo(1, { c: 1 });
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 14,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork3.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork3.baseline
@@ -7,7 +7,7 @@ foo(1, 1, 1, 1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 14,
         "length": 1
@@ -29,7 +29,7 @@ foo(1, 1, 1, 1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "...b",
       "span": {
         "start": 28,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork3.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork3.baseline
@@ -1,9 +1,13 @@
 foo(1, 1, 1, 1);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 48,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -13,18 +17,19 @@ foo(1, 1, 1, 1);
     {
       "text": ":"
     }
-  ],
-  "position": 48,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, 1, 1, 1);
        ^
 {
-  "text": [
+  "text": "",
+  "position": 51,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "...b",
+      "text": "",
       "span": {
         "start": 28,
         "length": 1
@@ -34,8 +39,5 @@ foo(1, 1, 1, 1);
     {
       "text": ":"
     }
-  ],
-  "position": 51,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork32.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork32.baseline
@@ -1,9 +1,13 @@
 function c2 () { foo2(1, 2); }
                       ^
 {
-  "text": [
+  "text": "",
+  "position": 293,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 55,
         "length": 1
@@ -13,18 +17,19 @@ function c2 () { foo2(1, 2); }
     {
       "text": ":"
     }
-  ],
-  "position": 293,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 function c2 () { foo2(1, 2); }
                          ^
 {
-  "text": [
+  "text": "",
+  "position": 296,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "d",
+      "text": "",
       "span": {
         "start": 66,
         "length": 1
@@ -34,18 +39,19 @@ function c2 () { foo2(1, 2); }
     {
       "text": ":"
     }
-  ],
-  "position": 296,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 function c3 () { foo3(1, 2); }
                       ^
 {
-  "text": [
+  "text": "",
+  "position": 324,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "e",
+      "text": "",
       "span": {
         "start": 95,
         "length": 1
@@ -55,18 +61,19 @@ function c3 () { foo3(1, 2); }
     {
       "text": ":"
     }
-  ],
-  "position": 324,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 function c3 () { foo3(1, 2); }
                          ^
 {
-  "text": [
+  "text": "",
+  "position": 327,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "f",
+      "text": "",
       "span": {
         "start": 106,
         "length": 1
@@ -76,18 +83,19 @@ function c3 () { foo3(1, 2); }
     {
       "text": ":"
     }
-  ],
-  "position": 327,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 function c4 () { foo4(1, 2); }
                       ^
 {
-  "text": [
+  "text": "",
+  "position": 355,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "g",
+      "text": "",
       "span": {
         "start": 135,
         "length": 1
@@ -97,18 +105,19 @@ function c4 () { foo4(1, 2); }
     {
       "text": ":"
     }
-  ],
-  "position": 355,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 function c4 () { foo4(1, 2); }
                          ^
 {
-  "text": [
+  "text": "",
+  "position": 358,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "h",
+      "text": "",
       "span": {
         "start": 146,
         "length": 1
@@ -118,8 +127,5 @@ function c4 () { foo4(1, 2); }
     {
       "text": ":"
     }
-  ],
-  "position": 358,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork32.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork32.baseline
@@ -7,7 +7,7 @@ function c2 () { foo2(1, 2); }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 55,
         "length": 1
@@ -29,7 +29,7 @@ function c2 () { foo2(1, 2); }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "d",
       "span": {
         "start": 66,
         "length": 1
@@ -51,7 +51,7 @@ function c3 () { foo3(1, 2); }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "e",
       "span": {
         "start": 95,
         "length": 1
@@ -73,7 +73,7 @@ function c3 () { foo3(1, 2); }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "f",
       "span": {
         "start": 106,
         "length": 1
@@ -95,7 +95,7 @@ function c4 () { foo4(1, 2); }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "g",
       "span": {
         "start": 135,
         "length": 1
@@ -117,7 +117,7 @@ function c4 () { foo4(1, 2); }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "h",
       "span": {
         "start": 146,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork33.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork33.baseline
@@ -7,7 +7,7 @@ foo2(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 55,
         "length": 1
@@ -29,7 +29,7 @@ foo2(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "d",
       "span": {
         "start": 66,
         "length": 1
@@ -51,7 +51,7 @@ foo3(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "e",
       "span": {
         "start": 95,
         "length": 1
@@ -73,7 +73,7 @@ foo3(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "f",
       "span": {
         "start": 106,
         "length": 1
@@ -95,7 +95,7 @@ foo4(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "g",
       "span": {
         "start": 135,
         "length": 1
@@ -117,7 +117,7 @@ foo4(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "h",
       "span": {
         "start": 146,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork33.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork33.baseline
@@ -1,9 +1,13 @@
 foo2(1, 2);
      ^
 {
-  "text": [
+  "text": "",
+  "position": 257,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 55,
         "length": 1
@@ -13,18 +17,19 @@ foo2(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 257,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo2(1, 2);
         ^
 {
-  "text": [
+  "text": "",
+  "position": 260,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "d",
+      "text": "",
       "span": {
         "start": 66,
         "length": 1
@@ -34,18 +39,19 @@ foo2(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 260,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo3(1, 2);
      ^
 {
-  "text": [
+  "text": "",
+  "position": 269,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "e",
+      "text": "",
       "span": {
         "start": 95,
         "length": 1
@@ -55,18 +61,19 @@ foo3(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 269,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo3(1, 2);
         ^
 {
-  "text": [
+  "text": "",
+  "position": 272,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "f",
+      "text": "",
       "span": {
         "start": 106,
         "length": 1
@@ -76,18 +83,19 @@ foo3(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 272,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo4(1, 2);
      ^
 {
-  "text": [
+  "text": "",
+  "position": 281,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "g",
+      "text": "",
       "span": {
         "start": 135,
         "length": 1
@@ -97,18 +105,19 @@ foo4(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 281,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo4(1, 2);
         ^
 {
-  "text": [
+  "text": "",
+  "position": 284,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "h",
+      "text": "",
       "span": {
         "start": 146,
         "length": 1
@@ -118,8 +127,5 @@ foo4(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 284,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork34.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork34.baseline
@@ -7,7 +7,7 @@ foo(1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -29,7 +29,7 @@ foo('');
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -51,7 +51,7 @@ foo(true);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -73,7 +73,7 @@ foo((1));
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -95,7 +95,7 @@ foo(foo(1));
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork34.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork34.baseline
@@ -1,9 +1,13 @@
 foo(1);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 29,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -13,18 +17,19 @@ foo(1);
     {
       "text": ":"
     }
-  ],
-  "position": 29,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo('');
     ^
 {
-  "text": [
+  "text": "",
+  "position": 37,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -34,18 +39,19 @@ foo('');
     {
       "text": ":"
     }
-  ],
-  "position": 37,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(true);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 46,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -55,18 +61,19 @@ foo(true);
     {
       "text": ":"
     }
-  ],
-  "position": 46,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo((1));
     ^
 {
-  "text": [
+  "text": "",
+  "position": 67,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -76,18 +83,19 @@ foo((1));
     {
       "text": ":"
     }
-  ],
-  "position": 67,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(foo(1));
         ^
 {
-  "text": [
+  "text": "",
+  "position": 81,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -97,8 +105,5 @@ foo(foo(1));
     {
       "text": ":"
     }
-  ],
-  "position": 81,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork35.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork35.baseline
@@ -1,9 +1,13 @@
 foo(1);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 29,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -13,18 +17,19 @@ foo(1);
     {
       "text": ":"
     }
-  ],
-  "position": 29,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo('');
     ^
 {
-  "text": [
+  "text": "",
+  "position": 37,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -34,18 +39,19 @@ foo('');
     {
       "text": ":"
     }
-  ],
-  "position": 37,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(true);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 46,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -55,18 +61,19 @@ foo(true);
     {
       "text": ":"
     }
-  ],
-  "position": 46,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(() => 1);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 57,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -76,18 +83,19 @@ foo(() => 1);
     {
       "text": ":"
     }
-  ],
-  "position": 57,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(function () { return 1 });
     ^
 {
-  "text": [
+  "text": "",
+  "position": 71,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -97,18 +105,19 @@ foo(function () { return 1 });
     {
       "text": ":"
     }
-  ],
-  "position": 71,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo({});
     ^
 {
-  "text": [
+  "text": "",
+  "position": 102,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -118,18 +127,19 @@ foo({});
     {
       "text": ":"
     }
-  ],
-  "position": 102,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo({ a: 1 });
     ^
 {
-  "text": [
+  "text": "",
+  "position": 111,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -139,18 +149,19 @@ foo({ a: 1 });
     {
       "text": ":"
     }
-  ],
-  "position": 111,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo([]);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 126,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -160,18 +171,19 @@ foo([]);
     {
       "text": ":"
     }
-  ],
-  "position": 126,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo([1]);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 135,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -181,18 +193,19 @@ foo([1]);
     {
       "text": ":"
     }
-  ],
-  "position": 135,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(foo);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 145,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -202,18 +215,19 @@ foo(foo);
     {
       "text": ":"
     }
-  ],
-  "position": 145,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo((1));
     ^
 {
-  "text": [
+  "text": "",
+  "position": 155,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -223,18 +237,19 @@ foo((1));
     {
       "text": ":"
     }
-  ],
-  "position": 155,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(foo(1));
     ^
 {
-  "text": [
+  "text": "",
+  "position": 165,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -244,18 +259,19 @@ foo(foo(1));
     {
       "text": ":"
     }
-  ],
-  "position": 165,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(foo(1));
         ^
 {
-  "text": [
+  "text": "",
+  "position": 169,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "v",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -265,8 +281,5 @@ foo(foo(1));
     {
       "text": ":"
     }
-  ],
-  "position": 169,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork35.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork35.baseline
@@ -7,7 +7,7 @@ foo(1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -29,7 +29,7 @@ foo('');
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -51,7 +51,7 @@ foo(true);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -73,7 +73,7 @@ foo(() => 1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -95,7 +95,7 @@ foo(function () { return 1 });
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -117,7 +117,7 @@ foo({});
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -139,7 +139,7 @@ foo({ a: 1 });
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -161,7 +161,7 @@ foo([]);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -183,7 +183,7 @@ foo([1]);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -205,7 +205,7 @@ foo(foo);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -227,7 +227,7 @@ foo((1));
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -249,7 +249,7 @@ foo(foo(1));
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1
@@ -271,7 +271,7 @@ foo(foo(1));
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "v",
       "span": {
         "start": 14,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork36.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork36.baseline
@@ -7,7 +7,7 @@ foo(a, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 14,
         "length": 1
@@ -29,7 +29,7 @@ foo(a, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 25,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork36.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork36.baseline
@@ -1,9 +1,13 @@
 foo(a, 2);
     ^
 {
-  "text": [
+  "text": "",
+  "position": 63,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 14,
         "length": 1
@@ -13,18 +17,19 @@ foo(a, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 63,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(a, 2);
        ^
 {
-  "text": [
+  "text": "",
+  "position": 66,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 25,
         "length": 1
@@ -34,8 +39,5 @@ foo(a, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 66,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork4.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork4.baseline
@@ -1,9 +1,13 @@
 foo(1)
     ^
 {
-  "text": [
+  "text": "",
+  "position": 166,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "w",
+      "text": "",
       "span": {
         "start": 21,
         "length": 1
@@ -13,18 +17,19 @@ foo(1)
     {
       "text": ":"
     }
-  ],
-  "position": 166,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, 2)
     ^
 {
-  "text": [
+  "text": "",
+  "position": 173,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 59,
         "length": 1
@@ -34,18 +39,19 @@ foo(1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 173,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, 2)
        ^
 {
-  "text": [
+  "text": "",
+  "position": 176,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 70,
         "length": 1
@@ -55,8 +61,5 @@ foo(1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 176,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork4.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork4.baseline
@@ -7,7 +7,7 @@ foo(1)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "w",
       "span": {
         "start": 21,
         "length": 1
@@ -29,7 +29,7 @@ foo(1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 59,
         "length": 1
@@ -51,7 +51,7 @@ foo(1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 70,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork5.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork5.baseline
@@ -1,9 +1,13 @@
 foo(1, 2, 3)
     ^
 {
-  "text": [
+  "text": "",
+  "position": 87,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 56,
         "length": 1
@@ -13,18 +17,19 @@ foo(1, 2, 3)
     {
       "text": ":"
     }
-  ],
-  "position": 87,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, 2, 3)
        ^
 {
-  "text": [
+  "text": "",
+  "position": 90,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 13,
         "length": 1
@@ -34,18 +39,19 @@ foo(1, 2, 3)
     {
       "text": ":"
     }
-  ],
-  "position": 90,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, 2, 3)
           ^
 {
-  "text": [
+  "text": "",
+  "position": 93,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 24,
         "length": 1
@@ -55,8 +61,5 @@ foo(1, 2, 3)
     {
       "text": ":"
     }
-  ],
-  "position": 93,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork5.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork5.baseline
@@ -7,7 +7,7 @@ foo(1, 2, 3)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 56,
         "length": 1
@@ -29,7 +29,7 @@ foo(1, 2, 3)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 13,
         "length": 1
@@ -51,7 +51,7 @@ foo(1, 2, 3)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 24,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork50.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork50.baseline
@@ -7,7 +7,7 @@ foo(1, '', false, 1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "f",
       "span": {
         "start": 70,
         "length": 1
@@ -29,7 +29,7 @@ foo(1, '', false, 1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 10,
         "length": 1
@@ -51,7 +51,7 @@ foo(1, '', false, 1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 21,
         "length": 1
@@ -73,7 +73,7 @@ foo(1, '', false, 1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "...c",
       "span": {
         "start": 36,
         "length": 1
@@ -95,7 +95,7 @@ foo1(1, "", "")
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "f1",
       "span": {
         "start": 120,
         "length": 2
@@ -117,7 +117,7 @@ foo1(1, "", "")
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "...args",
       "span": {
         "start": 135,
         "length": 4

--- a/tests/baselines/reference/inlayHintsShouldWork50.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork50.baseline
@@ -1,9 +1,13 @@
 foo(1, '', false, 1, 2)
     ^
 {
-  "text": [
+  "text": "",
+  "position": 161,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "f",
+      "text": "",
       "span": {
         "start": 70,
         "length": 1
@@ -13,18 +17,19 @@ foo(1, '', false, 1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 161,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, '', false, 1, 2)
        ^
 {
-  "text": [
+  "text": "",
+  "position": 164,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 10,
         "length": 1
@@ -34,18 +39,19 @@ foo(1, '', false, 1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 164,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, '', false, 1, 2)
            ^
 {
-  "text": [
+  "text": "",
+  "position": 168,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 21,
         "length": 1
@@ -55,18 +61,19 @@ foo(1, '', false, 1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 168,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, '', false, 1, 2)
                   ^
 {
-  "text": [
+  "text": "",
+  "position": 175,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "...c",
+      "text": "",
       "span": {
         "start": 36,
         "length": 1
@@ -76,18 +83,19 @@ foo(1, '', false, 1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 175,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo1(1, "", "")
      ^
 {
-  "text": [
+  "text": "",
+  "position": 186,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "f1",
+      "text": "",
       "span": {
         "start": 120,
         "length": 2
@@ -97,18 +105,19 @@ foo1(1, "", "")
     {
       "text": ":"
     }
-  ],
-  "position": 186,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo1(1, "", "")
         ^
 {
-  "text": [
+  "text": "",
+  "position": 189,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "...args",
+      "text": "",
       "span": {
         "start": 135,
         "length": 4
@@ -118,8 +127,5 @@ foo1(1, "", "")
     {
       "text": ":"
     }
-  ],
-  "position": 189,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork52.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork52.baseline
@@ -10,9 +10,13 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
     2,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 134,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "bParameter",
+      "text": "",
       "span": {
         "start": 34,
         "length": 10
@@ -22,18 +26,19 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
     {
       "text": ":"
     }
-  ],
-  "position": 134,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     3
     ^
 {
-  "text": [
+  "text": "",
+  "position": 338,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "cParameter",
+      "text": "",
       "span": {
         "start": 54,
         "length": 10
@@ -43,18 +48,19 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
     {
       "text": ":"
     }
-  ],
-  "position": 338,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     1,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 373,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "aParameter",
+      "text": "",
       "span": {
         "start": 14,
         "length": 10
@@ -64,18 +70,19 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
     {
       "text": ":"
     }
-  ],
-  "position": 373,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     2,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 380,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "bParameter",
+      "text": "",
       "span": {
         "start": 34,
         "length": 10
@@ -85,18 +92,19 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
     {
       "text": ":"
     }
-  ],
-  "position": 380,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     3
     ^
 {
-  "text": [
+  "text": "",
+  "position": 440,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "cParameter",
+      "text": "",
       "span": {
         "start": 54,
         "length": 10
@@ -106,8 +114,5 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
     {
       "text": ":"
     }
-  ],
-  "position": 440,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork52.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork52.baseline
@@ -16,7 +16,7 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "bParameter",
       "span": {
         "start": 34,
         "length": 10
@@ -38,7 +38,7 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "cParameter",
       "span": {
         "start": 54,
         "length": 10
@@ -60,7 +60,7 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "aParameter",
       "span": {
         "start": 14,
         "length": 10
@@ -82,7 +82,7 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "bParameter",
       "span": {
         "start": 34,
         "length": 10
@@ -104,7 +104,7 @@ function foo (aParameter: number, bParameter: number, cParameter: number) { }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "cParameter",
       "span": {
         "start": 54,
         "length": 10

--- a/tests/baselines/reference/inlayHintsShouldWork53.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork53.baseline
@@ -7,7 +7,7 @@ fn(/* nobody knows exactly what this param is */ 42);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "x",
       "span": {
         "start": 12,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork53.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork53.baseline
@@ -1,9 +1,13 @@
 fn(/* nobody knows exactly what this param is */ 42);
                                                  ^
 {
-  "text": [
+  "text": "",
+  "position": 76,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "x",
+      "text": "",
       "span": {
         "start": 12,
         "length": 1
@@ -13,8 +17,5 @@ fn(/* nobody knows exactly what this param is */ 42);
     {
       "text": ":"
     }
-  ],
-  "position": 76,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork6.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork6.baseline
@@ -1,9 +1,13 @@
 foo(1, 2, 3)
     ^
 {
-  "text": [
+  "text": "",
+  "position": 81,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 50,
         "length": 1
@@ -13,8 +17,5 @@ foo(1, 2, 3)
     {
       "text": ":"
     }
-  ],
-  "position": 81,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork6.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork6.baseline
@@ -7,7 +7,7 @@ foo(1, 2, 3)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 50,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork62.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork62.baseline
@@ -1,9 +1,13 @@
 trace(`${1}`);
       ^
 {
-  "text": [
+  "text": "",
+  "position": 41,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "message",
+      "text": "",
       "span": {
         "start": 15,
         "length": 7
@@ -13,18 +17,19 @@ trace(`${1}`);
     {
       "text": ":"
     }
-  ],
-  "position": 41,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 trace(``);
       ^
 {
-  "text": [
+  "text": "",
+  "position": 56,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "message",
+      "text": "",
       "span": {
         "start": 15,
         "length": 7
@@ -34,8 +39,5 @@ trace(``);
     {
       "text": ":"
     }
-  ],
-  "position": 56,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork62.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork62.baseline
@@ -7,7 +7,7 @@ trace(`${1}`);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "message",
       "span": {
         "start": 15,
         "length": 7
@@ -29,7 +29,7 @@ trace(``);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "message",
       "span": {
         "start": 15,
         "length": 7

--- a/tests/baselines/reference/inlayHintsShouldWork63.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork63.baseline
@@ -1,9 +1,13 @@
 foo(1, +1, -1, +"1");
     ^
 {
-  "text": [
+  "text": "",
+  "position": 64,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 13,
         "length": 1
@@ -13,18 +17,19 @@ foo(1, +1, -1, +"1");
     {
       "text": ":"
     }
-  ],
-  "position": 64,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, +1, -1, +"1");
        ^
 {
-  "text": [
+  "text": "",
+  "position": 67,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 24,
         "length": 1
@@ -34,18 +39,19 @@ foo(1, +1, -1, +"1");
     {
       "text": ":"
     }
-  ],
-  "position": 67,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, +1, -1, +"1");
            ^
 {
-  "text": [
+  "text": "",
+  "position": 71,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 35,
         "length": 1
@@ -55,18 +61,19 @@ foo(1, +1, -1, +"1");
     {
       "text": ":"
     }
-  ],
-  "position": 71,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 foo(1, +1, -1, +"1");
                ^
 {
-  "text": [
+  "text": "",
+  "position": 75,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "d",
+      "text": "",
       "span": {
         "start": 46,
         "length": 1
@@ -76,8 +83,5 @@ foo(1, +1, -1, +"1");
     {
       "text": ":"
     }
-  ],
-  "position": 75,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork63.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork63.baseline
@@ -7,7 +7,7 @@ foo(1, +1, -1, +"1");
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 13,
         "length": 1
@@ -29,7 +29,7 @@ foo(1, +1, -1, +"1");
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 24,
         "length": 1
@@ -51,7 +51,7 @@ foo(1, +1, -1, +"1");
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 35,
         "length": 1
@@ -73,7 +73,7 @@ foo(1, +1, -1, +"1");
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "d",
       "span": {
         "start": 46,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork64.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork64.baseline
@@ -7,7 +7,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 18,
         "length": 1
@@ -29,7 +29,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 33,
         "length": 1
@@ -51,7 +51,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 51,
         "length": 1
@@ -73,7 +73,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "d",
       "span": {
         "start": 64,
         "length": 1
@@ -95,7 +95,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "e",
       "span": {
         "start": 80,
         "length": 1
@@ -117,7 +117,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "f",
       "span": {
         "start": 96,
         "length": 1
@@ -139,7 +139,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "g",
       "span": {
         "start": 111,
         "length": 1
@@ -161,7 +161,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "h",
       "span": {
         "start": 126,
         "length": 1
@@ -183,7 +183,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "i",
       "span": {
         "start": 141,
         "length": 1
@@ -205,7 +205,7 @@
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "j",
       "span": {
         "start": 156,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork64.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork64.baseline
@@ -1,9 +1,13 @@
     "hello",
     ^
 {
-  "text": [
+  "text": "",
+  "position": 183,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 18,
         "length": 1
@@ -13,18 +17,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 183,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     undefined,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 196,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 33,
         "length": 1
@@ -34,18 +39,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 196,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     null,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 211,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 51,
         "length": 1
@@ -55,18 +61,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 211,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     true,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 221,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "d",
+      "text": "",
       "span": {
         "start": 64,
         "length": 1
@@ -76,18 +83,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 221,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     false,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 231,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "e",
+      "text": "",
       "span": {
         "start": 80,
         "length": 1
@@ -97,18 +105,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 231,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     Infinity,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 242,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "f",
+      "text": "",
       "span": {
         "start": 96,
         "length": 1
@@ -118,18 +127,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 242,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     -Infinity,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 256,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "g",
+      "text": "",
       "span": {
         "start": 111,
         "length": 1
@@ -139,18 +149,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 256,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     NaN,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 271,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "h",
+      "text": "",
       "span": {
         "start": 126,
         "length": 1
@@ -160,18 +171,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 271,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     /hello/g,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 280,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "i",
+      "text": "",
       "span": {
         "start": 141,
         "length": 1
@@ -181,18 +193,19 @@
     {
       "text": ":"
     }
-  ],
-  "position": 280,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
     123n,
     ^
 {
-  "text": [
+  "text": "",
+  "position": 294,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "j",
+      "text": "",
       "span": {
         "start": 156,
         "length": 1
@@ -202,8 +215,5 @@
     {
       "text": ":"
     }
-  ],
-  "position": 294,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork68.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork68.baseline
@@ -1,9 +1,13 @@
 const C1 = class extends foo(1) { }
                              ^
 {
-  "text": [
+  "text": "",
+  "position": 63,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 13,
         "length": 1
@@ -13,18 +17,19 @@ const C1 = class extends foo(1) { }
     {
       "text": ":"
     }
-  ],
-  "position": 63,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 class C2 extends foo(1) { }
                      ^
 {
-  "text": [
+  "text": "",
+  "position": 91,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 13,
         "length": 1
@@ -34,8 +39,5 @@ class C2 extends foo(1) { }
     {
       "text": ":"
     }
-  ],
-  "position": 91,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork68.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork68.baseline
@@ -7,7 +7,7 @@ const C1 = class extends foo(1) { }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 13,
         "length": 1
@@ -29,7 +29,7 @@ class C2 extends foo(1) { }
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 13,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork7.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork7.baseline
@@ -7,7 +7,7 @@ call(1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 22,
         "length": 1
@@ -29,7 +29,7 @@ call(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 44,
         "length": 1
@@ -51,7 +51,7 @@ call(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 55,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork7.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork7.baseline
@@ -1,9 +1,13 @@
 call(1);
      ^
 {
-  "text": [
+  "text": "",
+  "position": 105,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 22,
         "length": 1
@@ -13,18 +17,19 @@ call(1);
     {
       "text": ":"
     }
-  ],
-  "position": 105,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 call(1, 2);
      ^
 {
-  "text": [
+  "text": "",
+  "position": 114,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 44,
         "length": 1
@@ -34,18 +39,19 @@ call(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 114,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 call(1, 2);
         ^
 {
-  "text": [
+  "text": "",
+  "position": 117,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 55,
         "length": 1
@@ -55,8 +61,5 @@ call(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 117,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork8.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork8.baseline
@@ -1,9 +1,13 @@
 new Class(1)
           ^
 {
-  "text": [
+  "text": "",
+  "position": 136,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 30,
         "length": 1
@@ -13,18 +17,19 @@ new Class(1)
     {
       "text": ":"
     }
-  ],
-  "position": 136,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 new Class(1, 2)
           ^
 {
-  "text": [
+  "text": "",
+  "position": 149,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 58,
         "length": 1
@@ -34,18 +39,19 @@ new Class(1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 149,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 new Class(1, 2)
              ^
 {
-  "text": [
+  "text": "",
+  "position": 152,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 69,
         "length": 1
@@ -55,8 +61,5 @@ new Class(1, 2)
     {
       "text": ":"
     }
-  ],
-  "position": 152,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }

--- a/tests/baselines/reference/inlayHintsShouldWork8.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork8.baseline
@@ -7,7 +7,7 @@ new Class(1)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 30,
         "length": 1
@@ -29,7 +29,7 @@ new Class(1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 58,
         "length": 1
@@ -51,7 +51,7 @@ new Class(1, 2)
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 69,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork9.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork9.baseline
@@ -7,7 +7,7 @@ call(1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "a",
       "span": {
         "start": 22,
         "length": 1
@@ -29,7 +29,7 @@ call(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "b",
       "span": {
         "start": 44,
         "length": 1
@@ -51,7 +51,7 @@ call(1, 2);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "c",
       "span": {
         "start": 55,
         "length": 1
@@ -73,7 +73,7 @@ new call(1);
   "whitespaceAfter": true,
   "displayParts": [
     {
-      "text": "",
+      "text": "d",
       "span": {
         "start": 81,
         "length": 1

--- a/tests/baselines/reference/inlayHintsShouldWork9.baseline
+++ b/tests/baselines/reference/inlayHintsShouldWork9.baseline
@@ -1,9 +1,13 @@
 call(1);
      ^
 {
-  "text": [
+  "text": "",
+  "position": 131,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "a",
+      "text": "",
       "span": {
         "start": 22,
         "length": 1
@@ -13,18 +17,19 @@ call(1);
     {
       "text": ":"
     }
-  ],
-  "position": 131,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 call(1, 2);
      ^
 {
-  "text": [
+  "text": "",
+  "position": 140,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "b",
+      "text": "",
       "span": {
         "start": 44,
         "length": 1
@@ -34,18 +39,19 @@ call(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 140,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 call(1, 2);
         ^
 {
-  "text": [
+  "text": "",
+  "position": 143,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "c",
+      "text": "",
       "span": {
         "start": 55,
         "length": 1
@@ -55,18 +61,19 @@ call(1, 2);
     {
       "text": ":"
     }
-  ],
-  "position": 143,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }
 
 new call(1);
          ^
 {
-  "text": [
+  "text": "",
+  "position": 156,
+  "kind": "Parameter",
+  "whitespaceAfter": true,
+  "displayParts": [
     {
-      "text": "d",
+      "text": "",
       "span": {
         "start": 81,
         "length": 1
@@ -76,8 +83,5 @@ new call(1);
     {
       "text": ":"
     }
-  ],
-  "position": 156,
-  "kind": "Parameter",
-  "whitespaceAfter": true
+  ]
 }


### PR DESCRIPTION
This tweaks the API in #54734 to make it such that it's less likely to break consumers and require changes such as https://github.com/microsoft/monaco-editor/pull/4100.

Unfortunately, this will require another vscode change to modify https://github.com/microsoft/vscode/pull/189344/files.