### PR TITLE
Correctly resolve declared type for late bound property symbols of function expressions

### DIFF
--- a/tests/baselines/reference/expandoFunctionExpressionsWithDynamicNames2.symbols
+++ b/tests/baselines/reference/expandoFunctionExpressionsWithDynamicNames2.symbols
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts] ////
+
+=== expandoFunctionExpressionsWithDynamicNames2.ts ===
+const mySymbol = Symbol();
+>mySymbol : Symbol(mySymbol, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 0, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 0, 26))
+
+  (): void;
+  [mySymbol]: true;
+>[mySymbol] : Symbol(Foo[mySymbol], Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 2, 11))
+>mySymbol : Symbol(mySymbol, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 0, 5))
+}
+const foo: Foo = () => {};
+>foo : Symbol(foo, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 5, 5), Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 5, 26))
+>Foo : Symbol(Foo, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 0, 26))
+
+foo[mySymbol] = true;
+>foo : Symbol(foo, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 5, 5), Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 5, 26))
+>mySymbol : Symbol(mySymbol, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 0, 5))
+
+interface Bar {
+>Bar : Symbol(Bar, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 6, 21))
+
+  (): void;
+  test: true;
+>test : Symbol(Bar.test, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 9, 11))
+}
+const t = "test" as const;
+>t : Symbol(t, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 12, 5))
+>const : Symbol(const)
+
+const bar: Bar = () => {};
+>bar : Symbol(bar, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 13, 5), Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 13, 26))
+>Bar : Symbol(Bar, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 6, 21))
+
+bar[t] = true;
+>bar : Symbol(bar, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 13, 5), Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 13, 26))
+>t : Symbol(t, Decl(expandoFunctionExpressionsWithDynamicNames2.ts, 12, 5))
+

--- a/tests/baselines/reference/expandoFunctionExpressionsWithDynamicNames2.types
+++ b/tests/baselines/reference/expandoFunctionExpressionsWithDynamicNames2.types
@@ -1,0 +1,48 @@
+//// [tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts] ////
+
+=== expandoFunctionExpressionsWithDynamicNames2.ts ===
+const mySymbol = Symbol();
+>mySymbol : unique symbol
+>Symbol() : unique symbol
+>Symbol : SymbolConstructor
+
+interface Foo {
+  (): void;
+  [mySymbol]: true;
+>[mySymbol] : true
+>mySymbol : unique symbol
+>true : true
+}
+const foo: Foo = () => {};
+>foo : Foo
+>() => {} : { (): void; [mySymbol]: true; }
+
+foo[mySymbol] = true;
+>foo[mySymbol] = true : true
+>foo[mySymbol] : true
+>foo : Foo
+>mySymbol : unique symbol
+>true : true
+
+interface Bar {
+  (): void;
+  test: true;
+>test : true
+>true : true
+}
+const t = "test" as const;
+>t : "test"
+>"test" as const : "test"
+>"test" : "test"
+
+const bar: Bar = () => {};
+>bar : Bar
+>() => {} : { (): void; test: true; }
+
+bar[t] = true;
+>bar[t] = true : true
+>bar[t] : true
+>bar : Bar
+>t : "test"
+>true : true
+

--- a/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts
+++ b/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts
@@ -1,0 +1,19 @@
+// @strict: true
+// @lib: esnext
+// @noEmit: true
+
+const mySymbol = Symbol();
+interface Foo {
+  (): void;
+  [mySymbol]: true;
+}
+const foo: Foo = () => {};
+foo[mySymbol] = true;
+
+interface Bar {
+  (): void;
+  test: true;
+}
+const t = "test" as const;
+const bar: Bar = () => {};
+bar[t] = true;


### PR DESCRIPTION
noticed this while rechecking https://github.com/microsoft/TypeScript/issues/29821 (I'm not marking this PR as closing that issue since what was reported there was fixed already fixed by https://github.com/microsoft/TypeScript/pull/54726)