### PR TITLE
Attempt to make Search Terms more obvious in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,11 @@ body:
         What search terms did you use when trying to find an existing bug report?
 
         List them here so people in the future can find this one more easily.
+      placeholder: |
+        List of keywords you searched for before creating this issue.
+        Write them down here so that others can find this bug more easily and help provide feedback.
+
+        e.g. "function inference any", "jsx attribute spread", "move to file duplicate imports", "discriminated union inference", "ts2822"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,6 +17,8 @@ body:
       placeholder: |
         List of keywords you searched for before creating this issue.
         Write them down here so that others can find this suggestion more easily and help provide feedback.
+
+        e.g. "isArray readonly", "regex string types", "json const assertion import"
     validations:
       required: true
   - type: checkboxes


### PR DESCRIPTION
See: https://github.com/microsoft/TypeScript/pull/55153#issuecomment-1669731911

People seem to be just writing their issue in the search terms box. A placeholder may make it more obvious that it's not just the regular issue box.