### PR TITLE
Don't track private symbol roots in other files during js declaration emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8455,7 +8455,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // Lookup the root symbol of the chain of refs we'll use to access it and serialize it
                         const chain = lookupSymbolChainWorker(sym, context, meaning);
                         if (!(sym.flags & SymbolFlags.Property)) {
-                            includePrivateSymbol(chain[0]);
+                            // Only include referenced privates in the same file. Weird JS aliases may expose privates
+                            // from other files - assume JS transforms will make those available via expected means
+                            const root = chain[0];
+                            const contextFile = getSourceFileOfNode(oldcontext.enclosingDeclaration);
+                            if (some(root.declarations, d => getSourceFileOfNode(d) === contextFile)) {
+                                includePrivateSymbol(root);
+                            }
                         }
                     }
                     else if (oldcontext.tracker.inner?.trackSymbol) {

--- a/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.js
+++ b/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.js
@@ -1,0 +1,62 @@
+//// [tests/cases/compiler/jsDeclarationEmitDoesNotRenameImport.ts] ////
+
+//// [Test.js]
+/** @module test/Test */
+class Test {}
+export default Test;
+//// [Test.js]
+/** @module Test */
+class Test {}
+export default Test;
+//// [index.js]
+import Test from './test/Test.js'
+
+/**
+ * @typedef {Object} Options
+ * @property {typeof import("./Test.js").default} [test]
+ */
+
+class X extends Test {
+    /**
+     * @param {Options} options
+     */
+    constructor(options) {
+        super();
+        if (options.test) {
+            this.test = new options.test();
+        }
+    }
+}
+
+export default X;
+
+
+
+
+//// [Test.d.ts]
+export default Test;
+/** @module test/Test */
+declare class Test {
+}
+//// [Test.d.ts]
+export default Test;
+/** @module Test */
+declare class Test {
+}
+//// [index.d.ts]
+export default X;
+export type Options = {
+    test?: typeof import("./Test.js").default | undefined;
+};
+/**
+ * @typedef {Object} Options
+ * @property {typeof import("./Test.js").default} [test]
+ */
+declare class X extends Test {
+    /**
+     * @param {Options} options
+     */
+    constructor(options: Options);
+    test: import("./Test.js").default | undefined;
+}
+import Test from './test/Test.js';

--- a/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.symbols
+++ b/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.symbols
@@ -1,0 +1,59 @@
+//// [tests/cases/compiler/jsDeclarationEmitDoesNotRenameImport.ts] ////
+
+=== test/Test.js ===
+/** @module test/Test */
+class Test {}
+>Test : Symbol(Test, Decl(Test.js, 0, 0))
+
+export default Test;
+>Test : Symbol(Test, Decl(Test.js, 0, 0))
+
+=== Test.js ===
+/** @module Test */
+class Test {}
+>Test : Symbol(Test, Decl(Test.js, 0, 0))
+
+export default Test;
+>Test : Symbol(Test, Decl(Test.js, 0, 0))
+
+=== index.js ===
+import Test from './test/Test.js'
+>Test : Symbol(Test, Decl(index.js, 0, 6))
+
+/**
+ * @typedef {Object} Options
+ * @property {typeof import("./Test.js").default} [test]
+ */
+
+class X extends Test {
+>X : Symbol(X, Decl(index.js, 0, 33))
+>Test : Symbol(Test, Decl(index.js, 0, 6))
+
+    /**
+     * @param {Options} options
+     */
+    constructor(options) {
+>options : Symbol(options, Decl(index.js, 11, 16))
+
+        super();
+>super : Symbol(Test, Decl(Test.js, 0, 0))
+
+        if (options.test) {
+>options.test : Symbol(test, Decl(index.js, 4, 3))
+>options : Symbol(options, Decl(index.js, 11, 16))
+>test : Symbol(test, Decl(index.js, 4, 3))
+
+            this.test = new options.test();
+>this.test : Symbol(X.test, Decl(index.js, 13, 27))
+>this : Symbol(X, Decl(index.js, 0, 33))
+>test : Symbol(X.test, Decl(index.js, 13, 27))
+>options.test : Symbol(test, Decl(index.js, 4, 3))
+>options : Symbol(options, Decl(index.js, 11, 16))
+>test : Symbol(test, Decl(index.js, 4, 3))
+        }
+    }
+}
+
+export default X;
+>X : Symbol(X, Decl(index.js, 0, 33))
+

--- a/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.types
+++ b/tests/baselines/reference/jsDeclarationEmitDoesNotRenameImport.types
@@ -1,0 +1,62 @@
+//// [tests/cases/compiler/jsDeclarationEmitDoesNotRenameImport.ts] ////
+
+=== test/Test.js ===
+/** @module test/Test */
+class Test {}
+>Test : Test
+
+export default Test;
+>Test : Test
+
+=== Test.js ===
+/** @module Test */
+class Test {}
+>Test : Test
+
+export default Test;
+>Test : Test
+
+=== index.js ===
+import Test from './test/Test.js'
+>Test : typeof Test
+
+/**
+ * @typedef {Object} Options
+ * @property {typeof import("./Test.js").default} [test]
+ */
+
+class X extends Test {
+>X : X
+>Test : Test
+
+    /**
+     * @param {Options} options
+     */
+    constructor(options) {
+>options : Options
+
+        super();
+>super() : void
+>super : typeof Test
+
+        if (options.test) {
+>options.test : typeof import("Test").default | undefined
+>options : Options
+>test : typeof import("Test").default | undefined
+
+            this.test = new options.test();
+>this.test = new options.test() : import("Test").default
+>this.test : any
+>this : this
+>test : any
+>new options.test() : import("Test").default
+>options.test : typeof import("Test").default
+>options : Options
+>test : typeof import("Test").default
+        }
+    }
+}
+
+export default X;
+>X : X
+

--- a/tests/cases/compiler/jsDeclarationEmitDoesNotRenameImport.ts
+++ b/tests/cases/compiler/jsDeclarationEmitDoesNotRenameImport.ts
@@ -1,0 +1,34 @@
+// @allowJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @strict: false
+// @strictNullChecks: true
+// @filename: test/Test.js
+/** @module test/Test */
+class Test {}
+export default Test;
+// @filename: Test.js
+/** @module Test */
+class Test {}
+export default Test;
+// @filename: index.js
+import Test from './test/Test.js'
+
+/**
+ * @typedef {Object} Options
+ * @property {typeof import("./Test.js").default} [test]
+ */
+
+class X extends Test {
+    /**
+     * @param {Options} options
+     */
+    constructor(options) {
+        super();
+        if (options.test) {
+            this.test = new options.test();
+        }
+    }
+}
+
+export default X;


### PR DESCRIPTION
Fixes #55375

The linked issue only repro'd with `strict: false` and `strictNullChecks: true` because without those set, we'd reuse input type nodes much more, and not reprint the union type for the field in the `Option` type. When we traverse that field, we'd see the `Test` member in another module, and mistakenly try to add it as something to print in the current file. Now, we have guards against actually doing that already, but traversing it at all caused us to reserve the `Test` name for that symbol in the index file, and thus mangle the original `Test` name for the other symbol when we reprinted the import in the file later.
