### PR TITLE
Don't allow mixed-enum-operand binary ops.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36979,6 +36979,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 leftType = checkNonNullType(leftType, left);
                 rightType = checkNonNullType(rightType, right);
 
+                // If both are enum types, they must be the same enum type
+                if (leftType.flags & rightType.flags & TypeFlags.EnumLiteral) {
+                    if (getBaseTypeOfEnumLikeType(leftType).symbol !== getBaseTypeOfEnumLikeType(rightType).symbol) {
+                        error(errorNode, Diagnostics.Enum_declarations_can_only_merge_with_namespace_or_other_enum_declarations);
+                    }
+                }
+
                 let suggestedOperator: PunctuationSyntaxKind | undefined;
                 // if a user tries to apply a bitwise operator to 2 boolean operands
                 // try and return them a helpful suggestion
@@ -36992,6 +36999,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // otherwise just check each operand separately and report errors as normal
                     const leftOk = checkArithmeticOperandType(left, leftType, Diagnostics.The_left_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*isAwaitValid*/ true);
                     const rightOk = checkArithmeticOperandType(right, rightType, Diagnostics.The_right_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*isAwaitValid*/ true);
+
                     let resultType: Type;
                     // If both are any or unknown, allow operation; assume it will resolve to number
                     if ((isTypeAssignableToKind(leftType, TypeFlags.AnyOrUnknown) && isTypeAssignableToKind(rightType, TypeFlags.AnyOrUnknown)) ||

--- a/tests/baselines/reference/noEnumOpMixing.errors.txt
+++ b/tests/baselines/reference/noEnumOpMixing.errors.txt
@@ -1,0 +1,23 @@
+noEnumOpMixing.ts(5,9): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+noEnumOpMixing.ts(13,9): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+
+
+==== noEnumOpMixing.ts (2 errors) ====
+    enum A { x, y, z }
+    enum B { d, e, f }
+    
+    // Should error
+    let m = A.x | B.d;
+            ~~~~~~~~~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+    // Should OK
+    let n = A.x | A.y;
+    // Should OK
+    declare let a1: A, a2: A;
+    let o = a1 | a2;
+    // Should error
+    declare let b1: B;
+    let p = a1 | b1;
+            ~~~~~~~
+!!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+    

--- a/tests/baselines/reference/noEnumOpMixing.js
+++ b/tests/baselines/reference/noEnumOpMixing.js
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/noEnumOpMixing.ts] ////
+
+//// [noEnumOpMixing.ts]
+enum A { x, y, z }
+enum B { d, e, f }
+
+// Should error
+let m = A.x | B.d;
+// Should OK
+let n = A.x | A.y;
+// Should OK
+declare let a1: A, a2: A;
+let o = a1 | a2;
+// Should error
+declare let b1: B;
+let p = a1 | b1;
+
+
+//// [noEnumOpMixing.js]
+var A;
+(function (A) {
+    A[A["x"] = 0] = "x";
+    A[A["y"] = 1] = "y";
+    A[A["z"] = 2] = "z";
+})(A || (A = {}));
+var B;
+(function (B) {
+    B[B["d"] = 0] = "d";
+    B[B["e"] = 1] = "e";
+    B[B["f"] = 2] = "f";
+})(B || (B = {}));
+// Should error
+var m = A.x | B.d;
+// Should OK
+var n = A.x | A.y;
+var o = a1 | a2;
+var p = a1 | b1;

--- a/tests/baselines/reference/noEnumOpMixing.symbols
+++ b/tests/baselines/reference/noEnumOpMixing.symbols
@@ -1,0 +1,57 @@
+//// [tests/cases/compiler/noEnumOpMixing.ts] ////
+
+=== noEnumOpMixing.ts ===
+enum A { x, y, z }
+>A : Symbol(A, Decl(noEnumOpMixing.ts, 0, 0))
+>x : Symbol(A.x, Decl(noEnumOpMixing.ts, 0, 8))
+>y : Symbol(A.y, Decl(noEnumOpMixing.ts, 0, 11))
+>z : Symbol(A.z, Decl(noEnumOpMixing.ts, 0, 14))
+
+enum B { d, e, f }
+>B : Symbol(B, Decl(noEnumOpMixing.ts, 0, 18))
+>d : Symbol(B.d, Decl(noEnumOpMixing.ts, 1, 8))
+>e : Symbol(B.e, Decl(noEnumOpMixing.ts, 1, 11))
+>f : Symbol(B.f, Decl(noEnumOpMixing.ts, 1, 14))
+
+// Should error
+let m = A.x | B.d;
+>m : Symbol(m, Decl(noEnumOpMixing.ts, 4, 3))
+>A.x : Symbol(A.x, Decl(noEnumOpMixing.ts, 0, 8))
+>A : Symbol(A, Decl(noEnumOpMixing.ts, 0, 0))
+>x : Symbol(A.x, Decl(noEnumOpMixing.ts, 0, 8))
+>B.d : Symbol(B.d, Decl(noEnumOpMixing.ts, 1, 8))
+>B : Symbol(B, Decl(noEnumOpMixing.ts, 0, 18))
+>d : Symbol(B.d, Decl(noEnumOpMixing.ts, 1, 8))
+
+// Should OK
+let n = A.x | A.y;
+>n : Symbol(n, Decl(noEnumOpMixing.ts, 6, 3))
+>A.x : Symbol(A.x, Decl(noEnumOpMixing.ts, 0, 8))
+>A : Symbol(A, Decl(noEnumOpMixing.ts, 0, 0))
+>x : Symbol(A.x, Decl(noEnumOpMixing.ts, 0, 8))
+>A.y : Symbol(A.y, Decl(noEnumOpMixing.ts, 0, 11))
+>A : Symbol(A, Decl(noEnumOpMixing.ts, 0, 0))
+>y : Symbol(A.y, Decl(noEnumOpMixing.ts, 0, 11))
+
+// Should OK
+declare let a1: A, a2: A;
+>a1 : Symbol(a1, Decl(noEnumOpMixing.ts, 8, 11))
+>A : Symbol(A, Decl(noEnumOpMixing.ts, 0, 0))
+>a2 : Symbol(a2, Decl(noEnumOpMixing.ts, 8, 18))
+>A : Symbol(A, Decl(noEnumOpMixing.ts, 0, 0))
+
+let o = a1 | a2;
+>o : Symbol(o, Decl(noEnumOpMixing.ts, 9, 3))
+>a1 : Symbol(a1, Decl(noEnumOpMixing.ts, 8, 11))
+>a2 : Symbol(a2, Decl(noEnumOpMixing.ts, 8, 18))
+
+// Should error
+declare let b1: B;
+>b1 : Symbol(b1, Decl(noEnumOpMixing.ts, 11, 11))
+>B : Symbol(B, Decl(noEnumOpMixing.ts, 0, 18))
+
+let p = a1 | b1;
+>p : Symbol(p, Decl(noEnumOpMixing.ts, 12, 3))
+>a1 : Symbol(a1, Decl(noEnumOpMixing.ts, 8, 11))
+>b1 : Symbol(b1, Decl(noEnumOpMixing.ts, 11, 11))
+

--- a/tests/baselines/reference/noEnumOpMixing.types
+++ b/tests/baselines/reference/noEnumOpMixing.types
@@ -1,0 +1,58 @@
+//// [tests/cases/compiler/noEnumOpMixing.ts] ////
+
+=== noEnumOpMixing.ts ===
+enum A { x, y, z }
+>A : A
+>x : A.x
+>y : A.y
+>z : A.z
+
+enum B { d, e, f }
+>B : B
+>d : B.d
+>e : B.e
+>f : B.f
+
+// Should error
+let m = A.x | B.d;
+>m : number
+>A.x | B.d : number
+>A.x : A.x
+>A : typeof A
+>x : A.x
+>B.d : B.d
+>B : typeof B
+>d : B.d
+
+// Should OK
+let n = A.x | A.y;
+>n : number
+>A.x | A.y : number
+>A.x : A.x
+>A : typeof A
+>x : A.x
+>A.y : A.y
+>A : typeof A
+>y : A.y
+
+// Should OK
+declare let a1: A, a2: A;
+>a1 : A
+>a2 : A
+
+let o = a1 | a2;
+>o : number
+>a1 | a2 : number
+>a1 : A
+>a2 : A
+
+// Should error
+declare let b1: B;
+>b1 : B
+
+let p = a1 | b1;
+>p : number
+>a1 | b1 : number
+>a1 : A
+>b1 : B
+

--- a/tests/cases/compiler/noEnumOpMixing.ts
+++ b/tests/cases/compiler/noEnumOpMixing.ts
@@ -1,0 +1,13 @@
+enum A { x, y, z }
+enum B { d, e, f }
+
+// Should error
+let m = A.x | B.d;
+// Should OK
+let n = A.x | A.y;
+// Should OK
+declare let a1: A, a2: A;
+let o = a1 | a2;
+// Should error
+declare let b1: B;
+let p = a1 | b1;


### PR DESCRIPTION
This is a hacky implementation; do not merge