### PR TITLE
[experiment] remove a problematic optimization in instantiateSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18803,11 +18803,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function instantiateSymbol(symbol: Symbol, mapper: TypeMapper): Symbol {
         const links = getSymbolLinks(symbol);
-        if (links.type && !couldContainTypeVariables(links.type)) {
-            // If the type of the symbol is already resolved, and if that type could not possibly
-            // be affected by instantiation, simply return the symbol itself.
-            return symbol;
-        }
         if (getCheckFlags(symbol) & CheckFlags.Instantiated) {
             // If symbol being instantiated is itself a instantiation, fetch the original target and combine the
             // type mappers. This ensures that original type identities are properly preserved and that aliases

--- a/tests/cases/fourslash/jsxGenericQuickInfo.tsx
+++ b/tests/cases/fourslash/jsxGenericQuickInfo.tsx
@@ -28,7 +28,7 @@
 
 verify.quickInfoAt("0", "(property) PropsA<number>.renderItem: (item: number) => string");
 verify.quickInfoAt("1", "(parameter) item: number");
-verify.quickInfoAt("2", `(property) PropsA<T>.name: "A"`, 'comments for A');
+verify.quickInfoAt("2", `(property) PropsA<number>.name: "A"`, 'comments for A');
 verify.quickInfoAt("3", "(property) PropsA<number>.renderItem: (item: number) => string");
 verify.quickInfoAt("4", "(parameter) item: number");
-verify.quickInfoAt("5", `(property) PropsA<T>.name: "A"`, 'comments for A');
+verify.quickInfoAt("5", `(property) PropsA<number>.name: "A"`, 'comments for A');


### PR DESCRIPTION
See: https://github.com/microsoft/TypeScript/pull/55030#discussion_r1294988471

This is technically a fix for #50355, though I'm curious whether or not it hurts perf.

Interestingly, to make tests pass, I had to update a fourslash test for hover... but it actually looks like a good change?