### PR TITLE
Prevent detached diagnostics from running off the end of the file

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1803,7 +1803,7 @@ namespace Parser {
         return sourceFile;
 
         function reportPragmaDiagnostic(pos: number, end: number, diagnostic: DiagnosticMessage) {
-            parseDiagnostics.push(createDetachedDiagnostic(fileName, pos, end, diagnostic));
+            parseDiagnostics.push(createDetachedDiagnostic(fileName, sourceText, pos, end, diagnostic));
         }
     }
 
@@ -2118,7 +2118,7 @@ namespace Parser {
         const lastError = lastOrUndefined(parseDiagnostics);
         let result: DiagnosticWithDetachedLocation | undefined;
         if (!lastError || start !== lastError.start) {
-            result = createDetachedDiagnostic(fileName, start, length, message, ...args);
+            result = createDetachedDiagnostic(fileName, sourceText, start, length, message, ...args);
             parseDiagnostics.push(result);
         }
 
@@ -2470,7 +2470,7 @@ namespace Parser {
         if (lastError) {
             addRelatedInfo(
                 lastError,
-                createDetachedDiagnostic(fileName, openPosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, tokenToString(openKind), tokenToString(closeKind))
+                createDetachedDiagnostic(fileName, sourceText, openPosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, tokenToString(openKind), tokenToString(closeKind))
             );
         }
     }
@@ -4486,7 +4486,7 @@ namespace Parser {
             if (lastError && lastError.code === Diagnostics._0_expected.code) {
                 addRelatedInfo(
                     lastError,
-                    createDetachedDiagnostic(fileName, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, "{", "}")
+                    createDetachedDiagnostic(fileName, sourceText, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, "{", "}")
                 );
             }
         }
@@ -8326,7 +8326,7 @@ namespace Parser {
                 if (lastError && lastError.code === Diagnostics._0_expected.code) {
                     addRelatedInfo(
                         lastError,
-                        createDetachedDiagnostic(fileName, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, "{", "}")
+                        createDetachedDiagnostic(fileName, sourceText, openBracePosition, 1, Diagnostics.The_parser_expected_to_find_a_1_to_match_the_0_token_here, "{", "}")
                     );
                 }
             }
@@ -9429,7 +9429,7 @@ namespace Parser {
                             if (childTypeTag) {
                                 const lastError = parseErrorAtCurrentToken(Diagnostics.A_JSDoc_typedef_comment_may_not_contain_multiple_type_tags);
                                 if (lastError) {
-                                    addRelatedInfo(lastError, createDetachedDiagnostic(fileName, 0, 0, Diagnostics.The_tag_was_first_specified_here));
+                                    addRelatedInfo(lastError, createDetachedDiagnostic(fileName, sourceText, 0, 0, Diagnostics.The_tag_was_first_specified_here));
                                 }
                                 break;
                             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2150,19 +2150,16 @@ export function createDiagnosticForNodeArrayFromMessageChain(sourceFile: SourceF
     return createFileDiagnosticFromMessageChain(sourceFile, start, nodes.end - start, messageChain, relatedInformation);
 }
 
-function assertDiagnosticLocation(file: SourceFile | undefined, start: number, length: number) {
+function assertDiagnosticLocation(sourceText: string, start: number, length: number) {
     Debug.assertGreaterThanOrEqual(start, 0);
     Debug.assertGreaterThanOrEqual(length, 0);
-
-    if (file) {
-        Debug.assertLessThanOrEqual(start, file.text.length);
-        Debug.assertLessThanOrEqual(start + length, file.text.length);
-    }
+    Debug.assertLessThanOrEqual(start, sourceText.length);
+    Debug.assertLessThanOrEqual(start + length, sourceText.length);
 }
 
 /** @internal */
 export function createFileDiagnosticFromMessageChain(file: SourceFile, start: number, length: number, messageChain: DiagnosticMessageChain, relatedInformation?: DiagnosticRelatedInformation[]): DiagnosticWithLocation {
-    assertDiagnosticLocation(file, start, length);
+    assertDiagnosticLocation(file.text, start, length);
     return {
         file,
         start,
@@ -8152,8 +8149,12 @@ export function getLocaleSpecificMessage(message: DiagnosticMessage) {
 }
 
 /** @internal */
-export function createDetachedDiagnostic(fileName: string, start: number, length: number, message: DiagnosticMessage, ...args: DiagnosticArguments): DiagnosticWithDetachedLocation {
-    assertDiagnosticLocation(/*file*/ undefined, start, length);
+export function createDetachedDiagnostic(fileName: string, sourceText: string, start: number, length: number, message: DiagnosticMessage, ...args: DiagnosticArguments): DiagnosticWithDetachedLocation {
+    if ((start + length) > sourceText.length) {
+        length = sourceText.length - start;
+    }
+
+    assertDiagnosticLocation(sourceText, start, length);
     let text = getLocaleSpecificMessage(message);
 
     if (some(args)) {
@@ -8222,7 +8223,7 @@ export function attachFileToDiagnostics(diagnostics: DiagnosticWithDetachedLocat
 
 /** @internal */
 export function createFileDiagnostic(file: SourceFile, start: number, length: number, message: DiagnosticMessage, ...args: DiagnosticArguments): DiagnosticWithLocation {
-    assertDiagnosticLocation(file, start, length);
+    assertDiagnosticLocation(file.text, start, length);
 
     let text = getLocaleSpecificMessage(message);
 

--- a/tests/baselines/reference/parseUnmatchedTypeAssertion.errors.txt
+++ b/tests/baselines/reference/parseUnmatchedTypeAssertion.errors.txt
@@ -1,0 +1,21 @@
+parseUnmatchedTypeAssertion.ts(1,2): error TS1109: Expression expected.
+parseUnmatchedTypeAssertion.ts(1,12): error TS1141: String literal expected.
+parseUnmatchedTypeAssertion.ts(1,12): error TS2304: Cannot find name 'obju2c77'.
+parseUnmatchedTypeAssertion.ts(1,21): error TS1109: Expression expected.
+parseUnmatchedTypeAssertion.ts(2,1): error TS1005: '{' expected.
+
+
+==== parseUnmatchedTypeAssertion.ts (5 errors) ====
+    @<[[import(obju2c77,
+     ~
+!!! error TS1109: Expression expected.
+               ~~~~~~~~
+!!! error TS1141: String literal expected.
+               ~~~~~~~~
+!!! error TS2304: Cannot find name 'obju2c77'.
+                        
+!!! error TS1109: Expression expected.
+    
+    
+!!! error TS1005: '{' expected.
+!!! related TS1007 parseUnmatchedTypeAssertion.ts:2:1: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parseUnmatchedTypeAssertion.js
+++ b/tests/baselines/reference/parseUnmatchedTypeAssertion.js
@@ -1,0 +1,8 @@
+//// [tests/cases/compiler/parseUnmatchedTypeAssertion.ts] ////
+
+//// [parseUnmatchedTypeAssertion.ts]
+@<[[import(obju2c77,
+
+
+//// [parseUnmatchedTypeAssertion.js]
+;

--- a/tests/baselines/reference/parseUnmatchedTypeAssertion.symbols
+++ b/tests/baselines/reference/parseUnmatchedTypeAssertion.symbols
@@ -1,0 +1,6 @@
+//// [tests/cases/compiler/parseUnmatchedTypeAssertion.ts] ////
+
+=== parseUnmatchedTypeAssertion.ts ===
+@<[[import(obju2c77,
+>obju2c77 : Symbol(obju2c77)
+

--- a/tests/baselines/reference/parseUnmatchedTypeAssertion.types
+++ b/tests/baselines/reference/parseUnmatchedTypeAssertion.types
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/parseUnmatchedTypeAssertion.ts] ////
+
+=== parseUnmatchedTypeAssertion.ts ===
+@<[[import(obju2c77,
+> : any
+><[[import(obju2c77, : [[any]]
+
+> : any
+

--- a/tests/cases/compiler/parseUnmatchedTypeAssertion.ts
+++ b/tests/cases/compiler/parseUnmatchedTypeAssertion.ts
@@ -1,0 +1,1 @@
+@<[[import(obju2c77,


### PR DESCRIPTION
Fixes #55296

This is similar to #52450 and #53674; we can create diagnostics with hardcoded range lengths, but if the parse error starts at the end of the file, we'll crash.

I could band-aid this by special casing the one crash, but as you can see in the change, we have quite a few other places which assume it's okay to use a `length=1` diagnostic, when it's possible that it may not work.

So, just set the length to the maximum available (or zero) when this happens.

To make this more obvious, I've restructured things a little so that we check the ranges earlier. The stack trace in #55296 happens late because the diagnostics weren't checked until they were finally attached to the file, after parse was complete. It's possible that I could find a different way to do this that doesn't look so noisy, but I feel like this is more robust.

Realistically, I could just move `createDetachedDiagnostic` into `parser.ts`; it's only used there so that'd avoid some parameters. But, all of its related helpers are still in this utilities file.