### PR TITLE
Fix broken formatting rules around namespaced JSX attributes

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -751,7 +751,9 @@ function isJsxExpressionContext(context: FormattingContext): boolean {
 }
 
 function isNextTokenParentJsxAttribute(context: FormattingContext): boolean {
-    return context.nextTokenParent.kind === SyntaxKind.JsxAttribute;
+    return context.nextTokenParent.kind === SyntaxKind.JsxAttribute || (
+        context.nextTokenParent.kind === SyntaxKind.JsxNamespacedName && context.nextTokenParent.parent.kind === SyntaxKind.JsxAttribute
+    );
 }
 
 function isJsxAttributeContext(context: FormattingContext): boolean {

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -90,7 +90,7 @@ export function getAllRules(): RuleSpec[] {
         rule("IgnoreAfterLineComment", SyntaxKind.SingleLineCommentTrivia, anyToken, anyContext, RuleAction.StopProcessingSpaceActions),
 
         rule("NotSpaceBeforeColon", anyToken, SyntaxKind.ColonToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext, isNotTypeAnnotationContext], RuleAction.DeleteSpace),
-        rule("SpaceAfterColon", SyntaxKind.ColonToken, anyToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext], RuleAction.InsertSpace),
+        rule("SpaceAfterColon", SyntaxKind.ColonToken, anyToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext, isNextTokenParentNotJsxNamespacedName], RuleAction.InsertSpace),
         rule("NoSpaceBeforeQuestionMark", anyToken, SyntaxKind.QuestionToken, [isNonJsxSameLineTokenContext, isNotBinaryOpContext, isNotTypeAnnotationContext], RuleAction.DeleteSpace),
         // insert space after '?' only when it is used in conditional operator
         rule("SpaceAfterQuestionMarkInConditionalOperator", SyntaxKind.QuestionToken, anyToken, [isNonJsxSameLineTokenContext, isConditionalOperatorContext], RuleAction.InsertSpace),
@@ -179,6 +179,8 @@ export function getAllRules(): RuleSpec[] {
         rule("NoSpaceBeforeGreaterThanTokenInJsxOpeningElement", SyntaxKind.SlashToken, SyntaxKind.GreaterThanToken, [isJsxSelfClosingElementContext, isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
         rule("NoSpaceBeforeEqualInJsxAttribute", anyToken, SyntaxKind.EqualsToken, [isJsxAttributeContext, isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
         rule("NoSpaceAfterEqualInJsxAttribute", SyntaxKind.EqualsToken, anyToken, [isJsxAttributeContext, isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
+        rule("NoSpaceBeforeJsxNamespaceColon", SyntaxKind.Identifier, SyntaxKind.ColonToken, [isNextTokenParentJsxNamespacedName], RuleAction.DeleteSpace),
+        rule("NoSpaceAfterJsxNamespaceColon", SyntaxKind.ColonToken, SyntaxKind.Identifier, [isNextTokenParentJsxNamespacedName], RuleAction.DeleteSpace),
 
         // TypeScript-specific rules
         // Use of module as a function call. e.g.: import m2 = module("m2");
@@ -754,6 +756,14 @@ function isNextTokenParentJsxAttribute(context: FormattingContext): boolean {
 
 function isJsxAttributeContext(context: FormattingContext): boolean {
     return context.contextNode.kind === SyntaxKind.JsxAttribute;
+}
+
+function isNextTokenParentNotJsxNamespacedName(context: FormattingContext): boolean {
+    return context.nextTokenParent.kind !== SyntaxKind.JsxNamespacedName;
+}
+
+function isNextTokenParentJsxNamespacedName(context: FormattingContext): boolean {
+    return context.nextTokenParent.kind === SyntaxKind.JsxNamespacedName;
 }
 
 function isJsxSelfClosingElementContext(context: FormattingContext): boolean {

--- a/tests/cases/fourslash/formattingJsxTexts4.ts
+++ b/tests/cases/fourslash/formattingJsxTexts4.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+// Github issue #55293
+
+//@Filename: file.tsx
+//// function foo() {
+//// const a = <ns: foobar   x : test1   x :test2="string"  x:test3={true?1:0}  />;
+////
+//// return a;
+//// }
+
+format.document();
+
+verify.currentFileContentIs(
+`function foo() {
+    const a = <ns:foobar x:test1 x:test2="string" x:test3={true ? 1 : 0} />;
+
+    return a;
+}`);

--- a/tests/cases/fourslash/formattingJsxTexts4.ts
+++ b/tests/cases/fourslash/formattingJsxTexts4.ts
@@ -13,7 +13,9 @@ format.document();
 
 verify.currentFileContentIs(
 `function foo() {
-    const a = <ns:foobar x:test1 x:test2="string" x:test3={true ? 1 : 0} />;
+    const a = <ns:foobar   x:test1   x:test2="string"  x:test3={true ? 1 : 0} />;
 
     return a;
 }`);
+
+// the original whitespaces between attributes are not handled by TypeScript yet

--- a/tests/cases/fourslash/formattingJsxTexts4.ts
+++ b/tests/cases/fourslash/formattingJsxTexts4.ts
@@ -13,9 +13,7 @@ format.document();
 
 verify.currentFileContentIs(
 `function foo() {
-    const a = <ns:foobar   x:test1   x:test2="string"  x:test3={true ? 1 : 0} />;
+    const a = <ns:foobar x:test1 x:test2="string" x:test3={true ? 1 : 0} />;
 
     return a;
 }`);
-
-// the original whitespaces between attributes are not handled by TypeScript yet


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #55293

Formatting `const a = <div: aa foo : bar="test" foo:baz="5" />;` 

into `const a = <div:aa foo:bar="test" foo:baz="5" />;`