### PR TITLE
CodeMapper support

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -789,6 +789,8 @@ export class SessionClient implements LanguageService {
         });
     }
 
+    mapCode = notImplemented;
+
     private createFileLocationOrRangeRequestArgs(positionOrRange: number | TextRange, fileName: string): protocol.FileLocationOrRangeRequestArgs {
         return typeof positionOrRange === "number"
             ? this.createFileLocationRequestArgs(fileName, positionOrRange)

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -4515,16 +4515,10 @@ export class TestState {
         ranges: Range[],
         changes: string[] = [],
     ): void {
-        let fileName: string | undefined;
-        const focusLocations = ranges.map(({ fileName: fn, pos, end }) => {
-            if (!fileName) {
-                fileName = fn;
-            }
+        const fileName = this.activeFile.fileName;
+        const focusLocations = ranges.map(({ pos, end }) => {
             return [{ start: pos, length: end - pos }];
         });
-        if (!fileName) {
-            throw new Error("No ranges passed in, or something went wrong.");
-        }
         let before = this.getFileContent(fileName);
         focusLocations.sort((a, b) => a[0].start - b[0].start);
         for (const subLoc of focusLocations) {
@@ -4557,7 +4551,7 @@ export class TestState {
 // === ORIGINAL ===
 ${before}
 // === INCOMING CHANGES ===
-${changes}
+${changes.join("\n// ---\n")}
 // === MAPPED ===
 ${after}`;
         this.baseline("mapCode", baseline, ".mapCode.ts");

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -4512,13 +4512,15 @@ export class TestState {
     }
 
     public baselineMapCode(
-        ranges: Range[],
+        ranges: Range[][],
         changes: string[] = [],
     ): void {
         const fileName = this.activeFile.fileName;
-        const focusLocations = ranges.map(({ pos, end }) => {
-            return [{ start: pos, length: end - pos }];
-        });
+        const focusLocations = ranges.map(r =>
+            r.map(({ pos, end }) => {
+                return { start: pos, length: end - pos };
+            })
+        );
         let before = this.getFileContent(fileName);
         const edits = this.languageService.mapCode(
             fileName,
@@ -4529,6 +4531,9 @@ export class TestState {
             {},
         );
         this.applyChanges(edits);
+        focusLocations.forEach(r => {
+            r.sort((a, b) => a.start - b.start);
+        })
         focusLocations.sort((a, b) => a[0].start - b[0].start);
         for (const subLoc of focusLocations) {
             for (const { start, length } of subLoc) {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -4520,6 +4520,15 @@ export class TestState {
             return [{ start: pos, length: end - pos }];
         });
         let before = this.getFileContent(fileName);
+        const edits = this.languageService.mapCode(
+            fileName,
+            // We trim the leading whitespace stuff just so our test cases can be more readable.
+            changes,
+            focusLocations,
+            this.formatCodeSettings,
+            {},
+        );
+        this.applyChanges(edits);
         focusLocations.sort((a, b) => a[0].start - b[0].start);
         for (const subLoc of focusLocations) {
             for (const { start, length } of subLoc) {
@@ -4537,15 +4546,6 @@ export class TestState {
                 before = before.slice(0, start + offset) + "[|" + before.slice(start + offset, start + offset + length) + "|]" + before.slice(start + offset + length);
             }
         }
-        const edits = this.languageService.mapCode(
-            fileName,
-            // We trim the leading whitespace stuff just so our test cases can be more readable.
-            changes,
-            focusLocations,
-            this.formatCodeSettings,
-            {},
-        );
-        this.applyChanges(edits);
         const after = this.getFileContent(fileName);
         const baseline = `
 // === ORIGINAL ===

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -4510,6 +4510,32 @@ export class TestState {
 
         this.verifyCurrentFileContent(newFileContent);
     }
+
+    public baselineMapCode(
+        { fileName, pos }: Range,
+        changesFilename = "/incomingChanges",
+    ): void {
+        const changes = this.getFileContent(changesFilename);
+        const beforeContents = this.getFileContent(fileName);
+        const before = beforeContents.slice(0, pos) + "[||]" + beforeContents.slice(pos);
+        const edits = this.languageService.mapCode(
+            fileName,
+            [changes],
+            [[{ start: pos, length: 1 }]],
+            this.formatCodeSettings,
+            {},
+        );
+        this.applyChanges(edits);
+        const after = this.getFileContent(fileName);
+        const baseline = `
+// === ORIGINAL ===
+${before}
+// === INCOMING CHANGES ===
+${changes}
+// === MAPPED ===
+${after}`;
+        this.baseline("mapCode", baseline, ".mapCode.ts");
+    }
 }
 
 function updateTextRangeForTextChanges({ pos, end }: ts.TextRange, textChanges: readonly ts.TextChange[]): ts.TextRange {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -4513,9 +4513,8 @@ export class TestState {
 
     public baselineMapCode(
         ranges: Range[],
-        changesFilename: string,
+        changes: string[] = [],
     ): void {
-        const changes = this.getFileContent(changesFilename);
         let fileName: string | undefined;
         const focusLocations = ranges.map(({ fileName: fn, pos, end }) => {
             if (!fileName) {
@@ -4546,7 +4545,8 @@ export class TestState {
         }
         const edits = this.languageService.mapCode(
             fileName,
-            [changes],
+            // We trim the leading whitespace stuff just so our test cases can be more readable.
+            changes,
             focusLocations,
             this.formatCodeSettings,
             {},

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -4513,7 +4513,7 @@ export class TestState {
 
     public baselineMapCode(
         { fileName, pos }: Range,
-        changesFilename = "/incomingChanges",
+        changesFilename: string,
     ): void {
         const changes = this.getFileContent(changesFilename);
         const beforeContents = this.getFileContent(fileName);

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -4533,7 +4533,7 @@ export class TestState {
         this.applyChanges(edits);
         focusLocations.forEach(r => {
             r.sort((a, b) => a.start - b.start);
-        })
+        });
         focusLocations.sort((a, b) => a[0].start - b[0].start);
         for (const subLoc of focusLocations) {
             for (const { start, length } of subLoc) {

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -240,7 +240,7 @@ export class VerifyNegatable {
         this.state.uncommentSelection(newFileContent);
     }
 
-    public baselineMapCode(ranges: FourSlash.Range[], changes: string[] = []): void {
+    public baselineMapCode(ranges: FourSlash.Range[][], changes: string[] = []): void {
         this.state.baselineMapCode(ranges, changes);
     }
 }

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -240,8 +240,8 @@ export class VerifyNegatable {
         this.state.uncommentSelection(newFileContent);
     }
 
-    public baselineMapCode(range: FourSlash.Range, changesFilename: string): void {
-        this.state.baselineMapCode(range, changesFilename);
+    public baselineMapCode(ranges: FourSlash.Range[], changesFilename: string): void {
+        this.state.baselineMapCode(ranges, changesFilename);
     }
 }
 

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -240,7 +240,7 @@ export class VerifyNegatable {
         this.state.uncommentSelection(newFileContent);
     }
 
-    public baselineMapCode(range: FourSlash.Range, changesFilename?: string): void {
+    public baselineMapCode(range: FourSlash.Range, changesFilename: string): void {
         this.state.baselineMapCode(range, changesFilename);
     }
 }

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -240,8 +240,8 @@ export class VerifyNegatable {
         this.state.uncommentSelection(newFileContent);
     }
 
-    public baselineMapCode(ranges: FourSlash.Range[], changesFilename: string): void {
-        this.state.baselineMapCode(ranges, changesFilename);
+    public baselineMapCode(ranges: FourSlash.Range[], changes: string[] = []): void {
+        this.state.baselineMapCode(ranges, changes);
     }
 }
 

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -239,6 +239,10 @@ export class VerifyNegatable {
     public uncommentSelection(newFileContent: string) {
         this.state.uncommentSelection(newFileContent);
     }
+
+    public baselineMapCode(range: FourSlash.Range, changesFilename?: string): void {
+        this.state.baselineMapCode(range, changesFilename);
+    }
 }
 
 export class Verify extends VerifyNegatable {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -200,6 +200,7 @@ export const enum CommandTypes {
     ProvideCallHierarchyOutgoingCalls = "provideCallHierarchyOutgoingCalls",
     ProvideInlayHints = "provideInlayHints",
     WatchChange = "watchChange",
+    MapCode = "mapCode",
 }
 
 /**
@@ -2340,6 +2341,38 @@ export interface InlayHintItemDisplayPart {
 
 export interface InlayHintsResponse extends Response {
     body?: InlayHintItem[];
+}
+
+export interface MapCodeRequestArgs  extends FileRequestArgs {
+    /**
+     * The files and changes to try and apply/map.
+     */
+    mapping: MapCodeRequestDocumentMapping;
+}
+
+export interface MapCodeRequestDocumentMapping {
+    /**
+     * The specific code to map/insert/replace in the file.
+     */
+    contents: string[];
+
+    /**
+     * Areas of "focus" to inform the code mapper with. For example, cursor
+     * location, current selection, viewport, etc. Nested arrays denote
+     * priority: toplevel arrays are more important than inner arrays, and
+     * inner array priorities are based on items within that array. Items
+     * earlier in the arrays have higher priority.
+     */
+    focusLocations?: TextSpan[][];
+}
+
+export interface MapCodeRequest extends FileRequest {
+    command: CommandTypes.MapCode;
+    arguments: MapCodeRequestArgs;
+}
+
+export interface MapCodeResponse extends Response {
+    body: readonly FileCodeEdits[];
 }
 
 /**

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2343,7 +2343,7 @@ export interface InlayHintsResponse extends Response {
     body?: InlayHintItem[];
 }
 
-export interface MapCodeRequestArgs  extends FileRequestArgs {
+export interface MapCodeRequestArgs extends FileRequestArgs {
     /**
      * The files and changes to try and apply/map.
      */

--- a/src/services/_namespaces/ts.MapCode.ts
+++ b/src/services/_namespaces/ts.MapCode.ts
@@ -1,0 +1,3 @@
+/* Generated file to emulate the ts.MapCode namespace. */
+
+export * from "../mapCode.js";

--- a/src/services/_namespaces/ts.ts
+++ b/src/services/_namespaces/ts.ts
@@ -33,6 +33,8 @@ export { GoToDefinition };
 import * as InlayHints from "./ts.InlayHints.js";
 export { InlayHints };
 import * as JsDoc from "./ts.JsDoc.js";
+import * as MapCode from "./ts.MapCode.js";
+export { MapCode };
 export { JsDoc };
 import * as NavigateTo from "./ts.NavigateTo.js";
 export { NavigateTo };

--- a/src/services/mapCode.ts
+++ b/src/services/mapCode.ts
@@ -3,7 +3,6 @@ import {
     ClassElement,
     ClassLikeDeclaration,
     createSourceFile,
-    emptyArray,
     FileTextChanges,
     find,
     findAncestor,

--- a/src/services/mapCode.ts
+++ b/src/services/mapCode.ts
@@ -1,0 +1,330 @@
+import {
+    Block,
+    ClassElement,
+    ClassLikeDeclaration,
+    createSourceFile,
+    emptyArray,
+    FileTextChanges,
+    find,
+    findAncestor,
+    findLast,
+    flatten,
+    forEach,
+    formatting,
+    getTokenAtPosition,
+    isBlock,
+    isClassElement,
+    isClassLike,
+    isForInOrOfStatement,
+    isForStatement,
+    isIfStatement,
+    isInterfaceDeclaration,
+    isLabeledStatement,
+    isNamedDeclaration,
+    isSourceFile,
+    isTypeElement,
+    isWhileStatement,
+    LanguageServiceHost,
+    Mutable,
+    Node,
+    NodeArray,
+    or,
+    ScriptTarget,
+    some,
+    SourceFile,
+    Statement,
+    SyntaxKind,
+    textChanges,
+    TextSpan,
+    TypeElement,
+    UserPreferences,
+} from "./_namespaces/ts";
+import { ChangeTracker } from "./textChanges.js";
+
+/** @internal */
+export function mapCode(
+    sourceFile: SourceFile,
+    contents: string[],
+    focusLocations: TextSpan[][] | undefined,
+    host: LanguageServiceHost,
+    formatContext: formatting.FormatContext,
+    preferences: UserPreferences,
+): FileTextChanges[] {
+    try {
+        return textChanges.ChangeTracker.with(
+            { host, formatContext, preferences },
+            changeTracker => {
+                const parsed = contents.map(parse);
+                const flattenedLocations = focusLocations && flatten(focusLocations);
+                for (const nodes of parsed) {
+                    placeNodeGroup(
+                        sourceFile,
+                        changeTracker,
+                        nodes,
+                        flattenedLocations,
+                    );
+                }
+            },
+        );
+    }
+    catch (e) {
+        host.error?.(`mapCode: ${e}`);
+        return emptyArray;
+    }
+}
+
+/**
+ * Tries to parse something into either "top-level" statements, or into blocks
+ * of class-context definitions.
+ */
+function parse(content: string): NodeArray<Node> {
+    // We're going to speculatively parse different kinds of contexts to see
+    // which one makes the most sense, and grab the NodeArray from there. Do
+    // this as lazily as possible.
+    const nodeKinds = [
+        {
+            parse: () =>
+                createSourceFile(
+                    "__mapcode_content_nodes.ts",
+                    content,
+                    ScriptTarget.Latest,
+                    /*setParentNodes*/ true,
+                ),
+            body: (sf: SourceFile) => sf.statements,
+        },
+        {
+            parse: () =>
+                createSourceFile(
+                    "__mapcode_class_content_nodes.ts",
+                    `class __class {\n${content}\n}`,
+                    ScriptTarget.Latest,
+                    /*setParentNodes*/ true,
+                ),
+            body: (cw: SourceFile) => (cw.statements[0] as ClassLikeDeclaration).members,
+        },
+    ];
+
+    const parsedNodes = [];
+    for (const { parse, body } of nodeKinds) {
+        const sourceFile = parse();
+        const bod = body(sourceFile);
+        if (bod.length && sourceFile.parseDiagnostics.length === 0) {
+            // If we run into a case with no parse errors, this is likely the right kind.
+            return bod;
+        }
+        // We only want to keep the ones that have some kind of body.
+        else if (bod.length) {
+            // Otherwise, we'll need to look at others.
+            parsedNodes.push({ sourceFile, body: bod });
+        }
+    }
+    // Heuristic: fewer errors = more likely to be the right kind.
+    const { body } = parsedNodes.sort(
+        (a, b) =>
+            a.sourceFile.parseDiagnostics.length -
+            b.sourceFile.parseDiagnostics.length,
+    )[0];
+    return body;
+}
+
+function placeNodeGroup(
+    originalFile: SourceFile,
+    changeTracker: ChangeTracker,
+    changes: NodeArray<Node>,
+    focusLocations?: TextSpan[],
+) {
+    if (isClassElement(changes[0]) || isTypeElement(changes[0])) {
+        placeClassNodeGroup(
+            originalFile,
+            changeTracker,
+            changes as NodeArray<ClassElement>,
+            focusLocations,
+        );
+    }
+    else {
+        placeStatements(
+            originalFile,
+            changeTracker,
+            changes as NodeArray<Statement>,
+            focusLocations,
+        );
+    }
+}
+
+function placeClassNodeGroup(
+    originalFile: SourceFile,
+    changeTracker: ChangeTracker,
+    changes: NodeArray<ClassElement> | NodeArray<TypeElement>,
+    focusLocations?: TextSpan[],
+) {
+    let classOrInterface;
+    if (!focusLocations || !focusLocations.length) {
+        classOrInterface = find(originalFile.statements, or(isClassLike, isInterfaceDeclaration));
+    }
+    else {
+        classOrInterface = forEach(focusLocations, location =>
+            findAncestor(
+                getTokenAtPosition(originalFile, location.start),
+                or(isClassLike, isInterfaceDeclaration),
+            ));
+    }
+
+    if (!classOrInterface) {
+        throw new Error(
+            "Failed to find a class or interface to map the given code into.",
+        );
+    }
+
+    const firstMatch = classOrInterface.members.find(member => changes.some(change => matchNode(change, member)));
+    if (firstMatch) {
+        // can't be undefined here, since we know we have at least one match.
+        const lastMatch = findLast(
+            classOrInterface.members as NodeArray<ClassElement | TypeElement>,
+            member => changes.some(change => matchNode(change, member)),
+        )!;
+
+        forEach(changes, wipeNode);
+        changeTracker.replaceNodeRangeWithNodes(
+            originalFile,
+            firstMatch,
+            lastMatch,
+            changes,
+        );
+        return;
+    }
+
+    forEach(changes, wipeNode);
+    changeTracker.insertNodesAfter(
+        originalFile,
+        classOrInterface.members[classOrInterface.members.length - 1],
+        changes,
+    );
+}
+
+function placeStatements(
+    originalFile: SourceFile,
+    changeTracker: ChangeTracker,
+    changes: NodeArray<Statement>,
+    focusLocations?: TextSpan[],
+) {
+    if (!focusLocations?.length) {
+        changeTracker.insertNodesAtEndOfFile(
+            originalFile,
+            changes,
+            /*blankLineBetween*/ false,
+        );
+        return;
+    }
+
+    for (const location of focusLocations) {
+        const scope = findAncestor(
+            getTokenAtPosition(originalFile, location.start),
+            (block): block is Block | SourceFile =>
+                or(isBlock, isSourceFile)(block) &&
+                some(block.statements, origStmt => changes.some(newStmt => matchNode(newStmt, origStmt))),
+        );
+        if (scope) {
+            const start = scope.statements.find(stmt => changes.some(node => matchNode(node, stmt)));
+            if (start) {
+                // Can't be undefined here, since we know we have at least one match.
+                const end = findLast(scope.statements, stmt => changes.some(node => matchNode(node, stmt)))!;
+                forEach(changes, wipeNode);
+                changeTracker.replaceNodeRangeWithNodes(
+                    originalFile,
+                    start,
+                    end,
+                    changes,
+                );
+                return;
+            }
+        }
+    }
+
+    let scopeStatements: NodeArray<Statement> = originalFile.statements;
+    for (const location of focusLocations) {
+        const block = findAncestor(
+            getTokenAtPosition(originalFile, location.start),
+            isBlock,
+        );
+        if (block) {
+            scopeStatements = block.statements;
+            break;
+        }
+    }
+    forEach(changes, wipeNode);
+    changeTracker.insertNodesAfter(
+        originalFile,
+        scopeStatements[scopeStatements.length - 1],
+        changes,
+    );
+}
+
+function matchNode(a: Node, b: Node): boolean {
+    if (a.kind !== b.kind) {
+        return false;
+    }
+
+    if (a.kind === SyntaxKind.Constructor) {
+        return a.kind === b.kind;
+    }
+
+    if (isNamedDeclaration(a) && isNamedDeclaration(b)) {
+        return a.name.getText() === b.name.getText();
+    }
+
+    if (isIfStatement(a) && isIfStatement(b)) {
+        return (
+            a.expression.getText() === b.expression.getText()
+        );
+    }
+
+    if (isWhileStatement(a) && isWhileStatement(b)) {
+        return (
+            a.expression.getText() ===
+                b.expression.getText()
+        );
+    }
+
+    if (isForStatement(a) && isForStatement(b)) {
+        return (
+            a.initializer?.getText() ===
+                b.initializer?.getText() &&
+            a.incrementor?.getText() ===
+                b.incrementor?.getText() &&
+            a.condition?.getText() === b.condition?.getText()
+        );
+    }
+
+    if (isForInOrOfStatement(a) && isForInOrOfStatement(b)) {
+        return (
+            a.expression.getText() ===
+                b.expression.getText() &&
+            a.initializer.getText() ===
+                b.initializer.getText()
+        );
+    }
+
+    if (isLabeledStatement(a) && isLabeledStatement(b)) {
+        // If we're actually labeling/naming something, we should be a bit
+        // more lenient about when we match, so we don't care what the actual
+        // related statement is: we just replace.
+        return a.label.getText() === b.label.getText();
+    }
+
+    if (a.getText() === b.getText()) {
+        return true;
+    }
+
+    return false;
+}
+
+function wipeNode(node: Mutable<Node>) {
+    resetNodePositions(node);
+    node.parent = undefined!;
+}
+
+function resetNodePositions(node: Mutable<Node>) {
+    node.pos = -1;
+    node.end = -1;
+    node.forEachChild(resetNodePositions);
+}

--- a/src/services/mapCode.ts
+++ b/src/services/mapCode.ts
@@ -38,7 +38,7 @@ import {
     TextSpan,
     TypeElement,
     UserPreferences,
-} from "./_namespaces/ts";
+} from "./_namespaces/ts.js";
 import { ChangeTracker } from "./textChanges.js";
 
 /** @internal */

--- a/src/services/mapCode.ts
+++ b/src/services/mapCode.ts
@@ -50,27 +50,21 @@ export function mapCode(
     formatContext: formatting.FormatContext,
     preferences: UserPreferences,
 ): FileTextChanges[] {
-    try {
-        return textChanges.ChangeTracker.with(
-            { host, formatContext, preferences },
-            changeTracker => {
-                const parsed = contents.map(parse);
-                const flattenedLocations = focusLocations && flatten(focusLocations);
-                for (const nodes of parsed) {
-                    placeNodeGroup(
-                        sourceFile,
-                        changeTracker,
-                        nodes,
-                        flattenedLocations,
-                    );
-                }
-            },
-        );
-    }
-    catch (e) {
-        host.error?.(`mapCode: ${e}`);
-        return emptyArray;
-    }
+    return textChanges.ChangeTracker.with(
+        { host, formatContext, preferences },
+        changeTracker => {
+            const parsed = contents.map(parse);
+            const flattenedLocations = focusLocations && flatten(focusLocations);
+            for (const nodes of parsed) {
+                placeNodeGroup(
+                    sourceFile,
+                    changeTracker,
+                    nodes,
+                    flattenedLocations,
+                );
+            }
+        },
+    );
 }
 
 /**

--- a/src/services/mapCode.ts
+++ b/src/services/mapCode.ts
@@ -28,7 +28,6 @@ import {
     Node,
     NodeArray,
     or,
-    ScriptTarget,
     some,
     SourceFile,
     Statement,

--- a/src/services/mapCode.ts
+++ b/src/services/mapCode.ts
@@ -52,7 +52,7 @@ export function mapCode(
     return textChanges.ChangeTracker.with(
         { host, formatContext, preferences },
         changeTracker => {
-            const parsed = contents.map(parse);
+            const parsed = contents.map(c => parse(sourceFile, c));
             const flattenedLocations = focusLocations && flatten(focusLocations);
             for (const nodes of parsed) {
                 placeNodeGroup(
@@ -70,7 +70,7 @@ export function mapCode(
  * Tries to parse something into either "top-level" statements, or into blocks
  * of class-context definitions.
  */
-function parse(content: string): NodeArray<Node> {
+function parse(sourceFile: SourceFile, content: string): NodeArray<Node> {
     // We're going to speculatively parse different kinds of contexts to see
     // which one makes the most sense, and grab the NodeArray from there. Do
     // this as lazily as possible.
@@ -80,8 +80,9 @@ function parse(content: string): NodeArray<Node> {
                 createSourceFile(
                     "__mapcode_content_nodes.ts",
                     content,
-                    ScriptTarget.Latest,
+                    sourceFile.languageVersion,
                     /*setParentNodes*/ true,
+                    sourceFile.scriptKind,
                 ),
             body: (sf: SourceFile) => sf.statements,
         },
@@ -90,8 +91,9 @@ function parse(content: string): NodeArray<Node> {
                 createSourceFile(
                     "__mapcode_class_content_nodes.ts",
                     `class __class {\n${content}\n}`,
-                    ScriptTarget.Latest,
+                    sourceFile.languageVersion,
                     /*setParentNodes*/ true,
+                    sourceFile.scriptKind,
                 ),
             body: (cw: SourceFile) => (cw.statements[0] as ClassLikeDeclaration).members,
         },

--- a/src/services/mapCode.ts
+++ b/src/services/mapCode.ts
@@ -170,9 +170,8 @@ function placeClassNodeGroup(
     }
 
     if (!classOrInterface) {
-        throw new Error(
-            "Failed to find a class or interface to map the given code into.",
-        );
+        // No class? don't insert.
+        return;
     }
 
     const firstMatch = classOrInterface.members.find(member => changes.some(change => matchNode(change, member)));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -211,6 +211,7 @@ import {
     LinkedEditingInfo,
     LiteralType,
     map,
+    MapCode,
     mapDefined,
     MapLike,
     mapOneOrMany,
@@ -3165,6 +3166,17 @@ export function createLanguageService(
         return InlayHints.provideInlayHints(getInlayHintsContext(sourceFile, span, preferences));
     }
 
+    function mapCode(sourceFile: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences = emptyOptions): FileTextChanges[] {
+        return MapCode.mapCode(
+            syntaxTreeCache.getCurrentSourceFile(sourceFile),
+            contents,
+            focusLocations,
+            host,
+            formatting.getFormatContext(formatOptions, host),
+            preferences,
+        );
+    }
+
     const ls: LanguageService = {
         dispose,
         cleanupSemanticCache,
@@ -3236,6 +3248,7 @@ export function createLanguageService(
         provideInlayHints,
         getSupportedCodeFixes,
         getPasteEdits,
+        mapCode,
     };
 
     switch (languageServiceMode) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3166,7 +3166,7 @@ export function createLanguageService(
         return InlayHints.provideInlayHints(getInlayHintsContext(sourceFile, span, preferences));
     }
 
-    function mapCode(sourceFile: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences = emptyOptions): FileTextChanges[] {
+    function mapCode(sourceFile: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences): FileTextChanges[] {
         return MapCode.mapCode(
             syntaxTreeCache.getCurrentSourceFile(sourceFile),
             contents,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -683,6 +683,8 @@ export interface LanguageService {
 
     getSupportedCodeFixes(fileName?: string): readonly string[];
 
+ /** @internal */ mapCode(fileName: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences, updates?: FileTextChanges[]): readonly FileTextChanges[];
+
     dispose(): void;
     getPasteEdits(
         args: PasteEditsArgs,
@@ -1586,6 +1588,13 @@ export interface OutliningSpan {
      * Classification of the contents of the span
      */
     kind: OutliningSpanKind;
+}
+
+/** @internal */
+export interface MapCodeDocumentMapping {
+    fileName: string;
+    focusLocations?: TextSpan[][];
+    contents: string[];
 }
 
 export const enum OutliningSpanKind {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1590,13 +1590,6 @@ export interface OutliningSpan {
     kind: OutliningSpanKind;
 }
 
-/** @internal */
-export interface MapCodeDocumentMapping {
-    fileName: string;
-    focusLocations?: TextSpan[][];
-    contents: string[];
-}
-
 export const enum OutliningSpanKind {
     /** Single or multi-line comments */
     Comment = "comment",

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -683,7 +683,7 @@ export interface LanguageService {
 
     getSupportedCodeFixes(fileName?: string): readonly string[];
 
- /** @internal */ mapCode(fileName: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences, updates?: FileTextChanges[]): readonly FileTextChanges[];
+    /** @internal */ mapCode(fileName: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences, updates?: FileTextChanges[]): readonly FileTextChanges[];
 
     dispose(): void;
     getPasteEdits(

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -683,7 +683,7 @@ export interface LanguageService {
 
     getSupportedCodeFixes(fileName?: string): readonly string[];
 
-    /** @internal */ mapCode(fileName: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences, updates?: FileTextChanges[]): readonly FileTextChanges[];
+    /** @internal */ mapCode(fileName: string, contents: string[], focusLocations: TextSpan[][] | undefined, formatOptions: FormatCodeSettings, preferences: UserPreferences): readonly FileTextChanges[];
 
     dispose(): void;
     getPasteEdits(

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -121,6 +121,7 @@ declare namespace ts {
                 ProvideCallHierarchyOutgoingCalls = "provideCallHierarchyOutgoingCalls",
                 ProvideInlayHints = "provideInlayHints",
                 WatchChange = "watchChange",
+                MapCode = "mapCode",
             }
             /**
              * A TypeScript Server message
@@ -1768,6 +1769,46 @@ declare namespace ts {
             }
             export interface InlayHintsResponse extends Response {
                 body?: InlayHintItem[];
+            }
+            export interface MapCodeRequestArgs {
+                /**
+                 * The files and changes to try and apply/map.
+                 */
+                mappings: MapCodeRequestDocumentMapping[];
+                /**
+                 * Edits to apply before performing the mapping.
+                 */
+                updates?: FileCodeEdits[];
+            }
+            export interface MapCodeRequestDocumentMapping {
+                /**
+                 * The file for the request (absolute pathname required). `undefined`
+                 * if specific file is unknown.
+                 */
+                file?: string;
+                /**
+                 * Optional name of project that contains file
+                 */
+                projectFileName?: string;
+                /**
+                 * The specific code to map/insert/replace in the file.
+                 */
+                contents: string[];
+                /**
+                 * Areas of "focus" to inform the code mapper with. For example, cursor
+                 * location, current selection, viewport, etc. Nested arrays denote
+                 * priority: toplevel arrays are more important than inner arrays, and
+                 * inner array priorities are based on items within that array. Items
+                 * earlier in the arrays have higher priority.
+                 */
+                focusLocations?: FileSpan[][];
+            }
+            export interface MapCodeRequest extends Request {
+                command: CommandTypes.MapCode;
+                arguments: MapCodeRequestArgs;
+            }
+            export interface MapCodeResponse extends Response {
+                body: FileCodeEdits[];
             }
             /**
              * Synchronous request for semantic diagnostics of one file.
@@ -3469,6 +3510,7 @@ declare namespace ts {
             private getLinkedEditingRange;
             private getDocumentHighlights;
             private provideInlayHints;
+            private mapCode;
             private setCompilerOptionsForInferredProjects;
             private getProjectInfo;
             private getProjectInfoWorker;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1770,26 +1770,13 @@ declare namespace ts {
             export interface InlayHintsResponse extends Response {
                 body?: InlayHintItem[];
             }
-            export interface MapCodeRequestArgs {
+            export interface MapCodeRequestArgs extends FileRequestArgs {
                 /**
                  * The files and changes to try and apply/map.
                  */
-                mappings: MapCodeRequestDocumentMapping[];
-                /**
-                 * Edits to apply before performing the mapping.
-                 */
-                updates?: FileCodeEdits[];
+                mapping: MapCodeRequestDocumentMapping;
             }
             export interface MapCodeRequestDocumentMapping {
-                /**
-                 * The file for the request (absolute pathname required). `undefined`
-                 * if specific file is unknown.
-                 */
-                file?: string;
-                /**
-                 * Optional name of project that contains file
-                 */
-                projectFileName?: string;
                 /**
                  * The specific code to map/insert/replace in the file.
                  */
@@ -1801,14 +1788,14 @@ declare namespace ts {
                  * inner array priorities are based on items within that array. Items
                  * earlier in the arrays have higher priority.
                  */
-                focusLocations?: FileSpan[][];
+                focusLocations?: TextSpan[][];
             }
-            export interface MapCodeRequest extends Request {
+            export interface MapCodeRequest extends FileRequest {
                 command: CommandTypes.MapCode;
                 arguments: MapCodeRequestArgs;
             }
             export interface MapCodeResponse extends Response {
-                body: FileCodeEdits[];
+                body: readonly FileCodeEdits[];
             }
             /**
              * Synchronous request for semantic diagnostics of one file.

--- a/tests/baselines/reference/mapCodeClassInvalidClassMember.mapCode.ts
+++ b/tests/baselines/reference/mapCodeClassInvalidClassMember.mapCode.ts
@@ -1,0 +1,18 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+class MyClass {[||]
+}
+
+// === INCOMING CHANGES ===
+if (false) {
+    return "hello";
+}
+
+// === MAPPED ===
+class MyClass {
+}
+
+if (false) {
+    return "hello";
+}

--- a/tests/baselines/reference/mapCodeClassInvalidClassMember.mapCode.ts
+++ b/tests/baselines/reference/mapCodeClassInvalidClassMember.mapCode.ts
@@ -5,6 +5,7 @@ class MyClass {[||]
 }
 
 // === INCOMING CHANGES ===
+
 if (false) {
     return "hello";
 }

--- a/tests/baselines/reference/mapCodeFocusLocationReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeFocusLocationReplacement.mapCode.ts
@@ -1,0 +1,63 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        console.log("hello");
+        console.log("world");
+    }
+    return 1;
+}
+function bar() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y)[||] {
+        console.log("x");
+        console.log("y");
+    }
+    return 2;
+}
+function baz() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        console.log(x);
+        console.log(y);
+    }
+    return 3;
+}
+
+// === INCOMING CHANGES ===
+if (x === y) {
+    return x + y;
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        console.log("hello");
+        console.log("world");
+    }
+    return 1;
+}
+function bar() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        return x + y;
+    }
+    return 2;
+}
+function baz() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        console.log(x);
+        console.log(y);
+    }
+    return 3;
+}

--- a/tests/baselines/reference/mapCodeFocusLocationReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeFocusLocationReplacement.mapCode.ts
@@ -30,6 +30,7 @@ function baz() {
 }
 
 // === INCOMING CHANGES ===
+
 if (x === y) {
     return x + y;
 }

--- a/tests/baselines/reference/mapCodeMethodInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeMethodInsertion.mapCode.ts
@@ -15,6 +15,7 @@ class MyClass {[||]
 }
 
 // === INCOMING CHANGES ===
+
 quux() {
     return 4;
 }

--- a/tests/baselines/reference/mapCodeMethodInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeMethodInsertion.mapCode.ts
@@ -1,0 +1,37 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+class MyClass {[||]
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        return 2;
+    }
+    baz() {
+        return 3;
+    }
+}
+
+// === INCOMING CHANGES ===
+quux() {
+    return 4;
+}
+
+// === MAPPED ===
+class MyClass {
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        return 2;
+    }
+    baz() {
+        return 3;
+    }
+    quux() {
+        return 4;
+    }
+}

--- a/tests/baselines/reference/mapCodeMethodReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeMethodReplacement.mapCode.ts
@@ -1,0 +1,34 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+class MyClass {
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {[||]
+        return 2;
+    }
+    baz() {
+        return 3;
+    }
+}
+
+// === INCOMING CHANGES ===
+bar() {
+    return 'hello';
+}
+
+// === MAPPED ===
+class MyClass {
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        return "hello";
+    }
+    baz() {
+        return 3;
+    }
+}

--- a/tests/baselines/reference/mapCodeMethodReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeMethodReplacement.mapCode.ts
@@ -15,6 +15,7 @@ class MyClass {
 }
 
 // === INCOMING CHANGES ===
+
 bar() {
     return 'hello';
 }

--- a/tests/baselines/reference/mapCodeMixedClassDeclaration.mapCode.ts
+++ b/tests/baselines/reference/mapCodeMixedClassDeclaration.mapCode.ts
@@ -12,6 +12,7 @@ class MyClass {[||]
 }
 
 // === INCOMING CHANGES ===
+
 x = 3;
 bar() {
     return 'hello';

--- a/tests/baselines/reference/mapCodeMixedClassDeclaration.mapCode.ts
+++ b/tests/baselines/reference/mapCodeMixedClassDeclaration.mapCode.ts
@@ -1,0 +1,34 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+class MyClass {[||]
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        return 2;
+    }
+}
+
+// === INCOMING CHANGES ===
+x = 3;
+bar() {
+    return 'hello';
+}
+baz() {
+    return 3;
+}
+y = 2;
+
+// === MAPPED ===
+class MyClass {
+    x = 3;
+    bar() {
+        return "hello";
+    }
+    baz() {
+        return 3;
+    }
+    y = 2;
+}

--- a/tests/baselines/reference/mapCodeMultipleChangesAndRanges.mapCode.ts
+++ b/tests/baselines/reference/mapCodeMultipleChangesAndRanges.mapCode.ts
@@ -1,0 +1,52 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+
+[|function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}|]
+
+function bar() {
+    [|return 2|];
+}
+
+// === INCOMING CHANGES ===
+
+if (x === y) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// ---
+
+function bar() {
+    return 3;
+}
+
+// ---
+
+method() {
+    return 'nope';
+}
+
+// === MAPPED ===
+
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        console.log("goodbye");
+        console.log("world");
+    }
+    return 1;
+}
+
+function bar() {
+    return 3;
+}

--- a/tests/baselines/reference/mapCodeNestedClassIfInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedClassIfInsertion.mapCode.ts
@@ -1,0 +1,41 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+class MyClass {
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        if (true)[||] {
+            return 2;
+        }
+    }
+    baz() {
+        return 3;
+    }
+}
+
+// === INCOMING CHANGES ===
+if (false) {
+    return "hello";
+}
+
+// === MAPPED ===
+class MyClass {
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        if (true) {
+            return 2;
+            if (false) {
+                return "hello";
+            }
+        }
+    }
+    baz() {
+        return 3;
+    }
+}

--- a/tests/baselines/reference/mapCodeNestedClassIfInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedClassIfInsertion.mapCode.ts
@@ -17,6 +17,7 @@ class MyClass {
 }
 
 // === INCOMING CHANGES ===
+
 if (false) {
     return "hello";
 }

--- a/tests/baselines/reference/mapCodeNestedClassIfReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedClassIfReplacement.mapCode.ts
@@ -17,6 +17,7 @@ class MyClass {
 }
 
 // === INCOMING CHANGES ===
+
 if (true) {
     return "hello";
 }

--- a/tests/baselines/reference/mapCodeNestedClassIfReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedClassIfReplacement.mapCode.ts
@@ -1,0 +1,38 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+class MyClass {
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        if (true) [||]{
+            return 2;
+        }
+    }
+    baz() {
+        return 3;
+    }
+}
+
+// === INCOMING CHANGES ===
+if (true) {
+    return "hello";
+}
+
+// === MAPPED ===
+class MyClass {
+    x = 1;
+    foo() {
+        return 1;
+    }
+    bar() {
+        if (true) {
+            return "hello";
+        }
+    }
+    baz() {
+        return 3;
+    }
+}

--- a/tests/baselines/reference/mapCodeNestedForInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForInsertion.mapCode.ts
@@ -1,0 +1,33 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    for (let i = 0; i < 10; i++) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+for (let j = 0; j < 10; j++) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    for (let i = 0; i < 10; i++) {
+        console.log("hello");
+        console.log("you");
+        for (let j = 0; j < 10; j++) {
+            console.log("goodbye");
+            console.log("world");
+        }
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedForInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForInsertion.mapCode.ts
@@ -12,6 +12,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 for (let j = 0; j < 10; j++) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedForOfInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForOfInsertion.mapCode.ts
@@ -1,0 +1,29 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    for (const x of [1, 2, 3])[||] {
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+for (const y of [1, 2, 3]) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    for (const x of [1, 2, 3]) {
+        console.log("hello");
+        console.log("you");
+        for (const y of [1, 2, 3]) {
+            console.log("goodbye");
+            console.log("world");
+        }
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedForOfInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForOfInsertion.mapCode.ts
@@ -10,6 +10,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 for (const y of [1, 2, 3]) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedForOfReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForOfReplacement.mapCode.ts
@@ -10,6 +10,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 for (const x of [1, 2, 3]) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedForOfReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForOfReplacement.mapCode.ts
@@ -1,0 +1,25 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    for (const x of [1, 2, 3]) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+for (const x of [1, 2, 3]) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    for (const x of [1, 2, 3]) {
+        console.log("goodbye");
+        console.log("world");
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedForReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForReplacement.mapCode.ts
@@ -1,0 +1,25 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    for (let x = 0; x < 10; x++) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+for (let x = 0; x < 10; x++) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    for (let x = 0; x < 10; x++) {
+        console.log("goodbye");
+        console.log("world");
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedForReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedForReplacement.mapCode.ts
@@ -10,6 +10,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 for (let x = 0; x < 10; x++) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedIfInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedIfInsertion.mapCode.ts
@@ -1,0 +1,33 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+if (y === x) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        console.log("hello");
+        console.log("you");
+        if (y === x) {
+            console.log("goodbye");
+            console.log("world");
+        }
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedIfInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedIfInsertion.mapCode.ts
@@ -12,6 +12,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 if (y === x) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedIfReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedIfReplace.mapCode.ts
@@ -12,6 +12,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 if (x === y) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedIfReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedIfReplace.mapCode.ts
@@ -1,0 +1,29 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+if (x === y) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    if (x === y) {
+        console.log("goodbye");
+        console.log("world");
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedLabeledInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedLabeledInsertion.mapCode.ts
@@ -1,0 +1,37 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    myLabel: if (x === y) [||]{
+        console.log("hello");
+        console.log("you");
+        break myLabel;
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+otherLabel: if (y === x) {
+  console.log("goodbye");
+  console.log("world");
+  break otherLabel;
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    myLabel: if (x === y) {
+        console.log("hello");
+        console.log("you");
+        break myLabel;
+        otherLabel: if (y === x) {
+            console.log("goodbye");
+            console.log("world");
+            break otherLabel;
+        }
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedLabeledInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedLabeledInsertion.mapCode.ts
@@ -13,6 +13,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 otherLabel: if (y === x) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedLabeledReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedLabeledReplace.mapCode.ts
@@ -13,6 +13,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 myLabel: if (y === x) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedLabeledReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedLabeledReplace.mapCode.ts
@@ -1,0 +1,32 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    myLabel: if (x === y) [||]{
+        console.log("hello");
+        console.log("you");
+        break myLabel;
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+myLabel: if (y === x) {
+  console.log("goodbye");
+  console.log("world");
+  break myLabel;
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    myLabel: if (y === x) {
+        console.log("goodbye");
+        console.log("world");
+        break myLabel;
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedWhileInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedWhileInsertion.mapCode.ts
@@ -1,0 +1,33 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    while (x === y) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+while (y === x) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    while (x === y) {
+        console.log("hello");
+        console.log("you");
+        while (y === x) {
+            console.log("goodbye");
+            console.log("world");
+        }
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedWhileInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedWhileInsertion.mapCode.ts
@@ -12,6 +12,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 while (y === x) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNestedWhileReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedWhileReplace.mapCode.ts
@@ -1,0 +1,29 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    while (x === y) [||]{
+        console.log("hello");
+        console.log("you");
+    }
+    return 1;
+}
+
+// === INCOMING CHANGES ===
+while (x === y) {
+  console.log("goodbye");
+  console.log("world");
+}
+
+// === MAPPED ===
+function foo() {
+    const x: number = 1;
+    const y: number = 2;
+    while (x === y) {
+        console.log("goodbye");
+        console.log("world");
+    }
+    return 1;
+}

--- a/tests/baselines/reference/mapCodeNestedWhileReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNestedWhileReplace.mapCode.ts
@@ -12,6 +12,7 @@ function foo() {
 }
 
 // === INCOMING CHANGES ===
+
 while (x === y) {
   console.log("goodbye");
   console.log("world");

--- a/tests/baselines/reference/mapCodeNoChanges.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNoChanges.mapCode.ts
@@ -1,0 +1,27 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    return 1;
+}
+[||]
+function bar() {
+    return 2;
+}
+function baz() {
+    return 3;
+}
+
+// === INCOMING CHANGES ===
+
+// === MAPPED ===
+function foo() {
+    return 1;
+}
+
+function bar() {
+    return 2;
+}
+function baz() {
+    return 3;
+}

--- a/tests/baselines/reference/mapCodeNoRanges.mapCode.ts
+++ b/tests/baselines/reference/mapCodeNoRanges.mapCode.ts
@@ -1,0 +1,27 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    return 1;
+}
+function bar() {
+    return 2;
+}
+
+// === INCOMING CHANGES ===
+
+function baz() {
+    return 3;
+}
+
+// === MAPPED ===
+function foo() {
+    return 1;
+}
+function bar() {
+    return 2;
+}
+
+function baz() {
+    return 3;
+}

--- a/tests/baselines/reference/mapCodePlainJsInsertion.mapCode.ts
+++ b/tests/baselines/reference/mapCodePlainJsInsertion.mapCode.ts
@@ -1,0 +1,25 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    return 1;
+}[||]
+function bar() {
+    return 2;
+}
+// === INCOMING CHANGES ===
+
+function baz() {
+    return 3;
+}
+
+// === MAPPED ===
+function foo() {
+    return 1;
+}
+function bar() {
+    return 2;
+}
+function baz() {
+    return 3;
+}

--- a/tests/baselines/reference/mapCodeRangeReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeRangeReplacement.mapCode.ts
@@ -1,0 +1,43 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    return 1;
+}
+if (foo == bar) {
+    console.log("hello");
+    console.log("you");
+}
+[||]
+function bar() {
+    return 2;
+}
+function baz() {
+    return 3;
+}
+while (false) {
+    console.log("weee");
+}
+
+// === INCOMING CHANGES ===
+if (foo == bar) {
+    console.log("huh");
+}
+
+function baz() {
+    return 'baz';
+}
+
+// === MAPPED ===
+function foo() {
+    return 1;
+}
+if (foo == bar) {
+    console.log("huh");
+}
+function baz() {
+    return "baz";
+}
+while (false) {
+    console.log("weee");
+}

--- a/tests/baselines/reference/mapCodeRangeReplacement.mapCode.ts
+++ b/tests/baselines/reference/mapCodeRangeReplacement.mapCode.ts
@@ -20,6 +20,7 @@ while (false) {
 }
 
 // === INCOMING CHANGES ===
+
 if (foo == bar) {
     console.log("huh");
 }

--- a/tests/baselines/reference/mapCodeReplaceUsingRange.mapCode.ts
+++ b/tests/baselines/reference/mapCodeReplaceUsingRange.mapCode.ts
@@ -9,6 +9,7 @@ function bar() {
 }|]
 
 // === INCOMING CHANGES ===
+
 function foo() {
     return 3;
 }

--- a/tests/baselines/reference/mapCodeReplaceUsingRange.mapCode.ts
+++ b/tests/baselines/reference/mapCodeReplaceUsingRange.mapCode.ts
@@ -1,0 +1,22 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+[|function foo() {
+    return 1;
+}[||]
+function bar() {
+    return [|2;|]
+}|]
+
+// === INCOMING CHANGES ===
+function foo() {
+    return 3;
+}
+
+// === MAPPED ===
+function foo() {
+    return 3;
+}
+function bar() {
+    return 2;
+}

--- a/tests/baselines/reference/mapCodeToplevelInsert.mapCode.ts
+++ b/tests/baselines/reference/mapCodeToplevelInsert.mapCode.ts
@@ -1,0 +1,24 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    return 1;
+}[||]
+function bar() {
+    return 2;
+}
+// === INCOMING CHANGES ===
+function baz() {
+    return 3;
+}
+
+// === MAPPED ===
+function foo() {
+    return 1;
+}
+function bar() {
+    return 2;
+}
+function baz() {
+    return 3;
+}

--- a/tests/baselines/reference/mapCodeToplevelInsert.mapCode.ts
+++ b/tests/baselines/reference/mapCodeToplevelInsert.mapCode.ts
@@ -8,6 +8,7 @@ function bar() {
     return 2;
 }
 // === INCOMING CHANGES ===
+
 function baz() {
     return 3;
 }

--- a/tests/baselines/reference/mapCodeToplevelInsertNoClass.mapCode.ts
+++ b/tests/baselines/reference/mapCodeToplevelInsertNoClass.mapCode.ts
@@ -1,0 +1,21 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    return 1;
+}[||]
+function bar() {
+    return 2;
+}
+// === INCOMING CHANGES ===
+baz() {
+    return 3;
+}
+
+// === MAPPED ===
+function foo() {
+    return 1;
+}
+function bar() {
+    return 2;
+}

--- a/tests/baselines/reference/mapCodeToplevelInsertNoClass.mapCode.ts
+++ b/tests/baselines/reference/mapCodeToplevelInsertNoClass.mapCode.ts
@@ -8,6 +8,7 @@ function bar() {
     return 2;
 }
 // === INCOMING CHANGES ===
+
 baz() {
     return 3;
 }

--- a/tests/baselines/reference/mapCodeToplevelReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeToplevelReplace.mapCode.ts
@@ -1,0 +1,22 @@
+// === mapCode ===
+
+// === ORIGINAL ===
+function foo() {
+    return 1;
+}[||]
+function bar() {
+    return 2;
+}
+
+// === INCOMING CHANGES ===
+function foo() {
+    return 3;
+}
+
+// === MAPPED ===
+function foo() {
+    return 3;
+}
+function bar() {
+    return 2;
+}

--- a/tests/baselines/reference/mapCodeToplevelReplace.mapCode.ts
+++ b/tests/baselines/reference/mapCodeToplevelReplace.mapCode.ts
@@ -9,6 +9,7 @@ function bar() {
 }
 
 // === INCOMING CHANGES ===
+
 function foo() {
     return 3;
 }

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -452,7 +452,7 @@ declare namespace FourSlashInterface {
                 copiedFrom?: { file: string, range: { pos: number, end: number }[] };
             }
         }): void;
-        baselineMapCode(ranges: Range[], changes: string[]): void;
+        baselineMapCode(ranges: Range[][], changes: string[]): void;
     }
     class edit {
         caretPosition(): Marker;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -452,7 +452,7 @@ declare namespace FourSlashInterface {
                 copiedFrom?: { file: string, range: { pos: number, end: number }[] };
             }
         }): void;
-        baselineMapCode(ranges: Range[], changesFilename?: string): void;
+        baselineMapCode(ranges: Range[], changes: string[]): void;
     }
     class edit {
         caretPosition(): Marker;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -212,20 +212,6 @@ declare namespace FourSlashInterface {
         start: number;
         end: number;
     }
-    export interface TextChange {
-        span: TextSpan;
-        newText: string;
-    }
-    export interface FileTextChanges {
-        fileName: string;
-        textChanges: readonly TextChange[];
-        isNewFile?: boolean;
-    }
-    export interface MapCodeDocumentMapping {
-        fileName?: string;
-        focusLocations?: TextSpan[][];
-        contents: string[];
-    }
     class test_ {
         markers(): Marker[];
         markerNames(): string[];

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -212,6 +212,20 @@ declare namespace FourSlashInterface {
         start: number;
         end: number;
     }
+    export interface TextChange {
+        span: TextSpan;
+        newText: string;
+    }
+    export interface FileTextChanges {
+        fileName: string;
+        textChanges: readonly TextChange[];
+        isNewFile?: boolean;
+    }
+    export interface MapCodeDocumentMapping {
+        fileName?: string;
+        focusLocations?: TextSpan[][];
+        contents: string[];
+    }
     class test_ {
         markers(): Marker[];
         markerNames(): string[];
@@ -452,6 +466,7 @@ declare namespace FourSlashInterface {
                 copiedFrom?: { file: string, range: { pos: number, end: number }[] };
             }
         }): void;
+        baselineMapCode(range: Range, changesFilename?: string): void;
     }
     class edit {
         caretPosition(): Marker;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -466,7 +466,7 @@ declare namespace FourSlashInterface {
                 copiedFrom?: { file: string, range: { pos: number, end: number }[] };
             }
         }): void;
-        baselineMapCode(range: Range, changesFilename?: string): void;
+        baselineMapCode(ranges: Range[], changesFilename?: string): void;
     }
     class edit {
         caretPosition(): Marker;

--- a/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
+++ b/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
@@ -1,0 +1,13 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// if (false) {
+////     return "hello";
+//// }
+////
+// @Filename: /index.ts
+//// class MyClass {[||]
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
+++ b/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
@@ -10,4 +10,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
+++ b/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
@@ -5,7 +5,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 if (false) {
     return "hello";

--- a/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
+++ b/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// if (false) {
 ////     return "hello";
 //// }
@@ -10,4 +10,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
+++ b/tests/cases/fourslash/mapCodeClassInvalidClassMember.ts
@@ -1,13 +1,14 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// if (false) {
-////     return "hello";
-//// }
-////
 // @Filename: /index.ts
 //// class MyClass {[||]
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+if (false) {
+    return "hello";
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
+++ b/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
@@ -1,0 +1,38 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// if (x === y) {
+////     return x + y;
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     if (x === y) {
+////         console.log("hello");
+////         console.log("world");
+////     }
+////     return 1;
+//// }
+//// function bar() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     if (x === y)[||] {
+////         console.log("x");
+////         console.log("y");
+////     }
+////     return 2;
+//// }
+//// function baz() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     if (x === y) {
+////         console.log(x);
+////         console.log(y);
+////     }
+////     return 3;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
+++ b/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// if (x === y) {
 ////     return x + y;
 //// }
@@ -35,4 +35,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
+++ b/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
@@ -35,4 +35,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
+++ b/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// if (x === y) {
-////     return x + y;
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -35,4 +30,10 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+if (x === y) {
+    return x + y;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
+++ b/tests/cases/fourslash/mapCodeFocusLocationReplacement.ts
@@ -30,7 +30,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 if (x === y) {
     return x + y;

--- a/tests/cases/fourslash/mapCodeMethodInsertion.ts
+++ b/tests/cases/fourslash/mapCodeMethodInsertion.ts
@@ -1,0 +1,23 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// quux() {
+////     return 4;
+//// }
+////
+// @Filename: /index.ts
+//// class MyClass {[||]
+////     x = 1;
+////     foo() {
+////         return 1;
+////     }
+////     bar() {
+////         return 2;
+////     }
+////     baz() {
+////         return 3;
+////     }
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeMethodInsertion.ts
+++ b/tests/cases/fourslash/mapCodeMethodInsertion.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// quux() {
 ////     return 4;
 //// }
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeMethodInsertion.ts
+++ b/tests/cases/fourslash/mapCodeMethodInsertion.ts
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeMethodInsertion.ts
+++ b/tests/cases/fourslash/mapCodeMethodInsertion.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// quux() {
-////     return 4;
-//// }
-////
 // @Filename: /index.ts
 //// class MyClass {[||]
 ////     x = 1;
@@ -20,4 +15,10 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+quux() {
+    return 4;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeMethodInsertion.ts
+++ b/tests/cases/fourslash/mapCodeMethodInsertion.ts
@@ -15,7 +15,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 quux() {
     return 4;

--- a/tests/cases/fourslash/mapCodeMethodReplacement.ts
+++ b/tests/cases/fourslash/mapCodeMethodReplacement.ts
@@ -1,0 +1,23 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// bar() {
+////     return 'hello';
+//// }
+////
+// @Filename: /index.ts
+//// class MyClass {
+////     x = 1;
+////     foo() {
+////         return 1;
+////     }
+////     bar() {[||]
+////         return 2;
+////     }
+////     baz() {
+////         return 3;
+////     }
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeMethodReplacement.ts
+++ b/tests/cases/fourslash/mapCodeMethodReplacement.ts
@@ -15,7 +15,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 bar() {
     return 'hello';

--- a/tests/cases/fourslash/mapCodeMethodReplacement.ts
+++ b/tests/cases/fourslash/mapCodeMethodReplacement.ts
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeMethodReplacement.ts
+++ b/tests/cases/fourslash/mapCodeMethodReplacement.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// bar() {
-////     return 'hello';
-//// }
-////
 // @Filename: /index.ts
 //// class MyClass {
 ////     x = 1;
@@ -20,4 +15,10 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+bar() {
+    return 'hello';
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeMethodReplacement.ts
+++ b/tests/cases/fourslash/mapCodeMethodReplacement.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// bar() {
 ////     return 'hello';
 //// }
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
+++ b/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
@@ -12,7 +12,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 x = 3;
 bar() {

--- a/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
+++ b/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
@@ -1,0 +1,25 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// x = 3;
+//// bar() {
+////     return 'hello';
+//// }
+//// baz() {
+////     return 3;
+//// }
+//// y = 2;
+////
+// @Filename: /index.ts
+//// class MyClass {[||]
+////     x = 1;
+////     foo() {
+////         return 1;
+////     }
+////     bar() {
+////         return 2;
+////     }
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
+++ b/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
@@ -22,4 +22,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
+++ b/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
@@ -1,15 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// x = 3;
-//// bar() {
-////     return 'hello';
-//// }
-//// baz() {
-////     return 3;
-//// }
-//// y = 2;
-////
 // @Filename: /index.ts
 //// class MyClass {[||]
 ////     x = 1;
@@ -22,4 +12,15 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+x = 3;
+bar() {
+    return 'hello';
+}
+baz() {
+    return 3;
+}
+y = 2;
+`
+]);

--- a/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
+++ b/tests/cases/fourslash/mapCodeMixedClassDeclaration.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// x = 3;
 //// bar() {
 ////     return 'hello';
@@ -22,4 +22,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeMultipleChangesAndRanges.ts
+++ b/tests/cases/fourslash/mapCodeMultipleChangesAndRanges.ts
@@ -17,7 +17,8 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+const [r0, r1, r2] = test.ranges();
+verify.baselineMapCode([[r0], [r2, r1]], [
 `
 if (x === y) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeMultipleChangesAndRanges.ts
+++ b/tests/cases/fourslash/mapCodeMultipleChangesAndRanges.ts
@@ -1,0 +1,37 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /index.ts
+////
+//// [|function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     if (x === y) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }|]
+////
+//// function bar() {
+////     [|return 2|];
+//// }
+////
+
+verify.baselineMapCode(test.ranges(), [
+`
+if (x === y) {
+  console.log("goodbye");
+  console.log("world");
+}
+`,
+`
+function bar() {
+    return 3;
+}
+`,
+`
+method() {
+    return 'nope';
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// if (false) {
-////     return "hello";
-//// }
-////
 // @Filename: /index.ts
 //// class MyClass {
 ////     x = 1;
@@ -22,4 +17,10 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+if (false) {
+    return "hello";
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
@@ -1,0 +1,25 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// if (false) {
+////     return "hello";
+//// }
+////
+// @Filename: /index.ts
+//// class MyClass {
+////     x = 1;
+////     foo() {
+////         return 1;
+////     }
+////     bar() {
+////         if (true)[||] {
+////             return 2;
+////         }
+////     }
+////     baz() {
+////         return 3;
+////     }
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
@@ -17,7 +17,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 if (false) {
     return "hello";

--- a/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
@@ -22,4 +22,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfInsertion.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// if (false) {
 ////     return "hello";
 //// }
@@ -22,4 +22,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
@@ -17,7 +17,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 if (true) {
     return "hello";

--- a/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// if (true) {
-////     return "hello";
-//// }
-////
 // @Filename: /index.ts
 //// class MyClass {
 ////     x = 1;
@@ -22,4 +17,10 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+if (true) {
+    return "hello";
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
@@ -1,0 +1,25 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// if (true) {
+////     return "hello";
+//// }
+////
+// @Filename: /index.ts
+//// class MyClass {
+////     x = 1;
+////     foo() {
+////         return 1;
+////     }
+////     bar() {
+////         if (true) [||]{
+////             return 2;
+////         }
+////     }
+////     baz() {
+////         return 3;
+////     }
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
@@ -22,4 +22,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedClassIfReplacement.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// if (true) {
 ////     return "hello";
 //// }
@@ -22,4 +22,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForInsertion.ts
@@ -12,7 +12,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 for (let j = 0; j < 10; j++) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedForInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForInsertion.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// for (let j = 0; j < 10; j++) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -18,4 +12,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+for (let j = 0; j < 10; j++) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedForInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForInsertion.ts
@@ -1,0 +1,21 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// for (let j = 0; j < 10; j++) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     for (let i = 0; i < 10; i++) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedForInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForInsertion.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// for (let j = 0; j < 10; j++) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForInsertion.ts
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
@@ -10,7 +10,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 for (const y of [1, 2, 3]) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// for (const y of [1, 2, 3]) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     for (const x of [1, 2, 3])[||] {
@@ -16,4 +10,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+for (const y of [1, 2, 3]) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// for (const y of [1, 2, 3]) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -16,4 +16,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
@@ -1,0 +1,19 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// for (const y of [1, 2, 3]) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     for (const x of [1, 2, 3])[||] {
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfInsertion.ts
@@ -16,4 +16,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// for (const x of [1, 2, 3]) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     for (const x of [1, 2, 3]) [||]{
@@ -16,4 +10,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+for (const x of [1, 2, 3]) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
@@ -10,7 +10,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 for (const x of [1, 2, 3]) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
@@ -1,0 +1,19 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// for (const x of [1, 2, 3]) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     for (const x of [1, 2, 3]) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// for (const x of [1, 2, 3]) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -16,4 +16,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForOfReplacement.ts
@@ -16,4 +16,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForReplacement.ts
@@ -1,0 +1,19 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// for (let x = 0; x < 10; x++) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     for (let x = 0; x < 10; x++) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedForReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForReplacement.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// for (let x = 0; x < 10; x++) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     for (let x = 0; x < 10; x++) [||]{
@@ -16,4 +10,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+for (let x = 0; x < 10; x++) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedForReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForReplacement.ts
@@ -16,4 +16,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedForReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForReplacement.ts
@@ -10,7 +10,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 for (let x = 0; x < 10; x++) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedForReplacement.ts
+++ b/tests/cases/fourslash/mapCodeNestedForReplacement.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// for (let x = 0; x < 10; x++) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -16,4 +16,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// if (y === x) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
@@ -1,0 +1,21 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// if (y === x) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     if (x === y) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
@@ -12,7 +12,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 if (y === x) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// if (y === x) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -18,4 +12,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+if (y === x) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfInsertion.ts
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedIfReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfReplace.ts
@@ -1,0 +1,21 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// if (x === y) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     if (x === y) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedIfReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfReplace.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// if (x === y) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedIfReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfReplace.ts
@@ -12,7 +12,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 if (x === y) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedIfReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfReplace.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// if (x === y) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -18,4 +12,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+if (x === y) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedIfReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedIfReplace.ts
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
@@ -1,12 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// otherLabel: if (y === x) {
-////   console.log("goodbye");
-////   console.log("world");
-////   break otherLabel;
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -20,4 +13,12 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+otherLabel: if (y === x) {
+  console.log("goodbye");
+  console.log("world");
+  break otherLabel;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
@@ -13,7 +13,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 otherLabel: if (y === x) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// otherLabel: if (y === x) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledInsertion.ts
@@ -1,0 +1,23 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// otherLabel: if (y === x) {
+////   console.log("goodbye");
+////   console.log("world");
+////   break otherLabel;
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     myLabel: if (x === y) [||]{
+////         console.log("hello");
+////         console.log("you");
+////         break myLabel;
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
@@ -13,7 +13,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 myLabel: if (y === x) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// myLabel: if (y === x) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
@@ -1,0 +1,23 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// myLabel: if (y === x) {
+////   console.log("goodbye");
+////   console.log("world");
+////   break myLabel;
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     myLabel: if (x === y) [||]{
+////         console.log("hello");
+////         console.log("you");
+////         break myLabel;
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
@@ -20,4 +20,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedLabeledReplace.ts
@@ -1,12 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// myLabel: if (y === x) {
-////   console.log("goodbye");
-////   console.log("world");
-////   break myLabel;
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -20,4 +13,12 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+myLabel: if (y === x) {
+  console.log("goodbye");
+  console.log("world");
+  break myLabel;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// while (y === x) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
@@ -1,0 +1,21 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// while (y === x) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     while (x === y) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// while (y === x) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -18,4 +12,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+while (y === x) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
@@ -12,7 +12,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 while (y === x) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileInsertion.ts
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
@@ -1,11 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// while (x === y) {
-////   console.log("goodbye");
-////   console.log("world");
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     const x: number = 1;
@@ -18,4 +12,11 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+while (x === y) {
+  console.log("goodbye");
+  console.log("world");
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// while (x === y) {
 ////   console.log("goodbye");
 ////   console.log("world");
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
@@ -1,0 +1,21 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// while (x === y) {
+////   console.log("goodbye");
+////   console.log("world");
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     const x: number = 1;
+////     const y: number = 2;
+////     while (x === y) [||]{
+////         console.log("hello");
+////         console.log("you");
+////     }
+////     return 1;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
@@ -12,7 +12,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 while (x === y) {
   console.log("goodbye");

--- a/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
+++ b/tests/cases/fourslash/mapCodeNestedWhileReplace.ts
@@ -18,4 +18,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeNoChanges.ts
+++ b/tests/cases/fourslash/mapCodeNoChanges.ts
@@ -1,0 +1,16 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /index.ts
+//// function foo() {
+////     return 1;
+//// }
+//// [||]
+//// function bar() {
+////     return 2;
+//// }
+//// function baz() {
+////     return 3;
+//// }
+////
+
+verify.baselineMapCode(test.ranges(), []);

--- a/tests/cases/fourslash/mapCodeNoChanges.ts
+++ b/tests/cases/fourslash/mapCodeNoChanges.ts
@@ -13,4 +13,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), []);
+verify.baselineMapCode([test.ranges()], []);

--- a/tests/cases/fourslash/mapCodeNoRanges.ts
+++ b/tests/cases/fourslash/mapCodeNoRanges.ts
@@ -9,7 +9,7 @@
 //// }
 ////
 
-verify.baselineMapCode([], [
+verify.baselineMapCode([[]], [
 `
 function baz() {
     return 3;

--- a/tests/cases/fourslash/mapCodeNoRanges.ts
+++ b/tests/cases/fourslash/mapCodeNoRanges.ts
@@ -1,0 +1,19 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /index.ts
+//// function foo() {
+////     return 1;
+//// }
+//// function bar() {
+////     return 2;
+//// }
+////
+
+verify.baselineMapCode([], [
+`
+function baz() {
+    return 3;
+}
+`
+]);
+

--- a/tests/cases/fourslash/mapCodePlainJsInsertion.ts
+++ b/tests/cases/fourslash/mapCodePlainJsInsertion.ts
@@ -1,0 +1,17 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /topLevelInsert.js
+//// function foo() {
+////     return 1;
+//// }[||]
+//// function bar() {
+////     return 2;
+//// }
+
+verify.baselineMapCode([test.ranges()], [
+`
+function baz() {
+    return 3;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeRangeReplacement.ts
+++ b/tests/cases/fourslash/mapCodeRangeReplacement.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// if (foo == bar) {
 ////     console.log("huh");
 //// }
@@ -29,4 +29,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeRangeReplacement.ts
+++ b/tests/cases/fourslash/mapCodeRangeReplacement.ts
@@ -29,4 +29,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeRangeReplacement.ts
+++ b/tests/cases/fourslash/mapCodeRangeReplacement.ts
@@ -20,7 +20,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 if (foo == bar) {
     console.log("huh");

--- a/tests/cases/fourslash/mapCodeRangeReplacement.ts
+++ b/tests/cases/fourslash/mapCodeRangeReplacement.ts
@@ -1,14 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// if (foo == bar) {
-////     console.log("huh");
-//// }
-////
-//// function baz() {
-////     return 'baz';
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     return 1;
@@ -29,4 +20,14 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+if (foo == bar) {
+    console.log("huh");
+}
+
+function baz() {
+    return 'baz';
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeRangeReplacement.ts
+++ b/tests/cases/fourslash/mapCodeRangeReplacement.ts
@@ -1,0 +1,32 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// if (foo == bar) {
+////     console.log("huh");
+//// }
+////
+//// function baz() {
+////     return 'baz';
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     return 1;
+//// }
+//// if (foo == bar) {
+////     console.log("hello");
+////     console.log("you");
+//// }
+//// [||]
+//// function bar() {
+////     return 2;
+//// }
+//// function baz() {
+////     return 3;
+//// }
+//// while (false) {
+////     console.log("weee");
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeReplaceUsingRange.ts
+++ b/tests/cases/fourslash/mapCodeReplaceUsingRange.ts
@@ -1,16 +1,17 @@
 ///<reference path="fourslash.ts"/>
 
 // @Filename: /incomingChanges.ts
-//// function baz() {
+//// function foo() {
 ////     return 3;
 //// }
 ////
 // @Filename: /index.ts
-//// function foo() {
+//// [|function foo() {
 ////     return 1;
 //// }[||]
 //// function bar() {
-////     return 2;
-//// }
+////     return [|2;|]
+//// }|]
+////
 
 verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeReplaceUsingRange.ts
+++ b/tests/cases/fourslash/mapCodeReplaceUsingRange.ts
@@ -9,7 +9,7 @@
 //// }|]
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 function foo() {
     return 3;

--- a/tests/cases/fourslash/mapCodeReplaceUsingRange.ts
+++ b/tests/cases/fourslash/mapCodeReplaceUsingRange.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// function foo() {
-////     return 3;
-//// }
-////
 // @Filename: /index.ts
 //// [|function foo() {
 ////     return 1;
@@ -14,4 +9,10 @@
 //// }|]
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+function foo() {
+    return 3;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeToplevelInsert.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsert.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// function baz() {
 ////     return 3;
 //// }
@@ -13,4 +13,4 @@
 ////     return 2;
 //// }
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeToplevelInsert.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsert.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// function baz() {
-////     return 3;
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     return 1;
@@ -13,4 +8,10 @@
 ////     return 2;
 //// }
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+function baz() {
+    return 3;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeToplevelInsert.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsert.ts
@@ -1,0 +1,16 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// function baz() {
+////     return 3;
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     return 1;
+//// }[||]
+//// function bar() {
+////     return 2;
+//// }
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeToplevelInsert.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsert.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /index.ts
+// @Filename: /topLevelInsert.ts
 //// function foo() {
 ////     return 1;
 //// }[||]
@@ -8,7 +8,7 @@
 ////     return 2;
 //// }
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 function baz() {
     return 3;

--- a/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
@@ -13,4 +13,4 @@
 ////     return 2;
 //// }
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
@@ -1,0 +1,16 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges.ts
+//// baz() {
+////     return 3;
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     return 1;
+//// }[||]
+//// function bar() {
+////     return 2;
+//// }
+
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
@@ -8,7 +8,7 @@
 ////     return 2;
 //// }
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 baz() {
     return 3;

--- a/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
+++ b/tests/cases/fourslash/mapCodeToplevelInsertNoClass.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// baz() {
-////     return 3;
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     return 1;
@@ -13,4 +8,10 @@
 ////     return 2;
 //// }
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+baz() {
+    return 3;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeToplevelReplace.ts
+++ b/tests/cases/fourslash/mapCodeToplevelReplace.ts
@@ -1,0 +1,17 @@
+///<reference path="fourslash.ts"/>
+
+// @Filename: /incomingChanges
+//// function foo() {
+////     return 3;
+//// }
+////
+// @Filename: /index.ts
+//// function foo() {
+////     return 1;
+//// }[||]
+//// function bar() {
+////     return 2;
+//// }
+////
+
+verify.baselineMapCode(test.ranges()[0]);

--- a/tests/cases/fourslash/mapCodeToplevelReplace.ts
+++ b/tests/cases/fourslash/mapCodeToplevelReplace.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /index.ts
+// @Filename: /topLevelReplace.ts
 //// function foo() {
 ////     return 1;
 //// }[||]
@@ -9,7 +9,7 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), [
+verify.baselineMapCode([test.ranges()], [
 `
 function foo() {
     return 3;

--- a/tests/cases/fourslash/mapCodeToplevelReplace.ts
+++ b/tests/cases/fourslash/mapCodeToplevelReplace.ts
@@ -1,6 +1,6 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges
+// @Filename: /incomingChanges.ts
 //// function foo() {
 ////     return 3;
 //// }
@@ -14,4 +14,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0]);
+verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");

--- a/tests/cases/fourslash/mapCodeToplevelReplace.ts
+++ b/tests/cases/fourslash/mapCodeToplevelReplace.ts
@@ -1,10 +1,5 @@
 ///<reference path="fourslash.ts"/>
 
-// @Filename: /incomingChanges.ts
-//// function foo() {
-////     return 3;
-//// }
-////
 // @Filename: /index.ts
 //// function foo() {
 ////     return 1;
@@ -14,4 +9,10 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), [
+`
+function foo() {
+    return 3;
+}
+`
+]);

--- a/tests/cases/fourslash/mapCodeToplevelReplace.ts
+++ b/tests/cases/fourslash/mapCodeToplevelReplace.ts
@@ -14,4 +14,4 @@
 //// }
 ////
 
-verify.baselineMapCode(test.ranges()[0], "/incomingChanges.ts");
+verify.baselineMapCode(test.ranges(), "/incomingChanges.ts");


### PR DESCRIPTION
CodeMappers are a new language service feature that's designed to work as a deterministic aid to code generators like Copilot. The endpoint takes some arbitrary, generated code, some "focus locations" (generally things like cursor location, current selected method scope range, etc), and tries to "place" the AI-generated code in "the right place". While deterministic, it's fairly heuristic.

This version is able to also target "things that look like they match", like functions with the same name, or if statements with the same condition and actually _replace_ their definitions/bodies, instead of appending them to the given scope.

The intention is to make it easier to go from asking an AI assistant like copilot "give me code to do this", to code that actually fits where it's supposed to. Having the language service do this lets us make more informed decisions than what a simple diff codemapper (the default) might be able to do.