### PR TITLE
Make sure emitted d.ts files are LF, not CRLF

### DIFF
--- a/scripts/dtsBundler.mjs
+++ b/scripts/dtsBundler.mjs
@@ -417,7 +417,7 @@ const dprintPath = path.resolve(__dirname, "..", "node_modules", "dprint", "bin.
  * @returns {string}
  */
 function dprint(contents) {
-    return cp.execFileSync(
+    const result = cp.execFileSync(
         process.execPath,
         [dprintPath, "fmt", "--stdin", "ts"],
         {
@@ -427,6 +427,7 @@ function dprint(contents) {
             maxBuffer: 100 * 1024 * 1024, // 100 MB "ought to be enough for anyone"; https://github.com/nodejs/node/issues/9829
         },
     );
+    return result.replace(/\r\n/g, "\n");
 }
 
 fs.writeFileSync(output, dprint(publicContents));


### PR DESCRIPTION
Embarrassingly I forgot that #55403 meant that the dprint'd d.ts bundler output are now getting the wrong newlines, which was not intentional. Make sure we actually write out the right contents...

(The reason that we dprint the bundler outputs is that they are input formatting sensitive as the bundler is very very dumb, so when we change `src`, we may spuriously change the bundler output. Not ideal, but now that we have a formatter I could fix that.)