### PR TITLE
Add a code block to the default value of the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -77,6 +77,10 @@ body:
           - We have to pare too much extraneous code.
           - We have to clone a large repo and validate that the problem isn't elsewhere.
           - The sample is confusing or doesn't clearly demonstrate what's wrong.
+      value: |
+        ```ts
+        // Your code here
+        ```
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
As noted in https://github.com/microsoft/TypeScript/issues/55317#issuecomment-1670631682.

I had thought that the input box being a rich text editor (like a default issue) would have implied that code would need to be markdown-formatted, but that apparently didn't turn out. Just add a little example block.