### PR TITLE
Format with operatorPosition=nextLine

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -14,7 +14,7 @@
         "nextControlFlowPosition": "nextLine", // Stroustrup style braces.
         "trailingCommas": "onlyMultiLine",
         "preferHanging": false,
-        "operatorPosition": "maintain",
+        "operatorPosition": "nextLine",
 
         "arrowFunction.useParentheses": "preferNone",
         "conditionalExpression.linePerExpression": false, // Keep our "match/case"-ish conditionals.

--- a/scripts/build/projects.mjs
+++ b/scripts/build/projects.mjs
@@ -39,9 +39,9 @@ class ProjectQueue {
 
 const tscPath = resolve(
     findUpRoot(),
-    cmdLineOptions.lkg ? "./lib/tsc.js" :
-        cmdLineOptions.built ? "./built/local/tsc.js" :
-        "./node_modules/typescript/lib/tsc.js",
+    cmdLineOptions.lkg ? "./lib/tsc.js"
+        : cmdLineOptions.built ? "./built/local/tsc.js"
+        : "./node_modules/typescript/lib/tsc.js",
 );
 
 const execTsc = (/** @type {string[]} */ ...args) => exec(process.execPath, [tscPath, "-b", ...args], { hidePrompt: true });

--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -39,8 +39,8 @@ export async function exec(cmd, args, options = {}) {
                     resolve({ exitCode: exitCode ?? undefined });
                 }
                 else {
-                    const reason = options.token?.signaled ? options.token.reason ?? new CancelError() :
-                        new ExecError(exitCode);
+                    const reason = options.token?.signaled ? options.token.reason ?? new CancelError()
+                        : new ExecError(exitCode);
                     reject(reason);
                 }
                 subscription?.unsubscribe();

--- a/scripts/eslint/rules/no-keywords.cjs
+++ b/scripts/eslint/rules/no-keywords.cjs
@@ -46,10 +46,10 @@ module.exports = createRule({
         const checkProperties = node => {
             node.properties.forEach(property => {
                 if (
-                    property &&
-                    property.type === AST_NODE_TYPES.Property &&
-                    property.key.type === AST_NODE_TYPES.Identifier &&
-                    isKeyword(property.key.name)
+                    property
+                    && property.type === AST_NODE_TYPES.Property
+                    && property.key.type === AST_NODE_TYPES.Identifier
+                    && isKeyword(property.key.name)
                 ) {
                     report(property.key);
                 }
@@ -60,9 +60,9 @@ module.exports = createRule({
         const checkElements = node => {
             node.elements.forEach(element => {
                 if (
-                    element &&
-                    element.type === AST_NODE_TYPES.Identifier &&
-                    isKeyword(element.name)
+                    element
+                    && element.type === AST_NODE_TYPES.Identifier
+                    && isKeyword(element.name)
                 ) {
                     report(element);
                 }
@@ -77,9 +77,9 @@ module.exports = createRule({
 
             node.params.forEach(param => {
                 if (
-                    param &&
-                    param.type === AST_NODE_TYPES.Identifier &&
-                    isKeyword(param.name)
+                    param
+                    && param.type === AST_NODE_TYPES.Identifier
+                    && isKeyword(param.name)
                 ) {
                     report(param);
                 }
@@ -97,8 +97,8 @@ module.exports = createRule({
                 }
 
                 if (
-                    node.id.type === AST_NODE_TYPES.Identifier &&
-                    isKeyword(node.id.name)
+                    node.id.type === AST_NODE_TYPES.Identifier
+                    && isKeyword(node.id.name)
                 ) {
                     report(node.id);
                 }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -837,8 +837,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                             // 1. multiple export default of class declaration or function declaration by checking NodeFlags.Default
                             // 2. multiple export default of export assignment. This one doesn't have NodeFlags.Default on (as export default doesn't considered as modifiers)
                             if (
-                                symbol.declarations && symbol.declarations.length &&
-                                (node.kind === SyntaxKind.ExportAssignment && !(node as ExportAssignment).isExportEquals)
+                                symbol.declarations && symbol.declarations.length
+                                && (node.kind === SyntaxKind.ExportAssignment && !(node as ExportAssignment).isExportEquals)
                             ) {
                                 message = Diagnostics.A_module_cannot_have_multiple_default_exports;
                                 messageNeedsName = false;
@@ -1000,10 +1000,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             const saveActiveLabelList = activeLabelList;
             const saveHasExplicitReturn = hasExplicitReturn;
             const isImmediatelyInvoked = (
-                containerFlags & ContainerFlags.IsFunctionExpression &&
-                !hasSyntacticModifier(node, ModifierFlags.Async) &&
-                !(node as FunctionLikeDeclaration).asteriskToken &&
-                !!getImmediatelyInvokedFunctionExpression(node)
+                containerFlags & ContainerFlags.IsFunctionExpression
+                && !hasSyntacticModifier(node, ModifierFlags.Async)
+                && !(node as FunctionLikeDeclaration).asteriskToken
+                && !!getImmediatelyInvokedFunctionExpression(node)
             ) || node.kind === SyntaxKind.ClassStaticBlockDeclaration;
             // A non-async, non-generator IIFE is considered part of the containing control flow. Return statements behave
             // similarly to break statements that exit to a label just past the statement body.
@@ -1260,8 +1260,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             }
         }
         if (
-            expr.expression.kind === SyntaxKind.PropertyAccessExpression &&
-            containsNarrowableReference((expr.expression as PropertyAccessExpression).expression)
+            expr.expression.kind === SyntaxKind.PropertyAccessExpression
+            && containsNarrowableReference((expr.expression as PropertyAccessExpression).expression)
         ) {
             return true;
         }
@@ -1283,9 +1283,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             case SyntaxKind.ExclamationEqualsToken:
             case SyntaxKind.EqualsEqualsEqualsToken:
             case SyntaxKind.ExclamationEqualsEqualsToken:
-                return isNarrowableOperand(expr.left) || isNarrowableOperand(expr.right) ||
-                    isNarrowingTypeofOperands(expr.right, expr.left) || isNarrowingTypeofOperands(expr.left, expr.right) ||
-                    (isBooleanLiteral(expr.right) && isNarrowingExpression(expr.left) || isBooleanLiteral(expr.left) && isNarrowingExpression(expr.right));
+                return isNarrowableOperand(expr.left) || isNarrowableOperand(expr.right)
+                    || isNarrowingTypeofOperands(expr.right, expr.left) || isNarrowingTypeofOperands(expr.left, expr.right)
+                    || (isBooleanLiteral(expr.right) && isNarrowingExpression(expr.left) || isBooleanLiteral(expr.left) && isNarrowingExpression(expr.right));
             case SyntaxKind.InstanceOfKeyword:
                 return isNarrowableOperand(expr.left);
             case SyntaxKind.InKeyword:
@@ -1343,9 +1343,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             return flags & FlowFlags.TrueCondition ? antecedent : unreachableFlow;
         }
         if (
-            (expression.kind === SyntaxKind.TrueKeyword && flags & FlowFlags.FalseCondition ||
-                expression.kind === SyntaxKind.FalseKeyword && flags & FlowFlags.TrueCondition) &&
-            !isExpressionOfOptionalChainRoot(expression) && !isNullishCoalesce(expression.parent)
+            (expression.kind === SyntaxKind.TrueKeyword && flags & FlowFlags.FalseCondition
+                || expression.kind === SyntaxKind.FalseKeyword && flags & FlowFlags.TrueCondition)
+            && !isExpressionOfOptionalChainRoot(expression) && !isNullishCoalesce(expression.parent)
         ) {
             return unreachableFlow;
         }
@@ -1420,14 +1420,14 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
 
     function isTopLevelLogicalExpression(node: Node): boolean {
         while (
-            isParenthesizedExpression(node.parent) ||
-            isPrefixUnaryExpression(node.parent) && node.parent.operator === SyntaxKind.ExclamationToken
+            isParenthesizedExpression(node.parent)
+            || isPrefixUnaryExpression(node.parent) && node.parent.operator === SyntaxKind.ExclamationToken
         ) {
             node = node.parent;
         }
-        return !isStatementCondition(node) &&
-            !isLogicalExpression(node.parent) &&
-            !(isOptionalChain(node.parent) && node.parent.expression === node);
+        return !isStatementCondition(node)
+            && !isLogicalExpression(node.parent)
+            && !(isOptionalChain(node.parent) && node.parent.expression === node);
     }
 
     function doWithConditionalBranches<T>(action: (value: T) => void, value: T, trueTarget: FlowLabel, falseTarget: FlowLabel) {
@@ -2449,10 +2449,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     function checkContextualIdentifier(node: Identifier) {
         // Report error only if there are no parse errors in file
         if (
-            !file.parseDiagnostics.length &&
-            !(node.flags & NodeFlags.Ambient) &&
-            !(node.flags & NodeFlags.JSDoc) &&
-            !isIdentifierName(node)
+            !file.parseDiagnostics.length
+            && !(node.flags & NodeFlags.Ambient)
+            && !(node.flags & NodeFlags.JSDoc)
+            && !isIdentifierName(node)
         ) {
             // strict mode identifiers
             const originalKeywordKind = identifierToKeywordKind(node);
@@ -2461,9 +2461,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             }
 
             if (
-                inStrictMode &&
-                originalKeywordKind >= SyntaxKind.FirstFutureReservedWord &&
-                originalKeywordKind <= SyntaxKind.LastFutureReservedWord
+                inStrictMode
+                && originalKeywordKind >= SyntaxKind.FirstFutureReservedWord
+                && originalKeywordKind <= SyntaxKind.LastFutureReservedWord
             ) {
                 file.bindDiagnostics.push(createDiagnosticForNode(node, getStrictModeIdentifierMessage(node), declarationNameToString(node)));
             }
@@ -2587,9 +2587,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         if (languageVersion < ScriptTarget.ES2015) {
             // Report error if function is not top level function declaration
             if (
-                blockScopeContainer.kind !== SyntaxKind.SourceFile &&
-                blockScopeContainer.kind !== SyntaxKind.ModuleDeclaration &&
-                !isFunctionLikeOrClassStaticBlockDeclaration(blockScopeContainer)
+                blockScopeContainer.kind !== SyntaxKind.SourceFile
+                && blockScopeContainer.kind !== SyntaxKind.ModuleDeclaration
+                && !isFunctionLikeOrClassStaticBlockDeclaration(blockScopeContainer)
             ) {
                 // We check first if the name is inside class declaration or class expression; if so give explicit message
                 // otherwise report generic error message.
@@ -2796,10 +2796,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                     bindSpecialPropertyDeclaration(expr);
                 }
                 if (
-                    isInJSFile(expr) &&
-                    file.commonJsModuleIndicator &&
-                    isModuleExportsAccessExpression(expr) &&
-                    !lookupSymbolForName(blockScopeContainer, "module" as __String)
+                    isInJSFile(expr)
+                    && file.commonJsModuleIndicator
+                    && isModuleExportsAccessExpression(expr)
+                    && !lookupSymbolForName(blockScopeContainer, "module" as __String)
                 ) {
                     declareSymbol(file.locals!, /*parent*/ undefined, expr.expression, SymbolFlags.FunctionScopedVariable | SymbolFlags.ModuleExports, SymbolFlags.FunctionScopedVariableExcludes);
                 }
@@ -2985,9 +2985,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                 // falls through
             case SyntaxKind.JSDocPropertyTag:
                 const propTag = node as JSDocPropertyLikeTag;
-                const flags = propTag.isBracketed || propTag.typeExpression && propTag.typeExpression.type.kind === SyntaxKind.JSDocOptionalType ?
-                    SymbolFlags.Property | SymbolFlags.Optional :
-                    SymbolFlags.Property;
+                const flags = propTag.isBracketed || propTag.typeExpression && propTag.typeExpression.type.kind === SyntaxKind.JSDocOptionalType
+                    ? SymbolFlags.Property | SymbolFlags.Optional
+                    : SymbolFlags.Property;
                 return declareSymbolAndAddToSymbolTable(propTag, flags, SymbolFlags.PropertyExcludes);
             case SyntaxKind.JSDocTypedefTag:
             case SyntaxKind.JSDocCallbackTag:
@@ -3359,8 +3359,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                     return symbol;
                 }
                 else {
-                    const table = parent ? parent.exports! :
-                        file.jsGlobalAugmentations || (file.jsGlobalAugmentations = createSymbolTable());
+                    const table = parent ? parent.exports!
+                        : file.jsGlobalAugmentations || (file.jsGlobalAugmentations = createSymbolTable());
                     return declareSymbol(table, parent, id, flags, excludeFlags);
                 }
             });
@@ -3377,9 +3377,9 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         }
 
         // Set up the members collection if it doesn't exist already
-        const symbolTable = isPrototypeProperty ?
-            (namespaceSymbol.members || (namespaceSymbol.members = createSymbolTable())) :
-            (namespaceSymbol.exports || (namespaceSymbol.exports = createSymbolTable()));
+        const symbolTable = isPrototypeProperty
+            ? (namespaceSymbol.members || (namespaceSymbol.members = createSymbolTable()))
+            : (namespaceSymbol.exports || (namespaceSymbol.exports = createSymbolTable()));
 
         let includes = SymbolFlags.None;
         let excludes = SymbolFlags.None;
@@ -3451,11 +3451,11 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         if (node && isCallExpression(node)) {
             return !!getAssignedExpandoInitializer(node);
         }
-        let init = !node ? undefined :
-            isVariableDeclaration(node) ? node.initializer :
-            isBinaryExpression(node) ? node.right :
-            isPropertyAccessExpression(node) && isBinaryExpression(node.parent) ? node.parent.right :
-            undefined;
+        let init = !node ? undefined
+            : isVariableDeclaration(node) ? node.initializer
+            : isBinaryExpression(node) ? node.right
+            : isPropertyAccessExpression(node) && isBinaryExpression(node.parent) ? node.parent.right
+            : undefined;
         init = init && getRightMostAssignedExpression(init);
         if (init) {
             const isPrototypeAssignment = isPrototypeAccess(isVariableDeclaration(node!) ? node.name : isBinaryExpression(node!) ? node.left : node!);
@@ -3557,10 +3557,10 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         if (!isBindingPattern(node.name)) {
             const possibleVariableDecl = node.kind === SyntaxKind.VariableDeclaration ? node : node.parent.parent;
             if (
-                isInJSFile(node) &&
-                isVariableDeclarationInitializedToBareOrAccessedRequire(possibleVariableDecl) &&
-                !getJSDocTypeTag(node) &&
-                !(getCombinedModifierFlags(node) & ModifierFlags.Export)
+                isInJSFile(node)
+                && isVariableDeclarationInitializedToBareOrAccessedRequire(possibleVariableDecl)
+                && !getJSDocTypeTag(node)
+                && !(getCombinedModifierFlags(node) & ModifierFlags.Export)
             ) {
                 declareSymbolAndAddToSymbolTable(node as Declaration, SymbolFlags.Alias, SymbolFlags.AliasExcludes);
             }
@@ -3702,11 +3702,11 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
         if (currentFlow === unreachableFlow) {
             const reportError =
                 // report error on all statements except empty ones
-                (isStatementButNotDeclaration(node) && node.kind !== SyntaxKind.EmptyStatement) ||
+                (isStatementButNotDeclaration(node) && node.kind !== SyntaxKind.EmptyStatement)
                 // report error on class declarations
-                node.kind === SyntaxKind.ClassDeclaration ||
+                || node.kind === SyntaxKind.ClassDeclaration
                 // report error on instantiated modules or const-enums only modules if preserveConstEnums is set
-                (node.kind === SyntaxKind.ModuleDeclaration && shouldReportErrorOnModuleDeclaration(node as ModuleDeclaration));
+                || (node.kind === SyntaxKind.ModuleDeclaration && shouldReportErrorOnModuleDeclaration(node as ModuleDeclaration));
 
             if (reportError) {
                 currentFlow = reportedUnreachableFlow;
@@ -3721,12 +3721,12 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
                     //   - node is not block scoped variable statement and at least one variable declaration has initializer
                     //   Rationale: we don't want to report errors on non-initialized var's since they are hoisted
                     //   On the other side we do want to report errors on non-initialized 'lets' because of TDZ
-                    const isError = unreachableCodeIsError(options) &&
-                        !(node.flags & NodeFlags.Ambient) &&
-                        (
-                            !isVariableStatement(node) ||
-                            !!(getCombinedNodeFlags(node.declarationList) & NodeFlags.BlockScoped) ||
-                            node.declarationList.declarations.some(d => !!d.initializer)
+                    const isError = unreachableCodeIsError(options)
+                        && !(node.flags & NodeFlags.Ambient)
+                        && (
+                            !isVariableStatement(node)
+                            || !!(getCombinedNodeFlags(node.declarationList) & NodeFlags.BlockScoped)
+                            || node.declarationList.declarations.some(d => !!d.initializer)
                         );
 
                     eachUnreachableRange(node, (start, end) => errorOrSuggestionOnRange(isError, start, end, Diagnostics.Unreachable_code_detected));
@@ -3750,9 +3750,9 @@ function eachUnreachableRange(node: Node, cb: (start: Node, last: Node) => void)
 // As opposed to a pure declaration like an `interface`
 function isExecutableStatement(s: Statement): boolean {
     // Don't remove statements that can validly be used before they appear.
-    return !isFunctionDeclaration(s) && !isPurelyTypeDeclaration(s) && !isEnumDeclaration(s) &&
+    return !isFunctionDeclaration(s) && !isPurelyTypeDeclaration(s) && !isEnumDeclaration(s)
         // `var x;` may declare a variable used above
-        !(isVariableStatement(s) && !(getCombinedNodeFlags(s) & (NodeFlags.BlockScoped)) && s.declarationList.declarations.some(d => !d.initializer));
+        && !(isVariableStatement(s) && !(getCombinedNodeFlags(s) & (NodeFlags.BlockScoped)) && s.declarationList.declarations.some(d => !d.initializer));
 }
 
 function isPurelyTypeDeclaration(s: Statement): boolean {

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -320,18 +320,18 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
 
     const useOldState = BuilderState.canReuseOldState(state.referencedMap, oldState);
     const oldCompilerOptions = useOldState ? oldState!.compilerOptions : undefined;
-    const canCopySemanticDiagnostics = useOldState && oldState!.semanticDiagnosticsPerFile && !!state.semanticDiagnosticsPerFile &&
-        !compilerOptionsAffectSemanticDiagnostics(compilerOptions, oldCompilerOptions!);
+    const canCopySemanticDiagnostics = useOldState && oldState!.semanticDiagnosticsPerFile && !!state.semanticDiagnosticsPerFile
+        && !compilerOptionsAffectSemanticDiagnostics(compilerOptions, oldCompilerOptions!);
     // We can only reuse emit signatures (i.e. .d.ts signatures) if the .d.ts file is unchanged,
     // which will eg be depedent on change in options like declarationDir and outDir options are unchanged.
     // We need to look in oldState.compilerOptions, rather than oldCompilerOptions (i.e.we need to disregard useOldState) because
     // oldCompilerOptions can be undefined if there was change in say module from None to some other option
     // which would make useOldState as false since we can now use reference maps that are needed to track what to emit, what to check etc
     // but that option change does not affect d.ts file name so emitSignatures should still be reused.
-    const canCopyEmitSignatures = compilerOptions.composite &&
-        oldState?.emitSignatures &&
-        !outFilePath &&
-        !compilerOptionsAffectDeclarationPath(compilerOptions, oldState.compilerOptions);
+    const canCopyEmitSignatures = compilerOptions.composite
+        && oldState?.emitSignatures
+        && !outFilePath
+        && !compilerOptionsAffectDeclarationPath(compilerOptions, oldState.compilerOptions);
     if (useOldState) {
         // Copy old state's changed files set
         oldState!.changedFilesSet?.forEach(value => state.changedFilesSet.add(value));
@@ -357,17 +357,17 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
 
         // if not using old state, every file is changed
         if (
-            !useOldState ||
+            !useOldState
             // File wasn't present in old state
-            !(oldInfo = oldState!.fileInfos.get(sourceFilePath)) ||
+            || !(oldInfo = oldState!.fileInfos.get(sourceFilePath))
             // versions dont match
-            oldInfo.version !== info.version ||
+            || oldInfo.version !== info.version
             // Implied formats dont match
-            oldInfo.impliedFormat !== info.impliedFormat ||
+            || oldInfo.impliedFormat !== info.impliedFormat
             // Referenced files changed
-            !hasSameKeys(newReferences = referencedMap && referencedMap.getValues(sourceFilePath), oldReferencedMap && oldReferencedMap.getValues(sourceFilePath)) ||
+            || !hasSameKeys(newReferences = referencedMap && referencedMap.getValues(sourceFilePath), oldReferencedMap && oldReferencedMap.getValues(sourceFilePath))
             // Referenced file was deleted in the new program
-            newReferences && forEachKey(newReferences, path => !state.fileInfos.has(path) && oldState!.fileInfos.has(path))
+            || newReferences && forEachKey(newReferences, path => !state.fileInfos.has(path) && oldState!.fileInfos.has(path))
         ) {
             // Register file as changed file and do not copy semantic diagnostics, since all changed files need to be re-evaluated
             addFileToChangeSet(state, sourceFilePath);
@@ -378,9 +378,9 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
             if (emitDiagnostics) {
                 (state.emitDiagnosticsPerFile ??= new Map()).set(
                     sourceFilePath,
-                    oldState!.hasReusableDiagnostic ?
-                        convertToDiagnostics(emitDiagnostics as readonly ReusableDiagnostic[], newProgram) :
-                        repopulateDiagnostics(emitDiagnostics as readonly Diagnostic[], newProgram),
+                    oldState!.hasReusableDiagnostic
+                        ? convertToDiagnostics(emitDiagnostics as readonly ReusableDiagnostic[], newProgram)
+                        : repopulateDiagnostics(emitDiagnostics as readonly Diagnostic[], newProgram),
                 );
             }
 
@@ -393,9 +393,9 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
                 if (diagnostics) {
                     state.semanticDiagnosticsPerFile!.set(
                         sourceFilePath,
-                        oldState!.hasReusableDiagnostic ?
-                            convertToDiagnostics(diagnostics as readonly ReusableDiagnostic[], newProgram) :
-                            repopulateDiagnostics(diagnostics as readonly Diagnostic[], newProgram),
+                        oldState!.hasReusableDiagnostic
+                            ? convertToDiagnostics(diagnostics as readonly ReusableDiagnostic[], newProgram)
+                            : repopulateDiagnostics(diagnostics as readonly Diagnostic[], newProgram),
                     );
                     (state.semanticDiagnosticsFromOldState ??= new Set()).add(sourceFilePath);
                 }
@@ -425,9 +425,9 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
     else if (oldCompilerOptions) {
         // If options affect emit, then we need to do complete emit per compiler options
         // otherwise only the js or dts that needs to emitted because its different from previously emitted options
-        const pendingEmitKind = compilerOptionsAffectEmit(compilerOptions, oldCompilerOptions) ?
-            getBuilderFileEmit(compilerOptions) :
-            getPendingEmitKind(compilerOptions, oldCompilerOptions);
+        const pendingEmitKind = compilerOptionsAffectEmit(compilerOptions, oldCompilerOptions)
+            ? getBuilderFileEmit(compilerOptions)
+            : getPendingEmitKind(compilerOptions, oldCompilerOptions);
         if (pendingEmitKind !== BuilderFileEmit.None) {
             if (!outFilePath) {
                 // Add all files to affectedFilesPendingEmit since emit changed
@@ -446,9 +446,9 @@ function createBuilderProgramState(newProgram: Program, oldState: Readonly<Reusa
                 state.buildInfoEmitPending = true;
             }
             else {
-                state.programEmitPending = state.programEmitPending ?
-                    state.programEmitPending | pendingEmitKind :
-                    pendingEmitKind;
+                state.programEmitPending = state.programEmitPending
+                    ? state.programEmitPending | pendingEmitKind
+                    : pendingEmitKind;
             }
         }
     }
@@ -467,11 +467,11 @@ function addFileToChangeSet(state: BuilderProgramState, path: Path) {
  * If d.ts map options differ then swap the format, otherwise use as is
  */
 function getEmitSignatureFromOldSignature(options: CompilerOptions, oldOptions: CompilerOptions, oldEmitSignature: EmitSignature): EmitSignature {
-    return !!options.declarationMap === !!oldOptions.declarationMap ?
+    return !!options.declarationMap === !!oldOptions.declarationMap
         // Use same format of signature
-        oldEmitSignature :
+        ? oldEmitSignature
         // Convert to different format
-        isString(oldEmitSignature) ? [oldEmitSignature] : oldEmitSignature[0];
+        : isString(oldEmitSignature) ? [oldEmitSignature] : oldEmitSignature[0];
 }
 
 function repopulateDiagnostics(diagnostics: readonly Diagnostic[], newProgram: Program): readonly Diagnostic[] {
@@ -479,9 +479,9 @@ function repopulateDiagnostics(diagnostics: readonly Diagnostic[], newProgram: P
     return sameMap(diagnostics, diag => {
         if (isString(diag.messageText)) return diag;
         const repopulatedChain = convertOrRepopulateDiagnosticMessageChain(diag.messageText, diag.file, newProgram, chain => chain.repopulateInfo?.());
-        return repopulatedChain === diag.messageText ?
-            diag :
-            { ...diag, messageText: repopulatedChain };
+        return repopulatedChain === diag.messageText
+            ? diag
+            : { ...diag, messageText: repopulatedChain };
     });
 }
 
@@ -521,11 +521,11 @@ function convertToDiagnostics(diagnostics: readonly ReusableDiagnostic[], newPro
         result.source = diagnostic.source;
         result.skippedOn = diagnostic.skippedOn;
         const { relatedInformation } = diagnostic;
-        result.relatedInformation = relatedInformation ?
-            relatedInformation.length ?
-                relatedInformation.map(r => convertToDiagnosticRelatedInformation(r, newProgram, toPathInBuildInfoDirectory)) :
-                [] :
-            undefined;
+        result.relatedInformation = relatedInformation
+            ? relatedInformation.length
+                ? relatedInformation.map(r => convertToDiagnosticRelatedInformation(r, newProgram, toPathInBuildInfoDirectory))
+                : []
+            : undefined;
         return result;
     });
 
@@ -541,9 +541,9 @@ function convertToDiagnosticRelatedInformation(diagnostic: ReusableDiagnosticRel
     return {
         ...diagnostic,
         file: sourceFile,
-        messageText: isString(diagnostic.messageText) ?
-            diagnostic.messageText :
-            convertOrRepopulateDiagnosticMessageChain(diagnostic.messageText, sourceFile, newProgram, chain => (chain as ReusableRepopulateModuleNotFoundChain).info),
+        messageText: isString(diagnostic.messageText)
+            ? diagnostic.messageText
+            : convertOrRepopulateDiagnosticMessageChain(diagnostic.messageText, sourceFile, newProgram, chain => (chain as ReusableRepopulateModuleNotFoundChain).info),
     };
 }
 
@@ -712,9 +712,9 @@ function removeDiagnosticsOfLibraryFiles(state: BuilderProgramState) {
         const program = Debug.checkDefined(state.program);
         const options = program.getCompilerOptions();
         forEach(program.getSourceFiles(), f =>
-            program.isSourceFileDefaultLibrary(f) &&
-            !skipTypeChecking(f, options, program) &&
-            removeSemanticDiagnosticsOf(state, f.resolvedPath));
+            program.isSourceFileDefaultLibrary(f)
+            && !skipTypeChecking(f, options, program)
+            && removeSemanticDiagnosticsOf(state, f.resolvedPath));
     }
 }
 
@@ -1055,9 +1055,9 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
             // Ensure fileId
             const fileId = toFileId(key);
             tryAddRoot(key, fileId);
-            return value.impliedFormat ?
-                { version: value.version, impliedFormat: value.impliedFormat, signature: undefined, affectsGlobalScope: undefined } :
-                value.version;
+            return value.impliedFormat
+                ? { version: value.version, impliedFormat: value.impliedFormat, signature: undefined, affectsGlobalScope: undefined }
+                : value.version;
         });
         const program: ProgramBundleEmitBuildInfo = {
             fileNames,
@@ -1066,11 +1066,11 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
             options: convertToProgramBuildInfoCompilerOptions(state.compilerOptions),
             outSignature: state.outSignature,
             latestChangedDtsFile,
-            pendingEmit: !state.programEmitPending ?
-                undefined : // Pending is undefined or None is encoded as undefined
-                state.programEmitPending === getBuilderFileEmit(state.compilerOptions) ?
-                false : // Pending emit is same as deteremined by compilerOptions
-                state.programEmitPending, // Actual value
+            pendingEmit: !state.programEmitPending
+                ? undefined // Pending is undefined or None is encoded as undefined
+                : state.programEmitPending === getBuilderFileEmit(state.compilerOptions)
+                ? false // Pending emit is same as deteremined by compilerOptions
+                : state.programEmitPending, // Actual value
         };
         return createBuildInfo(program);
     }
@@ -1091,28 +1091,28 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
                 const emitSignature = state.emitSignatures?.get(key);
                 if (emitSignature !== actualSignature) {
                     (emitSignatures ||= []).push(
-                        emitSignature === undefined ?
-                            fileId : // There is no emit, encode as false
+                        emitSignature === undefined
+                            ? fileId // There is no emit, encode as false
                             // fileId, signature: emptyArray if signature only differs in dtsMap option than our own compilerOptions otherwise EmitSignature
-                            [fileId, !isString(emitSignature) && emitSignature[0] === actualSignature ? emptyArray as [] : emitSignature],
+                            : [fileId, !isString(emitSignature) && emitSignature[0] === actualSignature ? emptyArray as [] : emitSignature],
                     );
                 }
             }
         }
-        return value.version === actualSignature ?
-            value.affectsGlobalScope || value.impliedFormat ?
+        return value.version === actualSignature
+            ? value.affectsGlobalScope || value.impliedFormat
                 // If file version is same as signature, dont serialize signature
-                { version: value.version, signature: undefined, affectsGlobalScope: value.affectsGlobalScope, impliedFormat: value.impliedFormat } :
+                ? { version: value.version, signature: undefined, affectsGlobalScope: value.affectsGlobalScope, impliedFormat: value.impliedFormat }
                 // If file info only contains version and signature and both are same we can just write string
-                value.version :
-            actualSignature !== undefined ? // If signature is not same as version, encode signature in the fileInfo
-            oldSignature === undefined ?
+                : value.version
+            : actualSignature !== undefined // If signature is not same as version, encode signature in the fileInfo
+            ? oldSignature === undefined
                 // If we havent computed signature, use fileInfo as is
-                value :
+                ? value
                 // Serialize fileInfo with new updated signature
-                { version: value.version, signature: actualSignature, affectsGlobalScope: value.affectsGlobalScope, impliedFormat: value.impliedFormat } :
+                : { version: value.version, signature: actualSignature, affectsGlobalScope: value.affectsGlobalScope, impliedFormat: value.impliedFormat }
             // Signature of the FileInfo is undefined, serialize it as false
-            { version: value.version, signature: false, affectsGlobalScope: value.affectsGlobalScope, impliedFormat: value.impliedFormat };
+            : { version: value.version, signature: false, affectsGlobalScope: value.affectsGlobalScope, impliedFormat: value.impliedFormat };
     });
 
     let referencedMap: ProgramBuildInfoReferencedMap | undefined;
@@ -1134,11 +1134,11 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
                 if (!file || !sourceFileMayBeEmitted(file, state.program!)) continue;
                 const fileId = toFileId(path), pendingEmit = state.affectedFilesPendingEmit.get(path)!;
                 (affectedFilesPendingEmit ||= []).push(
-                    pendingEmit === fullEmitForOptions ?
-                        fileId : // Pending full emit per options
-                        pendingEmit === BuilderFileEmit.Dts ?
-                        [fileId] : // Pending on Dts only
-                        [fileId, pendingEmit], // Anything else
+                    pendingEmit === fullEmitForOptions
+                        ? fileId // Pending full emit per options
+                        : pendingEmit === BuilderFileEmit.Dts
+                        ? [fileId] // Pending on Dts only
+                        : [fileId, pendingEmit], // Anything else
                 );
             }
         }
@@ -1254,12 +1254,12 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
             for (const key of arrayFrom(diagnostics.keys()).sort(compareStringsCaseSensitive)) {
                 const value = diagnostics.get(key)!;
                 (result ||= []).push(
-                    value.length ?
-                        [
+                    value.length
+                        ? [
                             toFileId(key),
                             convertToReusableDiagnostics(value),
-                        ] :
-                        toFileId(key),
+                        ]
+                        : toFileId(key),
                 );
             }
         }
@@ -1275,11 +1275,11 @@ function getBuildInfo(state: BuilderProgramState): BuildInfo {
             result.source = diagnostic.source;
             result.skippedOn = diagnostic.skippedOn;
             const { relatedInformation } = diagnostic;
-            result.relatedInformation = relatedInformation ?
-                relatedInformation.length ?
-                    relatedInformation.map(r => convertToReusableDiagnosticRelatedInformation(r)) :
-                    [] :
-                undefined;
+            result.relatedInformation = relatedInformation
+                ? relatedInformation.length
+                    ? relatedInformation.map(r => convertToReusableDiagnosticRelatedInformation(r))
+                    : []
+                : undefined;
             return result;
         });
     }
@@ -1386,13 +1386,13 @@ export function computeSignatureWithDiagnostics(
     return (host.createHash ?? generateDjb2Hash)(text);
 
     function flattenDiagnosticMessageText(diagnostic: string | DiagnosticMessageChain | undefined): string {
-        return isString(diagnostic) ?
-            diagnostic :
-            diagnostic === undefined ?
-            "" :
-            !diagnostic.next ?
-            diagnostic.messageText :
-            diagnostic.messageText + diagnostic.next.map(flattenDiagnosticMessageText).join("\n");
+        return isString(diagnostic)
+            ? diagnostic
+            : diagnostic === undefined
+            ? ""
+            : !diagnostic.next
+            ? diagnostic.messageText
+            : diagnostic.messageText + diagnostic.next.map(flattenDiagnosticMessageText).join("\n");
     }
 
     function locationInfo(diagnostic: DiagnosticWithLocation) {
@@ -1477,8 +1477,8 @@ export function createBuilderProgram(kind: BuilderProgramKind, { newProgram, hos
     function emitNextAffectedFile(writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): AffectedFileResult<EmitResult> {
         let affected = getNextAffectedFile(state, cancellationToken, host);
         const programEmitKind = getBuilderFileEmit(state.compilerOptions);
-        let emitKind: BuilderFileEmit = emitOnlyDtsFiles ?
-            programEmitKind & BuilderFileEmit.AllDts : programEmitKind;
+        let emitKind: BuilderFileEmit = emitOnlyDtsFiles
+            ? programEmitKind & BuilderFileEmit.AllDts : programEmitKind;
         if (!affected) {
             if (!state.compilerOptions.outFile) {
                 const pendingAffectedFile = getNextAffectedFilePendingEmit(state, emitOnlyDtsFiles);
@@ -1516,11 +1516,11 @@ export function createBuilderProgram(kind: BuilderProgramKind, { newProgram, hos
         if (emitKind & BuilderFileEmit.AllDts) emitOnly = emitOnly === undefined ? EmitOnly.Dts : undefined;
         if (affected === state.program) {
             // Set up programEmit before calling emit so that its set in buildInfo
-            state.programEmitPending = state.changedFilesSet.size ?
-                getPendingEmitKind(programEmitKind, emitKind) :
-                state.programEmitPending ?
-                getPendingEmitKind(state.programEmitPending, emitKind) :
-                undefined;
+            state.programEmitPending = state.changedFilesSet.size
+                ? getPendingEmitKind(programEmitKind, emitKind)
+                : state.programEmitPending
+                ? getPendingEmitKind(state.programEmitPending, emitKind)
+                : undefined;
         }
         // Actual emit
         const result = state.program!.emit(
@@ -1763,11 +1763,11 @@ function addToAffectedFilesPendingEmit(state: BuilderProgramState, affectedFileP
 
 /** @internal */
 export function toBuilderStateFileInfoForMultiEmit(fileInfo: ProgramMultiFileEmitBuildInfoFileInfo): BuilderState.FileInfo {
-    return isString(fileInfo) ?
-        { version: fileInfo, signature: fileInfo, affectsGlobalScope: undefined, impliedFormat: undefined } :
-        isString(fileInfo.signature) ?
-        fileInfo as BuilderState.FileInfo :
-        { version: fileInfo.version, signature: fileInfo.signature === false ? undefined : fileInfo.version, affectsGlobalScope: fileInfo.affectsGlobalScope, impliedFormat: fileInfo.impliedFormat };
+    return isString(fileInfo)
+        ? { version: fileInfo, signature: fileInfo, affectsGlobalScope: undefined, impliedFormat: undefined }
+        : isString(fileInfo.signature)
+        ? fileInfo as BuilderState.FileInfo
+        : { version: fileInfo.version, signature: fileInfo.signature === false ? undefined : fileInfo.version, affectsGlobalScope: fileInfo.affectsGlobalScope, impliedFormat: fileInfo.impliedFormat };
 }
 
 /** @internal */
@@ -1820,10 +1820,10 @@ export function createBuilderProgramUsingProgramBuildInfo(buildInfo: BuildInfo, 
                 const key = toFilePath(value[0]);
                 emitSignatures!.set(
                     key,
-                    !isString(value[1]) && !value[1].length ?
+                    !isString(value[1]) && !value[1].length
                         // File signature is emit signature but differs in map
-                        [emitSignatures!.get(key)! as string] :
-                        value[1],
+                        ? [emitSignatures!.get(key)! as string]
+                        : value[1],
                 );
             }
         });

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -272,8 +272,8 @@ export namespace BuilderState {
             for (const declaration of symbol.declarations) {
                 const declarationSourceFile = getSourceFileOfNode(declaration);
                 if (
-                    declarationSourceFile &&
-                    declarationSourceFile !== sourceFile
+                    declarationSourceFile
+                    && declarationSourceFile !== sourceFile
                 ) {
                     addReferencedFile(declarationSourceFile.resolvedPath);
                 }
@@ -299,8 +299,8 @@ export namespace BuilderState {
         const fileInfos = new Map<Path, FileInfo>();
         const options = newProgram.getCompilerOptions();
         const isOutFile = options.outFile;
-        const referencedMap = options.module !== ModuleKind.None && !isOutFile ?
-            createManyToManyPathMap() : undefined;
+        const referencedMap = options.module !== ModuleKind.None && !isOutFile
+            ? createManyToManyPathMap() : undefined;
         const useOldState = canReuseOldState(referencedMap, oldState);
 
         // Ensure source files have parent pointers set
@@ -310,9 +310,9 @@ export namespace BuilderState {
         for (const sourceFile of newProgram.getSourceFiles()) {
             const version = Debug.checkDefined(sourceFile.version, "Program intended to be used with Builder should have source files with versions set");
             const oldUncommittedSignature = useOldState ? oldState!.oldSignatures?.get(sourceFile.resolvedPath) : undefined;
-            const signature = oldUncommittedSignature === undefined ?
-                useOldState ? oldState!.fileInfos.get(sourceFile.resolvedPath)?.signature : undefined :
-                oldUncommittedSignature || undefined;
+            const signature = oldUncommittedSignature === undefined
+                ? useOldState ? oldState!.fileInfos.get(sourceFile.resolvedPath)?.signature : undefined
+                : oldUncommittedSignature || undefined;
             if (referencedMap) {
                 const newReferences = getReferencedFiles(newProgram, sourceFile, newProgram.getCanonicalFileName);
                 if (newReferences) {
@@ -531,8 +531,8 @@ export namespace BuilderState {
      * Return true if the file will invalidate all files because it affectes global scope
      */
     function isFileAffectingGlobalScope(sourceFile: SourceFile) {
-        return containsGlobalScopeAugmentation(sourceFile) ||
-            !isExternalOrCommonJsModule(sourceFile) && !isJsonSourceFile(sourceFile) && !containsOnlyAmbientModules(sourceFile);
+        return containsGlobalScopeAugmentation(sourceFile)
+            || !isExternalOrCommonJsModule(sourceFile) && !isJsonSourceFile(sourceFile) && !containsOnlyAmbientModules(sourceFile);
     }
 
     /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1406,8 +1406,8 @@ export function getSymbolId(symbol: Symbol): SymbolId {
 /** @internal */
 export function isInstantiatedModule(node: ModuleDeclaration, preserveConstEnums: boolean) {
     const moduleState = getModuleInstanceState(node);
-    return moduleState === ModuleInstanceState.Instantiated ||
-        (preserveConstEnums && moduleState === ModuleInstanceState.ConstEnumOnly);
+    return moduleState === ModuleInstanceState.Instantiated
+        || (preserveConstEnums && moduleState === ModuleInstanceState.ConstEnumOnly);
 }
 
 /** @internal */
@@ -2537,8 +2537,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      */
     function mergeSymbol(target: Symbol, source: Symbol, unidirectional = false): Symbol {
         if (
-            !(target.flags & getExcludedSymbolFlags(source.flags)) ||
-            (source.flags | target.flags) & SymbolFlags.Assignment
+            !(target.flags & getExcludedSymbolFlags(source.flags))
+            || (source.flags | target.flags) & SymbolFlags.Assignment
         ) {
             if (source === target) {
                 // This can happen when an export assigned namespace exports something also erroneously exported at the top level
@@ -2796,10 +2796,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const declContainer = getEnclosingBlockScopeContainer(declaration);
         if (declarationFile !== useFile) {
             if (
-                (moduleKind && (declarationFile.externalModuleIndicator || useFile.externalModuleIndicator)) ||
-                (!compilerOptions.outFile) ||
-                isInTypeQuery(usage) ||
-                declaration.flags & NodeFlags.Ambient
+                (moduleKind && (declarationFile.externalModuleIndicator || useFile.externalModuleIndicator))
+                || (!compilerOptions.outFile)
+                || isInTypeQuery(usage)
+                || declaration.flags & NodeFlags.Ambient
             ) {
                 // nodes are in different files and order cannot be determined
                 return true;
@@ -2824,8 +2824,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // still might be illegal if declaration and usage are both binding elements (eg var [a = b, b = b] = [1, 2])
                 const errorBindingElement = getAncestor(usage, SyntaxKind.BindingElement) as BindingElement;
                 if (errorBindingElement) {
-                    return findAncestor(errorBindingElement, isBindingElement) !== findAncestor(declaration, isBindingElement) ||
-                        declaration.pos < errorBindingElement.pos;
+                    return findAncestor(errorBindingElement, isBindingElement) !== findAncestor(declaration, isBindingElement)
+                        || declaration.pos < errorBindingElement.pos;
                 }
                 // or it might be illegal if usage happens before parent variable is declared (eg var [a] = a)
                 return isBlockScopedNameDeclaredBeforeUse(getAncestor(declaration, SyntaxKind.VariableDeclaration) as Declaration, usage);
@@ -2839,13 +2839,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // or when used within a decorator in the class (e.g. `@dec(A.x) class A { static x = "x" }`),
                 // except when used in a function that is not an IIFE (e.g., `@dec(() => A.x) class A { ... }`)
                 const container = findAncestor(usage, n =>
-                    n === declaration ? "quit" :
-                        isComputedPropertyName(n) ? n.parent.parent === declaration :
-                        isDecorator(n) && (n.parent === declaration ||
-                            isMethodDeclaration(n.parent) && n.parent.parent === declaration ||
-                            isGetOrSetAccessorDeclaration(n.parent) && n.parent.parent === declaration ||
-                            isPropertyDeclaration(n.parent) && n.parent.parent === declaration ||
-                            isParameter(n.parent) && n.parent.parent.parent === declaration));
+                    n === declaration ? "quit"
+                        : isComputedPropertyName(n) ? n.parent.parent === declaration
+                        : isDecorator(n) && (n.parent === declaration
+                            || isMethodDeclaration(n.parent) && n.parent.parent === declaration
+                            || isGetOrSetAccessorDeclaration(n.parent) && n.parent.parent === declaration
+                            || isPropertyDeclaration(n.parent) && n.parent.parent === declaration
+                            || isParameter(n.parent) && n.parent.parent.parent === declaration));
                 if (!container) {
                     return true;
                 }
@@ -2977,8 +2977,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return true;
                     case SyntaxKind.PropertyDeclaration:
                         // even when stopping at any property declaration, they need to come from the same class
-                        return stopAtAnyPropertyDeclaration &&
-                                (isPropertyDeclaration(declaration) && node.parent === declaration.parent
+                        return stopAtAnyPropertyDeclaration
+                                && (isPropertyDeclaration(declaration) && node.parent === declaration.parent
                                     || isParameterPropertyDeclaration(declaration, declaration.parent) && node.parent === declaration.parent.parent)
                             ? "quit" : true;
                     case SyntaxKind.Block:
@@ -3137,11 +3137,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         if (meaning & result.flags & SymbolFlags.Type && lastLocation.kind !== SyntaxKind.JSDoc) {
                             useResult = result.flags & SymbolFlags.TypeParameter
                                 // type parameters are visible in parameter list, return type and type parameter list
-                                ? lastLocation === (location as FunctionLikeDeclaration).type ||
-                                    lastLocation.kind === SyntaxKind.Parameter ||
-                                    lastLocation.kind === SyntaxKind.JSDocParameterTag ||
-                                    lastLocation.kind === SyntaxKind.JSDocReturnTag ||
-                                    lastLocation.kind === SyntaxKind.TypeParameter
+                                ? lastLocation === (location as FunctionLikeDeclaration).type
+                                    || lastLocation.kind === SyntaxKind.Parameter
+                                    || lastLocation.kind === SyntaxKind.JSDocParameterTag
+                                    || lastLocation.kind === SyntaxKind.JSDocReturnTag
+                                    || lastLocation.kind === SyntaxKind.TypeParameter
                                 // local types not visible outside the function body
                                 : false;
                         }
@@ -3155,10 +3155,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 // technically for parameter list case here we might mix parameters and variables declared in function,
                                 // however it is detected separately when checking initializers of parameters
                                 // to make sure that they reference no variables declared after them.
-                                useResult = lastLocation.kind === SyntaxKind.Parameter ||
-                                    (
-                                        lastLocation === (location as FunctionLikeDeclaration).type &&
-                                        !!findAncestor(result.valueDeclaration, isParameter)
+                                useResult = lastLocation.kind === SyntaxKind.Parameter
+                                    || (
+                                        lastLocation === (location as FunctionLikeDeclaration).type
+                                        && !!findAncestor(result.valueDeclaration, isParameter)
                                     );
                             }
                         }
@@ -3209,9 +3209,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         //        which is not the desired behavior.
                         const moduleExport = moduleExports.get(name);
                         if (
-                            moduleExport &&
-                            moduleExport.flags === SymbolFlags.Alias &&
-                            (getDeclarationOfKind(moduleExport, SyntaxKind.ExportSpecifier) || getDeclarationOfKind(moduleExport, SyntaxKind.NamespaceExport))
+                            moduleExport
+                            && moduleExport.flags === SymbolFlags.Alias
+                            && (getDeclarationOfKind(moduleExport, SyntaxKind.ExportSpecifier) || getDeclarationOfKind(moduleExport, SyntaxKind.NamespaceExport))
                         ) {
                             break;
                         }
@@ -3394,8 +3394,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.Parameter:
                     if (
                         lastLocation && (
-                            lastLocation === (location as ParameterDeclaration).initializer ||
-                            lastLocation === (location as ParameterDeclaration).name && isBindingPattern(lastLocation)
+                            lastLocation === (location as ParameterDeclaration).initializer
+                            || lastLocation === (location as ParameterDeclaration).name && isBindingPattern(lastLocation)
                         )
                     ) {
                         if (!associatedDeclarationForContainingInitializerOrBindingName) {
@@ -3406,8 +3406,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.BindingElement:
                     if (
                         lastLocation && (
-                            lastLocation === (location as BindingElement).initializer ||
-                            lastLocation === (location as BindingElement).name && isBindingPattern(lastLocation)
+                            lastLocation === (location as BindingElement).initializer
+                            || lastLocation === (location as BindingElement).name && isBindingPattern(lastLocation)
                         )
                     ) {
                         if (isParameterDeclaration(location as BindingElement) && !associatedDeclarationForContainingInitializerOrBindingName) {
@@ -3427,9 +3427,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.ExportSpecifier:
                     // External module export bindings shouldn't be resolved to local symbols.
                     if (
-                        lastLocation &&
-                        lastLocation === (location as ExportSpecifier).propertyName &&
-                        (location as ExportSpecifier).parent.parent.moduleSpecifier
+                        lastLocation
+                        && lastLocation === (location as ExportSpecifier).propertyName
+                        && (location as ExportSpecifier).parent.parent.moduleSpecifier
                     ) {
                         location = location.parent.parent.parent;
                     }
@@ -3439,9 +3439,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 lastSelfReferenceLocation = location;
             }
             lastLocation = location;
-            location = isJSDocTemplateTag(location) ? getEffectiveContainerForJSDocTemplateTag(location) || location.parent :
-                isJSDocParameterTag(location) || isJSDocReturnTag(location) ? getHostSignatureFromJSDoc(location) || location.parent :
-                location.parent;
+            location = isJSDocTemplateTag(location) ? getEffectiveContainerForJSDocTemplateTag(location) || location.parent
+                : isJSDocParameterTag(location) || isJSDocReturnTag(location) ? getHostSignatureFromJSDoc(location) || location.parent
+                : location.parent;
         }
 
         // We just climbed up parents looking for the name, meaning that we started in a descendant node of `lastLocation`.
@@ -3496,16 +3496,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (nameNotFoundMessage) {
                 addLazyDiagnostic(() => {
                     if (
-                        !errorLocation ||
-                        errorLocation.parent.kind !== SyntaxKind.JSDocLink &&
-                            !checkAndReportErrorForMissingPrefix(errorLocation, name, nameArg!) && // TODO: GH#18217
-                            !checkAndReportErrorForInvalidInitializer() &&
-                            !checkAndReportErrorForExtendingInterface(errorLocation) &&
-                            !checkAndReportErrorForUsingTypeAsNamespace(errorLocation, name, meaning) &&
-                            !checkAndReportErrorForExportingPrimitiveType(errorLocation, name) &&
-                            !checkAndReportErrorForUsingNamespaceAsTypeOrValue(errorLocation, name, meaning) &&
-                            !checkAndReportErrorForUsingTypeAsValue(errorLocation, name, meaning) &&
-                            !checkAndReportErrorForUsingValueAsType(errorLocation, name, meaning)
+                        !errorLocation
+                        || errorLocation.parent.kind !== SyntaxKind.JSDocLink
+                            && !checkAndReportErrorForMissingPrefix(errorLocation, name, nameArg!) // TODO: GH#18217
+                            && !checkAndReportErrorForInvalidInitializer()
+                            && !checkAndReportErrorForExtendingInterface(errorLocation)
+                            && !checkAndReportErrorForUsingTypeAsNamespace(errorLocation, name, meaning)
+                            && !checkAndReportErrorForExportingPrimitiveType(errorLocation, name)
+                            && !checkAndReportErrorForUsingNamespaceAsTypeOrValue(errorLocation, name, meaning)
+                            && !checkAndReportErrorForUsingTypeAsValue(errorLocation, name, meaning)
+                            && !checkAndReportErrorForUsingValueAsType(errorLocation, name, meaning)
                     ) {
                         let suggestion: Symbol | undefined;
                         let suggestedLib: string | undefined;
@@ -3568,9 +3568,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // try to resolve name in /*1*/ which is used in variable position,
                 // we want to check for block-scoped
                 if (
-                    errorLocation &&
-                    (meaning & SymbolFlags.BlockScopedVariable ||
-                        ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))
+                    errorLocation
+                    && (meaning & SymbolFlags.BlockScopedVariable
+                        || ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))
                 ) {
                     const exportOrLocalSymbol = getExportSymbolOfValueSymbolIfExported(result);
                     if (exportOrLocalSymbol.flags & SymbolFlags.BlockScopedVariable || exportOrLocalSymbol.flags & SymbolFlags.Class || exportOrLocalSymbol.flags & SymbolFlags.Enum) {
@@ -3649,8 +3649,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (location.kind !== SyntaxKind.ArrowFunction && location.kind !== SyntaxKind.FunctionExpression) {
             // initializers in instance property declaration of class like entities are executed in constructor and thus deferred
             return isTypeQueryNode(location) || ((
-                isFunctionLikeDeclaration(location) ||
-                (location.kind === SyntaxKind.PropertyDeclaration && !isStatic(location))
+                isFunctionLikeDeclaration(location)
+                || (location.kind === SyntaxKind.PropertyDeclaration && !isStatic(location))
             ) && (!lastLocation || lastLocation !== (location as SignatureDeclaration | PropertyDeclaration).name)); // A name is evaluated within the enclosing scope - so it shouldn't count as deferred
         }
         if (lastLocation && lastLocation === (location as FunctionExpression | ArrowFunction).name) {
@@ -4210,8 +4210,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (exportStar) {
                 const defaultExport = exportStar.declarations?.find(decl =>
                     !!(
-                        isExportDeclaration(decl) && decl.moduleSpecifier &&
-                        resolveExternalModuleName(decl, decl.moduleSpecifier)?.exports?.has(InternalSymbolName.Default)
+                        isExportDeclaration(decl) && decl.moduleSpecifier
+                        && resolveExternalModuleName(decl, decl.moduleSpecifier)?.exports?.has(InternalSymbolName.Default)
                     )
                 );
                 if (defaultExport) {
@@ -4325,9 +4325,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
 
-                const symbol = symbolFromModule && symbolFromVariable && symbolFromModule !== symbolFromVariable ?
-                    combineValueAndTypeSymbols(symbolFromVariable, symbolFromModule) :
-                    symbolFromModule || symbolFromVariable;
+                const symbol = symbolFromModule && symbolFromVariable && symbolFromModule !== symbolFromVariable
+                    ? combineValueAndTypeSymbols(symbolFromVariable, symbolFromModule)
+                    : symbolFromModule || symbolFromVariable;
                 if (!symbol) {
                     errorNoModuleMemberSymbol(moduleSymbol, targetSymbol, node, name);
                 }
@@ -4368,13 +4368,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (localSymbol) {
             const exportedEqualsSymbol = exports?.get(InternalSymbolName.ExportEquals);
             if (exportedEqualsSymbol) {
-                getSymbolIfSameReference(exportedEqualsSymbol, localSymbol) ? reportInvalidImportEqualsExportMember(node, name, declarationName, moduleName) :
-                    error(name, Diagnostics.Module_0_has_no_exported_member_1, moduleName, declarationName);
+                getSymbolIfSameReference(exportedEqualsSymbol, localSymbol) ? reportInvalidImportEqualsExportMember(node, name, declarationName, moduleName)
+                    : error(name, Diagnostics.Module_0_has_no_exported_member_1, moduleName, declarationName);
             }
             else {
                 const exportedSymbol = exports ? find(symbolsToArray(exports), symbol => !!getSymbolIfSameReference(symbol, localSymbol)) : undefined;
-                const diagnostic = exportedSymbol ? error(name, Diagnostics.Module_0_declares_1_locally_but_it_is_exported_as_2, moduleName, declarationName, symbolToString(exportedSymbol)) :
-                    error(name, Diagnostics.Module_0_declares_1_locally_but_it_is_not_exported, moduleName, declarationName);
+                const diagnostic = exportedSymbol ? error(name, Diagnostics.Module_0_declares_1_locally_but_it_is_exported_as_2, moduleName, declarationName, symbolToString(exportedSymbol))
+                    : error(name, Diagnostics.Module_0_declares_1_locally_but_it_is_not_exported, moduleName, declarationName);
                 if (localSymbol.declarations) {
                     addRelatedInfo(diagnostic, ...map(localSymbol.declarations, (decl, index) => createDiagnosticForNode(decl, index === 0 ? Diagnostics._0_is_declared_here : Diagnostics.and_here, declarationName)));
                 }
@@ -4387,19 +4387,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function reportInvalidImportEqualsExportMember(node: Node, name: Identifier, declarationName: string, moduleName: string) {
         if (moduleKind >= ModuleKind.ES2015) {
-            const message = getESModuleInterop(compilerOptions) ? Diagnostics._0_can_only_be_imported_by_using_a_default_import :
-                Diagnostics._0_can_only_be_imported_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import;
+            const message = getESModuleInterop(compilerOptions) ? Diagnostics._0_can_only_be_imported_by_using_a_default_import
+                : Diagnostics._0_can_only_be_imported_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import;
             error(name, message, declarationName);
         }
         else {
             if (isInJSFile(node)) {
-                const message = getESModuleInterop(compilerOptions) ? Diagnostics._0_can_only_be_imported_by_using_a_require_call_or_by_using_a_default_import :
-                    Diagnostics._0_can_only_be_imported_by_using_a_require_call_or_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import;
+                const message = getESModuleInterop(compilerOptions) ? Diagnostics._0_can_only_be_imported_by_using_a_require_call_or_by_using_a_default_import
+                    : Diagnostics._0_can_only_be_imported_by_using_a_require_call_or_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import;
                 error(name, message, declarationName);
             }
             else {
-                const message = getESModuleInterop(compilerOptions) ? Diagnostics._0_can_only_be_imported_by_using_import_1_require_2_or_a_default_import :
-                    Diagnostics._0_can_only_be_imported_by_using_import_1_require_2_or_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import;
+                const message = getESModuleInterop(compilerOptions) ? Diagnostics._0_can_only_be_imported_by_using_import_1_require_2_or_a_default_import
+                    : Diagnostics._0_can_only_be_imported_by_using_import_1_require_2_or_by_turning_on_the_esModuleInterop_flag_and_using_a_default_import;
                 error(name, message, declarationName, declarationName, moduleName);
             }
         }
@@ -4446,9 +4446,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return getTargetofModuleDefault(moduleSymbol, node, !!dontResolveAlias);
             }
         }
-        const resolved = node.parent.parent.moduleSpecifier ?
-            getExternalModuleMember(node.parent.parent, node, dontResolveAlias) :
-            resolveEntityName(node.propertyName || node.name, meaning, /*ignoreErrors*/ false, dontResolveAlias);
+        const resolved = node.parent.parent.moduleSpecifier
+            ? getExternalModuleMember(node.parent.parent, node, dontResolveAlias)
+            : resolveEntityName(node.propertyName || node.name, meaning, /*ignoreErrors*/ false, dontResolveAlias);
         markSymbolOfAliasDeclarationIfTypeOnly(node, /*immediateTarget*/ undefined, resolved, /*overwriteEmpty*/ false);
         return resolved;
     }
@@ -4595,8 +4595,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         while (symbol.flags & SymbolFlags.Alias) {
             const target = getExportSymbolOfValueSymbolIfExported(resolveAlias(symbol));
             if (
-                !typeOnlyDeclarationIsExportStar && target === typeOnlyResolution ||
-                typeOnlyExportStarTargets?.get(target.escapedName) === target
+                !typeOnlyDeclarationIsExportStar && target === typeOnlyResolution
+                || typeOnlyExportStarTargets?.get(target.escapedName) === target
             ) {
                 break;
             }
@@ -4709,8 +4709,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const symbol = getSymbolOfDeclaration(node);
         const target = resolveAlias(symbol);
         if (target) {
-            const markAlias = target === unknownSymbol ||
-                ((getSymbolFlags(symbol, /*excludeTypeOnlyMeanings*/ true) & SymbolFlags.Value) && !isConstEnumOrConstEnumOnlyModule(target));
+            const markAlias = target === unknownSymbol
+                || ((getSymbolFlags(symbol, /*excludeTypeOnlyMeanings*/ true) & SymbolFlags.Value) && !isConstEnumOrConstEnumOnlyModule(target));
 
             if (markAlias) {
                 markAliasSymbolAsReferenced(symbol);
@@ -4829,12 +4829,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return namespace;
             }
             if (
-                namespace.valueDeclaration &&
-                isInJSFile(namespace.valueDeclaration) &&
-                getEmitModuleResolutionKind(compilerOptions) !== ModuleResolutionKind.Bundler &&
-                isVariableDeclaration(namespace.valueDeclaration) &&
-                namespace.valueDeclaration.initializer &&
-                isCommonJsRequire(namespace.valueDeclaration.initializer)
+                namespace.valueDeclaration
+                && isInJSFile(namespace.valueDeclaration)
+                && getEmitModuleResolutionKind(compilerOptions) !== ModuleResolutionKind.Bundler
+                && isVariableDeclaration(namespace.valueDeclaration)
+                && namespace.valueDeclaration.initializer
+                && isCommonJsRequire(namespace.valueDeclaration.initializer)
             ) {
                 const moduleName = (namespace.valueDeclaration.initializer as CallExpression).arguments[0] as StringLiteral;
                 const moduleSym = resolveExternalModuleName(moduleName, moduleName);
@@ -4939,9 +4939,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
         if (
-            host && (isObjectLiteralMethod(host) || isPropertyAssignment(host)) &&
-            isBinaryExpression(host.parent.parent) &&
-            getAssignmentDeclarationKind(host.parent.parent) === AssignmentDeclarationKind.Prototype
+            host && (isObjectLiteralMethod(host) || isPropertyAssignment(host))
+            && isBinaryExpression(host.parent.parent)
+            && getAssignmentDeclarationKind(host.parent.parent) === AssignmentDeclarationKind.Prototype
         ) {
             // X.prototype = { /** @param {K} p */m() { } } <-- look for K on X's declaration
             const symbol = getSymbolOfDeclaration(host.parent.parent.left as BindableStaticNameExpression);
@@ -4961,9 +4961,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!decl) {
             return undefined;
         }
-        const initializer = isAssignmentDeclaration(decl) ? getAssignedExpandoInitializer(decl) :
-            hasOnlyExpressionInitializer(decl) ? getDeclaredExpandoInitializer(decl) :
-            undefined;
+        const initializer = isAssignmentDeclaration(decl) ? getAssignedExpandoInitializer(decl)
+            : hasOnlyExpressionInitializer(decl) ? getDeclaredExpandoInitializer(decl)
+            : undefined;
         return initializer || decl;
     }
 
@@ -4989,8 +4989,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function resolveExternalModuleName(location: Node, moduleReferenceExpression: Expression, ignoreErrors?: boolean): Symbol | undefined {
         const isClassic = getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Classic;
-        const errorMessage = isClassic ?
-            Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
+        const errorMessage = isClassic
+            ? Diagnostics.Cannot_find_module_0_Did_you_mean_to_set_the_moduleResolution_option_to_nodenext_or_to_add_aliases_to_the_paths_option
             : Diagnostics.Cannot_find_module_0_or_its_corresponding_type_declarations;
         return resolveExternalModuleNameWorker(location, moduleReferenceExpression, ignoreErrors ? undefined : errorMessage);
     }
@@ -5015,13 +5015,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const currentSourceFile = getSourceFileOfNode(location);
         const contextSpecifier = isStringLiteralLike(location)
             ? location
-            : (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name ||
-                (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal ||
-                (isVariableDeclaration(location) && location.initializer && isRequireCall(location.initializer, /*requireStringLiteralLikeArgument*/ true) ? location.initializer.arguments[0] : undefined) ||
-                findAncestor(location, isImportCall)?.arguments[0] ||
-                findAncestor(location, isImportDeclaration)?.moduleSpecifier ||
-                findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression ||
-                findAncestor(location, isExportDeclaration)?.moduleSpecifier;
+            : (isModuleDeclaration(location) ? location : location.parent && isModuleDeclaration(location.parent) && location.parent.name === location ? location.parent : undefined)?.name
+                || (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal
+                || (isVariableDeclaration(location) && location.initializer && isRequireCall(location.initializer, /*requireStringLiteralLikeArgument*/ true) ? location.initializer.arguments[0] : undefined)
+                || findAncestor(location, isImportCall)?.arguments[0]
+                || findAncestor(location, isImportDeclaration)?.moduleSpecifier
+                || findAncestor(location, isExternalModuleImportEqualsDeclaration)?.moduleReference.expression
+                || findAncestor(location, isExportDeclaration)?.moduleSpecifier;
         const mode = contextSpecifier && isStringLiteralLike(contextSpecifier) ? host.getModeForUsageLocation(currentSourceFile, contextSpecifier) : currentSourceFile.impliedNodeFormat;
         const moduleResolutionKind = getEmitModuleResolutionKind(compilerOptions);
         const resolvedModule = host.getResolvedModule(currentSourceFile, moduleReference, mode)?.resolvedModule;
@@ -5036,8 +5036,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             if (resolvedModule.resolvedUsingTsExtension && isDeclarationFileName(moduleReference)) {
-                const importOrExport = findAncestor(location, isImportDeclaration)?.importClause ||
-                    findAncestor(location, or(isImportEqualsDeclaration, isExportDeclaration));
+                const importOrExport = findAncestor(location, isImportDeclaration)?.importClause
+                    || findAncestor(location, or(isImportEqualsDeclaration, isExportDeclaration));
                 if (importOrExport && !importOrExport.isTypeOnly || findAncestor(location, isImportCall)) {
                     error(
                         errorNode,
@@ -5047,8 +5047,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
             else if (resolvedModule.resolvedUsingTsExtension && !shouldAllowImportingTsExtension(compilerOptions, currentSourceFile.fileName)) {
-                const importOrExport = findAncestor(location, isImportDeclaration)?.importClause ||
-                    findAncestor(location, or(isImportEqualsDeclaration, isExportDeclaration));
+                const importOrExport = findAncestor(location, isImportDeclaration)?.importClause
+                    || findAncestor(location, or(isImportEqualsDeclaration, isExportDeclaration));
                 if (!(importOrExport?.isTypeOnly || findAncestor(location, isImportTypeNode))) {
                     const tsExtension = Debug.checkDefined(tryExtractTSExtension(moduleReference));
                     error(errorNode, Diagnostics.An_import_path_can_only_end_with_a_0_extension_when_allowImportingTsExtensions_is_enabled, tsExtension);
@@ -5174,13 +5174,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             else {
                 const isExtensionlessRelativePathImport = pathIsRelative(moduleReference) && !hasExtension(moduleReference);
-                const resolutionIsNode16OrNext = moduleResolutionKind === ModuleResolutionKind.Node16 ||
-                    moduleResolutionKind === ModuleResolutionKind.NodeNext;
+                const resolutionIsNode16OrNext = moduleResolutionKind === ModuleResolutionKind.Node16
+                    || moduleResolutionKind === ModuleResolutionKind.NodeNext;
                 if (
-                    !getResolveJsonModule(compilerOptions) &&
-                    fileExtensionIs(moduleReference, Extension.Json) &&
-                    moduleResolutionKind !== ModuleResolutionKind.Classic &&
-                    hasJsonModuleEmitEnabled(compilerOptions)
+                    !getResolveJsonModule(compilerOptions)
+                    && fileExtensionIs(moduleReference, Extension.Json)
+                    && moduleResolutionKind !== ModuleResolutionKind.Classic
+                    && hasJsonModuleEmitEnabled(compilerOptions)
                 ) {
                     error(errorNode, Diagnostics.Cannot_find_module_0_Consider_using_resolveJsonModule_to_import_module_with_json_extension, moduleReference);
                 }
@@ -5215,9 +5215,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
              */
             if (emitModuleKindIsNonNodeESM(moduleKind) || mode === ModuleKind.ESNext) {
                 const preferTs = isDeclarationFileName(moduleReference) && shouldAllowImportingTsExtension(compilerOptions);
-                const ext = tsExtension === Extension.Mts || tsExtension === Extension.Dmts ? preferTs ? ".mts" : ".mjs" :
-                    tsExtension === Extension.Cts || tsExtension === Extension.Dmts ? preferTs ? ".cts" : ".cjs" :
-                    preferTs ? ".ts" : ".js";
+                const ext = tsExtension === Extension.Mts || tsExtension === Extension.Dmts ? preferTs ? ".mts" : ".mjs"
+                    : tsExtension === Extension.Cts || tsExtension === Extension.Dmts ? preferTs ? ".cts" : ".cjs"
+                    : preferTs ? ".ts" : ".js";
                 return importSourceWithoutExtension + ext;
             }
             return importSourceWithoutExtension;
@@ -5298,8 +5298,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const referenceParent = referencingLocation.parent;
             if (
-                (isImportDeclaration(referenceParent) && getNamespaceDeclarationNode(referenceParent)) ||
-                isImportCall(referenceParent)
+                (isImportDeclaration(referenceParent) && getNamespaceDeclarationNode(referenceParent))
+                || isImportCall(referenceParent)
             ) {
                 const reference = isImportCall(referenceParent) ? referenceParent.arguments[0] : referenceParent.moduleSpecifier;
                 const type = getTypeOfSymbol(symbol);
@@ -5316,9 +5316,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         sigs = getSignaturesOfStructuredType(type, SignatureKind.Construct);
                     }
                     if (
-                        (sigs && sigs.length) ||
-                        getPropertyOfType(type, InternalSymbolName.Default, /*skipObjectFunctionPropertyAugment*/ true) ||
-                        isEsmCjsRef
+                        (sigs && sigs.length)
+                        || getPropertyOfType(type, InternalSymbolName.Default, /*skipObjectFunctionPropertyAugment*/ true)
+                        || isEsmCjsRef
                     ) {
                         const moduleType = type.flags & TypeFlags.StructuredType
                             ? getTypeWithSyntheticDefaultImportType(type, symbol, moduleSymbol!, reference)
@@ -5410,17 +5410,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function shouldTreatPropertiesOfExternalModuleAsExports(resolvedExternalModuleType: Type) {
-        return !(resolvedExternalModuleType.flags & TypeFlags.Primitive ||
-            getObjectFlags(resolvedExternalModuleType) & ObjectFlags.Class ||
+        return !(resolvedExternalModuleType.flags & TypeFlags.Primitive
+            || getObjectFlags(resolvedExternalModuleType) & ObjectFlags.Class
             // `isArrayOrTupleLikeType` is too expensive to use in this auto-imports hot path
-            isArrayType(resolvedExternalModuleType) ||
-            isTupleType(resolvedExternalModuleType));
+            || isArrayType(resolvedExternalModuleType)
+            || isTupleType(resolvedExternalModuleType));
     }
 
     function getExportsOfSymbol(symbol: Symbol): SymbolTable {
-        return symbol.flags & SymbolFlags.LateBindingContainer ? getResolvedMembersOrExportsOfSymbol(symbol, MembersOrExportsResolutionKind.resolvedExports) :
-            symbol.flags & SymbolFlags.Module ? getExportsOfModule(symbol) :
-            symbol.exports || emptySymbols;
+        return symbol.flags & SymbolFlags.LateBindingContainer ? getResolvedMembersOrExportsOfSymbol(symbol, MembersOrExportsResolutionKind.resolvedExports)
+            : symbol.flags & SymbolFlags.Module ? getExportsOfModule(symbol)
+            : symbol.exports || emptySymbols;
     }
 
     function getExportsOfModule(moduleSymbol: Symbol): SymbolTable {
@@ -5665,9 +5665,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const reexportContainers = enclosingDeclaration && getAlternativeContainingModules(symbol, enclosingDeclaration);
             const objectLiteralContainer = getVariableDeclarationOfObjectLiteral(container, meaning);
             if (
-                enclosingDeclaration &&
-                container.flags & getQualifiedLeftMeaning(meaning) &&
-                getAccessibleSymbolChain(container, enclosingDeclaration, SymbolFlags.Namespace, /*useOnlyExternalAliasing*/ false)
+                enclosingDeclaration
+                && container.flags & getQualifiedLeftMeaning(meaning)
+                && getAccessibleSymbolChain(container, enclosingDeclaration, SymbolFlags.Namespace, /*useOnlyExternalAliasing*/ false)
             ) {
                 return append(concatenate(concatenate([container], additionalContainers), reexportContainers), objectLiteralContainer); // This order expresses a preference for the real container if it is in scope
             }
@@ -5759,8 +5759,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function symbolIsValue(symbol: Symbol, includeTypeOnlyMembers?: boolean): boolean {
         return !!(
-            symbol.flags & SymbolFlags.Value ||
-            symbol.flags & SymbolFlags.Alias && getSymbolFlags(symbol, !includeTypeOnlyMembers) & SymbolFlags.Value
+            symbol.flags & SymbolFlags.Value
+            || symbol.flags & SymbolFlags.Alias && getSymbolFlags(symbol, !includeTypeOnlyMembers) & SymbolFlags.Value
         );
     }
 
@@ -5832,11 +5832,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // with at least two underscores. The @ character indicates that the name is denoted by a well known ES
     // Symbol instance and the # character indicates that the name is a PrivateIdentifier.
     function isReservedMemberName(name: __String) {
-        return (name as string).charCodeAt(0) === CharacterCodes._ &&
-            (name as string).charCodeAt(1) === CharacterCodes._ &&
-            (name as string).charCodeAt(2) !== CharacterCodes._ &&
-            (name as string).charCodeAt(2) !== CharacterCodes.at &&
-            (name as string).charCodeAt(2) !== CharacterCodes.hash;
+        return (name as string).charCodeAt(0) === CharacterCodes._
+            && (name as string).charCodeAt(1) === CharacterCodes._
+            && (name as string).charCodeAt(2) !== CharacterCodes._
+            && (name as string).charCodeAt(2) !== CharacterCodes.at
+            && (name as string).charCodeAt(2) !== CharacterCodes.hash;
     }
 
     function getNamedMembers(members: SymbolTable): Symbol[] {
@@ -5985,18 +5985,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function canQualifySymbol(symbolFromSymbolTable: Symbol, meaning: SymbolFlags) {
             // If the symbol is equivalent and doesn't need further qualification, this symbol is accessible
-            return !needsQualification(symbolFromSymbolTable, enclosingDeclaration, meaning) ||
+            return !needsQualification(symbolFromSymbolTable, enclosingDeclaration, meaning)
                 // If symbol needs qualification, make sure that parent is accessible, if it is then this symbol is accessible too
-                !!getAccessibleSymbolChain(symbolFromSymbolTable.parent, enclosingDeclaration, getQualifiedLeftMeaning(meaning), useOnlyExternalAliasing, visitedSymbolTablesMap);
+                || !!getAccessibleSymbolChain(symbolFromSymbolTable.parent, enclosingDeclaration, getQualifiedLeftMeaning(meaning), useOnlyExternalAliasing, visitedSymbolTablesMap);
         }
 
         function isAccessible(symbolFromSymbolTable: Symbol, resolvedAliasSymbol?: Symbol, ignoreQualification?: boolean) {
-            return (symbol === (resolvedAliasSymbol || symbolFromSymbolTable) || getMergedSymbol(symbol) === getMergedSymbol(resolvedAliasSymbol || symbolFromSymbolTable)) &&
+            return (symbol === (resolvedAliasSymbol || symbolFromSymbolTable) || getMergedSymbol(symbol) === getMergedSymbol(resolvedAliasSymbol || symbolFromSymbolTable))
                 // if the symbolFromSymbolTable is not external module (it could be if it was determined as ambient external module and would be in globals table)
                 // and if symbolFromSymbolTable or alias resolution matches the symbol,
                 // check the symbol can be qualified, it is only then this symbol is accessible
-                !some(symbolFromSymbolTable.declarations, hasNonGlobalAugmentationExternalModuleSymbol) &&
-                (ignoreQualification || canQualifySymbol(getMergedSymbol(symbolFromSymbolTable), meaning));
+                && !some(symbolFromSymbolTable.declarations, hasNonGlobalAugmentationExternalModuleSymbol)
+                && (ignoreQualification || canQualifySymbol(getMergedSymbol(symbolFromSymbolTable), meaning));
         }
 
         function trySymbolTable(symbols: SymbolTable, ignoreQualification: boolean | undefined, isLocalNameLookup: boolean | undefined): Symbol[] | undefined {
@@ -6255,16 +6255,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                 const anyImportSyntax = getAnyImportSyntax(declaration);
                 if (
-                    anyImportSyntax &&
-                    !hasSyntacticModifier(anyImportSyntax, ModifierFlags.Export) && // import clause without export
-                    isDeclarationVisible(anyImportSyntax.parent)
+                    anyImportSyntax
+                    && !hasSyntacticModifier(anyImportSyntax, ModifierFlags.Export) // import clause without export
+                    && isDeclarationVisible(anyImportSyntax.parent)
                 ) {
                     return addVisibleAlias(declaration, anyImportSyntax);
                 }
                 else if (
-                    isVariableDeclaration(declaration) && isVariableStatement(declaration.parent.parent) &&
-                    !hasSyntacticModifier(declaration.parent.parent, ModifierFlags.Export) && // unexported variable statement
-                    isDeclarationVisible(declaration.parent.parent.parent)
+                    isVariableDeclaration(declaration) && isVariableStatement(declaration.parent.parent)
+                    && !hasSyntacticModifier(declaration.parent.parent, ModifierFlags.Export) // unexported variable statement
+                    && isDeclarationVisible(declaration.parent.parent.parent)
                 ) {
                     return addVisibleAlias(declaration, declaration.parent.parent);
                 }
@@ -6321,16 +6321,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // get symbol of the first identifier of the entityName
         let meaning: SymbolFlags;
         if (
-            entityName.parent.kind === SyntaxKind.TypeQuery ||
-            entityName.parent.kind === SyntaxKind.ExpressionWithTypeArguments && !isPartOfTypeNode(entityName.parent) ||
-            entityName.parent.kind === SyntaxKind.ComputedPropertyName
+            entityName.parent.kind === SyntaxKind.TypeQuery
+            || entityName.parent.kind === SyntaxKind.ExpressionWithTypeArguments && !isPartOfTypeNode(entityName.parent)
+            || entityName.parent.kind === SyntaxKind.ComputedPropertyName
         ) {
             // Typeof value
             meaning = SymbolFlags.Value | SymbolFlags.ExportValue;
         }
         else if (
-            entityName.kind === SyntaxKind.QualifiedName || entityName.kind === SyntaxKind.PropertyAccessExpression ||
-            entityName.parent.kind === SyntaxKind.ImportEqualsDeclaration
+            entityName.kind === SyntaxKind.QualifiedName || entityName.kind === SyntaxKind.PropertyAccessExpression
+            || entityName.parent.kind === SyntaxKind.ImportEqualsDeclaration
         ) {
             // Left identifier from type reference or TypeAlias
             // Entity name of the import declaration
@@ -6554,9 +6554,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function withContext<T>(enclosingDeclaration: Node | undefined, flags: NodeBuilderFlags | undefined, tracker: SymbolTracker | undefined, cb: (context: NodeBuilderContext) => T): T | undefined {
             Debug.assert(enclosingDeclaration === undefined || (enclosingDeclaration.flags & NodeFlags.Synthesized) === 0);
-            const moduleResolverHost = tracker?.trackSymbol ? tracker.moduleResolverHost :
-                flags! & NodeBuilderFlags.DoNotIncludeSymbolChain ? createBasicNodeBuilderModuleSpecifierResolutionHost(host) :
-                undefined;
+            const moduleResolverHost = tracker?.trackSymbol ? tracker.moduleResolverHost
+                : flags! & NodeBuilderFlags.DoNotIncludeSymbolChain ? createBasicNodeBuilderModuleSpecifierResolutionHost(host)
+                : undefined;
             const context: NodeBuilderContext = {
                 enclosingDeclaration,
                 flags: flags || NodeBuilderFlags.None,
@@ -6764,8 +6764,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return factory.createInferTypeNode(typeParameterToDeclarationWithConstraint(type as TypeParameter, context, constraintNode));
                 }
                 if (
-                    context.flags & NodeBuilderFlags.GenerateNamesForShadowedTypeParams &&
-                    type.flags & TypeFlags.TypeParameter
+                    context.flags & NodeBuilderFlags.GenerateNamesForShadowedTypeParams
+                    && type.flags & TypeFlags.TypeParameter
                 ) {
                     const name = typeParameterToName(type, context);
                     context.approximateLength += idText(name).length;
@@ -6775,8 +6775,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (type.symbol) {
                     return symbolToTypeNode(type.symbol, context, SymbolFlags.Type);
                 }
-                const name = (type === markerSuperTypeForCheck || type === markerSubTypeForCheck) && varianceTypeParameter && varianceTypeParameter.symbol ?
-                    (type === markerSubTypeForCheck ? "sub-" : "super-") + symbolName(varianceTypeParameter.symbol) : "?";
+                const name = (type === markerSuperTypeForCheck || type === markerSubTypeForCheck) && varianceTypeParameter && varianceTypeParameter.symbol
+                    ? (type === markerSubTypeForCheck ? "sub-" : "super-") + symbolName(varianceTypeParameter.symbol) : "?";
                 return factory.createTypeReferenceNode(factory.createIdentifier(name), /*typeArguments*/ undefined);
             }
             if (type.flags & TypeFlags.Union && (type as UnionType).origin) {
@@ -7006,9 +7006,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     else if (
                         symbol.flags & SymbolFlags.Class
                             && !getBaseTypeVariableOfClass(symbol)
-                            && !(symbol.valueDeclaration && isClassLike(symbol.valueDeclaration) && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral && (!isClassDeclaration(symbol.valueDeclaration) || isSymbolAccessible(symbol, context.enclosingDeclaration, isInstanceType, /*shouldComputeAliasesToMakeVisible*/ false).accessibility !== SymbolAccessibility.Accessible)) ||
-                        symbol.flags & (SymbolFlags.Enum | SymbolFlags.ValueModule) ||
-                        shouldWriteTypeOfFunctionSymbol()
+                            && !(symbol.valueDeclaration && isClassLike(symbol.valueDeclaration) && context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral && (!isClassDeclaration(symbol.valueDeclaration) || isSymbolAccessible(symbol, context.enclosingDeclaration, isInstanceType, /*shouldComputeAliasesToMakeVisible*/ false).accessibility !== SymbolAccessibility.Accessible))
+                        || symbol.flags & (SymbolFlags.Enum | SymbolFlags.ValueModule)
+                        || shouldWriteTypeOfFunctionSymbol()
                     ) {
                         return symbolToTypeNode(symbol, context, isInstanceType);
                     }
@@ -7032,15 +7032,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return createTypeNodeFromObjectType(type);
                 }
                 function shouldWriteTypeOfFunctionSymbol() {
-                    const isStaticMethodSymbol = !!(symbol.flags & SymbolFlags.Method) && // typeof static method
-                        some(symbol.declarations, declaration => isStatic(declaration));
-                    const isNonLocalFunctionSymbol = !!(symbol.flags & SymbolFlags.Function) &&
-                        (symbol.parent || // is exported function symbol
-                            forEach(symbol.declarations, declaration => declaration.parent.kind === SyntaxKind.SourceFile || declaration.parent.kind === SyntaxKind.ModuleBlock));
+                    const isStaticMethodSymbol = !!(symbol.flags & SymbolFlags.Method) // typeof static method
+                        && some(symbol.declarations, declaration => isStatic(declaration));
+                    const isNonLocalFunctionSymbol = !!(symbol.flags & SymbolFlags.Function)
+                        && (symbol.parent // is exported function symbol
+                            || forEach(symbol.declarations, declaration => declaration.parent.kind === SyntaxKind.SourceFile || declaration.parent.kind === SyntaxKind.ModuleBlock));
                     if (isStaticMethodSymbol || isNonLocalFunctionSymbol) {
                         // typeof is allowed only for static/non local functions
-                        return (!!(context.flags & NodeBuilderFlags.UseTypeOfFunction) || (context.visitedTypes?.has(typeId))) && // it is type of the symbol uses itself recursively
-                            (!(context.flags & NodeBuilderFlags.UseStructuralFallback) || isValueSymbolAccessible(symbol, context.enclosingDeclaration)); // And the build is going to succeed without visibility error or there is no structural fallback allowed
+                        return (!!(context.flags & NodeBuilderFlags.UseTypeOfFunction) || (context.visitedTypes?.has(typeId))) // it is type of the symbol uses itself recursively
+                            && (!(context.flags & NodeBuilderFlags.UseStructuralFallback) || isValueSymbolAccessible(symbol, context.enclosingDeclaration)); // And the build is going to succeed without visibility error or there is no structural fallback allowed
                     }
                 }
             }
@@ -7048,10 +7048,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             function visitAndTransformType<T extends Type>(type: T, transform: (type: T) => TypeNode) {
                 const typeId = type.id;
                 const isConstructorObject = getObjectFlags(type) & ObjectFlags.Anonymous && type.symbol && type.symbol.flags & SymbolFlags.Class;
-                const id = getObjectFlags(type) & ObjectFlags.Reference && (type as TypeReference & T).node ? "N" + getNodeId((type as TypeReference & T).node!) :
-                    type.flags & TypeFlags.Conditional ? "N" + getNodeId((type as ConditionalType & T).root.node) :
-                    type.symbol ? (isConstructorObject ? "+" : "") + getSymbolId(type.symbol) :
-                    undefined;
+                const id = getObjectFlags(type) & ObjectFlags.Reference && (type as TypeReference & T).node ? "N" + getNodeId((type as TypeReference & T).node!)
+                    : type.flags & TypeFlags.Conditional ? "N" + getNodeId((type as ConditionalType & T).root.node)
+                    : type.symbol ? (isConstructorObject ? "+" : "") + getSymbolId(type.symbol)
+                    : undefined;
                 // Since instantiations of the same anonymous type have the same symbol, tracking symbols instead
                 // of types allows us to catch circular references to instantiations of the same anonymous type
                 if (!context.visitedTypes) {
@@ -7165,14 +7165,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (some(abstractSignatures)) {
                     const types = map(abstractSignatures, getOrCreateTypeFromSignature);
                     // count the number of type elements excluding abstract constructors
-                    const typeElementCount = resolved.callSignatures.length +
-                        (resolved.constructSignatures.length - abstractSignatures.length) +
-                        resolved.indexInfos.length +
+                    const typeElementCount = resolved.callSignatures.length
+                        + (resolved.constructSignatures.length - abstractSignatures.length)
+                        + resolved.indexInfos.length
                         // exclude `prototype` when writing a class expression as a type literal, as per
                         // the logic in `createTypeNodesFromResolvedType`.
-                        (context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral ?
-                            countWhere(resolved.properties, p => !(p.flags & SymbolFlags.Prototype)) :
-                            length(resolved.properties));
+                        + (context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral
+                            ? countWhere(resolved.properties, p => !(p.flags & SymbolFlags.Prototype))
+                            : length(resolved.properties));
                     // don't include an empty object literal if there were no other static-side
                     // properties to write, i.e. `abstract class C { }` becomes `abstract new () => {}`
                     // and not `(abstract new () => {}) & {}`
@@ -7220,14 +7220,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                         flags & ElementFlags.Variable ? factory.createToken(SyntaxKind.DotDotDotToken) : undefined,
                                         factory.createIdentifier(unescapeLeadingUnderscores(getTupleElementLabel(labeledElementDeclaration))),
                                         flags & ElementFlags.Optional ? factory.createToken(SyntaxKind.QuestionToken) : undefined,
-                                        flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) :
-                                            tupleConstituentNodes[i],
+                                        flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i])
+                                            : tupleConstituentNodes[i],
                                     );
                                 }
                                 else {
-                                    tupleConstituentNodes[i] = flags & ElementFlags.Variable ? factory.createRestTypeNode(flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) : tupleConstituentNodes[i]) :
-                                        flags & ElementFlags.Optional ? factory.createOptionalTypeNode(tupleConstituentNodes[i]) :
-                                        tupleConstituentNodes[i];
+                                    tupleConstituentNodes[i] = flags & ElementFlags.Variable ? factory.createRestTypeNode(flags & ElementFlags.Rest ? factory.createArrayTypeNode(tupleConstituentNodes[i]) : tupleConstituentNodes[i])
+                                        : flags & ElementFlags.Optional ? factory.createOptionalTypeNode(tupleConstituentNodes[i])
+                                        : tupleConstituentNodes[i];
                                 }
                             }
                             const tupleTypeNode = setEmitFlags(factory.createTupleTypeNode(tupleConstituentNodes), EmitFlags.SingleLine);
@@ -7242,10 +7242,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return undefined!; // TODO: GH#18217
                 }
                 else if (
-                    context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral &&
-                    type.symbol.valueDeclaration &&
-                    isClassLike(type.symbol.valueDeclaration) &&
-                    !isValueSymbolAccessible(type.symbol, context.enclosingDeclaration)
+                    context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral
+                    && type.symbol.valueDeclaration
+                    && isClassLike(type.symbol.valueDeclaration)
+                    && !isValueSymbolAccessible(type.symbol, context.enclosingDeclaration)
                 ) {
                     return createAnonymousTypeNode(type);
                 }
@@ -7429,8 +7429,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function addPropertyToElementList(propertySymbol: Symbol, context: NodeBuilderContext, typeElements: TypeElement[]) {
             const propertyIsReverseMapped = !!(getCheckFlags(propertySymbol) & CheckFlags.ReverseMapped);
-            const propertyType = shouldUsePlaceholderForProperty(propertySymbol, context) ?
-                anyType : getNonMissingTypeOfSymbol(propertySymbol);
+            const propertyType = shouldUsePlaceholderForProperty(propertySymbol, context)
+                ? anyType : getNonMissingTypeOfSymbol(propertySymbol);
             const saveEnclosingDeclaration = context.enclosingDeclaration;
             context.enclosingDeclaration = undefined;
             if (context.tracker.canTrackSymbol && isLateBoundName(propertySymbol.escapedName)) {
@@ -7791,21 +7791,21 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 modifiers = factory.createModifiersFromModifierFlags(flags | ModifierFlags.Abstract);
             }
 
-            const node = kind === SyntaxKind.CallSignature ? factory.createCallSignature(typeParameters, parameters, returnTypeNode) :
-                kind === SyntaxKind.ConstructSignature ? factory.createConstructSignature(typeParameters, parameters, returnTypeNode) :
-                kind === SyntaxKind.MethodSignature ? factory.createMethodSignature(modifiers, options?.name ?? factory.createIdentifier(""), options?.questionToken, typeParameters, parameters, returnTypeNode) :
-                kind === SyntaxKind.MethodDeclaration ? factory.createMethodDeclaration(modifiers, /*asteriskToken*/ undefined, options?.name ?? factory.createIdentifier(""), /*questionToken*/ undefined, typeParameters, parameters, returnTypeNode, /*body*/ undefined) :
-                kind === SyntaxKind.Constructor ? factory.createConstructorDeclaration(modifiers, parameters, /*body*/ undefined) :
-                kind === SyntaxKind.GetAccessor ? factory.createGetAccessorDeclaration(modifiers, options?.name ?? factory.createIdentifier(""), parameters, returnTypeNode, /*body*/ undefined) :
-                kind === SyntaxKind.SetAccessor ? factory.createSetAccessorDeclaration(modifiers, options?.name ?? factory.createIdentifier(""), parameters, /*body*/ undefined) :
-                kind === SyntaxKind.IndexSignature ? factory.createIndexSignature(modifiers, parameters, returnTypeNode) :
-                kind === SyntaxKind.JSDocFunctionType ? factory.createJSDocFunctionType(parameters, returnTypeNode) :
-                kind === SyntaxKind.FunctionType ? factory.createFunctionTypeNode(typeParameters, parameters, returnTypeNode ?? factory.createTypeReferenceNode(factory.createIdentifier(""))) :
-                kind === SyntaxKind.ConstructorType ? factory.createConstructorTypeNode(modifiers, typeParameters, parameters, returnTypeNode ?? factory.createTypeReferenceNode(factory.createIdentifier(""))) :
-                kind === SyntaxKind.FunctionDeclaration ? factory.createFunctionDeclaration(modifiers, /*asteriskToken*/ undefined, options?.name ? cast(options.name, isIdentifier) : factory.createIdentifier(""), typeParameters, parameters, returnTypeNode, /*body*/ undefined) :
-                kind === SyntaxKind.FunctionExpression ? factory.createFunctionExpression(modifiers, /*asteriskToken*/ undefined, options?.name ? cast(options.name, isIdentifier) : factory.createIdentifier(""), typeParameters, parameters, returnTypeNode, factory.createBlock([])) :
-                kind === SyntaxKind.ArrowFunction ? factory.createArrowFunction(modifiers, typeParameters, parameters, returnTypeNode, /*equalsGreaterThanToken*/ undefined, factory.createBlock([])) :
-                Debug.assertNever(kind);
+            const node = kind === SyntaxKind.CallSignature ? factory.createCallSignature(typeParameters, parameters, returnTypeNode)
+                : kind === SyntaxKind.ConstructSignature ? factory.createConstructSignature(typeParameters, parameters, returnTypeNode)
+                : kind === SyntaxKind.MethodSignature ? factory.createMethodSignature(modifiers, options?.name ?? factory.createIdentifier(""), options?.questionToken, typeParameters, parameters, returnTypeNode)
+                : kind === SyntaxKind.MethodDeclaration ? factory.createMethodDeclaration(modifiers, /*asteriskToken*/ undefined, options?.name ?? factory.createIdentifier(""), /*questionToken*/ undefined, typeParameters, parameters, returnTypeNode, /*body*/ undefined)
+                : kind === SyntaxKind.Constructor ? factory.createConstructorDeclaration(modifiers, parameters, /*body*/ undefined)
+                : kind === SyntaxKind.GetAccessor ? factory.createGetAccessorDeclaration(modifiers, options?.name ?? factory.createIdentifier(""), parameters, returnTypeNode, /*body*/ undefined)
+                : kind === SyntaxKind.SetAccessor ? factory.createSetAccessorDeclaration(modifiers, options?.name ?? factory.createIdentifier(""), parameters, /*body*/ undefined)
+                : kind === SyntaxKind.IndexSignature ? factory.createIndexSignature(modifiers, parameters, returnTypeNode)
+                : kind === SyntaxKind.JSDocFunctionType ? factory.createJSDocFunctionType(parameters, returnTypeNode)
+                : kind === SyntaxKind.FunctionType ? factory.createFunctionTypeNode(typeParameters, parameters, returnTypeNode ?? factory.createTypeReferenceNode(factory.createIdentifier("")))
+                : kind === SyntaxKind.ConstructorType ? factory.createConstructorTypeNode(modifiers, typeParameters, parameters, returnTypeNode ?? factory.createTypeReferenceNode(factory.createIdentifier("")))
+                : kind === SyntaxKind.FunctionDeclaration ? factory.createFunctionDeclaration(modifiers, /*asteriskToken*/ undefined, options?.name ? cast(options.name, isIdentifier) : factory.createIdentifier(""), typeParameters, parameters, returnTypeNode, /*body*/ undefined)
+                : kind === SyntaxKind.FunctionExpression ? factory.createFunctionExpression(modifiers, /*asteriskToken*/ undefined, options?.name ? cast(options.name, isIdentifier) : factory.createIdentifier(""), typeParameters, parameters, returnTypeNode, factory.createBlock([]))
+                : kind === SyntaxKind.ArrowFunction ? factory.createArrowFunction(modifiers, typeParameters, parameters, returnTypeNode, /*equalsGreaterThanToken*/ undefined, factory.createBlock([]))
+                : Debug.assertNever(kind);
 
             if (typeArguments) {
                 node.typeArguments = factory.createNodeArray(typeArguments);
@@ -7854,12 +7854,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         function typePredicateToTypePredicateNodeHelper(typePredicate: TypePredicate, context: NodeBuilderContext): TypePredicateNode {
-            const assertsModifier = typePredicate.kind === TypePredicateKind.AssertsThis || typePredicate.kind === TypePredicateKind.AssertsIdentifier ?
-                factory.createToken(SyntaxKind.AssertsKeyword) :
-                undefined;
-            const parameterName = typePredicate.kind === TypePredicateKind.Identifier || typePredicate.kind === TypePredicateKind.AssertsIdentifier ?
-                setEmitFlags(factory.createIdentifier(typePredicate.parameterName), EmitFlags.NoAsciiEscaping) :
-                factory.createThisTypeNode();
+            const assertsModifier = typePredicate.kind === TypePredicateKind.AssertsThis || typePredicate.kind === TypePredicateKind.AssertsIdentifier
+                ? factory.createToken(SyntaxKind.AssertsKeyword)
+                : undefined;
+            const parameterName = typePredicate.kind === TypePredicateKind.Identifier || typePredicate.kind === TypePredicateKind.AssertsIdentifier
+                ? setEmitFlags(factory.createIdentifier(typePredicate.parameterName), EmitFlags.NoAsciiEscaping)
+                : factory.createThisTypeNode();
             const typeNode = typePredicate.type && typeToTypeNodeHelper(typePredicate.type, context);
             return factory.createTypePredicateNode(assertsModifier, parameterName, typeNode);
         }
@@ -7900,12 +7900,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         function parameterToParameterDeclarationName(parameterSymbol: Symbol, parameterDeclaration: ParameterDeclaration | JSDocParameterTag | undefined, context: NodeBuilderContext) {
-            return parameterDeclaration ? parameterDeclaration.name ?
-                parameterDeclaration.name.kind === SyntaxKind.Identifier ? setEmitFlags(factory.cloneNode(parameterDeclaration.name), EmitFlags.NoAsciiEscaping) :
-                    parameterDeclaration.name.kind === SyntaxKind.QualifiedName ? setEmitFlags(factory.cloneNode(parameterDeclaration.name.right), EmitFlags.NoAsciiEscaping) :
-                    cloneBindingName(parameterDeclaration.name) :
-                symbolName(parameterSymbol) :
-                symbolName(parameterSymbol);
+            return parameterDeclaration ? parameterDeclaration.name
+                ? parameterDeclaration.name.kind === SyntaxKind.Identifier ? setEmitFlags(factory.cloneNode(parameterDeclaration.name), EmitFlags.NoAsciiEscaping)
+                    : parameterDeclaration.name.kind === SyntaxKind.QualifiedName ? setEmitFlags(factory.cloneNode(parameterDeclaration.name.right), EmitFlags.NoAsciiEscaping)
+                    : cloneBindingName(parameterDeclaration.name)
+                : symbolName(parameterSymbol)
+                : symbolName(parameterSymbol);
 
             function cloneBindingName(node: BindingName): BindingName {
                 return elideInitializerAndSetEmitFlags(node) as BindingName;
@@ -7964,8 +7964,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 let accessibleSymbolChain = getAccessibleSymbolChain(symbol, context.enclosingDeclaration, meaning, !!(context.flags & NodeBuilderFlags.UseOnlyExternalAliasing));
                 let parentSpecifiers: (string | undefined)[];
                 if (
-                    !accessibleSymbolChain ||
-                    needsQualification(accessibleSymbolChain[0], context.enclosingDeclaration, accessibleSymbolChain.length === 1 ? meaning : getQualifiedLeftMeaning(meaning))
+                    !accessibleSymbolChain
+                    || needsQualification(accessibleSymbolChain[0], context.enclosingDeclaration, accessibleSymbolChain.length === 1 ? meaning : getQualifiedLeftMeaning(meaning))
                 ) {
                     // Go up and add our parent.
                     const parents = getContainersOfSymbol(accessibleSymbolChain ? accessibleSymbolChain[0] : symbol, context.enclosingDeclaration, meaning);
@@ -7982,8 +7982,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             const parentChain = getSymbolChain(parent, getQualifiedLeftMeaning(meaning), /*endOfChain*/ false);
                             if (parentChain) {
                                 if (
-                                    parent.exports && parent.exports.get(InternalSymbolName.ExportEquals) &&
-                                    getSymbolIfSameReference(parent.exports.get(InternalSymbolName.ExportEquals)!, symbol)
+                                    parent.exports && parent.exports.get(InternalSymbolName.ExportEquals)
+                                    && getSymbolIfSameReference(parent.exports.get(InternalSymbolName.ExportEquals)!, symbol)
                                 ) {
                                     // parentChain root _is_ symbol - symbol is a module export=, so it kinda looks like it's own parent
                                     // No need to lookup an alias for the symbol in itself
@@ -8002,9 +8002,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 if (
                     // If this is the last part of outputting the symbol, always output. The cases apply only to parent symbols.
-                    endOfChain ||
+                    endOfChain
                     // If a parent symbol is an anonymous type, don't write it.
-                    !(symbol.flags & (SymbolFlags.TypeLiteral | SymbolFlags.ObjectLiteral))
+                    || !(symbol.flags & (SymbolFlags.TypeLiteral | SymbolFlags.ObjectLiteral))
                 ) {
                     // If a parent symbol is an external module, don't write it. (We prefer just `x` vs `"foo/bar".x`.)
                     if (!endOfChain && !yieldModuleSymbol && !!forEach(symbol.declarations, hasNonGlobalAugmentationExternalModuleSymbol)) {
@@ -8279,9 +8279,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 context.approximateLength += symbolName.length + 1;
 
                 if (
-                    !(context.flags & NodeBuilderFlags.ForbidIndexedAccessSymbolReferences) && parent &&
-                    getMembersOfSymbol(parent) && getMembersOfSymbol(parent).get(symbol.escapedName) &&
-                    getSymbolIfSameReference(getMembersOfSymbol(parent).get(symbol.escapedName)!, symbol)
+                    !(context.flags & NodeBuilderFlags.ForbidIndexedAccessSymbolReferences) && parent
+                    && getMembersOfSymbol(parent) && getMembersOfSymbol(parent).get(symbol.escapedName)
+                    && getSymbolIfSameReference(getMembersOfSymbol(parent).get(symbol.escapedName)!, symbol)
                 ) {
                     // Should use an indexed access
                     const LHS = createAccessFromSymbolChain(chain, index - 1, stopper);
@@ -8547,8 +8547,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const oldFlags = context.flags;
             if (
-                type.flags & TypeFlags.UniqueESSymbol &&
-                type.symbol === symbol && (!context.enclosingDeclaration || some(symbol.declarations, d => getSourceFileOfNode(d) === getSourceFileOfNode(context.enclosingDeclaration!)))
+                type.flags & TypeFlags.UniqueESSymbol
+                && type.symbol === symbol && (!context.enclosingDeclaration || some(symbol.declarations, d => getSourceFileOfNode(d) === getSourceFileOfNode(context.enclosingDeclaration!)))
             ) {
                 context.flags |= NodeBuilderFlags.AllowUniqueESSymbolType;
             }
@@ -8722,13 +8722,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isLiteralImportTypeNode(node)) {
                     const nodeSymbol = getNodeLinks(node).resolvedSymbol;
                     if (
-                        isInJSDoc(node) &&
-                        nodeSymbol &&
-                        (
+                        isInJSDoc(node)
+                        && nodeSymbol
+                        && (
                             // The import type resolved using jsdoc fallback logic
-                            (!node.isTypeOf && !(nodeSymbol.flags & SymbolFlags.Type)) ||
+                            (!node.isTypeOf && !(nodeSymbol.flags & SymbolFlags.Type))
                             // The import type had type arguments autofilled by js fallback logic
-                            !(length(node.typeArguments) >= getMinTypeArgumentCount(getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(nodeSymbol)))
+                            || !(length(node.typeArguments) >= getMinTypeArgumentCount(getLocalTypeParametersOfClassOrInterfaceOrTypeAlias(nodeSymbol)))
                         )
                     ) {
                         return setOriginalNode(typeToTypeNodeHelper(getTypeFromTypeNode(node), context), node);
@@ -8885,9 +8885,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const nsIndex = findIndex(statements, isModuleDeclaration);
                 let ns = nsIndex !== -1 ? statements[nsIndex] as ModuleDeclaration : undefined;
                 if (
-                    ns && exportAssignment && exportAssignment.isExportEquals &&
-                    isIdentifier(exportAssignment.expression) && isIdentifier(ns.name) && idText(ns.name) === idText(exportAssignment.expression) &&
-                    ns.body && isModuleBlock(ns.body)
+                    ns && exportAssignment && exportAssignment.isExportEquals
+                    && isIdentifier(exportAssignment.expression) && isIdentifier(ns.name) && idText(ns.name) === idText(exportAssignment.expression)
+                    && ns.body && isModuleBlock(ns.body)
                 ) {
                     // Pass 0: Correct situations where a module has both an `export = ns` and multiple top-level exports by stripping the export modifiers from
                     //  the top-level exports and exporting them in the targeted ns, as can occur when a js file has both typedefs and `module.export` assignments
@@ -9018,9 +9018,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // Not a cleanup, but as a final step: If there is a mix of `export` and non-`export` declarations, but no `export =` or `export {}` add a `export {};` so
                 // declaration privacy is respected.
                 if (
-                    enclosingDeclaration &&
-                    ((isSourceFile(enclosingDeclaration) && isExternalOrCommonJsModule(enclosingDeclaration)) || isModuleDeclaration(enclosingDeclaration)) &&
-                    (!some(statements, isExternalModuleIndicator) || (!hasScopeMarker(statements) && some(statements, needsScopeMarker)))
+                    enclosingDeclaration
+                    && ((isSourceFile(enclosingDeclaration) && isExternalOrCommonJsModule(enclosingDeclaration)) || isModuleDeclaration(enclosingDeclaration))
+                    && (!some(statements, isExternalModuleIndicator) || (!hasScopeMarker(statements) && some(statements, needsScopeMarker)))
                 ) {
                     statements.push(createEmptyExports(factory));
                 }
@@ -9108,9 +9108,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     isPrivate = true;
                 }
                 const modifierFlags = (!isPrivate ? ModifierFlags.Export : 0) | (isDefault && !needsPostExportDefault ? ModifierFlags.Default : 0);
-                const isConstMergedWithNS = symbol.flags & SymbolFlags.Module &&
-                    symbol.flags & (SymbolFlags.BlockScopedVariable | SymbolFlags.FunctionScopedVariable | SymbolFlags.Property) &&
-                    escapedSymbolName !== InternalSymbolName.ExportEquals;
+                const isConstMergedWithNS = symbol.flags & SymbolFlags.Module
+                    && symbol.flags & (SymbolFlags.BlockScopedVariable | SymbolFlags.FunctionScopedVariable | SymbolFlags.Property)
+                    && escapedSymbolName !== InternalSymbolName.ExportEquals;
                 const isConstMergedWithNSPrintableAsSignatureMerge = isConstMergedWithNS && isTypeRepresentableAsFunctionNamespaceMerge(getTypeOfSymbol(symbol), symbol);
                 if (symbol.flags & (SymbolFlags.Function | SymbolFlags.Method) || isConstMergedWithNSPrintableAsSignatureMerge) {
                     serializeAsFunctionNamespaceMerge(getTypeOfSymbol(symbol), symbol, getInternalSymbolName(symbol, symbolName), modifierFlags);
@@ -9300,35 +9300,35 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // anyway, as that's the only place the import they translate to is valid. In such a case, we might need to use a unique name
                 // for the moved import; which hopefully the above `getUnusedName` call should produce.
                 const isExternalImportAlias = !!(symbol.flags & SymbolFlags.Alias) && !some(symbol.declarations, d =>
-                    !!findAncestor(d, isExportDeclaration) ||
-                    isNamespaceExport(d) ||
-                    (isImportEqualsDeclaration(d) && !isExternalModuleReference(d.moduleReference)));
+                    !!findAncestor(d, isExportDeclaration)
+                    || isNamespaceExport(d)
+                    || (isImportEqualsDeclaration(d) && !isExternalModuleReference(d.moduleReference)));
                 deferredPrivatesStack[isExternalImportAlias ? 0 : (deferredPrivatesStack.length - 1)].set(getSymbolId(symbol), symbol);
             }
 
             function isExportingScope(enclosingDeclaration: Node) {
-                return ((isSourceFile(enclosingDeclaration) && (isExternalOrCommonJsModule(enclosingDeclaration) || isJsonSourceFile(enclosingDeclaration))) ||
-                    (isAmbientModule(enclosingDeclaration) && !isGlobalScopeAugmentation(enclosingDeclaration)));
+                return ((isSourceFile(enclosingDeclaration) && (isExternalOrCommonJsModule(enclosingDeclaration) || isJsonSourceFile(enclosingDeclaration)))
+                    || (isAmbientModule(enclosingDeclaration) && !isGlobalScopeAugmentation(enclosingDeclaration)));
             }
 
             // Prepends a `declare` and/or `export` modifier if the context requires it, and then adds `node` to `result` and returns `node`
             function addResult(node: Statement, additionalModifierFlags: ModifierFlags) {
                 if (canHaveModifiers(node)) {
                     let newModifierFlags: ModifierFlags = ModifierFlags.None;
-                    const enclosingDeclaration = context.enclosingDeclaration &&
-                        (isJSDocTypeAlias(context.enclosingDeclaration) ? getSourceFileOfNode(context.enclosingDeclaration) : context.enclosingDeclaration);
+                    const enclosingDeclaration = context.enclosingDeclaration
+                        && (isJSDocTypeAlias(context.enclosingDeclaration) ? getSourceFileOfNode(context.enclosingDeclaration) : context.enclosingDeclaration);
                     if (
-                        additionalModifierFlags & ModifierFlags.Export &&
-                        enclosingDeclaration && (isExportingScope(enclosingDeclaration) || isModuleDeclaration(enclosingDeclaration)) &&
-                        canHaveExportModifier(node)
+                        additionalModifierFlags & ModifierFlags.Export
+                        && enclosingDeclaration && (isExportingScope(enclosingDeclaration) || isModuleDeclaration(enclosingDeclaration))
+                        && canHaveExportModifier(node)
                     ) {
                         // Classes, namespaces, variables, functions, interfaces, and types should all be `export`ed in a module context if not private
                         newModifierFlags |= ModifierFlags.Export;
                     }
                     if (
-                        addingDeclare && !(newModifierFlags & ModifierFlags.Export) &&
-                        (!enclosingDeclaration || !(enclosingDeclaration.flags & NodeFlags.Ambient)) &&
-                        (isEnumDeclaration(node) || isVariableStatement(node) || isFunctionDeclaration(node) || isClassDeclaration(node) || isModuleDeclaration(node))
+                        addingDeclare && !(newModifierFlags & ModifierFlags.Export)
+                        && (!enclosingDeclaration || !(enclosingDeclaration.flags & NodeFlags.Ambient))
+                        && (isEnumDeclaration(node) || isVariableStatement(node) || isFunctionDeclaration(node) || isClassDeclaration(node) || isModuleDeclaration(node))
                     ) {
                         // Classes, namespaces, variables, enums, and functions all need `declare` modifiers to be valid in a declaration file top-level scope
                         newModifierFlags |= ModifierFlags.Ambient;
@@ -9469,9 +9469,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             const initializedValue = p.declarations && p.declarations[0] && isEnumMember(p.declarations[0]) ? getConstantValue(p.declarations[0]) : undefined;
                             return factory.createEnumMember(
                                 unescapeLeadingUnderscores(p.escapedName),
-                                initializedValue === undefined ? undefined :
-                                    typeof initializedValue === "string" ? factory.createStringLiteral(initializedValue) :
-                                    factory.createNumericLiteral(initializedValue),
+                                initializedValue === undefined ? undefined
+                                    : typeof initializedValue === "string" ? factory.createStringLiteral(initializedValue)
+                                    : factory.createNumericLiteral(initializedValue),
                             );
                         }),
                     ),
@@ -9564,8 +9564,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             function isNamespaceMember(p: Symbol) {
-                return !!(p.flags & (SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias)) ||
-                    !(p.flags & SymbolFlags.Prototype || p.escapedName === "prototype" || p.valueDeclaration && isStatic(p.valueDeclaration) && isClassLike(p.valueDeclaration.parent));
+                return !!(p.flags & (SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias))
+                    || !(p.flags & SymbolFlags.Prototype || p.escapedName === "prototype" || p.valueDeclaration && isStatic(p.valueDeclaration) && isClassLike(p.valueDeclaration.parent));
             }
 
             function sanitizeJSDocImplements(clauses: readonly ExpressionWithTypeArguments[]): ExpressionWithTypeArguments[] | undefined {
@@ -9637,15 +9637,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return !!valueDecl && isNamedDeclaration(valueDecl) && isPrivateIdentifier(valueDecl.name);
                 });
                 // Boil down all private properties into a single one.
-                const privateProperties = hasPrivateIdentifier ?
-                    [factory.createPropertyDeclaration(
+                const privateProperties = hasPrivateIdentifier
+                    ? [factory.createPropertyDeclaration(
                         /*modifiers*/ undefined,
                         factory.createPrivateIdentifier("#private"),
                         /*questionOrExclamationToken*/ undefined,
                         /*type*/ undefined,
                         /*initializer*/ undefined,
-                    )] :
-                    emptyArray;
+                    )]
+                    : emptyArray;
                 const publicProperties = flatMap<Symbol, ClassElement>(publicSymbolProps, p => serializePropertySymbolForClass(p, /*isStatic*/ false, baseTypes[0]));
                 // Consider static members empty if symbol also has function or module meaning - function namespacey emit will handle statics
                 const staticMembers = flatMap(
@@ -9655,13 +9655,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // When we encounter an `X.prototype.y` assignment in a JS file, we bind `X` as a class regardless as to whether
                 // the value is ever initialized with a class or function-like value. For cases where `X` could never be
                 // created via `new`, we will inject a `private constructor()` declaration to indicate it is not createable.
-                const isNonConstructableClassLikeInJsFile = !isClass &&
-                    !!symbol.valueDeclaration &&
-                    isInJSFile(symbol.valueDeclaration) &&
-                    !some(getSignaturesOfType(staticType, SignatureKind.Construct));
-                const constructors = isNonConstructableClassLikeInJsFile ?
-                    [factory.createConstructorDeclaration(factory.createModifiersFromModifierFlags(ModifierFlags.Private), [], /*body*/ undefined)] :
-                    serializeSignatures(SignatureKind.Construct, staticType, staticBaseType, SyntaxKind.Constructor) as ConstructorDeclaration[];
+                const isNonConstructableClassLikeInJsFile = !isClass
+                    && !!symbol.valueDeclaration
+                    && isInJSFile(symbol.valueDeclaration)
+                    && !some(getSignaturesOfType(staticType, SignatureKind.Construct));
+                const constructors = isNonConstructableClassLikeInJsFile
+                    ? [factory.createConstructorDeclaration(factory.createModifiersFromModifierFlags(ModifierFlags.Private), [], /*body*/ undefined)]
+                    : serializeSignatures(SignatureKind.Construct, staticType, staticBaseType, SyntaxKind.Constructor) as ConstructorDeclaration[];
                 const indexSignatures = serializeIndexSignatures(classType, baseTypes[0]);
                 context.enclosingDeclaration = oldEnclosing;
                 addResult(
@@ -10043,17 +10043,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // context source file, and whose property names are all valid identifiers and not late-bound, _and_
                 // whose input is not type annotated (if the input symbol has an annotation we can reuse, we should prefer it)
                 const ctxSrc = getSourceFileOfNode(context.enclosingDeclaration);
-                return getObjectFlags(typeToSerialize) & (ObjectFlags.Anonymous | ObjectFlags.Mapped) &&
-                    !some(typeToSerialize.symbol?.declarations, isTypeNode) && // If the type comes straight from a type node, we shouldn't try to break it up
-                    !length(getIndexInfosOfType(typeToSerialize)) &&
-                    !isClassInstanceSide(typeToSerialize) && // While a class instance is potentially representable as a NS, prefer printing a reference to the instance type and serializing the class
-                    !!(length(filter(getPropertiesOfType(typeToSerialize), isNamespaceMember)) || length(getSignaturesOfType(typeToSerialize, SignatureKind.Call))) &&
-                    !length(getSignaturesOfType(typeToSerialize, SignatureKind.Construct)) && // TODO: could probably serialize as function + ns + class, now that that's OK
-                    !getDeclarationWithTypeAnnotation(hostSymbol, enclosingDeclaration) &&
-                    !(typeToSerialize.symbol && some(typeToSerialize.symbol.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
-                    !some(getPropertiesOfType(typeToSerialize), p => isLateBoundName(p.escapedName)) &&
-                    !some(getPropertiesOfType(typeToSerialize), p => some(p.declarations, d => getSourceFileOfNode(d) !== ctxSrc)) &&
-                    every(getPropertiesOfType(typeToSerialize), p => {
+                return getObjectFlags(typeToSerialize) & (ObjectFlags.Anonymous | ObjectFlags.Mapped)
+                    && !some(typeToSerialize.symbol?.declarations, isTypeNode) // If the type comes straight from a type node, we shouldn't try to break it up
+                    && !length(getIndexInfosOfType(typeToSerialize))
+                    && !isClassInstanceSide(typeToSerialize) // While a class instance is potentially representable as a NS, prefer printing a reference to the instance type and serializing the class
+                    && !!(length(filter(getPropertiesOfType(typeToSerialize), isNamespaceMember)) || length(getSignaturesOfType(typeToSerialize, SignatureKind.Call)))
+                    && !length(getSignaturesOfType(typeToSerialize, SignatureKind.Construct)) // TODO: could probably serialize as function + ns + class, now that that's OK
+                    && !getDeclarationWithTypeAnnotation(hostSymbol, enclosingDeclaration)
+                    && !(typeToSerialize.symbol && some(typeToSerialize.symbol.declarations, d => getSourceFileOfNode(d) !== ctxSrc))
+                    && !some(getPropertiesOfType(typeToSerialize), p => isLateBoundName(p.escapedName))
+                    && !some(getPropertiesOfType(typeToSerialize), p => some(p.declarations, d => getSourceFileOfNode(d) !== ctxSrc))
+                    && every(getPropertiesOfType(typeToSerialize), p => {
                         if (!isIdentifierText(symbolName(p), languageVersion)) {
                             return false;
                         }
@@ -10106,8 +10106,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return [];
                     }
                     if (
-                        p.flags & SymbolFlags.Prototype || p.escapedName === "constructor" ||
-                        (baseType && getPropertyOfType(baseType, p.escapedName)
+                        p.flags & SymbolFlags.Prototype || p.escapedName === "constructor"
+                        || (baseType && getPropertyOfType(baseType, p.escapedName)
                             && isReadonlySymbol(getPropertyOfType(baseType, p.escapedName)!) === isReadonlySymbol(p)
                             && (p.flags & SymbolFlags.Optional) === (getPropertyOfType(baseType, p.escapedName)!.flags & SymbolFlags.Optional)
                             && isTypeIdenticalTo(getTypeOfSymbol(p), getTypeOfPropertyOfType(baseType, p.escapedName)!))
@@ -10453,9 +10453,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTopLevelInExternalModuleAugmentation(node: Node): boolean {
-        return node && node.parent &&
-            node.parent.kind === SyntaxKind.ModuleBlock &&
-            isExternalModuleAugmentation(node.parent.parent);
+        return node && node.parent
+            && node.parent.kind === SyntaxKind.ModuleBlock
+            && isExternalModuleAugmentation(node.parent.parent);
     }
 
     function isDefaultBindingContext(location: Node) {
@@ -10493,13 +10493,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             symbol = context.remappedSymbolReferences.get(getSymbolId(symbol))!;
         }
         if (
-            context && symbol.escapedName === InternalSymbolName.Default && !(context.flags & NodeBuilderFlags.UseAliasDefinedOutsideCurrentScope) &&
+            context && symbol.escapedName === InternalSymbolName.Default && !(context.flags & NodeBuilderFlags.UseAliasDefinedOutsideCurrentScope)
             // If it's not the first part of an entity name, it must print as `default`
-            (!(context.flags & NodeBuilderFlags.InInitialEntityName) ||
+            && (!(context.flags & NodeBuilderFlags.InInitialEntityName)
                 // if the symbol is synthesized, it will only be referenced externally it must print as `default`
-                !symbol.declarations ||
+                || !symbol.declarations
                 // if not in the same binding context (source file, module declaration), it must print as `default`
-                (context.enclosingDeclaration && findAncestor(symbol.declarations[0], isDefaultBindingContext) !== findAncestor(context.enclosingDeclaration, isDefaultBindingContext)))
+                || (context.enclosingDeclaration && findAncestor(symbol.declarations[0], isDefaultBindingContext) !== findAncestor(context.enclosingDeclaration, isDefaultBindingContext)))
         ) {
             return "default";
         }
@@ -10565,8 +10565,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return isDeclarationVisible(node.parent.parent);
                 case SyntaxKind.VariableDeclaration:
                     if (
-                        isBindingPattern((node as VariableDeclaration).name) &&
-                        !((node as VariableDeclaration).name as BindingPattern).elements.length
+                        isBindingPattern((node as VariableDeclaration).name)
+                        && !((node as VariableDeclaration).name as BindingPattern).elements.length
                     ) {
                         // If the binding pattern is empty, this variable declaration is not visible
                         return false;
@@ -10586,8 +10586,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const parent = getDeclarationContainer(node);
                     // If the node is not exported or it is not ambient module element (except import declaration)
                     if (
-                        !(getCombinedModifierFlagsCached(node as Declaration) & ModifierFlags.Export) &&
-                        !(node.kind !== SyntaxKind.ImportEqualsDeclaration && parent.kind !== SyntaxKind.SourceFile && parent.flags & NodeFlags.Ambient)
+                        !(getCombinedModifierFlagsCached(node as Declaration) & ModifierFlags.Export)
+                        && !(node.kind !== SyntaxKind.ImportEqualsDeclaration && parent.kind !== SyntaxKind.SourceFile && parent.flags & NodeFlags.Ambient)
                     ) {
                         return isGlobalSourceFile(parent);
                     }
@@ -10806,9 +10806,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      */
     function getTypeOfPropertyOrIndexSignatureOfType(type: Type, name: __String): Type | undefined {
         let propType;
-        return getTypeOfPropertyOfType(type, name) ||
-            (propType = getApplicableIndexInfoForName(type, name)?.type) &&
-                addOptionality(propType, /*isProperty*/ true, /*isOptional*/ true);
+        return getTypeOfPropertyOfType(type, name)
+            || (propType = getApplicableIndexInfoForName(type, name)?.type)
+                && addOptionality(propType, /*isProperty*/ true, /*isOptional*/ true);
     }
 
     function isTypeAny(type: Type | undefined) {
@@ -11016,9 +11016,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // remaining tuple element types. Otherwise, the rest element has an array type with same
                 // element type as the parent type.
                 const baseConstraint = mapType(parentType, t => t.flags & TypeFlags.InstantiableNonPrimitive ? getBaseConstraintOrType(t) : t);
-                type = everyType(baseConstraint, isTupleType) ?
-                    mapType(baseConstraint, t => sliceTupleType(t as TupleTypeReference, index)) :
-                    createArrayType(elementType);
+                type = everyType(baseConstraint, isTupleType)
+                    ? mapType(baseConstraint, t => sliceTupleType(t as TupleTypeReference, index))
+                    : createArrayType(elementType);
             }
             else if (isArrayLikeType(parentType)) {
                 const indexType = getNumberLiteralType(index);
@@ -11108,9 +11108,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (
-            (noImplicitAny || isInJSFile(declaration)) &&
-            isVariableDeclaration(declaration) && !isBindingPattern(declaration.name) &&
-            !(getCombinedModifierFlagsCached(declaration) & ModifierFlags.Export) && !(declaration.flags & NodeFlags.Ambient)
+            (noImplicitAny || isInJSFile(declaration))
+            && isVariableDeclaration(declaration) && !isBindingPattern(declaration.name)
+            && !(getCombinedModifierFlagsCached(declaration) & ModifierFlags.Export) && !(declaration.flags & NodeFlags.Ambient)
         ) {
             // If --noImplicitAny is on or the declaration is in a Javascript file,
             // use control flow tracked 'any' type for non-ambient, non-exported var or let variables with no
@@ -11168,16 +11168,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Use control flow analysis of this.xxx assignments in the constructor or static block to determine the type of the property.
             if (!hasStaticModifier(declaration)) {
                 const constructor = findConstructorDeclaration(declaration.parent);
-                const type = constructor ? getFlowTypeInConstructor(declaration.symbol, constructor) :
-                    getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :
-                    undefined;
+                const type = constructor ? getFlowTypeInConstructor(declaration.symbol, constructor)
+                    : getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol)
+                    : undefined;
                 return type && addOptionality(type, /*isProperty*/ true, isOptional);
             }
             else {
                 const staticBlocks = filter(declaration.parent.members, isClassStaticBlockDeclaration);
-                const type = staticBlocks.length ? getFlowTypeInStaticBlocks(declaration.symbol, staticBlocks) :
-                    getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol) :
-                    undefined;
+                const type = staticBlocks.length ? getFlowTypeInStaticBlocks(declaration.symbol, staticBlocks)
+                    : getEffectiveModifierFlags(declaration) & ModifierFlags.Ambient ? getTypeOfPropertyInBaseClass(declaration.symbol)
+                    : undefined;
                 return type && addOptionality(type, /*isProperty*/ true, isOptional);
             }
         }
@@ -11207,10 +11207,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (links.isConstructorDeclaredProperty === undefined) {
                 links.isConstructorDeclaredProperty = false;
                 links.isConstructorDeclaredProperty = !!getDeclaringConstructor(symbol) && every(symbol.declarations, declaration =>
-                    isBinaryExpression(declaration) &&
-                    isPossiblyAliasedThisProperty(declaration) &&
-                    (declaration.left.kind !== SyntaxKind.ElementAccessExpression || isStringOrNumericLiteralLike((declaration.left as ElementAccessExpression).argumentExpression)) &&
-                    !getAnnotatedTypeForAssignmentDeclaration(/*declaredType*/ undefined, declaration, symbol, declaration));
+                    isBinaryExpression(declaration)
+                    && isPossiblyAliasedThisProperty(declaration)
+                    && (declaration.left.kind !== SyntaxKind.ElementAccessExpression || isStringOrNumericLiteralLike((declaration.left as ElementAccessExpression).argumentExpression))
+                    && !getAnnotatedTypeForAssignmentDeclaration(/*declaredType*/ undefined, declaration, symbol, declaration));
             }
             return links.isConstructorDeclaredProperty;
         }
@@ -11221,8 +11221,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // A property is auto-typed when its declaration has no type annotation or initializer and we're in
         // noImplicitAny mode or a .js file.
         const declaration = symbol.valueDeclaration;
-        return declaration && isPropertyDeclaration(declaration) && !getEffectiveTypeAnnotationNode(declaration) &&
-            !declaration.initializer && (noImplicitAny || isInJSFile(declaration));
+        return declaration && isPropertyDeclaration(declaration) && !getEffectiveTypeAnnotationNode(declaration)
+            && !declaration.initializer && (noImplicitAny || isInJSFile(declaration));
     }
 
     function getDeclaringConstructor(symbol: Symbol) {
@@ -11323,9 +11323,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (symbol.declarations) {
                 let jsdocType: Type | undefined;
                 for (const declaration of symbol.declarations) {
-                    const expression = (isBinaryExpression(declaration) || isCallExpression(declaration)) ? declaration :
-                        isAccessExpression(declaration) ? isBinaryExpression(declaration.parent) ? declaration.parent : declaration :
-                        undefined;
+                    const expression = (isBinaryExpression(declaration) || isCallExpression(declaration)) ? declaration
+                        : isAccessExpression(declaration) ? isBinaryExpression(declaration.parent) ? declaration.parent : declaration
+                        : undefined;
                     if (!expression) {
                         continue; // Non-assignment declaration merged in (eg, an Identifier to mark the thing as a namespace) - skip over it and pull type info from elsewhere
                     }
@@ -11458,9 +11458,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             : isDirectExport ? getRegularTypeOfLiteralType(checkExpressionCached(expression.right))
             : getWidenedLiteralType(checkExpressionCached(expression.right));
         if (
-            type.flags & TypeFlags.Object &&
-            kind === AssignmentDeclarationKind.ModuleExports &&
-            symbol.escapedName === InternalSymbolName.ExportEquals
+            type.flags & TypeFlags.Object
+            && kind === AssignmentDeclarationKind.ModuleExports
+            && symbol.escapedName === InternalSymbolName.ExportEquals
         ) {
             const exportedType = resolveStructuredTypeMembers(type as ObjectType);
             const members = createSymbolTable();
@@ -11550,17 +11550,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const thisContainer = getThisContainer(expression, /*includeArrowFunctions*/ false, /*includeClassComputedPropertyName*/ false);
         // Properties defined in a constructor (or base constructor, or javascript constructor function) don't get undefined added.
         // Function expressions that are assigned to the prototype count as methods.
-        return thisContainer.kind === SyntaxKind.Constructor ||
-            thisContainer.kind === SyntaxKind.FunctionDeclaration ||
-            (thisContainer.kind === SyntaxKind.FunctionExpression && !isPrototypePropertyAssignment(thisContainer.parent));
+        return thisContainer.kind === SyntaxKind.Constructor
+            || thisContainer.kind === SyntaxKind.FunctionDeclaration
+            || (thisContainer.kind === SyntaxKind.FunctionExpression && !isPrototypePropertyAssignment(thisContainer.parent));
     }
 
     function getConstructorDefinedThisAssignmentTypes(types: Type[], declarations: Declaration[]): Type[] | undefined {
         Debug.assert(types.length === declarations.length);
         return types.filter((_, i) => {
             const declaration = declarations[i];
-            const expression = isBinaryExpression(declaration) ? declaration :
-                isBinaryExpression(declaration.parent) ? declaration.parent : undefined;
+            const expression = isBinaryExpression(declaration) ? declaration
+                : isBinaryExpression(declaration.parent) ? declaration.parent : undefined;
             return expression && isDeclarationInConstructor(expression);
         });
     }
@@ -11828,9 +11828,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             type = widenTypeForVariableLikeDeclaration(tryGetTypeFromEffectiveTypeNode(declaration) || checkExpressionCached((declaration as ExportAssignment).expression), declaration);
         }
         else if (
-            isBinaryExpression(declaration) ||
-            (isInJSFile(declaration) &&
-                (isCallExpression(declaration) || (isPropertyAccessExpression(declaration) || isBindableStaticElementAccessExpression(declaration)) && isBinaryExpression(declaration.parent)))
+            isBinaryExpression(declaration)
+            || (isInJSFile(declaration)
+                && (isCallExpression(declaration) || (isPropertyAccessExpression(declaration) || isBindableStaticElementAccessExpression(declaration)) && isBinaryExpression(declaration.parent)))
         ) {
             type = getWidenedTypeForAssignmentDeclaration(symbol);
         }
@@ -11850,9 +11850,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (symbol.flags & (SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.Enum | SymbolFlags.ValueModule)) {
                 return getTypeOfFuncClassEnumModule(symbol);
             }
-            type = isBinaryExpression(declaration.parent) ?
-                getWidenedTypeForAssignmentDeclaration(symbol) :
-                tryGetTypeFromEffectiveTypeNode(declaration) || anyType;
+            type = isBinaryExpression(declaration.parent)
+                ? getWidenedTypeForAssignmentDeclaration(symbol)
+                : tryGetTypeFromEffectiveTypeNode(declaration) || anyType;
         }
         else if (isPropertyAssignment(declaration)) {
             type = tryGetTypeFromEffectiveTypeNode(declaration) || checkPropertyAssignment(declaration);
@@ -11952,12 +11952,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             // We try to resolve a getter type annotation, a setter type annotation, or a getter function
             // body return type inference, in that order.
-            let type = getter && isInJSFile(getter) && getTypeForDeclarationFromJSDocComment(getter) ||
-                getAnnotatedAccessorType(getter) ||
-                getAnnotatedAccessorType(setter) ||
-                getAnnotatedAccessorType(accessor) ||
-                getter && getter.body && getReturnTypeFromBody(getter) ||
-                accessor && accessor.initializer && getWidenedTypeForVariableLikeDeclaration(accessor, /*reportErrors*/ true);
+            let type = getter && isInJSFile(getter) && getTypeForDeclarationFromJSDocComment(getter)
+                || getAnnotatedAccessorType(getter)
+                || getAnnotatedAccessorType(setter)
+                || getAnnotatedAccessorType(accessor)
+                || getter && getter.body && getReturnTypeFromBody(getter)
+                || accessor && accessor.initializer && getWidenedTypeForVariableLikeDeclaration(accessor, /*reportErrors*/ true);
             if (!type) {
                 if (setter && !isPrivateWithinAmbient(setter)) {
                     errorOrSuggestion(noImplicitAny, setter, Diagnostics.Property_0_implicitly_has_type_any_because_its_set_accessor_lacks_a_parameter_type_annotation, symbolToString(symbol));
@@ -12014,9 +12014,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getBaseTypeVariableOfClass(symbol: Symbol) {
         const baseConstructorType = getBaseConstructorTypeOfClass(getDeclaredTypeOfClassOrInterface(symbol));
-        return baseConstructorType.flags & TypeFlags.TypeVariable ? baseConstructorType :
-            baseConstructorType.flags & TypeFlags.Intersection ? find((baseConstructorType as IntersectionType).types, t => !!(t.flags & TypeFlags.TypeVariable)) :
-            undefined;
+        return baseConstructorType.flags & TypeFlags.TypeVariable ? baseConstructorType
+            : baseConstructorType.flags & TypeFlags.Intersection ? find((baseConstructorType as IntersectionType).types, t => !!(t.flags & TypeFlags.TypeVariable))
+            : undefined;
     }
 
     function getTypeOfFuncClassEnumModule(symbol: Symbol): Type {
@@ -12043,9 +12043,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return anyType;
         }
         else if (
-            declaration && (declaration.kind === SyntaxKind.BinaryExpression ||
-                isAccessExpression(declaration) &&
-                    declaration.parent.kind === SyntaxKind.BinaryExpression)
+            declaration && (declaration.kind === SyntaxKind.BinaryExpression
+                || isAccessExpression(declaration)
+                    && declaration.parent.kind === SyntaxKind.BinaryExpression)
         ) {
             return getWidenedTypeForAssignmentDeclaration(symbol);
         }
@@ -12170,17 +12170,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getWriteTypeOfSymbol(symbol: Symbol): Type {
         const checkFlags = getCheckFlags(symbol);
         if (symbol.flags & SymbolFlags.Property) {
-            return checkFlags & CheckFlags.SyntheticProperty ?
-                checkFlags & CheckFlags.DeferredType ?
-                    getWriteTypeOfSymbolWithDeferredType(symbol) || getTypeOfSymbolWithDeferredType(symbol) :
+            return checkFlags & CheckFlags.SyntheticProperty
+                ? checkFlags & CheckFlags.DeferredType
+                    ? getWriteTypeOfSymbolWithDeferredType(symbol) || getTypeOfSymbolWithDeferredType(symbol)
                     // NOTE: cast to TransientSymbol should be safe because only TransientSymbols can have CheckFlags.SyntheticProperty
-                    (symbol as TransientSymbol).links.writeType || (symbol as TransientSymbol).links.type! :
-                removeMissingType(getTypeOfSymbol(symbol), !!(symbol.flags & SymbolFlags.Optional));
+                    : (symbol as TransientSymbol).links.writeType || (symbol as TransientSymbol).links.type!
+                : removeMissingType(getTypeOfSymbol(symbol), !!(symbol.flags & SymbolFlags.Optional));
         }
         if (symbol.flags & SymbolFlags.Accessor) {
-            return checkFlags & CheckFlags.Instantiated ?
-                getWriteTypeOfInstantiatedSymbol(symbol) :
-                getWriteTypeOfAccessors(symbol);
+            return checkFlags & CheckFlags.Instantiated
+                ? getWriteTypeOfInstantiatedSymbol(symbol)
+                : getWriteTypeOfAccessors(symbol);
         }
         return getTypeOfSymbol(symbol);
     }
@@ -12303,9 +12303,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return concatenate(outerTypeParameters, getInferTypeParameters(node as ConditionalTypeNode));
                     }
                     const outerAndOwnTypeParameters = appendTypeParameters(outerTypeParameters, getEffectiveTypeParameterDeclarations(node as DeclarationWithTypeParameters));
-                    const thisType = includeThisTypes &&
-                        (node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.ClassExpression || node.kind === SyntaxKind.InterfaceDeclaration || isJSConstructor(node)) &&
-                        getDeclaredTypeOfClassOrInterface(getSymbolOfDeclaration(node as ClassLikeDeclaration | InterfaceDeclaration)).thisType;
+                    const thisType = includeThisTypes
+                        && (node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.ClassExpression || node.kind === SyntaxKind.InterfaceDeclaration || isJSConstructor(node))
+                        && getDeclaredTypeOfClassOrInterface(getSymbolOfDeclaration(node as ClassLikeDeclaration | InterfaceDeclaration)).thisType;
                     return thisType ? append(outerAndOwnTypeParameters, thisType) : outerAndOwnTypeParameters;
                 }
                 case SyntaxKind.JSDocParameterTag:
@@ -12351,11 +12351,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let result: TypeParameter[] | undefined;
         for (const node of symbol.declarations) {
             if (
-                node.kind === SyntaxKind.InterfaceDeclaration ||
-                node.kind === SyntaxKind.ClassDeclaration ||
-                node.kind === SyntaxKind.ClassExpression ||
-                isJSConstructor(node) ||
-                isTypeAlias(node)
+                node.kind === SyntaxKind.InterfaceDeclaration
+                || node.kind === SyntaxKind.ClassDeclaration
+                || node.kind === SyntaxKind.ClassExpression
+                || isJSConstructor(node)
+                || isTypeAlias(node)
             ) {
                 const declaration = node as InterfaceDeclaration | TypeAliasDeclaration | JSDocTypedefTag | JSDocCallbackTag;
                 result = appendTypeParameters(result, getEffectiveTypeParameterDeclarations(declaration));
@@ -12538,8 +12538,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let baseType: Type;
         const originalBaseType = baseConstructorType.symbol ? getDeclaredTypeOfSymbol(baseConstructorType.symbol) : undefined;
         if (
-            baseConstructorType.symbol && baseConstructorType.symbol.flags & SymbolFlags.Class &&
-            areAllOuterTypeParametersApplied(originalBaseType!)
+            baseConstructorType.symbol && baseConstructorType.symbol.flags & SymbolFlags.Class
+            && areAllOuterTypeParametersApplied(originalBaseType!)
         ) {
             // When base constructor type is a class with no captured type arguments we know that the constructors all have the same type parameters as the
             // class and all return the instance type of the class. There is no need for further checks and we can apply the
@@ -12607,8 +12607,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         // TODO: Given that we allow type parmeters here now, is this `!isGenericMappedType(type)` check really needed?
         // There's no reason a `T` should be allowed while a `Readonly<T>` should not.
-        return !!(type.flags & (TypeFlags.Object | TypeFlags.NonPrimitive | TypeFlags.Any) && !isGenericMappedType(type) ||
-            type.flags & TypeFlags.Intersection && every((type as IntersectionType).types, isValidBaseType));
+        return !!(type.flags & (TypeFlags.Object | TypeFlags.NonPrimitive | TypeFlags.Any) && !isGenericMappedType(type)
+            || type.flags & TypeFlags.Intersection && every((type as IntersectionType).types, isValidBaseType));
     }
 
     function resolveBaseTypesOfInterface(type: InterfaceType): void {
@@ -12765,9 +12765,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 const memberSymbol = getSymbolOfDeclaration(member);
                                 const value = getEnumMemberValue(member);
                                 const memberType = getFreshTypeOfLiteralType(
-                                    value !== undefined ?
-                                        getEnumLiteralType(value, getSymbolId(symbol), memberSymbol) :
-                                        createComputedEnumType(memberSymbol),
+                                    value !== undefined
+                                        ? getEnumLiteralType(value, getSymbolId(symbol), memberSymbol)
+                                        : createComputedEnumType(memberSymbol),
                                 );
                                 getSymbolLinks(memberSymbol).declaredType = memberType;
                                 memberTypeList.push(getRegularTypeOfLiteralType(memberType));
@@ -12776,9 +12776,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
             }
-            const enumType = memberTypeList.length ?
-                getUnionType(memberTypeList, UnionReduction.Literal, symbol, /*aliasTypeArguments*/ undefined) :
-                createComputedEnumType(symbol);
+            const enumType = memberTypeList.length
+                ? getUnionType(memberTypeList, UnionReduction.Literal, symbol, /*aliasTypeArguments*/ undefined)
+                : createComputedEnumType(symbol);
             if (enumType.flags & TypeFlags.Union) {
                 enumType.flags |= TypeFlags.EnumLiteral;
                 enumType.symbol = symbol;
@@ -12896,9 +12896,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isThislessFunctionLikeDeclaration(node: FunctionLikeDeclaration): boolean {
         const returnType = getEffectiveReturnTypeNode(node);
         const typeParameters = getEffectiveTypeParameterDeclarations(node);
-        return (node.kind === SyntaxKind.Constructor || (!!returnType && isThislessType(returnType))) &&
-            node.parameters.every(isThislessVariableLikeDeclaration) &&
-            typeParameters.every(isThislessTypeParameter);
+        return (node.kind === SyntaxKind.Constructor || (!!returnType && isThislessType(returnType)))
+            && node.parameters.every(isThislessVariableLikeDeclaration)
+            && typeParameters.every(isThislessTypeParameter);
     }
 
     /**
@@ -12997,9 +12997,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isLateBoundName(name: __String): boolean {
-        return (name as string).charCodeAt(0) === CharacterCodes._ &&
-            (name as string).charCodeAt(1) === CharacterCodes._ &&
-            (name as string).charCodeAt(2) === CharacterCodes.at;
+        return (name as string).charCodeAt(0) === CharacterCodes._
+            && (name as string).charCodeAt(1) === CharacterCodes._
+            && (name as string).charCodeAt(2) === CharacterCodes.at;
     }
 
     /**
@@ -13123,9 +13123,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const links = getSymbolLinks(symbol);
         if (!links[resolutionKind]) {
             const isStatic = resolutionKind === MembersOrExportsResolutionKind.resolvedExports;
-            const earlySymbols = !isStatic ? symbol.members :
-                symbol.flags & SymbolFlags.Module ? getExportsOfModuleWorker(symbol).exports :
-                symbol.exports;
+            const earlySymbols = !isStatic ? symbol.members
+                : symbol.flags & SymbolFlags.Module ? getExportsOfModuleWorker(symbol).exports
+                : symbol.exports;
 
             // In the event we recursively resolve the members/exports of the symbol, we
             // set the initial value of resolvedMembers/resolvedExports to the early-bound
@@ -13373,11 +13373,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const associatedNames = getUniqAssociatedNamesFromTupleType(restType, restName);
             const restParams = map(elementTypes, (t, i) => {
                 // Lookup the label from the individual tuple passed in before falling back to the signature `rest` parameter name
-                const name = associatedNames && associatedNames[i] ? associatedNames[i] :
-                    getParameterNameAtPosition(sig, restIndex + i, restType);
+                const name = associatedNames && associatedNames[i] ? associatedNames[i]
+                    : getParameterNameAtPosition(sig, restIndex + i, restType);
                 const flags = restType.target.elementFlags[i];
-                const checkFlags = flags & ElementFlags.Variable ? CheckFlags.RestParameter :
-                    flags & ElementFlags.Optional ? CheckFlags.OptionalParameter : 0;
+                const checkFlags = flags & ElementFlags.Variable ? CheckFlags.RestParameter
+                    : flags & ElementFlags.Optional ? CheckFlags.OptionalParameter : 0;
                 const symbol = createSymbol(SymbolFlags.FunctionScopedVariable, name, checkFlags);
                 symbol.links.type = flags & ElementFlags.Rest ? createArrayType(t) : t;
                 return symbol;
@@ -13582,10 +13582,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const leftName = i >= leftCount ? undefined : getParameterNameAtPosition(left, i);
             const rightName = i >= rightCount ? undefined : getParameterNameAtPosition(right, i);
 
-            const paramName = leftName === rightName ? leftName :
-                !leftName ? rightName :
-                !rightName ? leftName :
-                undefined;
+            const paramName = leftName === rightName ? leftName
+                : !leftName ? rightName
+                : !rightName ? leftName
+                : undefined;
             const paramSymbol = createSymbol(
                 SymbolFlags.FunctionScopedVariable | (isOptional && !isRestParam ? SymbolFlags.Optional : 0),
                 paramName || `arg${i}` as __String,
@@ -13803,8 +13803,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 indexInfos = append(indexInfos, baseConstructorIndexInfo);
             }
             if (
-                symbol.flags & SymbolFlags.Enum && (getDeclaredTypeOfSymbol(symbol).flags & TypeFlags.Enum ||
-                    some(type.properties, prop => !!(getTypeOfSymbol(prop).flags & TypeFlags.NumberLike)))
+                symbol.flags & SymbolFlags.Enum && (getDeclaredTypeOfSymbol(symbol).flags & TypeFlags.Enum
+                    || some(type.properties, prop => !!(getTypeOfSymbol(prop).flags & TypeFlags.NumberLike)))
             ) {
                 indexInfos = append(indexInfos, enumNumberIndexInfo);
             }
@@ -13827,9 +13827,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     mapDefined(
                         type.callSignatures,
                         sig =>
-                            isJSConstructor(sig.declaration) ?
-                                createSignature(sig.declaration, sig.typeParameters, sig.thisParameter, sig.parameters, classType, /*resolvedTypePredicate*/ undefined, sig.minArgumentCount, sig.flags & SignatureFlags.PropagatingFlags) :
-                                undefined,
+                            isJSConstructor(sig.declaration)
+                                ? createSignature(sig.declaration, sig.typeParameters, sig.thisParameter, sig.parameters, classType, /*resolvedTypePredicate*/ undefined, sig.minArgumentCount, sig.flags & SignatureFlags.PropagatingFlags)
+                                : undefined,
                     ),
                 );
             }
@@ -14009,10 +14009,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 else {
                     const modifiersProp = isTypeUsableAsPropertyName(keyType) ? getPropertyOfType(modifiersType, getPropertyNameFromType(keyType)) : undefined;
-                    const isOptional = !!(templateModifiers & MappedTypeModifiers.IncludeOptional ||
-                        !(templateModifiers & MappedTypeModifiers.ExcludeOptional) && modifiersProp && modifiersProp.flags & SymbolFlags.Optional);
-                    const isReadonly = !!(templateModifiers & MappedTypeModifiers.IncludeReadonly ||
-                        !(templateModifiers & MappedTypeModifiers.ExcludeReadonly) && modifiersProp && isReadonlySymbol(modifiersProp));
+                    const isOptional = !!(templateModifiers & MappedTypeModifiers.IncludeOptional
+                        || !(templateModifiers & MappedTypeModifiers.ExcludeOptional) && modifiersProp && modifiersProp.flags & SymbolFlags.Optional);
+                    const isReadonly = !!(templateModifiers & MappedTypeModifiers.IncludeReadonly
+                        || !(templateModifiers & MappedTypeModifiers.ExcludeReadonly) && modifiersProp && isReadonlySymbol(modifiersProp));
                     const stripOptional = strictNullChecks && !isOptional && modifiersProp && modifiersProp.flags & SymbolFlags.Optional;
                     const lateFlag: CheckFlags = modifiersProp ? getIsLateCheckFlag(modifiersProp) : 0;
                     const prop = createSymbol(SymbolFlags.Property | (isOptional ? SymbolFlags.Optional : 0), propName, lateFlag | CheckFlags.Mapped | (isReadonly ? CheckFlags.Readonly : 0) | (stripOptional ? CheckFlags.StripOptional : 0)) as MappedSymbol;
@@ -14027,13 +14027,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
             else if (isValidIndexKeyType(propNameType) || propNameType.flags & (TypeFlags.Any | TypeFlags.Enum)) {
-                const indexKeyType = propNameType.flags & (TypeFlags.Any | TypeFlags.String) ? stringType :
-                    propNameType.flags & (TypeFlags.Number | TypeFlags.Enum) ? numberType :
-                    propNameType;
+                const indexKeyType = propNameType.flags & (TypeFlags.Any | TypeFlags.String) ? stringType
+                    : propNameType.flags & (TypeFlags.Number | TypeFlags.Enum) ? numberType
+                    : propNameType;
                 const propType = instantiateType(templateType, appendTypeMapping(type.mapper, typeParameter, keyType));
                 const modifiersIndexInfo = getApplicableIndexInfo(modifiersType, propNameType);
-                const isReadonly = !!(templateModifiers & MappedTypeModifiers.IncludeReadonly ||
-                    !(templateModifiers & MappedTypeModifiers.ExcludeReadonly) && modifiersIndexInfo?.isReadonly);
+                const isReadonly = !!(templateModifiers & MappedTypeModifiers.IncludeReadonly
+                    || !(templateModifiers & MappedTypeModifiers.ExcludeReadonly) && modifiersIndexInfo?.isReadonly);
                 const indexInfo = createIndexInfo(indexKeyType, propType, isReadonly);
                 indexInfos = appendIndexInfo(indexInfos, indexInfo, /*union*/ true);
             }
@@ -14053,9 +14053,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // When creating an optional property in strictNullChecks mode, if 'undefined' isn't assignable to the
             // type, we include 'undefined' in the type. Similarly, when creating a non-optional property in strictNullChecks
             // mode, if the underlying property is optional we remove 'undefined' from the type.
-            let type = strictNullChecks && symbol.flags & SymbolFlags.Optional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true) :
-                symbol.links.checkFlags & CheckFlags.StripOptional ? removeMissingOrUndefinedType(propType) :
-                propType;
+            let type = strictNullChecks && symbol.flags & SymbolFlags.Optional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true)
+                : symbol.links.checkFlags & CheckFlags.StripOptional ? removeMissingOrUndefinedType(propType)
+                : propType;
             if (!popTypeResolution()) {
                 error(currentNode, Diagnostics.Type_of_property_0_circularly_references_itself_in_mapped_type_1, symbolToString(symbol), typeToString(mappedType));
                 type = errorType;
@@ -14066,26 +14066,26 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeParameterFromMappedType(type: MappedType) {
-        return type.typeParameter ||
-            (type.typeParameter = getDeclaredTypeOfTypeParameter(getSymbolOfDeclaration(type.declaration.typeParameter)));
+        return type.typeParameter
+            || (type.typeParameter = getDeclaredTypeOfTypeParameter(getSymbolOfDeclaration(type.declaration.typeParameter)));
     }
 
     function getConstraintTypeFromMappedType(type: MappedType) {
-        return type.constraintType ||
-            (type.constraintType = getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)) || errorType);
+        return type.constraintType
+            || (type.constraintType = getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)) || errorType);
     }
 
     function getNameTypeFromMappedType(type: MappedType) {
-        return type.declaration.nameType ?
-            type.nameType || (type.nameType = instantiateType(getTypeFromTypeNode(type.declaration.nameType), type.mapper)) :
-            undefined;
+        return type.declaration.nameType
+            ? type.nameType || (type.nameType = instantiateType(getTypeFromTypeNode(type.declaration.nameType), type.mapper))
+            : undefined;
     }
 
     function getTemplateTypeFromMappedType(type: MappedType) {
-        return type.templateType ||
-            (type.templateType = type.declaration.type ?
-                instantiateType(addOptionality(getTypeFromTypeNode(type.declaration.type), /*isProperty*/ true, !!(getMappedTypeModifiers(type) & MappedTypeModifiers.IncludeOptional)), type.mapper) :
-                errorType);
+        return type.templateType
+            || (type.templateType = type.declaration.type
+                ? instantiateType(addOptionality(getTypeFromTypeNode(type.declaration.type), /*isProperty*/ true, !!(getMappedTypeModifiers(type) & MappedTypeModifiers.IncludeOptional)), type.mapper)
+                : errorType);
     }
 
     function getConstraintDeclarationForMappedType(type: MappedType) {
@@ -14094,8 +14094,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isMappedTypeWithKeyofConstraintDeclaration(type: MappedType) {
         const constraintDeclaration = getConstraintDeclarationForMappedType(type)!; // TODO: GH#18217
-        return constraintDeclaration.kind === SyntaxKind.TypeOperator &&
-            (constraintDeclaration as TypeOperatorNode).operator === SyntaxKind.KeyOfKeyword;
+        return constraintDeclaration.kind === SyntaxKind.TypeOperator
+            && (constraintDeclaration as TypeOperatorNode).operator === SyntaxKind.KeyOfKeyword;
     }
 
     function getModifiersTypeFromMappedType(type: MappedType) {
@@ -14121,8 +14121,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getMappedTypeModifiers(type: MappedType): MappedTypeModifiers {
         const declaration = type.declaration;
-        return (declaration.readonlyToken ? declaration.readonlyToken.kind === SyntaxKind.MinusToken ? MappedTypeModifiers.ExcludeReadonly : MappedTypeModifiers.IncludeReadonly : 0) |
-            (declaration.questionToken ? declaration.questionToken.kind === SyntaxKind.MinusToken ? MappedTypeModifiers.ExcludeOptional : MappedTypeModifiers.IncludeOptional : 0);
+        return (declaration.readonlyToken ? declaration.readonlyToken.kind === SyntaxKind.MinusToken ? MappedTypeModifiers.ExcludeReadonly : MappedTypeModifiers.IncludeReadonly : 0)
+            | (declaration.questionToken ? declaration.questionToken.kind === SyntaxKind.MinusToken ? MappedTypeModifiers.ExcludeOptional : MappedTypeModifiers.IncludeOptional : 0);
     }
 
     // Return -1, 0, or 1, where -1 means optionality is stripped (i.e. -?), 0 means optionality is unchanged, and 1 means
@@ -14133,9 +14133,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getModifiersTypeOptionality(type: Type): number {
-        return type.flags & TypeFlags.Intersection ? Math.max(...map((type as IntersectionType).types, getModifiersTypeOptionality)) :
-            getObjectFlags(type) & ObjectFlags.Mapped ? getCombinedMappedTypeOptionality(type as MappedType) :
-            0;
+        return type.flags & TypeFlags.Intersection ? Math.max(...map((type as IntersectionType).types, getModifiersTypeOptionality))
+            : getObjectFlags(type) & ObjectFlags.Mapped ? getCombinedMappedTypeOptionality(type as MappedType)
+            : 0;
     }
 
     // Return -1, 0, or 1, for stripped, unchanged, or added optionality respectively. When a homomorphic mapped type doesn't
@@ -14254,9 +14254,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getPropertiesOfType(type: Type): Symbol[] {
         type = getReducedApparentType(type);
-        return type.flags & TypeFlags.UnionOrIntersection ?
-            getPropertiesOfUnionOrIntersectionType(type as UnionType) :
-            getPropertiesOfObjectType(type);
+        return type.flags & TypeFlags.UnionOrIntersection
+            ? getPropertiesOfUnionOrIntersectionType(type as UnionType)
+            : getPropertiesOfObjectType(type);
     }
 
     function forEachPropertyOfType(type: Type, action: (symbol: Symbol, escapedName: __String) => void): void {
@@ -14300,10 +14300,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getConstraintOfType(type: InstantiableType | UnionOrIntersectionType): Type | undefined {
-        return type.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(type as TypeParameter) :
-            type.flags & TypeFlags.IndexedAccess ? getConstraintOfIndexedAccess(type as IndexedAccessType) :
-            type.flags & TypeFlags.Conditional ? getConstraintOfConditionalType(type as ConditionalType) :
-            getBaseConstraintOfType(type);
+        return type.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(type as TypeParameter)
+            : type.flags & TypeFlags.IndexedAccess ? getConstraintOfIndexedAccess(type as IndexedAccessType)
+            : type.flags & TypeFlags.Conditional ? getConstraintOfConditionalType(type as ConditionalType)
+            : getBaseConstraintOfType(type);
     }
 
     function getConstraintOfTypeParameter(typeParameter: TypeParameter): Type | undefined {
@@ -14317,13 +14317,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isConstTypeVariable(type: Type | undefined, depth = 0): boolean {
         return depth < 5 && !!(type && (
-            type.flags & TypeFlags.TypeParameter && some((type as TypeParameter).symbol?.declarations, d => hasSyntacticModifier(d, ModifierFlags.Const)) ||
-            type.flags & TypeFlags.UnionOrIntersection && some((type as UnionOrIntersectionType).types, t => isConstTypeVariable(t, depth)) ||
-            type.flags & TypeFlags.IndexedAccess && isConstTypeVariable((type as IndexedAccessType).objectType, depth + 1) ||
-            type.flags & TypeFlags.Conditional && isConstTypeVariable(getConstraintOfConditionalType(type as ConditionalType), depth + 1) ||
-            type.flags & TypeFlags.Substitution && isConstTypeVariable((type as SubstitutionType).baseType, depth) ||
-            getObjectFlags(type) & ObjectFlags.Mapped && isConstMappedType(type as MappedType, depth) ||
-            isGenericTupleType(type) && findIndex(getElementTypes(type), (t, i) => !!(type.target.elementFlags[i] & ElementFlags.Variadic) && isConstTypeVariable(t, depth)) >= 0
+            type.flags & TypeFlags.TypeParameter && some((type as TypeParameter).symbol?.declarations, d => hasSyntacticModifier(d, ModifierFlags.Const))
+            || type.flags & TypeFlags.UnionOrIntersection && some((type as UnionOrIntersectionType).types, t => isConstTypeVariable(t, depth))
+            || type.flags & TypeFlags.IndexedAccess && isConstTypeVariable((type as IndexedAccessType).objectType, depth + 1)
+            || type.flags & TypeFlags.Conditional && isConstTypeVariable(getConstraintOfConditionalType(type as ConditionalType), depth + 1)
+            || type.flags & TypeFlags.Substitution && isConstTypeVariable((type as SubstitutionType).baseType, depth)
+            || getObjectFlags(type) & ObjectFlags.Mapped && isConstMappedType(type as MappedType, depth)
+            || isGenericTupleType(type) && findIndex(getElementTypes(type), (t, i) => !!(type.target.elementFlags[i] & ElementFlags.Variadic) && isConstTypeVariable(t, depth)) >= 0
         ));
     }
 
@@ -14523,9 +14523,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function computeBaseConstraint(t: Type): Type | undefined {
             if (t.flags & TypeFlags.TypeParameter) {
                 const constraint = getConstraintFromTypeParameter(t as TypeParameter);
-                return (t as TypeParameter).isThisType || !constraint ?
-                    constraint :
-                    getBaseConstraint(constraint);
+                return (t as TypeParameter).isThisType || !constraint
+                    ? constraint
+                    : getBaseConstraint(constraint);
             }
             if (t.flags & TypeFlags.UnionOrIntersection) {
                 const types = (t as UnionOrIntersectionType).types;
@@ -14546,9 +14546,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!different) {
                     return t;
                 }
-                return t.flags & TypeFlags.Union && baseTypes.length === types.length ? getUnionType(baseTypes) :
-                    t.flags & TypeFlags.Intersection && baseTypes.length ? getIntersectionType(baseTypes) :
-                    undefined;
+                return t.flags & TypeFlags.Union && baseTypes.length === types.length ? getUnionType(baseTypes)
+                    : t.flags & TypeFlags.Intersection && baseTypes.length ? getIntersectionType(baseTypes)
+                    : undefined;
             }
             if (t.flags & TypeFlags.Index) {
                 return stringNumberSymbolType;
@@ -14669,9 +14669,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isMappedTypeGenericIndexedAccess(type: Type) {
         let objectType;
-        return !!(type.flags & TypeFlags.IndexedAccess && getObjectFlags(objectType = (type as IndexedAccessType).objectType) & ObjectFlags.Mapped &&
-            !isGenericMappedType(objectType) && isGenericIndexType((type as IndexedAccessType).indexType) &&
-            !(getMappedTypeModifiers(objectType as MappedType) & MappedTypeModifiers.ExcludeOptional) && !(objectType as MappedType).declaration.nameType);
+        return !!(type.flags & TypeFlags.IndexedAccess && getObjectFlags(objectType = (type as IndexedAccessType).objectType) & ObjectFlags.Mapped
+            && !isGenericMappedType(objectType) && isGenericIndexType((type as IndexedAccessType).indexType)
+            && !(getMappedTypeModifiers(objectType as MappedType) & MappedTypeModifiers.ExcludeOptional) && !(objectType as MappedType).declaration.nameType);
     }
 
     /**
@@ -14682,18 +14682,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getApparentType(type: Type): Type {
         const t = type.flags & TypeFlags.Instantiable ? getBaseConstraintOfType(type) || unknownType : type;
         const objectFlags = getObjectFlags(t);
-        return objectFlags & ObjectFlags.Mapped ? getApparentTypeOfMappedType(t as MappedType) :
-            objectFlags & ObjectFlags.Reference && t !== type ? getTypeWithThisArgument(t, type) :
-            t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(t as IntersectionType, type) :
-            t.flags & TypeFlags.StringLike ? globalStringType :
-            t.flags & TypeFlags.NumberLike ? globalNumberType :
-            t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType() :
-            t.flags & TypeFlags.BooleanLike ? globalBooleanType :
-            t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType() :
-            t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
-            t.flags & TypeFlags.Index ? stringNumberSymbolType :
-            t.flags & TypeFlags.Unknown && !strictNullChecks ? emptyObjectType :
-            t;
+        return objectFlags & ObjectFlags.Mapped ? getApparentTypeOfMappedType(t as MappedType)
+            : objectFlags & ObjectFlags.Reference && t !== type ? getTypeWithThisArgument(t, type)
+            : t.flags & TypeFlags.Intersection ? getApparentTypeOfIntersectionType(t as IntersectionType, type)
+            : t.flags & TypeFlags.StringLike ? globalStringType
+            : t.flags & TypeFlags.NumberLike ? globalNumberType
+            : t.flags & TypeFlags.BigIntLike ? getGlobalBigIntType()
+            : t.flags & TypeFlags.BooleanLike ? globalBooleanType
+            : t.flags & TypeFlags.ESSymbolLike ? getGlobalESSymbolType()
+            : t.flags & TypeFlags.NonPrimitive ? emptyObjectType
+            : t.flags & TypeFlags.Index ? stringNumberSymbolType
+            : t.flags & TypeFlags.Unknown && !strictNullChecks ? emptyObjectType
+            : t;
     }
 
     function getReducedApparentType(type: Type): Type {
@@ -14760,10 +14760,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     else if (!isUnion && !isReadonlySymbol(prop)) {
                         checkFlags &= ~CheckFlags.Readonly;
                     }
-                    checkFlags |= (!(modifiers & ModifierFlags.NonPublicAccessibilityModifier) ? CheckFlags.ContainsPublic : 0) |
-                        (modifiers & ModifierFlags.Protected ? CheckFlags.ContainsProtected : 0) |
-                        (modifiers & ModifierFlags.Private ? CheckFlags.ContainsPrivate : 0) |
-                        (modifiers & ModifierFlags.Static ? CheckFlags.ContainsStatic : 0);
+                    checkFlags |= (!(modifiers & ModifierFlags.NonPublicAccessibilityModifier) ? CheckFlags.ContainsPublic : 0)
+                        | (modifiers & ModifierFlags.Protected ? CheckFlags.ContainsProtected : 0)
+                        | (modifiers & ModifierFlags.Private ? CheckFlags.ContainsPrivate : 0)
+                        | (modifiers & ModifierFlags.Static ? CheckFlags.ContainsStatic : 0);
                     if (!isPrototypeProperty(prop)) {
                         syntheticFlag = CheckFlags.SyntheticProperty;
                     }
@@ -14785,11 +14785,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
         if (
-            !singleProp ||
-            isUnion &&
-                (propSet || checkFlags & CheckFlags.Partial) &&
-                checkFlags & (CheckFlags.ContainsPrivate | CheckFlags.ContainsProtected) &&
-                !(propSet && getCommonDeclarationsOfSymbols(propSet.values()))
+            !singleProp
+            || isUnion
+                && (propSet || checkFlags & CheckFlags.Partial)
+                && checkFlags & (CheckFlags.ContainsPrivate | CheckFlags.ContainsProtected)
+                && !(propSet && getCommonDeclarationsOfSymbols(propSet.values()))
         ) {
             // No property was found, or, in a union, a property has a private or protected declaration in one
             // constituent, but is missing or has a different declaration in another constituent.
@@ -14884,14 +14884,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // these partial properties when identifying discriminant properties, but otherwise they are filtered out
     // and do not appear to be present in the union type.
     function getUnionOrIntersectionProperty(type: UnionOrIntersectionType, name: __String, skipObjectFunctionPropertyAugment?: boolean): Symbol | undefined {
-        let property = type.propertyCacheWithoutObjectFunctionPropertyAugment?.get(name) ||
-                !skipObjectFunctionPropertyAugment ? type.propertyCache?.get(name) : undefined;
+        let property = type.propertyCacheWithoutObjectFunctionPropertyAugment?.get(name)
+                || !skipObjectFunctionPropertyAugment ? type.propertyCache?.get(name) : undefined;
         if (!property) {
             property = createUnionOrIntersectionProperty(type, name, skipObjectFunctionPropertyAugment);
             if (property) {
-                const properties = skipObjectFunctionPropertyAugment ?
-                    type.propertyCacheWithoutObjectFunctionPropertyAugment ||= createSymbolTable() :
-                    type.propertyCache ||= createSymbolTable();
+                const properties = skipObjectFunctionPropertyAugment
+                    ? type.propertyCacheWithoutObjectFunctionPropertyAugment ||= createSymbolTable()
+                    : type.propertyCache ||= createSymbolTable();
                 properties.set(name, property);
                 if (skipObjectFunctionPropertyAugment && !type.propertyCache?.get(name)) {
                     const properties = type.propertyCache ||= createSymbolTable();
@@ -14942,8 +14942,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         else if (type.flags & TypeFlags.Intersection) {
             if (!((type as IntersectionType).objectFlags & ObjectFlags.IsNeverIntersectionComputed)) {
-                (type as IntersectionType).objectFlags |= ObjectFlags.IsNeverIntersectionComputed |
-                    (some(getPropertiesOfUnionOrIntersectionType(type as IntersectionType), isNeverReducedProperty) ? ObjectFlags.IsNeverIntersection : 0);
+                (type as IntersectionType).objectFlags |= ObjectFlags.IsNeverIntersectionComputed
+                    | (some(getPropertiesOfUnionOrIntersectionType(type as IntersectionType), isNeverReducedProperty) ? ObjectFlags.IsNeverIntersection : 0);
             }
             return (type as IntersectionType).objectFlags & ObjectFlags.IsNeverIntersection ? neverType : type;
         }
@@ -14969,9 +14969,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isDiscriminantWithNeverType(prop: Symbol) {
         // Return true for a synthetic non-optional property with non-uniform types, where at least one is
         // a literal type and none is never, that reduces to never.
-        return !(prop.flags & SymbolFlags.Optional) &&
-            (getCheckFlags(prop) & (CheckFlags.Discriminant | CheckFlags.HasNeverType)) === CheckFlags.Discriminant &&
-            !!(getTypeOfSymbol(prop).flags & TypeFlags.Never);
+        return !(prop.flags & SymbolFlags.Optional)
+            && (getCheckFlags(prop) & (CheckFlags.Discriminant | CheckFlags.HasNeverType)) === CheckFlags.Discriminant
+            && !!(getTypeOfSymbol(prop).flags & TypeFlags.Never);
     }
 
     function isConflictingPrivateProperty(prop: Symbol) {
@@ -14987,8 +14987,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * literal-typed properties are reducible).
      */
     function isGenericReducibleType(type: Type): boolean {
-        return !!(type.flags & TypeFlags.Union && (type as UnionType).objectFlags & ObjectFlags.ContainsIntersections && some((type as UnionType).types, isGenericReducibleType) ||
-            type.flags & TypeFlags.Intersection && isReducibleIntersection(type as IntersectionType));
+        return !!(type.flags & TypeFlags.Union && (type as UnionType).objectFlags & ObjectFlags.ContainsIntersections && some((type as UnionType).types, isGenericReducibleType)
+            || type.flags & TypeFlags.Intersection && isReducibleIntersection(type as IntersectionType));
     }
 
     function isReducibleIntersection(type: IntersectionType) {
@@ -15033,10 +15033,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return symbol;
             }
             if (skipObjectFunctionPropertyAugment) return undefined;
-            const functionType = resolved === anyFunctionType ? globalFunctionType :
-                resolved.callSignatures.length ? globalCallableFunctionType :
-                resolved.constructSignatures.length ? globalNewableFunctionType :
-                undefined;
+            const functionType = resolved === anyFunctionType ? globalFunctionType
+                : resolved.callSignatures.length ? globalCallableFunctionType
+                : resolved.constructSignatures.length ? globalNewableFunctionType
+                : undefined;
             if (functionType) {
                 const symbol = getPropertyOfObjectType(functionType, name);
                 if (symbol) {
@@ -15131,18 +15131,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // When more than one index signature is applicable we create a synthetic IndexInfo. Instead of computing
         // the intersected key type, we just use unknownType for the key type as nothing actually depends on the
         // keyType property of the returned IndexInfo.
-        return applicableInfos ? createIndexInfo(unknownType, getIntersectionType(map(applicableInfos, info => info.type)), reduceLeft(applicableInfos, (isReadonly, info) => isReadonly && info.isReadonly, /*initial*/ true)) :
-            applicableInfo ? applicableInfo :
-            stringIndexInfo && isApplicableIndexType(keyType, stringType) ? stringIndexInfo :
-            undefined;
+        return applicableInfos ? createIndexInfo(unknownType, getIntersectionType(map(applicableInfos, info => info.type)), reduceLeft(applicableInfos, (isReadonly, info) => isReadonly && info.isReadonly, /*initial*/ true))
+            : applicableInfo ? applicableInfo
+            : stringIndexInfo && isApplicableIndexType(keyType, stringType) ? stringIndexInfo
+            : undefined;
     }
 
     function isApplicableIndexType(source: Type, target: Type): boolean {
         // A 'string' index signature applies to types assignable to 'string' or 'number', and a 'number' index
         // signature applies to types assignable to 'number', `${number}` and numeric string literal types.
-        return isTypeAssignableTo(source, target) ||
-            target === stringType && isTypeAssignableTo(source, numberType) ||
-            target === numberType && (source === numericStringType || !!(source.flags & TypeFlags.StringLiteral) && isNumericLiteralName((source as StringLiteralType).value));
+        return isTypeAssignableTo(source, target)
+            || target === stringType && isTypeAssignableTo(source, numberType)
+            || target === numberType && (source === numericStringType || !!(source.flags & TypeFlags.StringLiteral) && isNumericLiteralName((source as StringLiteralType).value));
     }
 
     function getIndexInfosOfStructuredType(type: Type): readonly IndexInfo[] {
@@ -15234,9 +15234,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const iife = getImmediatelyInvokedFunctionExpression(node.parent);
         if (iife) {
-            return !node.type &&
-                !node.dotDotDotToken &&
-                node.parent.parameters.indexOf(node) >= getEffectiveCallArguments(iife).length;
+            return !node.type
+                && !node.dotDotDotToken
+                && node.parent.parameters.indexOf(node) >= getEffectiveCallArguments(iife).length;
         }
 
         return false;
@@ -15313,11 +15313,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             let hasThisParameter = false;
             const iife = getImmediatelyInvokedFunctionExpression(declaration);
             const isJSConstructSignature = isJSDocConstructSignature(declaration);
-            const isUntypedSignatureInJSFile = !iife &&
-                isInJSFile(declaration) &&
-                isValueSignatureDeclaration(declaration) &&
-                !hasJSDocParameterTags(declaration) &&
-                !getJSDocType(declaration);
+            const isUntypedSignatureInJSFile = !iife
+                && isInJSFile(declaration)
+                && isValueSignatureDeclaration(declaration)
+                && !hasJSDocParameterTags(declaration)
+                && !getJSDocType(declaration);
             if (isUntypedSignatureInJSFile) {
                 flags |= SignatureFlags.IsUntypedSignatureInJSFile;
             }
@@ -15352,9 +15352,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
 
                 // Record a new minimum argument count if this is not an optional parameter
-                const isOptionalParameter = hasEffectiveQuestionToken(param) ||
-                    isParameter(param) && param.initializer || isRestParameter(param) ||
-                    iife && parameters.length > iife.arguments.length && !type;
+                const isOptionalParameter = hasEffectiveQuestionToken(param)
+                    || isParameter(param) && param.initializer || isRestParameter(param)
+                    || iife && parameters.length > iife.arguments.length && !type;
                 if (!isOptionalParameter) {
                     minArgumentCount = parameters.length;
                 }
@@ -15362,9 +15362,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             // If only one accessor includes a this-type annotation, the other behaves as if it had the same type annotation
             if (
-                (declaration.kind === SyntaxKind.GetAccessor || declaration.kind === SyntaxKind.SetAccessor) &&
-                hasBindableName(declaration) &&
-                (!hasThisParameter || !thisParameter)
+                (declaration.kind === SyntaxKind.GetAccessor || declaration.kind === SyntaxKind.SetAccessor)
+                && hasBindableName(declaration)
+                && (!hasThisParameter || !thisParameter)
             ) {
                 const otherKind = declaration.kind === SyntaxKind.GetAccessor ? SyntaxKind.SetAccessor : SyntaxKind.GetAccessor;
                 const other = getDeclarationOfKind<AccessorDeclaration>(getSymbolOfDeclaration(declaration), otherKind);
@@ -15378,16 +15378,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             const hostDeclaration = isJSDocSignature(declaration) ? getEffectiveJSDocHost(declaration) : declaration;
-            const classType = hostDeclaration && isConstructorDeclaration(hostDeclaration) ?
-                getDeclaredTypeOfClassOrInterface(getMergedSymbol((hostDeclaration.parent as ClassDeclaration).symbol))
+            const classType = hostDeclaration && isConstructorDeclaration(hostDeclaration)
+                ? getDeclaredTypeOfClassOrInterface(getMergedSymbol((hostDeclaration.parent as ClassDeclaration).symbol))
                 : undefined;
             const typeParameters = classType ? classType.localTypeParameters : getTypeParametersFromDeclaration(declaration);
             if (hasRestParameter(declaration) || isInJSFile(declaration) && maybeAddJsSyntheticRestParameter(declaration, parameters)) {
                 flags |= SignatureFlags.HasRestParameter;
             }
             if (
-                isConstructorTypeNode(declaration) && hasSyntacticModifier(declaration, ModifierFlags.Abstract) ||
-                isConstructorDeclaration(declaration) && hasSyntacticModifier(declaration.parent, ModifierFlags.Abstract)
+                isConstructorTypeNode(declaration) && hasSyntacticModifier(declaration, ModifierFlags.Abstract)
+                || isConstructorDeclaration(declaration) && hasSyntacticModifier(declaration.parent, ModifierFlags.Abstract)
             ) {
                 flags |= SignatureFlags.Abstract;
             }
@@ -15520,10 +15520,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // If this is a function or method declaration, get the signature from the @type tag for the sake of optional parameters.
             // Exclude contextually-typed kinds because we already apply the @type tag to the context, plus applying it here to the initializer would supress checks that the two are compatible.
             result.push(
-                (!isFunctionExpressionOrArrowFunction(decl) &&
-                    !isObjectLiteralMethod(decl) &&
-                    getSignatureOfTypeTag(decl)) ||
-                    getSignatureFromDeclaration(decl),
+                (!isFunctionExpressionOrArrowFunction(decl)
+                    && !isObjectLiteralMethod(decl)
+                    && getSignatureOfTypeTag(decl))
+                    || getSignatureFromDeclaration(decl),
             );
         }
         return result;
@@ -15566,9 +15566,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 if (type || jsdocPredicate) {
-                    signature.resolvedTypePredicate = type && isTypePredicateNode(type) ?
-                        createTypePredicateFromTypePredicateNode(type, signature) :
-                        jsdocPredicate || noTypePredicate;
+                    signature.resolvedTypePredicate = type && isTypePredicateNode(type)
+                        ? createTypePredicateFromTypePredicateNode(type, signature)
+                        : jsdocPredicate || noTypePredicate;
                 }
                 else if (signature.declaration && isFunctionLikeDeclaration(signature.declaration) && (!signature.resolvedReturnType || signature.resolvedReturnType.flags & TypeFlags.Boolean) && getParameterCount(signature) > 0) {
                     const { declaration } = signature;
@@ -15587,9 +15587,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function createTypePredicateFromTypePredicateNode(node: TypePredicateNode, signature: Signature): TypePredicate {
         const parameterName = node.parameterName;
         const type = node.type && getTypeFromTypeNode(node.type);
-        return parameterName.kind === SyntaxKind.ThisType ?
-            createTypePredicate(node.assertsModifier ? TypePredicateKind.AssertsThis : TypePredicateKind.This, /*parameterName*/ undefined, /*parameterIndex*/ undefined, type) :
-            createTypePredicate(node.assertsModifier ? TypePredicateKind.AssertsIdentifier : TypePredicateKind.Identifier, parameterName.escapedText as string, findIndex(signature.parameters, p => p.escapedName === parameterName.escapedText), type);
+        return parameterName.kind === SyntaxKind.ThisType
+            ? createTypePredicate(node.assertsModifier ? TypePredicateKind.AssertsThis : TypePredicateKind.This, /*parameterName*/ undefined, /*parameterIndex*/ undefined, type)
+            : createTypePredicate(node.assertsModifier ? TypePredicateKind.AssertsIdentifier : TypePredicateKind.Identifier, parameterName.escapedText as string, findIndex(signature.parameters, p => p.escapedName === parameterName.escapedText), type);
     }
 
     function getUnionOrIntersectionType(types: Type[], kind: TypeFlags | undefined, unionReduction?: UnionReduction) {
@@ -15601,10 +15601,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!pushTypeResolution(signature, TypeSystemPropertyName.ResolvedReturnType)) {
                 return errorType;
             }
-            let type = signature.target ? instantiateType(getReturnTypeOfSignature(signature.target), signature.mapper) :
-                signature.compositeSignatures ? instantiateType(getUnionOrIntersectionType(map(signature.compositeSignatures, getReturnTypeOfSignature), signature.compositeKind, UnionReduction.Subtype), signature.mapper) :
-                getReturnTypeFromAnnotation(signature.declaration!) ||
-                (nodeIsMissing((signature.declaration as FunctionLikeDeclaration).body) ? anyType : getReturnTypeFromBody(signature.declaration as FunctionLikeDeclaration));
+            let type = signature.target ? instantiateType(getReturnTypeOfSignature(signature.target), signature.mapper)
+                : signature.compositeSignatures ? instantiateType(getUnionOrIntersectionType(map(signature.compositeSignatures, getReturnTypeOfSignature), signature.compositeKind, UnionReduction.Subtype), signature.mapper)
+                : getReturnTypeFromAnnotation(signature.declaration!)
+                    || (nodeIsMissing((signature.declaration as FunctionLikeDeclaration).body) ? anyType : getReturnTypeFromBody(signature.declaration as FunctionLikeDeclaration));
             if (signature.flags & SignatureFlags.IsInnerCallChain) {
                 type = addOptionalTypeMarker(type);
             }
@@ -15667,8 +15667,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isResolvingReturnTypeOfSignature(signature: Signature): boolean {
-        return signature.compositeSignatures && some(signature.compositeSignatures, isResolvingReturnTypeOfSignature) ||
-            !signature.resolvedReturnType && findResolutionCycleStartIndex(signature, TypeSystemPropertyName.ResolvedReturnType) >= 0;
+        return signature.compositeSignatures && some(signature.compositeSignatures, isResolvingReturnTypeOfSignature)
+            || !signature.resolvedReturnType && findResolutionCycleStartIndex(signature, TypeSystemPropertyName.ResolvedReturnType) >= 0;
     }
 
     function getRestTypeOfSignature(signature: Signature): Type {
@@ -15718,9 +15718,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getErasedSignature(signature: Signature): Signature {
-        return signature.typeParameters ?
-            signature.erasedSignatureCache || (signature.erasedSignatureCache = createErasedSignature(signature)) :
-            signature;
+        return signature.typeParameters
+            ? signature.erasedSignatureCache || (signature.erasedSignatureCache = createErasedSignature(signature))
+            : signature;
     }
 
     function createErasedSignature(signature: Signature) {
@@ -15729,9 +15729,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getCanonicalSignature(signature: Signature): Signature {
-        return signature.typeParameters ?
-            signature.canonicalSignatureCache || (signature.canonicalSignatureCache = createCanonicalSignature(signature)) :
-            signature;
+        return signature.typeParameters
+            ? signature.canonicalSignatureCache || (signature.canonicalSignatureCache = createCanonicalSignature(signature))
+            : signature;
     }
 
     function createCanonicalSignature(signature: Signature) {
@@ -15830,8 +15830,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isValidIndexKeyType(type: Type): boolean {
-        return !!(type.flags & (TypeFlags.String | TypeFlags.Number | TypeFlags.ESSymbol)) || isPatternLiteralType(type) ||
-            !!(type.flags & TypeFlags.Intersection) && !isGenericType(type) && some((type as IntersectionType).types, isValidIndexKeyType);
+        return !!(type.flags & (TypeFlags.String | TypeFlags.Number | TypeFlags.ESSymbol)) || isPatternLiteralType(type)
+            || !!(type.flags & TypeFlags.Intersection) && !isGenericType(type) && some((type as IntersectionType).types, isValidIndexKeyType);
     }
 
     function getConstraintDeclaration(type: TypeParameter): TypeNode | undefined {
@@ -15879,9 +15879,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // When an 'infer T' declaration is immediately contained in a rest parameter declaration, a rest type
                     // or a named rest tuple element, we infer an 'unknown[]' constraint.
                     else if (
-                        grandParent.kind === SyntaxKind.Parameter && (grandParent as ParameterDeclaration).dotDotDotToken ||
-                        grandParent.kind === SyntaxKind.RestType ||
-                        grandParent.kind === SyntaxKind.NamedTupleMember && (grandParent as NamedTupleMember).dotDotDotToken
+                        grandParent.kind === SyntaxKind.Parameter && (grandParent as ParameterDeclaration).dotDotDotToken
+                        || grandParent.kind === SyntaxKind.RestType
+                        || grandParent.kind === SyntaxKind.NamedTupleMember && (grandParent as NamedTupleMember).dotDotDotToken
                     ) {
                         inferences = append(inferences, createArrayType(unknownType));
                     }
@@ -15899,10 +15899,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // clause of a conditional whose check type is also a mapped type, give it a constraint equal to the template
                     // of the check type's mapped type
                     else if (
-                        grandParent.kind === SyntaxKind.MappedType && (grandParent as MappedTypeNode).type &&
-                        skipParentheses((grandParent as MappedTypeNode).type!) === declaration.parent && grandParent.parent.kind === SyntaxKind.ConditionalType &&
-                        (grandParent.parent as ConditionalTypeNode).extendsType === grandParent && (grandParent.parent as ConditionalTypeNode).checkType.kind === SyntaxKind.MappedType &&
-                        ((grandParent.parent as ConditionalTypeNode).checkType as MappedTypeNode).type
+                        grandParent.kind === SyntaxKind.MappedType && (grandParent as MappedTypeNode).type
+                        && skipParentheses((grandParent as MappedTypeNode).type!) === declaration.parent && grandParent.parent.kind === SyntaxKind.ConditionalType
+                        && (grandParent.parent as ConditionalTypeNode).extendsType === grandParent && (grandParent.parent as ConditionalTypeNode).checkType.kind === SyntaxKind.MappedType
+                        && ((grandParent.parent as ConditionalTypeNode).checkType as MappedTypeNode).type
                     ) {
                         const checkMappedType = (grandParent.parent as ConditionalTypeNode).checkType as MappedTypeNode;
                         const nodeType = getTypeFromTypeNode(checkMappedType.type!);
@@ -16038,10 +16038,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return type.target.localTypeParameters?.map(() => errorType) || emptyArray;
             }
             const node = type.node;
-            const typeArguments = !node ? emptyArray :
-                node.kind === SyntaxKind.TypeReference ? concatenate(type.target.outerTypeParameters, getEffectiveTypeArguments(node, type.target.localTypeParameters!)) :
-                node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] :
-                map(node.elements, getTypeFromTypeNode);
+            const typeArguments = !node ? emptyArray
+                : node.kind === SyntaxKind.TypeReference ? concatenate(type.target.outerTypeParameters, getEffectiveTypeArguments(node, type.target.localTypeParameters!))
+                : node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)]
+                : map(node.elements, getTypeFromTypeNode);
             if (popTypeResolution()) {
                 type.resolvedTypeArguments = type.mapper ? instantiateTypes(typeArguments, type.mapper) : typeArguments;
             }
@@ -16074,13 +16074,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const isJsImplicitAny = !noImplicitAny && isJs;
             if (!isJsImplicitAny && (numTypeArguments < minTypeArgumentCount || numTypeArguments > typeParameters.length)) {
                 const missingAugmentsTag = isJs && isExpressionWithTypeArguments(node) && !isJSDocAugmentsTag(node.parent);
-                const diag = minTypeArgumentCount === typeParameters.length ?
-                    missingAugmentsTag ?
-                        Diagnostics.Expected_0_type_arguments_provide_these_with_an_extends_tag :
-                        Diagnostics.Generic_type_0_requires_1_type_argument_s :
-                    missingAugmentsTag ?
-                    Diagnostics.Expected_0_1_type_arguments_provide_these_with_an_extends_tag :
-                    Diagnostics.Generic_type_0_requires_between_1_and_2_type_arguments;
+                const diag = minTypeArgumentCount === typeParameters.length
+                    ? missingAugmentsTag
+                        ? Diagnostics.Expected_0_type_arguments_provide_these_with_an_extends_tag
+                        : Diagnostics.Generic_type_0_requires_1_type_argument_s
+                    : missingAugmentsTag
+                    ? Diagnostics.Expected_0_1_type_arguments_provide_these_with_an_extends_tag
+                    : Diagnostics.Generic_type_0_requires_between_1_and_2_type_arguments;
 
                 const typeStr = typeToString(type, /*enclosingDeclaration*/ undefined, TypeFormatFlags.WriteArrayAsGenericType);
                 error(node, diag, typeStr, minTypeArgumentCount, typeParameters.length);
@@ -16145,9 +16145,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (numTypeArguments < minTypeArgumentCount || numTypeArguments > typeParameters.length) {
                 error(
                     node,
-                    minTypeArgumentCount === typeParameters.length ?
-                        Diagnostics.Generic_type_0_requires_1_type_argument_s :
-                        Diagnostics.Generic_type_0_requires_between_1_and_2_type_arguments,
+                    minTypeArgumentCount === typeParameters.length
+                        ? Diagnostics.Generic_type_0_requires_1_type_argument_s
+                        : Diagnostics.Generic_type_0_requires_between_1_and_2_type_arguments,
                     symbolToString(symbol),
                     minTypeArgumentCount,
                     typeParameters.length,
@@ -16208,14 +16208,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getUnresolvedSymbolForEntityName(name: EntityNameOrEntityNameExpression) {
-        const identifier = name.kind === SyntaxKind.QualifiedName ? name.right :
-            name.kind === SyntaxKind.PropertyAccessExpression ? name.name :
-            name;
+        const identifier = name.kind === SyntaxKind.QualifiedName ? name.right
+            : name.kind === SyntaxKind.PropertyAccessExpression ? name.name
+            : name;
         const text = identifier.escapedText;
         if (text) {
-            const parentSymbol = name.kind === SyntaxKind.QualifiedName ? getUnresolvedSymbolForEntityName(name.left) :
-                name.kind === SyntaxKind.PropertyAccessExpression ? getUnresolvedSymbolForEntityName(name.expression) :
-                undefined;
+            const parentSymbol = name.kind === SyntaxKind.QualifiedName ? getUnresolvedSymbolForEntityName(name.left)
+                : name.kind === SyntaxKind.PropertyAccessExpression ? getUnresolvedSymbolForEntityName(name.expression)
+                : undefined;
             const path = parentSymbol ? `${getSymbolPath(parentSymbol)}.${text}` : text as string;
             let result = unresolvedSymbols.get(path);
             if (!result) {
@@ -16234,8 +16234,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return unknownSymbol;
         }
         const symbol = resolveEntityName(name, meaning, ignoreErrors);
-        return symbol && symbol !== unknownSymbol ? symbol :
-            ignoreErrors ? unknownSymbol : getUnresolvedSymbolForEntityName(name);
+        return symbol && symbol !== unknownSymbol ? symbol
+            : ignoreErrors ? unknownSymbol : getUnresolvedSymbolForEntityName(name);
     }
 
     function getTypeReferenceType(node: NodeWithTypeArguments, symbol: Symbol): Type {
@@ -16297,10 +16297,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // This is effectively a more conservative and predictable form of couldContainTypeVariables. We want to
         // preserve NoInfer<T> only for types that could contain type variables, but we don't want to exhaustively
         // examine all object type members.
-        return !!(type.flags & TypeFlags.UnionOrIntersection && some((type as UnionOrIntersectionType).types, isNoInferTargetType) ||
-            type.flags & TypeFlags.Substitution && !isNoInferType(type) && isNoInferTargetType((type as SubstitutionType).baseType) ||
-            type.flags & TypeFlags.Object && !isEmptyAnonymousObjectType(type) ||
-            type.flags & (TypeFlags.Instantiable & ~TypeFlags.Substitution) && !isPatternLiteralType(type));
+        return !!(type.flags & TypeFlags.UnionOrIntersection && some((type as UnionOrIntersectionType).types, isNoInferTargetType)
+            || type.flags & TypeFlags.Substitution && !isNoInferType(type) && isNoInferTargetType((type as SubstitutionType).baseType)
+            || type.flags & TypeFlags.Object && !isEmptyAnonymousObjectType(type)
+            || type.flags & (TypeFlags.Instantiable & ~TypeFlags.Substitution) && !isPatternLiteralType(type));
     }
 
     function isNoInferType(type: Type) {
@@ -16309,9 +16309,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getSubstitutionType(baseType: Type, constraint: Type) {
-        return constraint.flags & TypeFlags.AnyOrUnknown || constraint === baseType || baseType.flags & TypeFlags.Any ?
-            baseType :
-            getOrCreateSubstitutionType(baseType, constraint);
+        return constraint.flags & TypeFlags.AnyOrUnknown || constraint === baseType || baseType.flags & TypeFlags.Any
+            ? baseType
+            : getOrCreateSubstitutionType(baseType, constraint);
     }
 
     function getOrCreateSubstitutionType(baseType: Type, constraint: Type) {
@@ -16336,9 +16336,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getImpliedConstraint(type: Type, checkNode: TypeNode, extendsNode: TypeNode): Type | undefined {
-        return isUnaryTupleTypeNode(checkNode) && isUnaryTupleTypeNode(extendsNode) ? getImpliedConstraint(type, (checkNode as TupleTypeNode).elements[0], (extendsNode as TupleTypeNode).elements[0]) :
-            getActualTypeVariable(getTypeFromTypeNode(checkNode)) === getActualTypeVariable(type) ? getTypeFromTypeNode(extendsNode) :
-            undefined;
+        return isUnaryTupleTypeNode(checkNode) && isUnaryTupleTypeNode(extendsNode) ? getImpliedConstraint(type, (checkNode as TupleTypeNode).elements[0], (extendsNode as TupleTypeNode).elements[0])
+            : getActualTypeVariable(getTypeFromTypeNode(checkNode)) === getActualTypeVariable(type) ? getTypeFromTypeNode(extendsNode)
+            : undefined;
     }
 
     function getConditionalFlowTypeOfType(type: Type, node: Node) {
@@ -16772,9 +16772,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.RestType:
                 return getRestTypeElementFlags(node as RestTypeNode);
             case SyntaxKind.NamedTupleMember:
-                return (node as NamedTupleMember).questionToken ? ElementFlags.Optional :
-                    (node as NamedTupleMember).dotDotDotToken ? getRestTypeElementFlags(node as NamedTupleMember) :
-                    ElementFlags.Required;
+                return (node as NamedTupleMember).questionToken ? ElementFlags.Optional
+                    : (node as NamedTupleMember).dotDotDotToken ? getRestTypeElementFlags(node as NamedTupleMember)
+                    : ElementFlags.Required;
             default:
                 return ElementFlags.Required;
         }
@@ -16802,9 +16802,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // because it is possibly contained in a circular chain of eagerly resolved types.
     function isDeferredTypeReferenceNode(node: TypeReferenceNode | ArrayTypeNode | TupleTypeNode, hasDefaultTypeArguments?: boolean) {
         return !!getAliasSymbolForTypeNode(node) || isResolvedByTypeAlias(node) && (
-                    node.kind === SyntaxKind.ArrayType ? mayResolveTypeAlias(node.elementType) :
-                        node.kind === SyntaxKind.TupleType ? some(node.elements, mayResolveTypeAlias) :
-                        hasDefaultTypeArguments || some(node.typeArguments, mayResolveTypeAlias)
+                    node.kind === SyntaxKind.ArrayType ? mayResolveTypeAlias(node.elementType)
+                        : node.kind === SyntaxKind.TupleType ? some(node.elements, mayResolveTypeAlias)
+                        : hasDefaultTypeArguments || some(node.typeArguments, mayResolveTypeAlias)
                 );
     }
 
@@ -16857,8 +16857,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.IndexedAccessType:
                 return mayResolveTypeAlias((node as IndexedAccessTypeNode).objectType) || mayResolveTypeAlias((node as IndexedAccessTypeNode).indexType);
             case SyntaxKind.ConditionalType:
-                return mayResolveTypeAlias((node as ConditionalTypeNode).checkType) || mayResolveTypeAlias((node as ConditionalTypeNode).extendsType) ||
-                    mayResolveTypeAlias((node as ConditionalTypeNode).trueType) || mayResolveTypeAlias((node as ConditionalTypeNode).falseType);
+                return mayResolveTypeAlias((node as ConditionalTypeNode).checkType) || mayResolveTypeAlias((node as ConditionalTypeNode).extendsType)
+                    || mayResolveTypeAlias((node as ConditionalTypeNode).trueType) || mayResolveTypeAlias((node as ConditionalTypeNode).falseType);
         }
         return false;
     }
@@ -16871,8 +16871,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 links.resolvedType = emptyObjectType;
             }
             else if (!(node.kind === SyntaxKind.TupleType && some(node.elements, e => !!(getTupleElementFlags(e) & ElementFlags.Variadic))) && isDeferredTypeReferenceNode(node)) {
-                links.resolvedType = node.kind === SyntaxKind.TupleType && node.elements.length === 0 ? target :
-                    createDeferredTypeReference(target, node, /*mapper*/ undefined);
+                links.resolvedType = node.kind === SyntaxKind.TupleType && node.elements.length === 0 ? target
+                    : createDeferredTypeReference(target, node, /*mapper*/ undefined);
             }
             else {
                 const elementTypes = node.kind === SyntaxKind.ArrayType ? [getTypeFromTypeNode(node.elementType)] : map(node.elements, getTypeFromTypeNode);
@@ -16888,9 +16888,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function createTupleType(elementTypes: readonly Type[], elementFlags?: readonly ElementFlags[], readonly = false, namedMemberDeclarations: readonly (NamedTupleMember | ParameterDeclaration | undefined)[] = []) {
         const tupleTarget = getTupleTargetType(elementFlags || map(elementTypes, _ => ElementFlags.Required), readonly, namedMemberDeclarations);
-        return tupleTarget === emptyGenericType ? emptyObjectType :
-            elementTypes.length ? createNormalizedTypeReference(tupleTarget, elementTypes) :
-            tupleTarget;
+        return tupleTarget === emptyGenericType ? emptyObjectType
+            : elementTypes.length ? createNormalizedTypeReference(tupleTarget, elementTypes)
+            : tupleTarget;
     }
 
     function getTupleTargetType(elementFlags: readonly ElementFlags[], readonly: boolean, namedMemberDeclarations: readonly (NamedTupleMember | ParameterDeclaration | undefined)[]): GenericType {
@@ -16898,9 +16898,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // [...X[]] is equivalent to just X[]
             return readonly ? globalReadonlyArrayType : globalArrayType;
         }
-        const key = map(elementFlags, f => f & ElementFlags.Required ? "#" : f & ElementFlags.Optional ? "?" : f & ElementFlags.Rest ? "." : "*").join() +
-            (readonly ? "R" : "") +
-            (some(namedMemberDeclarations, node => !!node) ? "," + map(namedMemberDeclarations, node => node ? getNodeId(node) : "_").join(",") : "");
+        const key = map(elementFlags, f => f & ElementFlags.Required ? "#" : f & ElementFlags.Optional ? "?" : f & ElementFlags.Rest ? "." : "*").join()
+            + (readonly ? "R" : "")
+            + (some(namedMemberDeclarations, node => !!node) ? "," + map(namedMemberDeclarations, node => node ? getNodeId(node) : "_").join(",") : "");
         let type = tupleTypes.get(key);
         if (!type) {
             tupleTypes.set(key, type = createTupleTargetType(elementFlags, readonly, namedMemberDeclarations));
@@ -16984,9 +16984,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Transform [A, ...(X | Y | Z)] into [A, ...X] | [A, ...Y] | [A, ...Z]
             const unionIndex = findIndex(elementTypes, (t, i) => !!(target.elementFlags[i] & ElementFlags.Variadic && t.flags & (TypeFlags.Never | TypeFlags.Union)));
             if (unionIndex >= 0) {
-                return checkCrossProductUnion(map(elementTypes, (t, i) => target.elementFlags[i] & ElementFlags.Variadic ? t : unknownType)) ?
-                    mapType(elementTypes[unionIndex], t => createNormalizedTupleType(target, replaceElement(elementTypes, unionIndex, t))) :
-                    errorType;
+                return checkCrossProductUnion(map(elementTypes, (t, i) => target.elementFlags[i] & ElementFlags.Variadic ? t : unknownType))
+                    ? mapType(elementTypes[unionIndex], t => createNormalizedTupleType(target, replaceElement(elementTypes, unionIndex, t)))
+                    : errorType;
             }
         }
         // We have optional, rest, or variadic elements that may need normalizing. Normalization ensures that all variadic
@@ -17047,9 +17047,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             expandedDeclarations.splice(firstRestIndex + 1, lastOptionalOrRestIndex - firstRestIndex);
         }
         const tupleTarget = getTupleTargetType(expandedFlags, target.readonly, expandedDeclarations);
-        return tupleTarget === emptyGenericType ? emptyObjectType :
-            expandedFlags.length ? createTypeReference(tupleTarget, expandedTypes) :
-            tupleTarget;
+        return tupleTarget === emptyGenericType ? emptyObjectType
+            : expandedFlags.length ? createTypeReference(tupleTarget, expandedTypes)
+            : tupleTarget;
 
         function addElement(type: Type, flags: ElementFlags, declaration: NamedTupleMember | ParameterDeclaration | undefined) {
             if (flags & ElementFlags.Required) {
@@ -17070,8 +17070,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function sliceTupleType(type: TupleTypeReference, index: number, endSkipCount = 0) {
         const target = type.target;
         const endIndex = getTypeReferenceArity(type) - endSkipCount;
-        return index > target.fixedLength ? getRestArrayTypeOfTupleType(type) || createTupleType(emptyArray) :
-            createTupleType(getTypeArguments(type).slice(index, endIndex), target.elementFlags.slice(index, endIndex), /*readonly*/ false, target.labeledElementDeclarations && target.labeledElementDeclarations.slice(index, endIndex));
+        return index > target.fixedLength ? getRestArrayTypeOfTupleType(type) || createTupleType(emptyArray)
+            : createTupleType(getTypeArguments(type).slice(index, endIndex), target.elementFlags.slice(index, endIndex), /*readonly*/ false, target.labeledElementDeclarations && target.labeledElementDeclarations.slice(index, endIndex));
     }
 
     function getKnownKeysOfTupleType(type: TupleTypeReference) {
@@ -17151,9 +17151,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // saves a lot of work for large lists of the same union type, such as when resolving `Record<A, B>[A]`,
             // where A and B are large union types.
             if (type !== lastType) {
-                includes = type.flags & TypeFlags.Union ?
-                    addTypesToUnion(typeSet, includes | (isNamedUnionType(type) ? TypeFlags.Union : 0), (type as UnionType).types) :
-                    addTypeToUnion(typeSet, includes, type);
+                includes = type.flags & TypeFlags.Union
+                    ? addTypesToUnion(typeSet, includes | (isNamedUnionType(type) ? TypeFlags.Union : 0), (type as UnionType).types)
+                    : addTypeToUnion(typeSet, includes, type);
                 lastType = type;
             }
         }
@@ -17196,9 +17196,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // Find the first property with a unit type, if any. When constituents have a property by the same name
                 // but of a different unit type, we can quickly disqualify them from subtype checks. This helps subtype
                 // reduction of large discriminated union types.
-                const keyProperty = source.flags & (TypeFlags.Object | TypeFlags.Intersection | TypeFlags.InstantiableNonPrimitive) ?
-                    find(getPropertiesOfType(source), p => isUnitType(getTypeOfSymbol(p))) :
-                    undefined;
+                const keyProperty = source.flags & (TypeFlags.Object | TypeFlags.Intersection | TypeFlags.InstantiableNonPrimitive)
+                    ? find(getPropertiesOfType(source), p => isUnitType(getTypeOfSymbol(p)))
+                    : undefined;
                 const keyPropertyType = keyProperty && getRegularTypeOfLiteralType(getTypeOfSymbol(keyProperty));
                 for (const target of types) {
                     if (source !== target) {
@@ -17223,9 +17223,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         }
                         if (
                             isTypeRelatedTo(source, target, strictSubtypeRelation) && (
-                                !(getObjectFlags(getTargetType(source)) & ObjectFlags.Class) ||
-                                !(getObjectFlags(getTargetType(target)) & ObjectFlags.Class) ||
-                                isTypeDerivedFrom(source, target)
+                                !(getObjectFlags(getTargetType(source)) & ObjectFlags.Class)
+                                || !(getObjectFlags(getTargetType(target)) & ObjectFlags.Class)
+                                || isTypeDerivedFrom(source, target)
                             )
                         ) {
                             orderedRemoveItemAt(types, i);
@@ -17245,12 +17245,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             i--;
             const t = types[i];
             const flags = t.flags;
-            const remove = flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) && includes & TypeFlags.String ||
-                flags & TypeFlags.NumberLiteral && includes & TypeFlags.Number ||
-                flags & TypeFlags.BigIntLiteral && includes & TypeFlags.BigInt ||
-                flags & TypeFlags.UniqueESSymbol && includes & TypeFlags.ESSymbol ||
-                reduceVoidUndefined && flags & TypeFlags.Undefined && includes & TypeFlags.Void ||
-                isFreshLiteralType(t) && containsType(types, (t as LiteralType).regularType);
+            const remove = flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) && includes & TypeFlags.String
+                || flags & TypeFlags.NumberLiteral && includes & TypeFlags.Number
+                || flags & TypeFlags.BigIntLiteral && includes & TypeFlags.BigInt
+                || flags & TypeFlags.UniqueESSymbol && includes & TypeFlags.ESSymbol
+                || reduceVoidUndefined && flags & TypeFlags.Undefined && includes & TypeFlags.Void
+                || isFreshLiteralType(t) && containsType(types, (t as LiteralType).regularType);
             if (remove) {
                 orderedRemoveItemAt(types, i);
             }
@@ -17272,9 +17272,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTypeMatchedByTemplateLiteralOrStringMapping(type: Type, template: TemplateLiteralType | StringMappingType) {
-        return template.flags & TypeFlags.TemplateLiteral ?
-            isTypeMatchedByTemplateLiteralType(type, template as TemplateLiteralType) :
-            isMemberOfStringMapping(type, template);
+        return template.flags & TypeFlags.TemplateLiteral
+            ? isTypeMatchedByTemplateLiteralType(type, template as TemplateLiteralType)
+            : isMemberOfStringMapping(type, template);
     }
 
     function removeConstrainedTypeVariables(types: Type[]) {
@@ -17378,9 +17378,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const includes = addTypesToUnion(typeSet, 0 as TypeFlags, types);
         if (unionReduction !== UnionReduction.None) {
             if (includes & TypeFlags.AnyOrUnknown) {
-                return includes & TypeFlags.Any ?
-                    includes & TypeFlags.IncludesWildcard ? wildcardType : anyType :
-                    unknownType;
+                return includes & TypeFlags.Any
+                    ? includes & TypeFlags.IncludesWildcard ? wildcardType : anyType
+                    : unknownType;
             }
             if (includes & TypeFlags.Undefined) {
                 // If type set contains both undefinedType and missingType, remove missingType
@@ -17404,9 +17404,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
             if (typeSet.length === 0) {
-                return includes & TypeFlags.Null ? includes & TypeFlags.IncludesNonWideningType ? nullType : nullWideningType :
-                    includes & TypeFlags.Undefined ? includes & TypeFlags.IncludesNonWideningType ? undefinedType : undefinedWideningType :
-                    neverType;
+                return includes & TypeFlags.Null ? includes & TypeFlags.IncludesNonWideningType ? nullType : nullWideningType
+                    : includes & TypeFlags.Undefined ? includes & TypeFlags.IncludesNonWideningType ? undefinedType : undefinedWideningType
+                    : neverType;
             }
         }
         if (!origin && includes & TypeFlags.Union) {
@@ -17431,8 +17431,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 origin = createOriginUnionOrIntersectionType(TypeFlags.Union, reducedTypes);
             }
         }
-        const objectFlags = (includes & TypeFlags.NotPrimitiveUnion ? 0 : ObjectFlags.PrimitiveUnion) |
-            (includes & TypeFlags.Intersection ? ObjectFlags.ContainsIntersections : 0);
+        const objectFlags = (includes & TypeFlags.NotPrimitiveUnion ? 0 : ObjectFlags.PrimitiveUnion)
+            | (includes & TypeFlags.Intersection ? ObjectFlags.ContainsIntersections : 0);
         return getUnionTypeFromSortedList(typeSet, objectFlags, aliasSymbol, aliasTypeArguments, origin);
     }
 
@@ -17476,10 +17476,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (types.length === 1) {
             return types[0];
         }
-        const typeKey = !origin ? getTypeListId(types) :
-            origin.flags & TypeFlags.Union ? `|${getTypeListId((origin as UnionType).types)}` :
-            origin.flags & TypeFlags.Intersection ? `&${getTypeListId((origin as IntersectionType).types)}` :
-            `#${(origin as IndexType).type.id}|${getTypeListId(types)}`; // origin type id alone is insufficient, as `keyof x` may resolve to multiple WIP values while `x` is still resolving
+        const typeKey = !origin ? getTypeListId(types)
+            : origin.flags & TypeFlags.Union ? `|${getTypeListId((origin as UnionType).types)}`
+            : origin.flags & TypeFlags.Intersection ? `&${getTypeListId((origin as IntersectionType).types)}`
+            : `#${(origin as IndexType).type.id}|${getTypeListId(types)}`; // origin type id alone is insufficient, as `keyof x` may resolve to multiple WIP values while `x` is still resolving
         const id = typeKey + getAliasId(aliasSymbol, aliasTypeArguments);
         let type = unionTypes.get(id);
         if (!type) {
@@ -17555,12 +17555,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         while (i > 0) {
             i--;
             const t = types[i];
-            const remove = t.flags & TypeFlags.String && includes & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ||
-                t.flags & TypeFlags.Number && includes & TypeFlags.NumberLiteral ||
-                t.flags & TypeFlags.BigInt && includes & TypeFlags.BigIntLiteral ||
-                t.flags & TypeFlags.ESSymbol && includes & TypeFlags.UniqueESSymbol ||
-                t.flags & TypeFlags.Void && includes & TypeFlags.Undefined ||
-                isEmptyAnonymousObjectType(t) && includes & TypeFlags.DefinitelyNonNullable;
+            const remove = t.flags & TypeFlags.String && includes & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping)
+                || t.flags & TypeFlags.Number && includes & TypeFlags.NumberLiteral
+                || t.flags & TypeFlags.BigInt && includes & TypeFlags.BigIntLiteral
+                || t.flags & TypeFlags.ESSymbol && includes & TypeFlags.UniqueESSymbol
+                || t.flags & TypeFlags.Void && includes & TypeFlags.Undefined
+                || isEmptyAnonymousObjectType(t) && includes & TypeFlags.DefinitelyNonNullable;
             if (remove) {
                 orderedRemoveItemAt(types, i);
             }
@@ -17573,11 +17573,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function eachUnionContains(unionTypes: UnionType[], type: Type) {
         for (const u of unionTypes) {
             if (!containsType(u.types, type)) {
-                const primitive = type.flags & TypeFlags.StringLiteral ? stringType :
-                    type.flags & (TypeFlags.Enum | TypeFlags.NumberLiteral) ? numberType :
-                    type.flags & TypeFlags.BigIntLiteral ? bigintType :
-                    type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
-                    undefined;
+                const primitive = type.flags & TypeFlags.StringLiteral ? stringType
+                    : type.flags & (TypeFlags.Enum | TypeFlags.NumberLiteral) ? numberType
+                    : type.flags & TypeFlags.BigIntLiteral ? bigintType
+                    : type.flags & TypeFlags.UniqueESSymbol ? esSymbolType
+                    : undefined;
                 if (!primitive || !containsType(u.types, primitive)) {
                     return false;
                 }
@@ -17699,13 +17699,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return contains(typeSet, silentNeverType) ? silentNeverType : neverType;
         }
         if (
-            strictNullChecks && includes & TypeFlags.Nullable && includes & (TypeFlags.Object | TypeFlags.NonPrimitive | TypeFlags.IncludesEmptyObject) ||
-            includes & TypeFlags.NonPrimitive && includes & (TypeFlags.DisjointDomains & ~TypeFlags.NonPrimitive) ||
-            includes & TypeFlags.StringLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.StringLike) ||
-            includes & TypeFlags.NumberLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.NumberLike) ||
-            includes & TypeFlags.BigIntLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.BigIntLike) ||
-            includes & TypeFlags.ESSymbolLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.ESSymbolLike) ||
-            includes & TypeFlags.VoidLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.VoidLike)
+            strictNullChecks && includes & TypeFlags.Nullable && includes & (TypeFlags.Object | TypeFlags.NonPrimitive | TypeFlags.IncludesEmptyObject)
+            || includes & TypeFlags.NonPrimitive && includes & (TypeFlags.DisjointDomains & ~TypeFlags.NonPrimitive)
+            || includes & TypeFlags.StringLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.StringLike)
+            || includes & TypeFlags.NumberLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.NumberLike)
+            || includes & TypeFlags.BigIntLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.BigIntLike)
+            || includes & TypeFlags.ESSymbolLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.ESSymbolLike)
+            || includes & TypeFlags.VoidLike && includes & (TypeFlags.DisjointDomains & ~TypeFlags.VoidLike)
         ) {
             return neverType;
         }
@@ -17719,12 +17719,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return includes & TypeFlags.IncludesEmptyObject ? neverType : includes & TypeFlags.Undefined ? undefinedType : nullType;
         }
         if (
-            includes & TypeFlags.String && includes & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ||
-            includes & TypeFlags.Number && includes & TypeFlags.NumberLiteral ||
-            includes & TypeFlags.BigInt && includes & TypeFlags.BigIntLiteral ||
-            includes & TypeFlags.ESSymbol && includes & TypeFlags.UniqueESSymbol ||
-            includes & TypeFlags.Void && includes & TypeFlags.Undefined ||
-            includes & TypeFlags.IncludesEmptyObject && includes & TypeFlags.DefinitelyNonNullable
+            includes & TypeFlags.String && includes & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping)
+            || includes & TypeFlags.Number && includes & TypeFlags.NumberLiteral
+            || includes & TypeFlags.BigInt && includes & TypeFlags.BigIntLiteral
+            || includes & TypeFlags.ESSymbol && includes & TypeFlags.UniqueESSymbol
+            || includes & TypeFlags.Void && includes & TypeFlags.Undefined
+            || includes & TypeFlags.IncludesEmptyObject && includes & TypeFlags.DefinitelyNonNullable
         ) {
             if (!noSupertypeReduction) removeRedundantSupertypes(typeSet, includes);
         }
@@ -17742,8 +17742,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const typeVariable = typeSet[typeVarIndex];
             const primitiveType = typeSet[1 - typeVarIndex];
             if (
-                typeVariable.flags & TypeFlags.TypeVariable &&
-                (primitiveType.flags & (TypeFlags.Primitive | TypeFlags.NonPrimitive) && !isGenericStringLikeType(primitiveType) || includes & TypeFlags.IncludesEmptyObject)
+                typeVariable.flags & TypeFlags.TypeVariable
+                && (primitiveType.flags & (TypeFlags.Primitive | TypeFlags.NonPrimitive) && !isGenericStringLikeType(primitiveType) || includes & TypeFlags.IncludesEmptyObject)
             ) {
                 // We have an intersection T & P or P & T, where T is a type variable and P is a primitive type, the object type, or {}.
                 const constraint = getBaseConstraintOfType(typeVariable);
@@ -17847,9 +17847,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getConstituentCount(type: Type): number {
-        return !(type.flags & TypeFlags.UnionOrIntersection) || type.aliasSymbol ? 1 :
-            type.flags & TypeFlags.Union && (type as UnionType).origin ? getConstituentCount((type as UnionType).origin!) :
-            getConstituentCountOfTypes((type as UnionOrIntersectionType).types);
+        return !(type.flags & TypeFlags.UnionOrIntersection) || type.aliasSymbol ? 1
+            : type.flags & TypeFlags.Union && (type as UnionType).origin ? getConstituentCount((type as UnionType).origin!)
+            : getConstituentCountOfTypes((type as UnionOrIntersectionType).types);
     }
 
     function getConstituentCountOfTypes(types: Type[]): number {
@@ -17886,9 +17886,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getIndexTypeForGenericType(type: InstantiableType | UnionOrIntersectionType, indexFlags: IndexFlags) {
-        return indexFlags & IndexFlags.StringsOnly ?
-            type.resolvedStringIndexType || (type.resolvedStringIndexType = createIndexType(type, IndexFlags.StringsOnly)) :
-            type.resolvedIndexType || (type.resolvedIndexType = createIndexType(type, IndexFlags.None));
+        return indexFlags & IndexFlags.StringsOnly
+            ? type.resolvedStringIndexType || (type.resolvedStringIndexType = createIndexType(type, IndexFlags.StringsOnly))
+            : type.resolvedIndexType || (type.resolvedIndexType = createIndexType(type, IndexFlags.None));
     }
 
     /**
@@ -17951,13 +17951,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const typeVariable = getTypeParameterFromMappedType(mappedType);
         return isDistributive(getNameTypeFromMappedType(mappedType) || typeVariable);
         function isDistributive(type: Type): boolean {
-            return type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Primitive | TypeFlags.Never | TypeFlags.TypeParameter | TypeFlags.Object | TypeFlags.NonPrimitive) ? true :
-                type.flags & TypeFlags.Conditional ? (type as ConditionalType).root.isDistributive && (type as ConditionalType).checkType === typeVariable :
-                type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral) ? every((type as UnionOrIntersectionType | TemplateLiteralType).types, isDistributive) :
-                type.flags & TypeFlags.IndexedAccess ? isDistributive((type as IndexedAccessType).objectType) && isDistributive((type as IndexedAccessType).indexType) :
-                type.flags & TypeFlags.Substitution ? isDistributive((type as SubstitutionType).baseType) && isDistributive((type as SubstitutionType).constraint) :
-                type.flags & TypeFlags.StringMapping ? isDistributive((type as StringMappingType).type) :
-                false;
+            return type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Primitive | TypeFlags.Never | TypeFlags.TypeParameter | TypeFlags.Object | TypeFlags.NonPrimitive) ? true
+                : type.flags & TypeFlags.Conditional ? (type as ConditionalType).root.isDistributive && (type as ConditionalType).checkType === typeVariable
+                : type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral) ? every((type as UnionOrIntersectionType | TemplateLiteralType).types, isDistributive)
+                : type.flags & TypeFlags.IndexedAccess ? isDistributive((type as IndexedAccessType).objectType) && isDistributive((type as IndexedAccessType).indexType)
+                : type.flags & TypeFlags.Substitution ? isDistributive((type as SubstitutionType).baseType) && isDistributive((type as SubstitutionType).constraint)
+                : type.flags & TypeFlags.StringMapping ? isDistributive((type as StringMappingType).type)
+                : false;
         }
     }
 
@@ -17986,8 +17986,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             let type = getSymbolLinks(getLateBoundSymbol(prop)).nameType;
             if (!type) {
                 const name = getNameOfDeclaration(prop.valueDeclaration) as PropertyName | JsxAttributeName;
-                type = prop.escapedName === InternalSymbolName.Default ? getStringLiteralType("default") :
-                    name && getLiteralTypeFromPropertyName(name) || (!isKnownSymbol(prop) ? getStringLiteralType(symbolName(prop)) : undefined);
+                type = prop.escapedName === InternalSymbolName.Default ? getStringLiteralType("default")
+                    : name && getLiteralTypeFromPropertyName(name) || (!isKnownSymbol(prop) ? getStringLiteralType(symbolName(prop)) : undefined);
             }
             if (type && type.flags & include) {
                 return type;
@@ -18004,30 +18004,30 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const origin = includeOrigin && (getObjectFlags(type) & (ObjectFlags.ClassOrInterface | ObjectFlags.Reference) || type.aliasSymbol) ? createOriginIndexType(type) : undefined;
         const propertyTypes = map(getPropertiesOfType(type), prop => getLiteralTypeFromProperty(prop, include));
         const indexKeyTypes = map(getIndexInfosOfType(type), info =>
-            info !== enumNumberIndexInfo && isKeyTypeIncluded(info.keyType, include) ?
-                info.keyType === stringType && include & TypeFlags.Number ? stringOrNumberType : info.keyType : neverType);
+            info !== enumNumberIndexInfo && isKeyTypeIncluded(info.keyType, include)
+                ? info.keyType === stringType && include & TypeFlags.Number ? stringOrNumberType : info.keyType : neverType);
         return getUnionType(concatenate(propertyTypes, indexKeyTypes), UnionReduction.Literal, /*aliasSymbol*/ undefined, /*aliasTypeArguments*/ undefined, origin);
     }
 
     function shouldDeferIndexType(type: Type, indexFlags = IndexFlags.None) {
-        return !!(type.flags & TypeFlags.InstantiableNonPrimitive ||
-            isGenericTupleType(type) ||
-            isGenericMappedType(type) && (!hasDistributiveNameType(type) || getMappedTypeNameTypeKind(type) === MappedTypeNameTypeKind.Remapping) ||
-            type.flags & TypeFlags.Union && !(indexFlags & IndexFlags.NoReducibleCheck) && isGenericReducibleType(type) ||
-            type.flags & TypeFlags.Intersection && maybeTypeOfKind(type, TypeFlags.Instantiable) && some((type as IntersectionType).types, isEmptyAnonymousObjectType));
+        return !!(type.flags & TypeFlags.InstantiableNonPrimitive
+            || isGenericTupleType(type)
+            || isGenericMappedType(type) && (!hasDistributiveNameType(type) || getMappedTypeNameTypeKind(type) === MappedTypeNameTypeKind.Remapping)
+            || type.flags & TypeFlags.Union && !(indexFlags & IndexFlags.NoReducibleCheck) && isGenericReducibleType(type)
+            || type.flags & TypeFlags.Intersection && maybeTypeOfKind(type, TypeFlags.Instantiable) && some((type as IntersectionType).types, isEmptyAnonymousObjectType));
     }
 
     function getIndexType(type: Type, indexFlags = IndexFlags.None): Type {
         type = getReducedType(type);
-        return isNoInferType(type) ? getNoInferType(getIndexType((type as SubstitutionType).baseType, indexFlags)) :
-            shouldDeferIndexType(type, indexFlags) ? getIndexTypeForGenericType(type as InstantiableType | UnionOrIntersectionType, indexFlags) :
-            type.flags & TypeFlags.Union ? getIntersectionType(map((type as UnionType).types, t => getIndexType(t, indexFlags))) :
-            type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags))) :
-            getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags) :
-            type === wildcardType ? wildcardType :
-            type.flags & TypeFlags.Unknown ? neverType :
-            type.flags & (TypeFlags.Any | TypeFlags.Never) ? stringNumberSymbolType :
-            getLiteralTypeFromProperties(type, (indexFlags & IndexFlags.NoIndexSignatures ? TypeFlags.StringLiteral : TypeFlags.StringLike) | (indexFlags & IndexFlags.StringsOnly ? 0 : TypeFlags.NumberLike | TypeFlags.ESSymbolLike), indexFlags === IndexFlags.None);
+        return isNoInferType(type) ? getNoInferType(getIndexType((type as SubstitutionType).baseType, indexFlags))
+            : shouldDeferIndexType(type, indexFlags) ? getIndexTypeForGenericType(type as InstantiableType | UnionOrIntersectionType, indexFlags)
+            : type.flags & TypeFlags.Union ? getIntersectionType(map((type as UnionType).types, t => getIndexType(t, indexFlags)))
+            : type.flags & TypeFlags.Intersection ? getUnionType(map((type as IntersectionType).types, t => getIndexType(t, indexFlags)))
+            : getObjectFlags(type) & ObjectFlags.Mapped ? getIndexTypeForMappedType(type as MappedType, indexFlags)
+            : type === wildcardType ? wildcardType
+            : type.flags & TypeFlags.Unknown ? neverType
+            : type.flags & (TypeFlags.Any | TypeFlags.Never) ? stringNumberSymbolType
+            : getLiteralTypeFromProperties(type, (indexFlags & IndexFlags.NoIndexSignatures ? TypeFlags.StringLiteral : TypeFlags.StringLike) | (indexFlags & IndexFlags.StringsOnly ? 0 : TypeFlags.NumberLike | TypeFlags.ESSymbolLike), indexFlags === IndexFlags.None);
     }
 
     function getExtractStringType(type: Type) {
@@ -18076,9 +18076,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getTemplateLiteralType(texts: readonly string[], types: readonly Type[]): Type {
         const unionIndex = findIndex(types, t => !!(t.flags & (TypeFlags.Never | TypeFlags.Union)));
         if (unionIndex >= 0) {
-            return checkCrossProductUnion(types) ?
-                mapType(types[unionIndex], t => getTemplateLiteralType(texts, replaceElement(types, unionIndex, t))) :
-                errorType;
+            return checkCrossProductUnion(types)
+                ? mapType(types[unionIndex], t => getTemplateLiteralType(texts, replaceElement(types, unionIndex, t)))
+                : errorType;
         }
         if (contains(types, wildcardType)) {
             return wildcardType;
@@ -18145,11 +18145,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTemplateStringForType(type: Type) {
-        return type.flags & TypeFlags.StringLiteral ? (type as StringLiteralType).value :
-            type.flags & TypeFlags.NumberLiteral ? "" + (type as NumberLiteralType).value :
-            type.flags & TypeFlags.BigIntLiteral ? pseudoBigIntToString((type as BigIntLiteralType).value) :
-            type.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) ? (type as IntrinsicType).intrinsicName :
-            undefined;
+        return type.flags & TypeFlags.StringLiteral ? (type as StringLiteralType).value
+            : type.flags & TypeFlags.NumberLiteral ? "" + (type as NumberLiteralType).value
+            : type.flags & TypeFlags.BigIntLiteral ? pseudoBigIntToString((type as BigIntLiteralType).value)
+            : type.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) ? (type as IntrinsicType).intrinsicName
+            : undefined;
     }
 
     function createTemplateLiteralType(texts: readonly string[], types: readonly Type[]) {
@@ -18160,15 +18160,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getStringMappingType(symbol: Symbol, type: Type): Type {
-        return type.flags & (TypeFlags.Union | TypeFlags.Never) ? mapType(type, t => getStringMappingType(symbol, t)) :
-            type.flags & TypeFlags.StringLiteral ? getStringLiteralType(applyStringMapping(symbol, (type as StringLiteralType).value)) :
-            type.flags & TypeFlags.TemplateLiteral ? getTemplateLiteralType(...applyTemplateStringMapping(symbol, (type as TemplateLiteralType).texts, (type as TemplateLiteralType).types)) :
+        return type.flags & (TypeFlags.Union | TypeFlags.Never) ? mapType(type, t => getStringMappingType(symbol, t))
+            : type.flags & TypeFlags.StringLiteral ? getStringLiteralType(applyStringMapping(symbol, (type as StringLiteralType).value))
+            : type.flags & TypeFlags.TemplateLiteral ? getTemplateLiteralType(...applyTemplateStringMapping(symbol, (type as TemplateLiteralType).texts, (type as TemplateLiteralType).types))
             // Mapping<Mapping<T>> === Mapping<T>
-            type.flags & TypeFlags.StringMapping && symbol === type.symbol ? type :
-            type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type) :
+            : type.flags & TypeFlags.StringMapping && symbol === type.symbol ? type
+            : type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.StringMapping) || isGenericIndexType(type) ? getStringMappingTypeForGenericType(symbol, type)
             // This handles Mapping<`${number}`> and Mapping<`${bigint}`>
-            isPatternLiteralPlaceholderType(type) ? getStringMappingTypeForGenericType(symbol, getTemplateLiteralType(["", ""], [type])) :
-            type;
+            : isPatternLiteralPlaceholderType(type) ? getStringMappingTypeForGenericType(symbol, getTemplateLiteralType(["", ""], [type]))
+            : type;
     }
 
     function applyStringMapping(symbol: Symbol, str: string) {
@@ -18254,12 +18254,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getPropertyNameFromIndex(indexType: Type, accessNode: PropertyName | ObjectBindingPattern | ArrayBindingPattern | IndexedAccessTypeNode | ElementAccessExpression | SyntheticExpression | undefined) {
-        return isTypeUsableAsPropertyName(indexType) ?
-            getPropertyNameFromType(indexType) :
-            accessNode && isPropertyName(accessNode) ?
+        return isTypeUsableAsPropertyName(indexType)
+            ? getPropertyNameFromType(indexType)
+            : accessNode && isPropertyName(accessNode)
             // late bound names are handled in the first branch, so here we only need to handle normal names
-            getPropertyNameForPropertyNameNode(accessNode) :
-            undefined;
+            ? getPropertyNameForPropertyNameNode(accessNode)
+            : undefined;
     }
 
     function isUncalledFunctionReference(node: Node, symbol: Symbol) {
@@ -18301,9 +18301,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 const propType = accessFlags & AccessFlags.Writing ? getWriteTypeOfSymbol(prop) : getTypeOfSymbol(prop);
-                return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ? getFlowTypeOfReference(accessExpression, propType) :
-                    accessNode && isIndexedAccessTypeNode(accessNode) && containsMissingType(propType) ? getUnionType([propType, undefinedType]) :
-                    propType;
+                return accessExpression && getAssignmentTargetKind(accessExpression) !== AssignmentKind.Definite ? getFlowTypeOfReference(accessExpression, propType)
+                    : accessNode && isIndexedAccessTypeNode(accessNode) && containsMissingType(propType) ? getUnionType([propType, undefinedType])
+                    : propType;
             }
             if (everyType(objectType, isTupleType) && isNumericLiteralName(propName)) {
                 const index = +propName;
@@ -18355,12 +18355,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // e.g. E[E.A] for enum E { A }, undefined shouldn't
                 // be included in the result type
                 if (
-                    (accessFlags & AccessFlags.IncludeUndefined) &&
-                    !(objectType.symbol &&
-                        objectType.symbol.flags & (SymbolFlags.RegularEnum | SymbolFlags.ConstEnum) &&
-                        (indexType.symbol &&
-                            indexType.flags & TypeFlags.EnumLiteral &&
-                            getParentOfSymbol(indexType.symbol) === objectType.symbol))
+                    (accessFlags & AccessFlags.IncludeUndefined)
+                    && !(objectType.symbol
+                        && objectType.symbol.flags & (SymbolFlags.RegularEnum | SymbolFlags.ConstEnum)
+                        && (indexType.symbol
+                            && indexType.flags & TypeFlags.EnumLiteral
+                            && getParentOfSymbol(indexType.symbol) === objectType.symbol))
                 ) {
                     return getUnionType([indexInfo.type, missingType]);
                 }
@@ -18470,10 +18470,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getIndexNodeForAccessExpression(accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression) {
-        return accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode.argumentExpression :
-            accessNode.kind === SyntaxKind.IndexedAccessType ? accessNode.indexType :
-            accessNode.kind === SyntaxKind.ComputedPropertyName ? accessNode.expression :
-            accessNode;
+        return accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode.argumentExpression
+            : accessNode.kind === SyntaxKind.IndexedAccessType ? accessNode.indexType
+            : accessNode.kind === SyntaxKind.ComputedPropertyName ? accessNode.expression
+            : accessNode;
     }
 
     function isPatternLiteralPlaceholderType(type: Type): boolean {
@@ -18497,8 +18497,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isPatternLiteralType(type: Type) {
         // A pattern literal type is a template literal or a string mapping type that contains only
         // non-generic pattern literal placeholders.
-        return !!(type.flags & TypeFlags.TemplateLiteral) && every((type as TemplateLiteralType).types, isPatternLiteralPlaceholderType) ||
-            !!(type.flags & TypeFlags.StringMapping) && isPatternLiteralPlaceholderType((type as StringMappingType).type);
+        return !!(type.flags & TypeFlags.TemplateLiteral) && every((type as TemplateLiteralType).types, isPatternLiteralPlaceholderType)
+            || !!(type.flags & TypeFlags.StringMapping) && isPatternLiteralPlaceholderType((type as StringMappingType).type);
     }
 
     function isGenericStringLikeType(type: Type) {
@@ -18520,26 +18520,26 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getGenericObjectFlags(type: Type): ObjectFlags {
         if (type.flags & (TypeFlags.UnionOrIntersection)) {
             if (!((type as UnionOrIntersectionType).objectFlags & ObjectFlags.IsGenericTypeComputed)) {
-                (type as UnionOrIntersectionType).objectFlags |= ObjectFlags.IsGenericTypeComputed |
-                    reduceLeft((type as UnionOrIntersectionType).types, (flags, t) => flags | getGenericObjectFlags(t), 0);
+                (type as UnionOrIntersectionType).objectFlags |= ObjectFlags.IsGenericTypeComputed
+                    | reduceLeft((type as UnionOrIntersectionType).types, (flags, t) => flags | getGenericObjectFlags(t), 0);
             }
             return (type as UnionOrIntersectionType).objectFlags & ObjectFlags.IsGenericType;
         }
         if (type.flags & TypeFlags.Substitution) {
             if (!((type as SubstitutionType).objectFlags & ObjectFlags.IsGenericTypeComputed)) {
-                (type as SubstitutionType).objectFlags |= ObjectFlags.IsGenericTypeComputed |
-                    getGenericObjectFlags((type as SubstitutionType).baseType) | getGenericObjectFlags((type as SubstitutionType).constraint);
+                (type as SubstitutionType).objectFlags |= ObjectFlags.IsGenericTypeComputed
+                    | getGenericObjectFlags((type as SubstitutionType).baseType) | getGenericObjectFlags((type as SubstitutionType).constraint);
             }
             return (type as SubstitutionType).objectFlags & ObjectFlags.IsGenericType;
         }
-        return (type.flags & TypeFlags.InstantiableNonPrimitive || isGenericMappedType(type) || isGenericTupleType(type) ? ObjectFlags.IsGenericObjectType : 0) |
-            (type.flags & (TypeFlags.InstantiableNonPrimitive | TypeFlags.Index) || isGenericStringLikeType(type) ? ObjectFlags.IsGenericIndexType : 0);
+        return (type.flags & TypeFlags.InstantiableNonPrimitive || isGenericMappedType(type) || isGenericTupleType(type) ? ObjectFlags.IsGenericObjectType : 0)
+            | (type.flags & (TypeFlags.InstantiableNonPrimitive | TypeFlags.Index) || isGenericStringLikeType(type) ? ObjectFlags.IsGenericIndexType : 0);
     }
 
     function getSimplifiedType(type: Type, writing: boolean): Type {
-        return type.flags & TypeFlags.IndexedAccess ? getSimplifiedIndexedAccessType(type as IndexedAccessType, writing) :
-            type.flags & TypeFlags.Conditional ? getSimplifiedConditionalType(type as ConditionalType, writing) :
-            type;
+        return type.flags & TypeFlags.IndexedAccess ? getSimplifiedIndexedAccessType(type as IndexedAccessType, writing)
+            : type.flags & TypeFlags.Conditional ? getSimplifiedConditionalType(type as ConditionalType, writing)
+            : type;
     }
 
     function distributeIndexOverObjectType(objectType: Type, indexType: Type, writing: boolean) {
@@ -18689,9 +18689,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // preserve backwards compatibility. For example, an element access 'this["foo"]' has always been resolved
         // eagerly using the constraint type of 'this' at the given location.
         if (
-            isGenericIndexType(indexType) || (accessNode && accessNode.kind !== SyntaxKind.IndexedAccessType ?
-                isGenericTupleType(objectType) && !indexTypeLessThan(indexType, getTotalFixedElementCount(objectType.target)) :
-                isGenericObjectType(objectType) && !(isTupleType(objectType) && indexTypeLessThan(indexType, getTotalFixedElementCount(objectType.target))) || isGenericReducibleType(objectType))
+            isGenericIndexType(indexType) || (accessNode && accessNode.kind !== SyntaxKind.IndexedAccessType
+                ? isGenericTupleType(objectType) && !indexTypeLessThan(indexType, getTotalFixedElementCount(objectType.target))
+                : isGenericObjectType(objectType) && !(isTupleType(objectType) && indexTypeLessThan(indexType, getTotalFixedElementCount(objectType.target))) || isGenericReducibleType(objectType))
         ) {
             if (objectType.flags & TypeFlags.AnyOrUnknown) {
                 return objectType;
@@ -18769,8 +18769,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (
             type.flags & TypeFlags.IndexedAccess && (
-                (type as IndexedAccessType).objectType.flags & TypeFlags.Substitution ||
-                (type as IndexedAccessType).indexType.flags & TypeFlags.Substitution
+                (type as IndexedAccessType).objectType.flags & TypeFlags.Substitution
+                || (type as IndexedAccessType).indexType.flags & TypeFlags.Substitution
             )
         ) {
             return getIndexedAccessType(getActualTypeVariable((type as IndexedAccessType).objectType), getActualTypeVariable((type as IndexedAccessType).indexType));
@@ -18779,8 +18779,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isSimpleTupleType(node: TypeNode): boolean {
-        return isTupleTypeNode(node) && length(node.elements) > 0 &&
-            !some(node.elements, e => isOptionalTypeNode(e) || isRestTypeNode(e) || isNamedTupleMember(e) && !!(e.questionToken || e.dotDotDotToken));
+        return isTupleTypeNode(node) && length(node.elements) > 0
+            && !some(node.elements, e => isOptionalTypeNode(e) || isRestTypeNode(e) || isNamedTupleMember(e) && !!(e.questionToken || e.dotDotDotToken));
     }
 
     function isDeferredType(type: Type, checkTuples: boolean) {
@@ -18814,8 +18814,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // When the check and extends types are simple tuple types of the same arity, we defer resolution of the
             // conditional type when any tuple elements are generic. This is such that non-distributable conditional
             // types can be written `[X] extends [Y] ? ...` and be deferred similarly to `X extends Y ? ...`.
-            const checkTuples = isSimpleTupleType(checkTypeNode) && isSimpleTupleType(extendsTypeNode) &&
-                length((checkTypeNode as TupleTypeNode).elements) === length((extendsTypeNode as TupleTypeNode).elements);
+            const checkTuples = isSimpleTupleType(checkTypeNode) && isSimpleTupleType(extendsTypeNode)
+                && length((checkTypeNode as TupleTypeNode).elements) === length((extendsTypeNode as TupleTypeNode).elements);
             const checkTypeDeferred = isDeferredType(checkType, checkTuples);
             let combinedMapper: TypeMapper | undefined;
             if (root.inferTypeParameters) {
@@ -18962,8 +18962,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isDistributionDependent(root: ConditionalRoot) {
         return root.isDistributive && (
-            isTypeParameterPossiblyReferenced(root.checkType as TypeParameter, root.node.trueType) ||
-            isTypeParameterPossiblyReferenced(root.checkType as TypeParameter, root.node.falseType)
+            isTypeParameterPossiblyReferenced(root.checkType as TypeParameter, root.node.trueType)
+            || isTypeParameterPossiblyReferenced(root.checkType as TypeParameter, root.node.falseType)
         );
     }
 
@@ -19268,9 +19268,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     /** We approximate own properties as non-methods plus methods that are inside the object literal */
     function isSpreadableProperty(prop: Symbol): boolean {
-        return !some(prop.declarations, isPrivateIdentifierClassElementDeclaration) &&
-            (!(prop.flags & (SymbolFlags.Method | SymbolFlags.GetAccessor | SymbolFlags.SetAccessor)) ||
-                !prop.declarations?.some(decl => isClassLike(decl.parent)));
+        return !some(prop.declarations, isPrivateIdentifierClassElementDeclaration)
+            && (!(prop.flags & (SymbolFlags.Method | SymbolFlags.GetAccessor | SymbolFlags.SetAccessor))
+                || !prop.declarations?.some(decl => isClassLike(decl.parent)));
     }
 
     function getSpreadSymbol(prop: Symbol, readonly: boolean) {
@@ -19311,9 +19311,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getRegularTypeOfLiteralType(type: Type): Type {
-        return type.flags & TypeFlags.Freshable ? (type as FreshableType).regularType :
-            type.flags & TypeFlags.Union ? ((type as UnionType).regularType || ((type as UnionType).regularType = mapType(type, getRegularTypeOfLiteralType) as UnionType)) :
-            type;
+        return type.flags & TypeFlags.Freshable ? (type as FreshableType).regularType
+            : type.flags & TypeFlags.Union ? ((type as UnionType).regularType || ((type as UnionType).regularType = mapType(type, getRegularTypeOfLiteralType) as UnionType))
+            : type;
     }
 
     function isFreshLiteralType(type: Type) {
@@ -19322,29 +19322,29 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getStringLiteralType(value: string): StringLiteralType {
         let type;
-        return stringLiteralTypes.get(value) ||
-            (stringLiteralTypes.set(value, type = createLiteralType(TypeFlags.StringLiteral, value) as StringLiteralType), type);
+        return stringLiteralTypes.get(value)
+            || (stringLiteralTypes.set(value, type = createLiteralType(TypeFlags.StringLiteral, value) as StringLiteralType), type);
     }
 
     function getNumberLiteralType(value: number): NumberLiteralType {
         let type;
-        return numberLiteralTypes.get(value) ||
-            (numberLiteralTypes.set(value, type = createLiteralType(TypeFlags.NumberLiteral, value) as NumberLiteralType), type);
+        return numberLiteralTypes.get(value)
+            || (numberLiteralTypes.set(value, type = createLiteralType(TypeFlags.NumberLiteral, value) as NumberLiteralType), type);
     }
 
     function getBigIntLiteralType(value: PseudoBigInt): BigIntLiteralType {
         let type;
         const key = pseudoBigIntToString(value);
-        return bigIntLiteralTypes.get(key) ||
-            (bigIntLiteralTypes.set(key, type = createLiteralType(TypeFlags.BigIntLiteral, value) as BigIntLiteralType), type);
+        return bigIntLiteralTypes.get(key)
+            || (bigIntLiteralTypes.set(key, type = createLiteralType(TypeFlags.BigIntLiteral, value) as BigIntLiteralType), type);
     }
 
     function getEnumLiteralType(value: string | number, enumId: number, symbol: Symbol): LiteralType {
         let type;
         const key = `${enumId}${typeof value === "string" ? "@" : "#"}${value}`;
         const flags = TypeFlags.EnumLiteral | (typeof value === "string" ? TypeFlags.StringLiteral : TypeFlags.NumberLiteral);
-        return enumLiteralTypes.get(key) ||
-            (enumLiteralTypes.set(key, type = createLiteralType(flags, value, symbol)), type);
+        return enumLiteralTypes.get(key)
+            || (enumLiteralTypes.set(key, type = createLiteralType(flags, value, symbol)), type);
     }
 
     function getTypeFromLiteralTypeNode(node: LiteralTypeNode): Type {
@@ -19386,8 +19386,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const parent = container && container.parent;
         if (parent && (isClassLike(parent) || parent.kind === SyntaxKind.InterfaceDeclaration)) {
             if (
-                !isStatic(container) &&
-                (!isConstructorDeclaration(container) || isNodeDescendantOf(node, container.body))
+                !isStatic(container)
+                && (!isConstructorDeclaration(container) || isNodeDescendantOf(node, container.body))
             ) {
                 return getDeclaredTypeOfClassOrInterface(getSymbolOfDeclaration(parent as ClassLikeDeclaration | InterfaceDeclaration)).thisType!;
             }
@@ -19443,8 +19443,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getTypeFromNamedTupleTypeNode(node: NamedTupleMember): Type {
         const links = getNodeLinks(node);
-        return links.resolvedType || (links.resolvedType = node.dotDotDotToken ? getTypeFromRestTypeNode(node) :
-            addOptionality(getTypeFromTypeNode(node.type), /*isProperty*/ true, !!node.questionToken));
+        return links.resolvedType || (links.resolvedType = node.dotDotDotToken ? getTypeFromRestTypeNode(node)
+            : addOptionality(getTypeFromTypeNode(node.type), /*isProperty*/ true, !!node.questionToken));
     }
 
     function getTypeFromTypeNode(node: TypeNode): Type {
@@ -19747,12 +19747,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getObjectTypeInstantiation(type: AnonymousType | DeferredTypeReference, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]) {
-        const declaration = type.objectFlags & ObjectFlags.Reference ? (type as TypeReference).node! :
-            type.objectFlags & ObjectFlags.InstantiationExpressionType ? (type as InstantiationExpressionType).node :
-            type.symbol.declarations![0];
+        const declaration = type.objectFlags & ObjectFlags.Reference ? (type as TypeReference).node!
+            : type.objectFlags & ObjectFlags.InstantiationExpressionType ? (type as InstantiationExpressionType).node
+            : type.symbol.declarations![0];
         const links = getNodeLinks(declaration);
-        const target = type.objectFlags & ObjectFlags.Reference ? links.resolvedType! as DeferredTypeReference :
-            type.objectFlags & ObjectFlags.Instantiated ? type.target! : type;
+        const target = type.objectFlags & ObjectFlags.Reference ? links.resolvedType! as DeferredTypeReference
+            : type.objectFlags & ObjectFlags.Instantiated ? type.target! : type;
         let typeParameters = links.outerTypeParameters;
         if (!typeParameters) {
             // The first time an anonymous type is instantiated we compute and store a list of the type
@@ -19766,9 +19766,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             typeParameters = outerTypeParameters || emptyArray;
             const allDeclarations = type.objectFlags & (ObjectFlags.Reference | ObjectFlags.InstantiationExpressionType) ? [declaration] : type.symbol.declarations!;
-            typeParameters = (target.objectFlags & (ObjectFlags.Reference | ObjectFlags.InstantiationExpressionType) || target.symbol.flags & SymbolFlags.Method || target.symbol.flags & SymbolFlags.TypeLiteral) && !target.aliasTypeArguments ?
-                filter(typeParameters, tp => some(allDeclarations, d => isTypeParameterPossiblyReferenced(tp, d))) :
-                typeParameters;
+            typeParameters = (target.objectFlags & (ObjectFlags.Reference | ObjectFlags.InstantiationExpressionType) || target.symbol.flags & SymbolFlags.Method || target.symbol.flags & SymbolFlags.TypeLiteral) && !target.aliasTypeArguments
+                ? filter(typeParameters, tp => some(allDeclarations, d => isTypeParameterPossiblyReferenced(tp, d)))
+                : typeParameters;
             links.outerTypeParameters = typeParameters;
         }
         if (typeParameters.length) {
@@ -19787,9 +19787,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             let result = target.instantiations.get(id);
             if (!result) {
                 const newMapper = createTypeMapper(typeParameters, typeArguments);
-                result = target.objectFlags & ObjectFlags.Reference ? createDeferredTypeReference((type as DeferredTypeReference).target, (type as DeferredTypeReference).node, newMapper, newAliasSymbol, newAliasTypeArguments) :
-                    target.objectFlags & ObjectFlags.Mapped ? instantiateMappedType(target as MappedType, newMapper, newAliasSymbol, newAliasTypeArguments) :
-                    instantiateAnonymousType(target, newMapper, newAliasSymbol, newAliasTypeArguments);
+                result = target.objectFlags & ObjectFlags.Reference ? createDeferredTypeReference((type as DeferredTypeReference).target, (type as DeferredTypeReference).node, newMapper, newAliasSymbol, newAliasTypeArguments)
+                    : target.objectFlags & ObjectFlags.Mapped ? instantiateMappedType(target as MappedType, newMapper, newAliasSymbol, newAliasTypeArguments)
+                    : instantiateAnonymousType(target, newMapper, newAliasSymbol, newAliasTypeArguments);
                 target.instantiations.set(id, result); // Set cached result early in case we recursively invoke instantiation while eagerly computing type variable visibility below
                 const resultObjectFlags = getObjectFlags(result);
                 if (result.flags & TypeFlags.ObjectFlagsType && !(resultObjectFlags & ObjectFlags.CouldContainTypeVariablesComputed)) {
@@ -19814,8 +19814,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function maybeTypeParameterReference(node: Node) {
-        return !(node.parent.kind === SyntaxKind.TypeReference && (node.parent as TypeReferenceNode).typeArguments && node === (node.parent as TypeReferenceNode).typeName ||
-            node.parent.kind === SyntaxKind.ImportType && (node.parent as ImportTypeNode).typeArguments && node === (node.parent as ImportTypeNode).qualifier);
+        return !(node.parent.kind === SyntaxKind.TypeReference && (node.parent as TypeReferenceNode).typeArguments && node === (node.parent as TypeReferenceNode).typeName
+            || node.parent.kind === SyntaxKind.ImportType && (node.parent as ImportTypeNode).typeArguments && node === (node.parent as ImportTypeNode).qualifier);
     }
 
     function isTypeParameterPossiblyReferenced(tp: TypeParameter, node: Node) {
@@ -19838,29 +19838,29 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.ThisType:
                     return !!tp.isThisType;
                 case SyntaxKind.Identifier:
-                    return !tp.isThisType && isPartOfTypeNode(node) && maybeTypeParameterReference(node) &&
-                        getTypeFromTypeNodeWorker(node as TypeNode) === tp; // use worker because we're looking for === equality
+                    return !tp.isThisType && isPartOfTypeNode(node) && maybeTypeParameterReference(node)
+                        && getTypeFromTypeNodeWorker(node as TypeNode) === tp; // use worker because we're looking for === equality
                 case SyntaxKind.TypeQuery:
                     const entityName = (node as TypeQueryNode).exprName;
                     const firstIdentifier = getFirstIdentifier(entityName);
                     if (!isThisIdentifier(firstIdentifier)) { // Don't attempt to analyze typeof this.xxx
                         const firstIdentifierSymbol = getResolvedSymbol(firstIdentifier);
                         const tpDeclaration = tp.symbol.declarations![0]; // There is exactly one declaration, otherwise `containsReference` is not called
-                        const tpScope = tpDeclaration.kind === SyntaxKind.TypeParameter ? tpDeclaration.parent : // Type parameter is a regular type parameter, e.g. foo<T>
-                            tp.isThisType ? tpDeclaration : // Type parameter is the this type, and its declaration is the class declaration.
-                            undefined; // Type parameter's declaration was unrecognized, e.g. comes from JSDoc annotation.
+                        const tpScope = tpDeclaration.kind === SyntaxKind.TypeParameter ? tpDeclaration.parent // Type parameter is a regular type parameter, e.g. foo<T>
+                            : tp.isThisType ? tpDeclaration // Type parameter is the this type, and its declaration is the class declaration.
+                            : undefined; // Type parameter's declaration was unrecognized, e.g. comes from JSDoc annotation.
                         if (firstIdentifierSymbol.declarations && tpScope) {
-                            return some(firstIdentifierSymbol.declarations, idDecl => isNodeDescendantOf(idDecl, tpScope)) ||
-                                some((node as TypeQueryNode).typeArguments, containsReference);
+                            return some(firstIdentifierSymbol.declarations, idDecl => isNodeDescendantOf(idDecl, tpScope))
+                                || some((node as TypeQueryNode).typeArguments, containsReference);
                         }
                     }
                     return true;
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
-                    return !(node as FunctionLikeDeclaration).type && !!(node as FunctionLikeDeclaration).body ||
-                        some((node as FunctionLikeDeclaration).typeParameters, containsReference) ||
-                        some((node as FunctionLikeDeclaration).parameters, containsReference) ||
-                        !!(node as FunctionLikeDeclaration).type && containsReference((node as FunctionLikeDeclaration).type!);
+                    return !(node as FunctionLikeDeclaration).type && !!(node as FunctionLikeDeclaration).body
+                        || some((node as FunctionLikeDeclaration).typeParameters, containsReference)
+                        || some((node as FunctionLikeDeclaration).parameters, containsReference)
+                        || !!(node as FunctionLikeDeclaration).type && containsReference((node as FunctionLikeDeclaration).type!);
             }
             return !!forEachChild(node, containsReference);
         }
@@ -19904,8 +19904,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!type.declaration.nameType) {
                     let constraint;
                     if (
-                        isArrayType(t) || t.flags & TypeFlags.Any && findResolutionCycleStartIndex(typeVariable!, TypeSystemPropertyName.ImmediateBaseConstraint) < 0 &&
-                            (constraint = getConstraintOfTypeParameter(typeVariable!)) && everyType(constraint, isArrayOrTupleType)
+                        isArrayType(t) || t.flags & TypeFlags.Any && findResolutionCycleStartIndex(typeVariable!, TypeSystemPropertyName.ImmediateBaseConstraint) < 0
+                            && (constraint = getConstraintOfTypeParameter(typeVariable!)) && everyType(constraint, isArrayOrTupleType)
                     ) {
                         return instantiateMappedArrayType(t, type, prependTypeMapping(typeVariable!, t, mapper));
                     }
@@ -19941,32 +19941,32 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const fixedMapper = fixedLength ? prependTypeMapping(typeVariable, tupleType, mapper) : mapper;
         const newElementTypes = map(getElementTypes(tupleType), (type, i) => {
             const flags = elementFlags[i];
-            return i < fixedLength ? instantiateMappedTypeTemplate(mappedType, getStringLiteralType("" + i), !!(flags & ElementFlags.Optional), fixedMapper) :
-                flags & ElementFlags.Variadic ? instantiateType(mappedType, prependTypeMapping(typeVariable, type, mapper)) :
-                getElementTypeOfArrayType(instantiateType(mappedType, prependTypeMapping(typeVariable, createArrayType(type), mapper))) ?? unknownType;
+            return i < fixedLength ? instantiateMappedTypeTemplate(mappedType, getStringLiteralType("" + i), !!(flags & ElementFlags.Optional), fixedMapper)
+                : flags & ElementFlags.Variadic ? instantiateType(mappedType, prependTypeMapping(typeVariable, type, mapper))
+                : getElementTypeOfArrayType(instantiateType(mappedType, prependTypeMapping(typeVariable, createArrayType(type), mapper))) ?? unknownType;
         });
         const modifiers = getMappedTypeModifiers(mappedType);
-        const newElementFlags = modifiers & MappedTypeModifiers.IncludeOptional ? map(elementFlags, f => f & ElementFlags.Required ? ElementFlags.Optional : f) :
-            modifiers & MappedTypeModifiers.ExcludeOptional ? map(elementFlags, f => f & ElementFlags.Optional ? ElementFlags.Required : f) :
-            elementFlags;
+        const newElementFlags = modifiers & MappedTypeModifiers.IncludeOptional ? map(elementFlags, f => f & ElementFlags.Required ? ElementFlags.Optional : f)
+            : modifiers & MappedTypeModifiers.ExcludeOptional ? map(elementFlags, f => f & ElementFlags.Optional ? ElementFlags.Required : f)
+            : elementFlags;
         const newReadonly = getModifiedReadonlyState(tupleType.target.readonly, getMappedTypeModifiers(mappedType));
-        return contains(newElementTypes, errorType) ? errorType :
-            createTupleType(newElementTypes, newElementFlags, newReadonly, tupleType.target.labeledElementDeclarations);
+        return contains(newElementTypes, errorType) ? errorType
+            : createTupleType(newElementTypes, newElementFlags, newReadonly, tupleType.target.labeledElementDeclarations);
     }
 
     function instantiateMappedArrayType(arrayType: Type, mappedType: MappedType, mapper: TypeMapper) {
         const elementType = instantiateMappedTypeTemplate(mappedType, numberType, /*isOptional*/ true, mapper);
-        return isErrorType(elementType) ? errorType :
-            createArrayType(elementType, getModifiedReadonlyState(isReadonlyArrayType(arrayType), getMappedTypeModifiers(mappedType)));
+        return isErrorType(elementType) ? errorType
+            : createArrayType(elementType, getModifiedReadonlyState(isReadonlyArrayType(arrayType), getMappedTypeModifiers(mappedType)));
     }
 
     function instantiateMappedTypeTemplate(type: MappedType, key: Type, isOptional: boolean, mapper: TypeMapper) {
         const templateMapper = appendTypeMapping(mapper, getTypeParameterFromMappedType(type), key);
         const propType = instantiateType(getTemplateTypeFromMappedType(type.target as MappedType || type), templateMapper);
         const modifiers = getMappedTypeModifiers(type);
-        return strictNullChecks && modifiers & MappedTypeModifiers.IncludeOptional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true) :
-            strictNullChecks && modifiers & MappedTypeModifiers.ExcludeOptional && isOptional ? getTypeWithFacts(propType, TypeFacts.NEUndefined) :
-            propType;
+        return strictNullChecks && modifiers & MappedTypeModifiers.IncludeOptional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType, /*isProperty*/ true)
+            : strictNullChecks && modifiers & MappedTypeModifiers.ExcludeOptional && isOptional ? getTypeWithFacts(propType, TypeFacts.NEUndefined)
+            : propType;
     }
 
     function instantiateAnonymousType(type: AnonymousType, mapper: TypeMapper, aliasSymbol?: Symbol, aliasTypeArguments?: readonly Type[]): AnonymousType {
@@ -20008,9 +20008,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // Distributive conditional types are distributed over union types. For example, when the
                 // distributive conditional type T extends U ? X : Y is instantiated with A | B for T, the
                 // result is (A extends U ? X : Y) | (B extends U ? X : Y).
-                result = distributionType && checkType !== distributionType && distributionType.flags & (TypeFlags.Union | TypeFlags.Never) ?
-                    mapTypeWithAlias(distributionType, t => getConditionalType(root, prependTypeMapping(checkType, t, newMapper), forConstraint), aliasSymbol, aliasTypeArguments) :
-                    getConditionalType(root, newMapper, forConstraint, aliasSymbol, aliasTypeArguments);
+                result = distributionType && checkType !== distributionType && distributionType.flags & (TypeFlags.Union | TypeFlags.Never)
+                    ? mapTypeWithAlias(distributionType, t => getConditionalType(root, prependTypeMapping(checkType, t, newMapper), forConstraint), aliasSymbol, aliasTypeArguments)
+                    : getConditionalType(root, newMapper, forConstraint, aliasSymbol, aliasTypeArguments);
                 root.instantiations!.set(id, result);
             }
             return result;
@@ -20073,9 +20073,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const newAliasSymbol = aliasSymbol || type.aliasSymbol;
             const newAliasTypeArguments = aliasSymbol ? aliasTypeArguments : instantiateTypes(type.aliasTypeArguments, mapper);
-            return flags & TypeFlags.Intersection || origin && origin.flags & TypeFlags.Intersection ?
-                getIntersectionType(newTypes, newAliasSymbol, newAliasTypeArguments) :
-                getUnionType(newTypes, UnionReduction.Literal, newAliasSymbol, newAliasTypeArguments);
+            return flags & TypeFlags.Intersection || origin && origin.flags & TypeFlags.Intersection
+                ? getIntersectionType(newTypes, newAliasSymbol, newAliasTypeArguments)
+                : getUnionType(newTypes, UnionReduction.Literal, newAliasSymbol, newAliasTypeArguments);
         }
         if (flags & TypeFlags.Index) {
             return getIndexType(instantiateType((type as IndexType).type, mapper));
@@ -20135,8 +20135,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getPermissiveInstantiation(type: Type) {
-        return type.flags & (TypeFlags.Primitive | TypeFlags.AnyOrUnknown | TypeFlags.Never) ? type :
-            type.permissiveInstantiation || (type.permissiveInstantiation = instantiateType(type, permissiveMapper));
+        return type.flags & (TypeFlags.Primitive | TypeFlags.AnyOrUnknown | TypeFlags.Never) ? type
+            : type.permissiveInstantiation || (type.permissiveInstantiation = instantiateType(type, permissiveMapper));
     }
 
     function getRestrictiveInstantiation(type: Type) {
@@ -20175,11 +20175,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.ArrayLiteralExpression:
                 return some((node as ArrayLiteralExpression).elements, isContextSensitive);
             case SyntaxKind.ConditionalExpression:
-                return isContextSensitive((node as ConditionalExpression).whenTrue) ||
-                    isContextSensitive((node as ConditionalExpression).whenFalse);
+                return isContextSensitive((node as ConditionalExpression).whenTrue)
+                    || isContextSensitive((node as ConditionalExpression).whenFalse);
             case SyntaxKind.BinaryExpression:
-                return ((node as BinaryExpression).operatorToken.kind === SyntaxKind.BarBarToken || (node as BinaryExpression).operatorToken.kind === SyntaxKind.QuestionQuestionToken) &&
-                    (isContextSensitive((node as BinaryExpression).left) || isContextSensitive((node as BinaryExpression).right));
+                return ((node as BinaryExpression).operatorToken.kind === SyntaxKind.BarBarToken || (node as BinaryExpression).operatorToken.kind === SyntaxKind.QuestionQuestionToken)
+                    && (isContextSensitive((node as BinaryExpression).left) || isContextSensitive((node as BinaryExpression).right));
             case SyntaxKind.PropertyAssignment:
                 return isContextSensitive((node as PropertyAssignment).initializer);
             case SyntaxKind.ParenthesizedExpression:
@@ -20216,8 +20216,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isContextSensitiveFunctionOrObjectLiteralMethod(func: Node): func is FunctionExpression | ArrowFunction | MethodDeclaration {
-        return (isFunctionExpressionOrArrowFunction(func) || isObjectLiteralMethod(func)) &&
-            isContextSensitiveFunctionLikeDeclaration(func);
+        return (isFunctionExpressionOrArrowFunction(func) || isObjectLiteralMethod(func))
+            && isContextSensitiveFunctionLikeDeclaration(func);
     }
 
     function getTypeWithoutSignatures(type: Type): Type {
@@ -20280,14 +20280,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // Note that this check ignores type parameters and only considers the
     // inheritance hierarchy.
     function isTypeDerivedFrom(source: Type, target: Type): boolean {
-        return source.flags & TypeFlags.Union ? every((source as UnionType).types, t => isTypeDerivedFrom(t, target)) :
-            target.flags & TypeFlags.Union ? some((target as UnionType).types, t => isTypeDerivedFrom(source, t)) :
-            source.flags & TypeFlags.Intersection ? some((source as IntersectionType).types, t => isTypeDerivedFrom(t, target)) :
-            source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target) :
-            isEmptyAnonymousObjectType(target) ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) :
-            target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) && !isEmptyAnonymousObjectType(source) :
-            target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType) :
-            hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
+        return source.flags & TypeFlags.Union ? every((source as UnionType).types, t => isTypeDerivedFrom(t, target))
+            : target.flags & TypeFlags.Union ? some((target as UnionType).types, t => isTypeDerivedFrom(source, t))
+            : source.flags & TypeFlags.Intersection ? some((source as IntersectionType).types, t => isTypeDerivedFrom(t, target))
+            : source.flags & TypeFlags.InstantiableNonPrimitive ? isTypeDerivedFrom(getBaseConstraintOfType(source) || unknownType, target)
+            : isEmptyAnonymousObjectType(target) ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive))
+            : target === globalObjectType ? !!(source.flags & (TypeFlags.Object | TypeFlags.NonPrimitive)) && !isEmptyAnonymousObjectType(source)
+            : target === globalFunctionType ? !!(source.flags & TypeFlags.Object) && isFunctionObjectType(source as ObjectType)
+            : hasBaseType(source, getTargetType(target)) || (isArrayType(target) && !isReadonlyArrayType(target) && isTypeDerivedFrom(source, globalReadonlyArrayType));
     }
 
     /**
@@ -20908,8 +20908,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         const targetCount = getParameterCount(target);
-        const sourceHasMoreParameters = !hasEffectiveRestParameter(target) &&
-            (checkMode & SignatureCheckMode.StrictArity ? hasEffectiveRestParameter(source) || getParameterCount(source) > targetCount : getMinArgumentCount(source) > targetCount);
+        const sourceHasMoreParameters = !hasEffectiveRestParameter(target)
+            && (checkMode & SignatureCheckMode.StrictArity ? hasEffectiveRestParameter(source) || getParameterCount(source) > targetCount : getMinArgumentCount(source) > targetCount);
         if (sourceHasMoreParameters) {
             if (reportErrors && !(checkMode & SignatureCheckMode.StrictArity)) {
                 // the second condition should be redundant, because there is no error reporting when comparing signatures by strict arity
@@ -20932,8 +20932,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         const kind = target.declaration ? target.declaration.kind : SyntaxKind.Unknown;
-        const strictVariance = !(checkMode & SignatureCheckMode.Callback) && strictFunctionTypes && kind !== SyntaxKind.MethodDeclaration &&
-            kind !== SyntaxKind.MethodSignature && kind !== SyntaxKind.Constructor;
+        const strictVariance = !(checkMode & SignatureCheckMode.Callback) && strictFunctionTypes && kind !== SyntaxKind.MethodDeclaration
+            && kind !== SyntaxKind.MethodSignature && kind !== SyntaxKind.Constructor;
         let result = Ternary.True;
 
         const sourceThisType = getThisTypeOfSignature(source);
@@ -20970,11 +20970,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // with respect to T.
                 const sourceSig = checkMode & SignatureCheckMode.Callback || isInstantiatedGenericParameter(source, i) ? undefined : getSingleCallSignature(getNonNullableType(sourceType));
                 const targetSig = checkMode & SignatureCheckMode.Callback || isInstantiatedGenericParameter(target, i) ? undefined : getSingleCallSignature(getNonNullableType(targetType));
-                const callbacks = sourceSig && targetSig && !getTypePredicateOfSignature(sourceSig) && !getTypePredicateOfSignature(targetSig) &&
-                    getTypeFacts(sourceType, TypeFacts.IsUndefinedOrNull) === getTypeFacts(targetType, TypeFacts.IsUndefinedOrNull);
-                let related = callbacks ?
-                    compareSignaturesRelated(targetSig, sourceSig, (checkMode & SignatureCheckMode.StrictArity) | (strictVariance ? SignatureCheckMode.StrictCallback : SignatureCheckMode.BivariantCallback), reportErrors, errorReporter, incompatibleErrorReporter, compareTypes, reportUnreliableMarkers) :
-                    !(checkMode & SignatureCheckMode.Callback) && !strictVariance && compareTypes(sourceType, targetType, /*reportErrors*/ false) || compareTypes(targetType, sourceType, reportErrors);
+                const callbacks = sourceSig && targetSig && !getTypePredicateOfSignature(sourceSig) && !getTypePredicateOfSignature(targetSig)
+                    && getTypeFacts(sourceType, TypeFacts.IsUndefinedOrNull) === getTypeFacts(targetType, TypeFacts.IsUndefinedOrNull);
+                let related = callbacks
+                    ? compareSignaturesRelated(targetSig, sourceSig, (checkMode & SignatureCheckMode.StrictArity) | (strictVariance ? SignatureCheckMode.StrictCallback : SignatureCheckMode.BivariantCallback), reportErrors, errorReporter, incompatibleErrorReporter, compareTypes, reportUnreliableMarkers)
+                    : !(checkMode & SignatureCheckMode.Callback) && !strictVariance && compareTypes(sourceType, targetType, /*reportErrors*/ false) || compareTypes(targetType, sourceType, reportErrors);
                 // With strict arity, (x: number | undefined) => void is a subtype of (x?: number | undefined) => void
                 if (related && checkMode & SignatureCheckMode.StrictArity && i >= getMinArgumentCount(source) && i < getMinArgumentCount(target) && compareTypes(sourceType, targetType, /*reportErrors*/ false)) {
                     related = Ternary.False;
@@ -21020,8 +21020,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // When relating callback signatures, we still need to relate return types bi-variantly as otherwise
                 // the containing type wouldn't be co-variant. For example, interface Foo<T> { add(cb: () => T): void }
                 // wouldn't be co-variant for T without this rule.
-                result &= checkMode & SignatureCheckMode.BivariantCallback && compareTypes(targetReturnType, sourceReturnType, /*reportErrors*/ false) ||
-                    compareTypes(sourceReturnType, targetReturnType, reportErrors);
+                result &= checkMode & SignatureCheckMode.BivariantCallback && compareTypes(targetReturnType, sourceReturnType, /*reportErrors*/ false)
+                    || compareTypes(sourceReturnType, targetReturnType, reportErrors);
                 if (!result && reportErrors && incompatibleErrorReporter) {
                     incompatibleErrorReporter(sourceReturnType, targetReturnType);
                 }
@@ -21056,9 +21056,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
 
-        const related = source.type === target.type ? Ternary.True :
-            source.type && target.type ? compareTypes(source.type, target.type, reportErrors) :
-            Ternary.False;
+        const related = source.type === target.type ? Ternary.True
+            : source.type && target.type ? compareTypes(source.type, target.type, reportErrors)
+            : Ternary.False;
         if (related === Ternary.False && reportErrors) {
             errorReporter!(Diagnostics.Type_predicate_0_is_not_assignable_to_1, typePredicateToString(source), typePredicateToString(target));
         }
@@ -21084,25 +21084,25 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isEmptyResolvedType(t: ResolvedType) {
-        return t !== anyFunctionType &&
-            t.properties.length === 0 &&
-            t.callSignatures.length === 0 &&
-            t.constructSignatures.length === 0 &&
-            t.indexInfos.length === 0;
+        return t !== anyFunctionType
+            && t.properties.length === 0
+            && t.callSignatures.length === 0
+            && t.constructSignatures.length === 0
+            && t.indexInfos.length === 0;
     }
 
     function isEmptyObjectType(type: Type): boolean {
-        return type.flags & TypeFlags.Object ? !isGenericMappedType(type) && isEmptyResolvedType(resolveStructuredTypeMembers(type as ObjectType)) :
-            type.flags & TypeFlags.NonPrimitive ? true :
-            type.flags & TypeFlags.Union ? some((type as UnionType).types, isEmptyObjectType) :
-            type.flags & TypeFlags.Intersection ? every((type as UnionType).types, isEmptyObjectType) :
-            false;
+        return type.flags & TypeFlags.Object ? !isGenericMappedType(type) && isEmptyResolvedType(resolveStructuredTypeMembers(type as ObjectType))
+            : type.flags & TypeFlags.NonPrimitive ? true
+            : type.flags & TypeFlags.Union ? some((type as UnionType).types, isEmptyObjectType)
+            : type.flags & TypeFlags.Intersection ? every((type as UnionType).types, isEmptyObjectType)
+            : false;
     }
 
     function isEmptyAnonymousObjectType(type: Type) {
         return !!(getObjectFlags(type) & ObjectFlags.Anonymous && (
-            (type as ResolvedType).members && isEmptyResolvedType(type as ResolvedType) ||
-            type.symbol && type.symbol.flags & SymbolFlags.TypeLiteral && getMembersOfSymbol(type.symbol).size === 0
+            (type as ResolvedType).members && isEmptyResolvedType(type as ResolvedType)
+            || type.symbol && type.symbol.flags & SymbolFlags.TypeLiteral && getMembersOfSymbol(type.symbol).size === 0
         ));
     }
 
@@ -21110,8 +21110,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (strictNullChecks && type.flags & TypeFlags.Union) {
             if (!((type as UnionType).objectFlags & ObjectFlags.IsUnknownLikeUnionComputed)) {
                 const types = (type as UnionType).types;
-                (type as UnionType).objectFlags |= ObjectFlags.IsUnknownLikeUnionComputed | (types.length >= 3 && types[0].flags & TypeFlags.Undefined &&
-                        types[1].flags & TypeFlags.Null && some(types, isEmptyAnonymousObjectType) ? ObjectFlags.IsUnknownLikeUnion : 0);
+                (type as UnionType).objectFlags |= ObjectFlags.IsUnknownLikeUnionComputed | (types.length >= 3 && types[0].flags & TypeFlags.Undefined
+                        && types[1].flags & TypeFlags.Null && some(types, isEmptyAnonymousObjectType) ? ObjectFlags.IsUnknownLikeUnion : 0);
             }
             return !!((type as UnionType).objectFlags & ObjectFlags.IsUnknownLikeUnion);
         }
@@ -21123,9 +21123,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isStringIndexSignatureOnlyType(type: Type): boolean {
-        return type.flags & TypeFlags.Object && !isGenericMappedType(type) && getPropertiesOfType(type).length === 0 && getIndexInfosOfType(type).length === 1 && !!getIndexInfoOfType(type, stringType) ||
-            type.flags & TypeFlags.UnionOrIntersection && every((type as UnionOrIntersectionType).types, isStringIndexSignatureOnlyType) ||
-            false;
+        return type.flags & TypeFlags.Object && !isGenericMappedType(type) && getPropertiesOfType(type).length === 0 && getIndexInfosOfType(type).length === 1 && !!getIndexInfoOfType(type, stringType)
+            || type.flags & TypeFlags.UnionOrIntersection && every((type as UnionOrIntersectionType).types, isStringIndexSignatureOnlyType)
+            || false;
     }
 
     function isEnumTypeRelatedTo(source: Symbol, target: Symbol, errorReporter?: ErrorReporter) {
@@ -21210,28 +21210,28 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (t & TypeFlags.Never) return false;
         if (s & TypeFlags.StringLike && t & TypeFlags.String) return true;
         if (
-            s & TypeFlags.StringLiteral && s & TypeFlags.EnumLiteral &&
-            t & TypeFlags.StringLiteral && !(t & TypeFlags.EnumLiteral) &&
-            (source as StringLiteralType).value === (target as StringLiteralType).value
+            s & TypeFlags.StringLiteral && s & TypeFlags.EnumLiteral
+            && t & TypeFlags.StringLiteral && !(t & TypeFlags.EnumLiteral)
+            && (source as StringLiteralType).value === (target as StringLiteralType).value
         ) return true;
         if (s & TypeFlags.NumberLike && t & TypeFlags.Number) return true;
         if (
-            s & TypeFlags.NumberLiteral && s & TypeFlags.EnumLiteral &&
-            t & TypeFlags.NumberLiteral && !(t & TypeFlags.EnumLiteral) &&
-            (source as NumberLiteralType).value === (target as NumberLiteralType).value
+            s & TypeFlags.NumberLiteral && s & TypeFlags.EnumLiteral
+            && t & TypeFlags.NumberLiteral && !(t & TypeFlags.EnumLiteral)
+            && (source as NumberLiteralType).value === (target as NumberLiteralType).value
         ) return true;
         if (s & TypeFlags.BigIntLike && t & TypeFlags.BigInt) return true;
         if (s & TypeFlags.BooleanLike && t & TypeFlags.Boolean) return true;
         if (s & TypeFlags.ESSymbolLike && t & TypeFlags.ESSymbol) return true;
         if (
-            s & TypeFlags.Enum && t & TypeFlags.Enum && source.symbol.escapedName === target.symbol.escapedName &&
-            isEnumTypeRelatedTo(source.symbol, target.symbol, errorReporter)
+            s & TypeFlags.Enum && t & TypeFlags.Enum && source.symbol.escapedName === target.symbol.escapedName
+            && isEnumTypeRelatedTo(source.symbol, target.symbol, errorReporter)
         ) return true;
         if (s & TypeFlags.EnumLiteral && t & TypeFlags.EnumLiteral) {
             if (s & TypeFlags.Union && t & TypeFlags.Union && isEnumTypeRelatedTo(source.symbol, target.symbol, errorReporter)) return true;
             if (
-                s & TypeFlags.Literal && t & TypeFlags.Literal && (source as LiteralType).value === (target as LiteralType).value &&
-                isEnumTypeRelatedTo(source.symbol, target.symbol, errorReporter)
+                s & TypeFlags.Literal && t & TypeFlags.Literal && (source as LiteralType).value === (target as LiteralType).value
+                && isEnumTypeRelatedTo(source.symbol, target.symbol, errorReporter)
             ) return true;
         }
         // In non-strictNullChecks mode, `undefined` and `null` are assignable to anything except `never`.
@@ -21246,9 +21246,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // with a matching value. These rules exist such that enums can be used for bit-flag purposes.
             if (s & TypeFlags.Number && (t & TypeFlags.Enum || t & TypeFlags.NumberLiteral && t & TypeFlags.EnumLiteral)) return true;
             if (
-                s & TypeFlags.NumberLiteral && !(s & TypeFlags.EnumLiteral) && (t & TypeFlags.Enum ||
-                    t & TypeFlags.NumberLiteral && t & TypeFlags.EnumLiteral &&
-                        (source as NumberLiteralType).value === (target as NumberLiteralType).value)
+                s & TypeFlags.NumberLiteral && !(s & TypeFlags.EnumLiteral) && (t & TypeFlags.Enum
+                    || t & TypeFlags.NumberLiteral && t & TypeFlags.EnumLiteral
+                        && (source as NumberLiteralType).value === (target as NumberLiteralType).value)
             ) return true;
             // Anything is assignable to a union containing undefined, null, and {}
             if (isUnknownLikeUnionType(target)) return true;
@@ -21294,13 +21294,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getNormalizedType(type: Type, writing: boolean): Type {
         while (true) {
-            const t = isFreshLiteralType(type) ? (type as FreshableType).regularType :
-                isGenericTupleType(type) ? getNormalizedTupleType(type, writing) :
-                getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) || type :
-                type.flags & TypeFlags.UnionOrIntersection ? getNormalizedUnionOrIntersectionType(type as UnionOrIntersectionType, writing) :
-                type.flags & TypeFlags.Substitution ? writing ? (type as SubstitutionType).baseType : getSubstitutionIntersection(type as SubstitutionType) :
-                type.flags & TypeFlags.Simplifiable ? getSimplifiedType(type, writing) :
-                type;
+            const t = isFreshLiteralType(type) ? (type as FreshableType).regularType
+                : isGenericTupleType(type) ? getNormalizedTupleType(type, writing)
+                : getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).node ? createTypeReference((type as TypeReference).target, getTypeArguments(type as TypeReference)) : getSingleBaseForNonAugmentingSubtype(type) || type
+                : type.flags & TypeFlags.UnionOrIntersection ? getNormalizedUnionOrIntersectionType(type as UnionOrIntersectionType, writing)
+                : type.flags & TypeFlags.Substitution ? writing ? (type as SubstitutionType).baseType : getSubstitutionIntersection(type as SubstitutionType)
+                : type.flags & TypeFlags.Simplifiable ? getSimplifiedType(type, writing)
+                : type;
             if (t === type) return t;
             type = t;
         }
@@ -21393,9 +21393,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const id = getRelationKey(source, target, /*intersectionState*/ IntersectionState.None, relation, /*ignoreConstraints*/ false);
             relation.set(id, RelationComparisonResult.Reported | RelationComparisonResult.Failed);
             tracing?.instant(tracing.Phase.CheckTypes, "checkTypeRelatedTo_DepthLimit", { sourceId: source.id, targetId: target.id, depth: sourceDepth, targetDepth });
-            const message = relationCount <= 0 ?
-                Diagnostics.Excessive_complexity_comparing_types_0_and_1 :
-                Diagnostics.Excessive_stack_depth_comparing_types_0_and_1;
+            const message = relationCount <= 0
+                ? Diagnostics.Excessive_complexity_comparing_types_0_and_1
+                : Diagnostics.Excessive_stack_depth_comparing_types_0_and_1;
             const diag = error(errorNode || currentNode, message, typeToString(source), typeToString(target));
             if (errorOutputContainer) {
                 (errorOutputContainer.errors || (errorOutputContainer.errors = [])).push(diag);
@@ -21527,12 +21527,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             secondaryRootErrors.unshift([mappedMsg, args[0], args[1]]);
                         }
                         else {
-                            const prefix = (msg.code === Diagnostics.Construct_signature_return_types_0_and_1_are_incompatible.code ||
-                                    msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
+                            const prefix = (msg.code === Diagnostics.Construct_signature_return_types_0_and_1_are_incompatible.code
+                                    || msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
                                 ? "new "
                                 : "";
-                            const params = (msg.code === Diagnostics.Call_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code ||
-                                    msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
+                            const params = (msg.code === Diagnostics.Call_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code
+                                    || msg.code === Diagnostics.Construct_signatures_with_no_arguments_have_incompatible_return_types_0_and_1.code)
                                 ? ""
                                 : "...";
                             path = `${prefix}${path}(${params})`;
@@ -21615,9 +21615,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             // If `target` is of indexed access type (And `source` it is not), we use the object type of `target` for better error reporting
-            const targetFlags = target.flags & TypeFlags.IndexedAccess && !(source.flags & TypeFlags.IndexedAccess) ?
-                (target as IndexedAccessType).objectType.flags :
-                target.flags;
+            const targetFlags = target.flags & TypeFlags.IndexedAccess && !(source.flags & TypeFlags.IndexedAccess)
+                ? (target as IndexedAccessType).objectType.flags
+                : target.flags;
 
             if (targetFlags & TypeFlags.TypeParameter && target !== markerSuperTypeForCheck && target !== markerSubTypeForCheck) {
                 const constraint = getBaseConstraintOfType(target);
@@ -21677,10 +21677,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const targetType = symbolValueDeclarationIsContextSensitive(target.symbol) ? typeToString(target, target.symbol.valueDeclaration) : typeToString(target);
 
             if (
-                (globalStringType === source && stringType === target) ||
-                (globalNumberType === source && numberType === target) ||
-                (globalBooleanType === source && booleanType === target) ||
-                (getGlobalESSymbolType() === source && esSymbolType === target)
+                (globalStringType === source && stringType === target)
+                || (globalNumberType === source && numberType === target)
+                || (globalBooleanType === source && booleanType === target)
+                || (getGlobalESSymbolType() === source && esSymbolType === target)
             ) {
                 reportError(Diagnostics._0_is_a_primitive_but_1_is_a_wrapper_object_Prefer_using_0_when_possible, targetType, sourceType);
             }
@@ -21738,8 +21738,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // skip all the checks we don't need and just return `isSimpleTypeRelatedTo` result
             if (originalSource.flags & TypeFlags.Object && originalTarget.flags & TypeFlags.Primitive) {
                 if (
-                    relation === comparableRelation && !(originalTarget.flags & TypeFlags.Never) && isSimpleTypeRelatedTo(originalTarget, originalSource, relation) ||
-                    isSimpleTypeRelatedTo(originalSource, originalTarget, relation, reportErrors ? reportError : undefined)
+                    relation === comparableRelation && !(originalTarget.flags & TypeFlags.Never) && isSimpleTypeRelatedTo(originalTarget, originalSource, relation)
+                    || isSimpleTypeRelatedTo(originalSource, originalTarget, relation, reportErrors ? reportError : undefined)
                 ) {
                     return Ternary.True;
                 }
@@ -21778,9 +21778,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // plus a single non-nullable type. If so, remove null and/or undefined from the target type.
             if (source.flags & TypeFlags.DefinitelyNonNullable && target.flags & TypeFlags.Union) {
                 const types = (target as UnionType).types;
-                const candidate = types.length === 2 && types[0].flags & TypeFlags.Nullable ? types[1] :
-                    types.length === 3 && types[0].flags & TypeFlags.Nullable && types[1].flags & TypeFlags.Nullable ? types[2] :
-                    undefined;
+                const candidate = types.length === 2 && types[0].flags & TypeFlags.Nullable ? types[1]
+                    : types.length === 3 && types[0].flags & TypeFlags.Nullable && types[1].flags & TypeFlags.Nullable ? types[2]
+                    : undefined;
                 if (candidate && !(candidate.flags & TypeFlags.Nullable)) {
                     target = getNormalizedType(candidate, /*writing*/ true);
                     if (source === target) return Ternary.True;
@@ -21788,8 +21788,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             if (
-                relation === comparableRelation && !(target.flags & TypeFlags.Never) && isSimpleTypeRelatedTo(target, source, relation) ||
-                isSimpleTypeRelatedTo(source, target, relation, reportErrors ? reportError : undefined)
+                relation === comparableRelation && !(target.flags & TypeFlags.Never) && isSimpleTypeRelatedTo(target, source, relation)
+                || isSimpleTypeRelatedTo(source, target, relation, reportErrors ? reportError : undefined)
             ) return Ternary.True;
 
             if (source.flags & TypeFlags.StructuredOrInstantiable || target.flags & TypeFlags.StructuredOrInstantiable) {
@@ -21803,11 +21803,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
 
-                const isPerformingCommonPropertyChecks = (relation !== comparableRelation || isUnitType(source)) &&
-                    !(intersectionState & IntersectionState.Target) &&
-                    source.flags & (TypeFlags.Primitive | TypeFlags.Object | TypeFlags.Intersection) && source !== globalObjectType &&
-                    target.flags & (TypeFlags.Object | TypeFlags.Intersection) && isWeakType(target) &&
-                    (getPropertiesOfType(source).length > 0 || typeHasCallOrConstructSignatures(source));
+                const isPerformingCommonPropertyChecks = (relation !== comparableRelation || isUnitType(source))
+                    && !(intersectionState & IntersectionState.Target)
+                    && source.flags & (TypeFlags.Primitive | TypeFlags.Object | TypeFlags.Intersection) && source !== globalObjectType
+                    && target.flags & (TypeFlags.Object | TypeFlags.Intersection) && isWeakType(target)
+                    && (getPropertiesOfType(source).length > 0 || typeHasCallOrConstructSignatures(source));
                 const isComparingJsxAttributes = !!(getObjectFlags(source) & ObjectFlags.JsxAttributes);
                 if (isPerformingCommonPropertyChecks && !hasCommonProperties(source, target, isComparingJsxAttributes)) {
                     if (reportErrors) {
@@ -21816,8 +21816,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const calls = getSignaturesOfType(source, SignatureKind.Call);
                         const constructs = getSignaturesOfType(source, SignatureKind.Construct);
                         if (
-                            calls.length > 0 && isRelatedTo(getReturnTypeOfSignature(calls[0]), target, RecursionFlags.Source, /*reportErrors*/ false) ||
-                            constructs.length > 0 && isRelatedTo(getReturnTypeOfSignature(constructs[0]), target, RecursionFlags.Source, /*reportErrors*/ false)
+                            calls.length > 0 && isRelatedTo(getReturnTypeOfSignature(calls[0]), target, RecursionFlags.Source, /*reportErrors*/ false)
+                            || constructs.length > 0 && isRelatedTo(getReturnTypeOfSignature(constructs[0]), target, RecursionFlags.Source, /*reportErrors*/ false)
                         ) {
                             reportError(Diagnostics.Value_of_type_0_has_no_properties_in_common_with_type_1_Did_you_mean_to_call_it, sourceString, targetString);
                         }
@@ -21830,11 +21830,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                 traceUnionsOrIntersectionsTooLarge(source, target);
 
-                const skipCaching = source.flags & TypeFlags.Union && (source as UnionType).types.length < 4 && !(target.flags & TypeFlags.Union) ||
-                    target.flags & TypeFlags.Union && (target as UnionType).types.length < 4 && !(source.flags & TypeFlags.StructuredOrInstantiable);
-                const result = skipCaching ?
-                    unionOrIntersectionRelatedTo(source, target, reportErrors, intersectionState) :
-                    recursiveTypeRelatedTo(source, target, reportErrors, intersectionState, recursionFlags);
+                const skipCaching = source.flags & TypeFlags.Union && (source as UnionType).types.length < 4 && !(target.flags & TypeFlags.Union)
+                    || target.flags & TypeFlags.Union && (target as UnionType).types.length < 4 && !(source.flags & TypeFlags.StructuredOrInstantiable);
+                const result = skipCaching
+                    ? unionOrIntersectionRelatedTo(source, target, reportErrors, intersectionState)
+                    : recursiveTypeRelatedTo(source, target, reportErrors, intersectionState, recursionFlags);
                 if (result) {
                     return result;
                 }
@@ -21873,8 +21873,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const intrinsicAttributes = getJsxType(JsxNames.IntrinsicAttributes, errorNode);
                 const intrinsicClassAttributes = getJsxType(JsxNames.IntrinsicClassAttributes, errorNode);
                 if (
-                    !isErrorType(intrinsicAttributes) && !isErrorType(intrinsicClassAttributes) &&
-                    (contains(targetTypes, intrinsicAttributes) || contains(targetTypes, intrinsicClassAttributes))
+                    !isErrorType(intrinsicAttributes) && !isErrorType(intrinsicClassAttributes)
+                    && (contains(targetTypes, intrinsicAttributes) || contains(targetTypes, intrinsicClassAttributes))
                 ) {
                     // do not report top error
                     return;
@@ -21944,8 +21944,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const isComparingJsxAttributes = !!(getObjectFlags(source) & ObjectFlags.JsxAttributes);
             if (
-                (relation === assignableRelation || relation === comparableRelation) &&
-                (isTypeSubsetOf(globalObjectType, target) || (!isComparingJsxAttributes && isEmptyObjectType(target)))
+                (relation === assignableRelation || relation === comparableRelation)
+                && (isTypeSubsetOf(globalObjectType, target) || (!isComparingJsxAttributes && isEmptyObjectType(target)))
             ) {
                 return false;
             }
@@ -22045,9 +22045,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return Ternary.True;
                     }
                 }
-                return relation === comparableRelation ?
-                    someTypeRelatedToType(source as UnionType, target, reportErrors && !(source.flags & TypeFlags.Primitive), intersectionState) :
-                    eachTypeRelatedToType(source as UnionType, target, reportErrors && !(source.flags & TypeFlags.Primitive), intersectionState);
+                return relation === comparableRelation
+                    ? someTypeRelatedToType(source as UnionType, target, reportErrors && !(source.flags & TypeFlags.Primitive), intersectionState)
+                    : eachTypeRelatedToType(source as UnionType, target, reportErrors && !(source.flags & TypeFlags.Primitive), intersectionState);
             }
             if (target.flags & TypeFlags.Union) {
                 return typeRelatedToSomeType(getRegularTypeOfObjectLiteral(source), target as UnionType, reportErrors && !(source.flags & TypeFlags.Primitive) && !(target.flags & TypeFlags.Primitive), intersectionState);
@@ -22068,8 +22068,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return Ternary.False;
                     }
                     if (!(source.flags & TypeFlags.Intersection)) {
-                        return isRelatedTo(source, target, RecursionFlags.Source, /*reportErrors*/ false) ||
-                            isRelatedTo(target, source, RecursionFlags.Source, /*reportErrors*/ false);
+                        return isRelatedTo(source, target, RecursionFlags.Source, /*reportErrors*/ false)
+                            || isRelatedTo(target, source, RecursionFlags.Source, /*reportErrors*/ false);
                     }
                 }
             }
@@ -22101,8 +22101,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 if (
                     relation !== comparableRelation && getObjectFlags(target) & ObjectFlags.PrimitiveUnion && !(source.flags & TypeFlags.EnumLiteral) && (
-                        source.flags & (TypeFlags.StringLiteral | TypeFlags.BooleanLiteral | TypeFlags.BigIntLiteral) ||
-                        (relation === subtypeRelation || relation === strictSubtypeRelation) && source.flags & TypeFlags.NumberLiteral
+                        source.flags & (TypeFlags.StringLiteral | TypeFlags.BooleanLiteral | TypeFlags.BigIntLiteral)
+                        || (relation === subtypeRelation || relation === strictSubtypeRelation) && source.flags & TypeFlags.NumberLiteral
                     )
                 ) {
                     // When relating a literal type to a union of primitive types, we know the relation is false unless
@@ -22112,10 +22112,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // identically named enum types are related (see isEnumTypeRelatedTo). We exclude the comparable
                     // relation in entirety because it needs to be checked in both directions.
                     const alternateForm = source === (source as StringLiteralType).regularType ? (source as StringLiteralType).freshType : (source as StringLiteralType).regularType;
-                    const primitive = source.flags & TypeFlags.StringLiteral ? stringType :
-                        source.flags & TypeFlags.NumberLiteral ? numberType :
-                        source.flags & TypeFlags.BigIntLiteral ? bigintType :
-                        undefined;
+                    const primitive = source.flags & TypeFlags.StringLiteral ? stringType
+                        : source.flags & TypeFlags.NumberLiteral ? numberType
+                        : source.flags & TypeFlags.BigIntLiteral ? bigintType
+                        : undefined;
                     return primitive && containsType(targetTypes, primitive) || alternateForm && containsType(targetTypes, alternateForm) ? Ternary.True : Ternary.False;
                 }
                 const match = getMatchingUnionConstituentForType(target as UnionType, source);
@@ -22172,8 +22172,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function getUndefinedStrippedTargetIfNeeded(source: Type, target: Type) {
             if (
-                source.flags & TypeFlags.Union && target.flags & TypeFlags.Union &&
-                !((source as UnionType).types[0].flags & TypeFlags.Undefined) && (target as UnionType).types[0].flags & TypeFlags.Undefined
+                source.flags & TypeFlags.Union && target.flags & TypeFlags.Union
+                && !((source as UnionType).types[0].flags & TypeFlags.Undefined) && (target as UnionType).types[0].flags & TypeFlags.Undefined
             ) {
                 return extractTypesOfKind(target, ~TypeFlags.Undefined);
             }
@@ -22448,8 +22448,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 //   let weak: { a?: { x?: number } } & { c?: string } = wrong;  // Nested weak object type
                 //
                 if (
-                    result && !(intersectionState & IntersectionState.Target) && target.flags & TypeFlags.Intersection &&
-                    !isGenericObjectType(target) && source.flags & (TypeFlags.Object | TypeFlags.Intersection)
+                    result && !(intersectionState & IntersectionState.Target) && target.flags & TypeFlags.Intersection
+                    && !isGenericObjectType(target) && source.flags & (TypeFlags.Object | TypeFlags.Intersection)
                 ) {
                     result &= propertiesRelatedTo(source, target, reportErrors, /*excludedProperties*/ undefined, /*optionalsOnly*/ false, IntersectionState.None);
                     if (result && isObjectLiteralType(source) && getObjectFlags(source) & ObjectFlags.FreshLiteral) {
@@ -22464,9 +22464,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 //   }
                 //
                 else if (
-                    result && isNonGenericObjectType(target) && !isArrayOrTupleType(target) &&
-                    source.flags & TypeFlags.Intersection && getApparentType(source).flags & TypeFlags.StructuredType &&
-                    !some((source as IntersectionType).types, t => t === target || !!(getObjectFlags(t) & ObjectFlags.NonInferrableType))
+                    result && isNonGenericObjectType(target) && !isArrayOrTupleType(target)
+                    && source.flags & TypeFlags.Intersection && getApparentType(source).flags & TypeFlags.StructuredType
+                    && !some((source as IntersectionType).types, t => t === target || !!(getObjectFlags(t) & ObjectFlags.NonInferrableType))
                 ) {
                     result &= propertiesRelatedTo(source, target, reportErrors, /*excludedProperties*/ undefined, /*optionalsOnly*/ true, intersectionState);
                 }
@@ -22549,9 +22549,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // Source is an intersection, target is a union (e.g. { a } & { b: boolean } <=> { a, b: true } | { a, b: false }).
                 // Source is an intersection, target instantiable (e.g. string & { tag } <=> T["a"] constrained to string & { tag }).
                 if (
-                    !(sourceFlags & TypeFlags.Instantiable ||
-                        sourceFlags & TypeFlags.Object && targetFlags & TypeFlags.Union ||
-                        sourceFlags & TypeFlags.Intersection && targetFlags & (TypeFlags.Object | TypeFlags.Union | TypeFlags.Instantiable))
+                    !(sourceFlags & TypeFlags.Instantiable
+                        || sourceFlags & TypeFlags.Object && targetFlags & TypeFlags.Union
+                        || sourceFlags & TypeFlags.Intersection && targetFlags & (TypeFlags.Object | TypeFlags.Union | TypeFlags.Instantiable))
                 ) {
                     return Ternary.False;
                 }
@@ -22561,8 +22561,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // is more predictable than other, interned types, which may or may not have an alias depending on
             // the order in which things were checked.
             if (
-                sourceFlags & (TypeFlags.Object | TypeFlags.Conditional) && source.aliasSymbol && source.aliasTypeArguments &&
-                source.aliasSymbol === target.aliasSymbol && !(isMarkerType(source) || isMarkerType(target))
+                sourceFlags & (TypeFlags.Object | TypeFlags.Conditional) && source.aliasSymbol && source.aliasTypeArguments
+                && source.aliasSymbol === target.aliasSymbol && !(isMarkerType(source) || isMarkerType(target))
             ) {
                 const variances = getAliasVariances(source.aliasSymbol);
                 if (variances === emptyArray) {
@@ -22581,8 +22581,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // For a generic type T and a type U that is assignable to T, [...U] is assignable to T, U is assignable to readonly [...T],
             // and U is assignable to [...T] when U is constrained to a mutable array or tuple type.
             if (
-                isSingleElementGenericTupleType(source) && !source.target.readonly && (result = isRelatedTo(getTypeArguments(source)[0], target, RecursionFlags.Source)) ||
-                isSingleElementGenericTupleType(target) && (target.target.readonly || isMutableArrayOrTuple(getBaseConstraintOfType(source) || source)) && (result = isRelatedTo(source, getTypeArguments(target)[0], RecursionFlags.Target))
+                isSingleElementGenericTupleType(source) && !source.target.readonly && (result = isRelatedTo(getTypeArguments(source)[0], target, RecursionFlags.Source))
+                || isSingleElementGenericTupleType(target) && (target.target.readonly || isMutableArrayOrTuple(getBaseConstraintOfType(source) || source)) && (result = isRelatedTo(source, getTypeArguments(target)[0], RecursionFlags.Target))
             ) {
                 return result;
             }
@@ -22717,8 +22717,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // If the mapped type has shape `{ [P in Q]: T[P] }`,
                     // source `S` is related to target if `T` = `S`, i.e. `S` is related to `{ [P in Q]: S[P] }`.
                     if (
-                        !keysRemapped && templateType.flags & TypeFlags.IndexedAccess && (templateType as IndexedAccessType).objectType === source &&
-                        (templateType as IndexedAccessType).indexType === getTypeParameterFromMappedType(target)
+                        !keysRemapped && templateType.flags & TypeFlags.IndexedAccess && (templateType as IndexedAccessType).objectType === source
+                        && (templateType as IndexedAccessType).indexType === getTypeParameterFromMappedType(target)
                     ) {
                         return Ternary.True;
                     }
@@ -22910,8 +22910,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         mapper = ctx.mapper;
                     }
                     if (
-                        isTypeIdenticalTo(sourceExtends, (target as ConditionalType).extendsType) &&
-                        (isRelatedTo((source as ConditionalType).checkType, (target as ConditionalType).checkType, RecursionFlags.Both) || isRelatedTo((target as ConditionalType).checkType, (source as ConditionalType).checkType, RecursionFlags.Both))
+                        isTypeIdenticalTo(sourceExtends, (target as ConditionalType).extendsType)
+                        && (isRelatedTo((source as ConditionalType).checkType, (target as ConditionalType).checkType, RecursionFlags.Both) || isRelatedTo((target as ConditionalType).checkType, (source as ConditionalType).checkType, RecursionFlags.Both))
                     ) {
                         if (result = isRelatedTo(instantiateType(getTrueTypeFromConditionalType(source as ConditionalType), mapper), getTrueTypeFromConditionalType(target as ConditionalType), RecursionFlags.Both, reportErrors)) {
                             result &= isRelatedTo(getFalseTypeFromConditionalType(source as ConditionalType), getFalseTypeFromConditionalType(target as ConditionalType), RecursionFlags.Both, reportErrors);
@@ -22961,8 +22961,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return Ternary.False;
                 }
                 if (
-                    getObjectFlags(source) & ObjectFlags.Reference && getObjectFlags(target) & ObjectFlags.Reference && (source as TypeReference).target === (target as TypeReference).target &&
-                    !isTupleType(source) && !(isMarkerType(source) || isMarkerType(target))
+                    getObjectFlags(source) & ObjectFlags.Reference && getObjectFlags(target) & ObjectFlags.Reference && (source as TypeReference).target === (target as TypeReference).target
+                    && !isTupleType(source) && !(isMarkerType(source) || isMarkerType(target))
                 ) {
                     // When strictNullChecks is disabled, the element type of the empty array literal is undefinedWideningType,
                     // and an empty array literal wouldn't be assignable to a `never[]` without this check.
@@ -23098,8 +23098,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // related to Y, where X' is an instantiation of X in which P is replaced with Q. Notice
         // that S and T are contra-variant whereas X and Y are co-variant.
         function mappedTypeRelatedTo(source: MappedType, target: MappedType, reportErrors: boolean): Ternary {
-            const modifiersRelated = relation === comparableRelation || (relation === identityRelation ? getMappedTypeModifiers(source) === getMappedTypeModifiers(target) :
-                getCombinedMappedTypeOptionality(source) <= getCombinedMappedTypeOptionality(target));
+            const modifiersRelated = relation === comparableRelation || (relation === identityRelation ? getMappedTypeModifiers(source) === getMappedTypeModifiers(target)
+                : getCombinedMappedTypeOptionality(source) <= getCombinedMappedTypeOptionality(target));
             if (modifiersRelated) {
                 let result: Ternary;
                 const targetConstraint = getConstraintTypeFromMappedType(target);
@@ -23271,8 +23271,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // They're still assignable to one another, since `readonly` doesn't affect assignability.
             // This is only applied during the strictSubtypeRelation -- currently used in subtype reduction
             if (
-                relation === strictSubtypeRelation &&
-                isReadonlySymbol(sourceProp) && !isReadonlySymbol(targetProp)
+                relation === strictSubtypeRelation
+                && isReadonlySymbol(sourceProp) && !isReadonlySymbol(targetProp)
             ) {
                 return Ternary.False;
             }
@@ -23327,8 +23327,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const props = arrayFrom(getUnmatchedProperties(source, target, requireOptionalProperties, /*matchDiscriminantProperties*/ false));
             if (
-                !headMessage || (headMessage.code !== Diagnostics.Class_0_incorrectly_implements_interface_1.code &&
-                    headMessage.code !== Diagnostics.Class_0_incorrectly_implements_class_1_Did_you_mean_to_extend_1_and_inherit_its_members_as_a_subclass.code)
+                !headMessage || (headMessage.code !== Diagnostics.Class_0_incorrectly_implements_interface_1.code
+                    && headMessage.code !== Diagnostics.Class_0_incorrectly_implements_class_1_Did_you_mean_to_extend_1_and_inherit_its_members_as_a_subclass.code)
             ) {
                 shouldSkipElaboration = true; // Retain top-level error for interface implementing issues, otherwise omit it
             }
@@ -23442,8 +23442,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         const sourceType = removeMissingType(sourceTypeArguments[sourcePosition], !!(sourceFlags & targetFlags & ElementFlags.Optional));
                         const targetType = targetTypeArguments[targetPosition];
 
-                        const targetCheckType = sourceFlags & ElementFlags.Variadic && targetFlags & ElementFlags.Rest ? createArrayType(targetType) :
-                            removeMissingType(targetType, !!(targetFlags & ElementFlags.Optional));
+                        const targetCheckType = sourceFlags & ElementFlags.Variadic && targetFlags & ElementFlags.Rest ? createArrayType(targetType)
+                            : removeMissingType(targetType, !!(targetFlags & ElementFlags.Optional));
                         const related = isRelatedTo(sourceType, targetCheckType, RecursionFlags.Both, reportErrors, /*headMessage*/ undefined, intersectionState);
                         if (!related) {
                             if (reportErrors && (targetArity > 1 || sourceArity > 1)) {
@@ -23542,13 +23542,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             const sourceSignatures = getSignaturesOfType(
                 source,
-                (sourceIsJSConstructor && kind === SignatureKind.Construct) ?
-                    SignatureKind.Call : kind,
+                (sourceIsJSConstructor && kind === SignatureKind.Construct)
+                    ? SignatureKind.Call : kind,
             );
             const targetSignatures = getSignaturesOfType(
                 target,
-                (targetIsJSConstructor && kind === SignatureKind.Construct) ?
-                    SignatureKind.Call : kind,
+                (targetIsJSConstructor && kind === SignatureKind.Construct)
+                    ? SignatureKind.Call : kind,
             );
 
             if (kind === SignatureKind.Construct && sourceSignatures.length && targetSignatures.length) {
@@ -23574,8 +23574,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const sourceObjectFlags = getObjectFlags(source);
             const targetObjectFlags = getObjectFlags(target);
             if (
-                sourceObjectFlags & ObjectFlags.Instantiated && targetObjectFlags & ObjectFlags.Instantiated && source.symbol === target.symbol ||
-                sourceObjectFlags & ObjectFlags.Reference && targetObjectFlags & ObjectFlags.Reference && (source as TypeReference).target === (target as TypeReference).target
+                sourceObjectFlags & ObjectFlags.Instantiated && targetObjectFlags & ObjectFlags.Instantiated && source.symbol === target.symbol
+                || sourceObjectFlags & ObjectFlags.Reference && targetObjectFlags & ObjectFlags.Reference && (source as TypeReference).target === (target as TypeReference).target
             ) {
                 // We have instantiations of the same anonymous type (which typically will be the type of a
                 // method). Simply do a pairwise comparison of the signatures in the two signature lists instead
@@ -23601,8 +23601,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const targetSignature = first(targetSignatures);
                 result = signatureRelatedTo(sourceSignature, targetSignature, eraseGenerics, reportErrors, intersectionState, incompatibleReporter(sourceSignature, targetSignature));
                 if (
-                    !result && reportErrors && kind === SignatureKind.Construct && (sourceObjectFlags & targetObjectFlags) &&
-                    (targetSignature.declaration?.kind === SyntaxKind.Constructor || sourceSignature.declaration?.kind === SyntaxKind.Constructor)
+                    !result && reportErrors && kind === SignatureKind.Construct && (sourceObjectFlags & targetObjectFlags)
+                    && (targetSignature.declaration?.kind === SyntaxKind.Constructor || sourceSignature.declaration?.kind === SyntaxKind.Constructor)
                 ) {
                     const constructSignatureToString = (signature: Signature) => signatureToString(signature, /*enclosingDeclaration*/ undefined, TypeFormatFlags.WriteArrowStyleSignature, kind);
                     reportError(Diagnostics.Type_0_is_not_assignable_to_type_1, constructSignatureToString(sourceSignature), constructSignatureToString(targetSignature));
@@ -23640,8 +23640,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const typeProperties = getPropertiesOfObjectType(source);
             if ((typeCallSignatures.length || typeConstructSignatures.length) && !typeProperties.length) {
                 if (
-                    (getSignaturesOfType(target, SignatureKind.Call).length && typeCallSignatures.length) ||
-                    (getSignaturesOfType(target, SignatureKind.Construct).length && typeConstructSignatures.length)
+                    (getSignaturesOfType(target, SignatureKind.Call).length && typeCallSignatures.length)
+                    || (getSignaturesOfType(target, SignatureKind.Construct).length && typeConstructSignatures.length)
                 ) {
                     return true; // target has similar signature kinds to source, still focus on the unmatched property
                 }
@@ -23668,9 +23668,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
          * See signatureAssignableTo, compareSignaturesIdentical
          */
         function signatureRelatedTo(source: Signature, target: Signature, erase: boolean, reportErrors: boolean, intersectionState: IntersectionState, incompatibleReporter: (source: Type, target: Type) => void): Ternary {
-            const checkMode = relation === subtypeRelation ? SignatureCheckMode.StrictTopSignature :
-                relation === strictSubtypeRelation ? SignatureCheckMode.StrictTopSignature | SignatureCheckMode.StrictArity :
-                SignatureCheckMode.None;
+            const checkMode = relation === subtypeRelation ? SignatureCheckMode.StrictTopSignature
+                : relation === strictSubtypeRelation ? SignatureCheckMode.StrictTopSignature | SignatureCheckMode.StrictArity
+                : SignatureCheckMode.None;
             return compareSignaturesRelated(erase ? getErasedSignature(source) : source, erase ? getErasedSignature(target) : target, checkMode, reportErrors, reportError, incompatibleReporter, isRelatedToWorker, reportUnreliableMapper);
             function isRelatedToWorker(source: Type, target: Type, reportErrors?: boolean) {
                 return isRelatedTo(source, target, RecursionFlags.Both, reportErrors, /*headMessage*/ undefined, intersectionState);
@@ -23751,9 +23751,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const targetHasStringIndex = some(indexInfos, info => info.keyType === stringType);
             let result = Ternary.True;
             for (const targetInfo of indexInfos) {
-                const related = relation !== strictSubtypeRelation && !sourceIsPrimitive && targetHasStringIndex && targetInfo.type.flags & TypeFlags.Any ? Ternary.True :
-                    isGenericMappedType(source) && targetHasStringIndex ? isRelatedTo(getTemplateTypeFromMappedType(source), targetInfo.type, RecursionFlags.Both, reportErrors) :
-                    typeRelatedToIndexInfo(source, targetInfo, reportErrors, intersectionState);
+                const related = relation !== strictSubtypeRelation && !sourceIsPrimitive && targetHasStringIndex && targetInfo.type.flags & TypeFlags.Any ? Ternary.True
+                    : isGenericMappedType(source) && targetHasStringIndex ? isRelatedTo(getTemplateTypeFromMappedType(source), targetInfo.type, RecursionFlags.Both, reportErrors)
+                    : typeRelatedToIndexInfo(source, targetInfo, reportErrors, intersectionState);
                 if (!related) {
                     return Ternary.False;
                 }
@@ -23862,11 +23862,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getBestMatchingType(source: Type, target: UnionOrIntersectionType, isRelatedTo = compareTypesAssignable) {
-        return findMatchingDiscriminantType(source, target, isRelatedTo) ||
-            findMatchingTypeReferenceOrTypeAliasReference(source, target) ||
-            findBestTypeForObjectLiteral(source, target) ||
-            findBestTypeForInvokable(source, target) ||
-            findMostOverlappyType(source, target);
+        return findMatchingDiscriminantType(source, target, isRelatedTo)
+            || findMatchingTypeReferenceOrTypeAliasReference(source, target)
+            || findBestTypeForObjectLiteral(source, target)
+            || findBestTypeForInvokable(source, target)
+            || findMostOverlappyType(source, target);
     }
 
     function discriminateTypeByDiscriminableItems(target: UnionType, discriminators: (readonly [() => Type, __String])[], related: (source: Type, target: Type) => boolean | Ternary) {
@@ -23906,8 +23906,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isWeakType(type: Type): boolean {
         if (type.flags & TypeFlags.Object) {
             const resolved = resolveStructuredTypeMembers(type as ObjectType);
-            return resolved.callSignatures.length === 0 && resolved.constructSignatures.length === 0 && resolved.indexInfos.length === 0 &&
-                resolved.properties.length > 0 && every(resolved.properties, p => !!(p.flags & SymbolFlags.Optional));
+            return resolved.callSignatures.length === 0 && resolved.constructSignatures.length === 0 && resolved.indexInfos.length === 0
+                && resolved.properties.length > 0 && every(resolved.properties, p => !!(p.flags & SymbolFlags.Optional));
         }
         if (type.flags & TypeFlags.Intersection) {
             return every((type as IntersectionType).types, isWeakType);
@@ -23926,9 +23926,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getVariances(type: GenericType): VarianceFlags[] {
         // Arrays and tuples are known to be covariant, no need to spend time computing this.
-        return type === globalArrayType || type === globalReadonlyArrayType || type.objectFlags & ObjectFlags.Tuple ?
-            arrayVariances :
-            getVariancesWorker(type.symbol, type.typeParameters);
+        return type === globalArrayType || type === globalReadonlyArrayType || type.objectFlags & ObjectFlags.Tuple
+            ? arrayVariances
+            : getVariancesWorker(type.symbol, type.typeParameters);
     }
 
     function getAliasVariances(symbol: Symbol) {
@@ -23953,9 +23953,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const variances = [];
             for (const tp of typeParameters) {
                 const modifiers = getTypeParameterModifiers(tp);
-                let variance = modifiers & ModifierFlags.Out ?
-                    modifiers & ModifierFlags.In ? VarianceFlags.Invariant : VarianceFlags.Covariant :
-                    modifiers & ModifierFlags.In ? VarianceFlags.Contravariant : undefined;
+                let variance = modifiers & ModifierFlags.Out
+                    ? modifiers & ModifierFlags.In ? VarianceFlags.Invariant : VarianceFlags.Covariant
+                    : modifiers & ModifierFlags.In ? VarianceFlags.Contravariant : undefined;
                 if (variance === undefined) {
                     let unmeasurable = false;
                     let unreliable = false;
@@ -23966,8 +23966,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // invariance, covariance, contravariance or bivariance.
                     const typeWithSuper = createMarkerType(symbol, tp, markerSuperType);
                     const typeWithSub = createMarkerType(symbol, tp, markerSubType);
-                    variance = (isTypeAssignableTo(typeWithSub, typeWithSuper) ? VarianceFlags.Covariant : 0) |
-                        (isTypeAssignableTo(typeWithSuper, typeWithSub) ? VarianceFlags.Contravariant : 0);
+                    variance = (isTypeAssignableTo(typeWithSub, typeWithSuper) ? VarianceFlags.Covariant : 0)
+                        | (isTypeAssignableTo(typeWithSuper, typeWithSub) ? VarianceFlags.Contravariant : 0);
                     // If the instantiations appear to be related bivariantly it may be because the
                     // type parameter is independent (i.e. it isn't witnessed anywhere in the generic
                     // type). To determine this we compare instantiations where the type parameter is
@@ -24003,9 +24003,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isErrorType(type)) {
             return type;
         }
-        const result = symbol.flags & SymbolFlags.TypeAlias ?
-            getTypeAliasInstantiation(symbol, instantiateTypes(getSymbolLinks(symbol).typeParameters!, mapper)) :
-            createTypeReference(type as GenericType, instantiateTypes((type as GenericType).typeParameters, mapper));
+        const result = symbol.flags & SymbolFlags.TypeAlias
+            ? getTypeAliasInstantiation(symbol, instantiateTypes(getSymbolLinks(symbol).typeParameters!, mapper))
+            : createTypeReference(type as GenericType, instantiateTypes((type as GenericType).typeParameters, mapper));
         markerTypes.add(getTypeId(result));
         return result;
     }
@@ -24087,9 +24087,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             target = temp;
         }
         const postFix = intersectionState ? ":" + intersectionState : "";
-        return isTypeReferenceWithGenericArguments(source) && isTypeReferenceWithGenericArguments(target) ?
-            getGenericTypeReferenceRelationKey(source as TypeReference, target as TypeReference, postFix, ignoreConstraints) :
-            `${source.id},${target.id}${postFix}`;
+        return isTypeReferenceWithGenericArguments(source) && isTypeReferenceWithGenericArguments(target)
+            ? getGenericTypeReferenceRelationKey(source as TypeReference, target as TypeReference, postFix, ignoreConstraints)
+            : `${source.id},${target.id}${postFix}`;
     }
 
     // Invoke the callback for each underlying property symbol of the given symbol and return the first
@@ -24133,16 +24133,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // Return true if source property is a valid override of protected parts of target property.
     function isValidOverrideOf(sourceProp: Symbol, targetProp: Symbol) {
         return !forEachProperty(targetProp, tp =>
-            getDeclarationModifierFlagsFromSymbol(tp) & ModifierFlags.Protected ?
-                !isPropertyInClassDerivedFrom(sourceProp, getDeclaringClass(tp)) : false);
+            getDeclarationModifierFlagsFromSymbol(tp) & ModifierFlags.Protected
+                ? !isPropertyInClassDerivedFrom(sourceProp, getDeclaringClass(tp)) : false);
     }
 
     // Return true if the given class derives from each of the declaring classes of the protected
     // constituents of the given property.
     function isClassDerivedFromDeclaringClasses<T extends Type>(checkClass: T, prop: Symbol, writing: boolean) {
         return forEachProperty(prop, p =>
-                getDeclarationModifierFlagsFromSymbol(p, writing) & ModifierFlags.Protected ?
-                    !hasBaseType(checkClass, getDeclaringClass(p)) : false) ? undefined : checkClass;
+                getDeclarationModifierFlagsFromSymbol(p, writing) & ModifierFlags.Protected
+                    ? !hasBaseType(checkClass, getDeclaringClass(p)) : false) ? undefined : checkClass;
     }
 
     // Return true if the given type is deeply nested. We consider this to be the case when the given stack contains
@@ -24192,9 +24192,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getMappedTargetWithSymbol(type: Type) {
         let target;
         while (
-            (getObjectFlags(type) & ObjectFlags.InstantiatedMapped) === ObjectFlags.InstantiatedMapped &&
-            (target = getModifiersTypeFromMappedType(type as MappedType)) &&
-            (target.symbol || target.flags & TypeFlags.Intersection && some((target as IntersectionType).types, t => !!t.symbol))
+            (getObjectFlags(type) & ObjectFlags.InstantiatedMapped) === ObjectFlags.InstantiatedMapped
+            && (target = getModifiersTypeFromMappedType(type as MappedType))
+            && (target.symbol || target.flags & TypeFlags.Intersection && some((target as IntersectionType).types, t => !!t.symbol))
         ) {
             type = target;
         }
@@ -24297,9 +24297,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // A source signature matches a target signature if the two signatures have the same number of required,
         // optional, and rest parameters.
         if (
-            sourceParameterCount === targetParameterCount &&
-            sourceMinArgumentCount === targetMinArgumentCount &&
-            sourceHasRestParameter === targetHasRestParameter
+            sourceParameterCount === targetParameterCount
+            && sourceMinArgumentCount === targetMinArgumentCount
+            && sourceHasRestParameter === targetHasRestParameter
         ) {
             return true;
         }
@@ -24334,8 +24334,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const s = source.typeParameters![i];
                 const t = target.typeParameters[i];
                 if (
-                    !(s === t || compareTypes(instantiateType(getConstraintFromTypeParameter(s), mapper) || unknownType, getConstraintFromTypeParameter(t) || unknownType) &&
-                            compareTypes(instantiateType(getDefaultFromTypeParameter(s), mapper) || unknownType, getDefaultFromTypeParameter(t) || unknownType))
+                    !(s === t || compareTypes(instantiateType(getConstraintFromTypeParameter(s), mapper) || unknownType, getConstraintFromTypeParameter(t) || unknownType)
+                            && compareTypes(instantiateType(getDefaultFromTypeParameter(s), mapper) || unknownType, getDefaultFromTypeParameter(t) || unknownType))
                 ) {
                     return Ternary.False;
                 }
@@ -24369,18 +24369,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!ignoreReturnTypes) {
             const sourceTypePredicate = getTypePredicateOfSignature(source);
             const targetTypePredicate = getTypePredicateOfSignature(target);
-            result &= sourceTypePredicate || targetTypePredicate ?
-                compareTypePredicatesIdentical(sourceTypePredicate, targetTypePredicate, compareTypes) :
-                compareTypes(getReturnTypeOfSignature(source), getReturnTypeOfSignature(target));
+            result &= sourceTypePredicate || targetTypePredicate
+                ? compareTypePredicatesIdentical(sourceTypePredicate, targetTypePredicate, compareTypes)
+                : compareTypes(getReturnTypeOfSignature(source), getReturnTypeOfSignature(target));
         }
         return result;
     }
 
     function compareTypePredicatesIdentical(source: TypePredicate | undefined, target: TypePredicate | undefined, compareTypes: (s: Type, t: Type) => Ternary): Ternary {
-        return !(source && target && typePredicateKindsMatch(source, target)) ? Ternary.False :
-            source.type === target.type ? Ternary.True :
-            source.type && target.type ? compareTypes(source.type, target.type) :
-            Ternary.False;
+        return !(source && target && typePredicateKindsMatch(source, target)) ? Ternary.False
+            : source.type === target.type ? Ternary.True
+            : source.type && target.type ? compareTypes(source.type, target.type)
+            : Ternary.False;
     }
 
     function literalTypesWithSameBaseType(types: Type[]): boolean {
@@ -24410,9 +24410,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // When the candidate types are all literal types with the same base type, return a union
         // of those literal types. Otherwise, return the leftmost type for which no type to the
         // right is a supertype.
-        const superTypeOrUnion = literalTypesWithSameBaseType(primaryTypes) ?
-            getUnionType(primaryTypes) :
-            reduceLeft(primaryTypes, (s, t) => isTypeSubtypeOf(s, t) ? t : s)!;
+        const superTypeOrUnion = literalTypesWithSameBaseType(primaryTypes)
+            ? getUnionType(primaryTypes)
+            : reduceLeft(primaryTypes, (s, t) => isTypeSubtypeOf(s, t) ? t : s)!;
         // Add any nullable types that occurred in the candidates back to the result.
         return primaryTypes === types ? superTypeOrUnion : getNullableType(superTypeOrUnion, getCombinedTypeFlags(types) & TypeFlags.Nullable);
     }
@@ -24497,9 +24497,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isTupleLikeType(type: Type): boolean {
         let lengthType;
-        return isTupleType(type) ||
-            !!getPropertyOfType(type, "0" as __String) ||
-            isArrayLikeType(type) && !!(lengthType = getTypeOfPropertyOfType(type, "length" as __String)) && everyType(lengthType, t => !!(t.flags & TypeFlags.NumberLiteral));
+        return isTupleType(type)
+            || !!getPropertyOfType(type, "0" as __String)
+            || isArrayLikeType(type) && !!(lengthType = getTypeOfPropertyOfType(type, "length" as __String)) && everyType(lengthType, t => !!(t.flags & TypeFlags.NumberLiteral));
     }
 
     function isArrayOrTupleLikeType(type: Type): boolean {
@@ -24537,19 +24537,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isLiteralType(type: Type): boolean {
-        return type.flags & TypeFlags.Boolean ? true :
-            type.flags & TypeFlags.Union ? type.flags & TypeFlags.EnumLiteral ? true : every((type as UnionType).types, isUnitType) :
-            isUnitType(type);
+        return type.flags & TypeFlags.Boolean ? true
+            : type.flags & TypeFlags.Union ? type.flags & TypeFlags.EnumLiteral ? true : every((type as UnionType).types, isUnitType)
+            : isUnitType(type);
     }
 
     function getBaseTypeOfLiteralType(type: Type): Type {
-        return type.flags & TypeFlags.EnumLike ? getBaseTypeOfEnumLikeType(type as LiteralType) :
-            type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType :
-            type.flags & TypeFlags.NumberLiteral ? numberType :
-            type.flags & TypeFlags.BigIntLiteral ? bigintType :
-            type.flags & TypeFlags.BooleanLiteral ? booleanType :
-            type.flags & TypeFlags.Union ? getBaseTypeOfLiteralTypeUnion(type as UnionType) :
-            type;
+        return type.flags & TypeFlags.EnumLike ? getBaseTypeOfEnumLikeType(type as LiteralType)
+            : type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType
+            : type.flags & TypeFlags.NumberLiteral ? numberType
+            : type.flags & TypeFlags.BigIntLiteral ? bigintType
+            : type.flags & TypeFlags.BooleanLiteral ? booleanType
+            : type.flags & TypeFlags.Union ? getBaseTypeOfLiteralTypeUnion(type as UnionType)
+            : type;
     }
 
     function getBaseTypeOfLiteralTypeUnion(type: UnionType) {
@@ -24560,28 +24560,28 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // This like getBaseTypeOfLiteralType, but instead treats enum literals as strings/numbers instead
     // of returning their enum base type (which depends on the types of other literals in the enum).
     function getBaseTypeOfLiteralTypeForComparison(type: Type): Type {
-        return type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType :
-            type.flags & (TypeFlags.NumberLiteral | TypeFlags.Enum) ? numberType :
-            type.flags & TypeFlags.BigIntLiteral ? bigintType :
-            type.flags & TypeFlags.BooleanLiteral ? booleanType :
-            type.flags & TypeFlags.Union ? mapType(type, getBaseTypeOfLiteralTypeForComparison) :
-            type;
+        return type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? stringType
+            : type.flags & (TypeFlags.NumberLiteral | TypeFlags.Enum) ? numberType
+            : type.flags & TypeFlags.BigIntLiteral ? bigintType
+            : type.flags & TypeFlags.BooleanLiteral ? booleanType
+            : type.flags & TypeFlags.Union ? mapType(type, getBaseTypeOfLiteralTypeForComparison)
+            : type;
     }
 
     function getWidenedLiteralType(type: Type): Type {
-        return type.flags & TypeFlags.EnumLike && isFreshLiteralType(type) ? getBaseTypeOfEnumLikeType(type as LiteralType) :
-            type.flags & TypeFlags.StringLiteral && isFreshLiteralType(type) ? stringType :
-            type.flags & TypeFlags.NumberLiteral && isFreshLiteralType(type) ? numberType :
-            type.flags & TypeFlags.BigIntLiteral && isFreshLiteralType(type) ? bigintType :
-            type.flags & TypeFlags.BooleanLiteral && isFreshLiteralType(type) ? booleanType :
-            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedLiteralType) :
-            type;
+        return type.flags & TypeFlags.EnumLike && isFreshLiteralType(type) ? getBaseTypeOfEnumLikeType(type as LiteralType)
+            : type.flags & TypeFlags.StringLiteral && isFreshLiteralType(type) ? stringType
+            : type.flags & TypeFlags.NumberLiteral && isFreshLiteralType(type) ? numberType
+            : type.flags & TypeFlags.BigIntLiteral && isFreshLiteralType(type) ? bigintType
+            : type.flags & TypeFlags.BooleanLiteral && isFreshLiteralType(type) ? booleanType
+            : type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedLiteralType)
+            : type;
     }
 
     function getWidenedUniqueESSymbolType(type: Type): Type {
-        return type.flags & TypeFlags.UniqueESSymbol ? esSymbolType :
-            type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedUniqueESSymbolType) :
-            type;
+        return type.flags & TypeFlags.UniqueESSymbol ? esSymbolType
+            : type.flags & TypeFlags.Union ? mapType(type as UnionType, getWidenedUniqueESSymbolType)
+            : type;
     }
 
     function getWidenedLiteralLikeTypeForContextualType(type: Type, contextualType: Type | undefined) {
@@ -24593,9 +24593,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getWidenedLiteralLikeTypeForContextualReturnTypeIfNeeded(type: Type | undefined, contextualSignatureReturnType: Type | undefined, isAsync: boolean) {
         if (type && isUnitType(type)) {
-            const contextualType = !contextualSignatureReturnType ? undefined :
-                isAsync ? getPromisedTypeOfPromise(contextualSignatureReturnType) :
-                contextualSignatureReturnType;
+            const contextualType = !contextualSignatureReturnType ? undefined
+                : isAsync ? getPromisedTypeOfPromise(contextualSignatureReturnType)
+                : contextualSignatureReturnType;
             type = getWidenedLiteralLikeTypeForContextualType(type, contextualType);
         }
         return type;
@@ -24603,8 +24603,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded(type: Type | undefined, contextualSignatureReturnType: Type | undefined, kind: IterationTypeKind, isAsyncGenerator: boolean) {
         if (type && isUnitType(type)) {
-            const contextualType = !contextualSignatureReturnType ? undefined :
-                getIterationTypeOfGeneratorFunctionReturnType(kind, contextualSignatureReturnType, isAsyncGenerator);
+            const contextualType = !contextualSignatureReturnType ? undefined
+                : getIterationTypeOfGeneratorFunctionReturnType(kind, contextualSignatureReturnType, isAsyncGenerator);
             type = getWidenedLiteralLikeTypeForContextualType(type, contextualType);
         }
         return type;
@@ -24664,8 +24664,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTupleTypeStructureMatching(t1: TupleTypeReference, t2: TupleTypeReference) {
-        return getTypeReferenceArity(t1) === getTypeReferenceArity(t2) &&
-            every(t1.target.elementFlags, (f, i) => (f & ElementFlags.Variable) === (t2.target.elementFlags[i] & ElementFlags.Variable));
+        return getTypeReferenceArity(t1) === getTypeReferenceArity(t2)
+            && every(t1.target.elementFlags, (f, i) => (f & ElementFlags.Variable) === (t2.target.elementFlags[i] & ElementFlags.Variable));
     }
 
     function isZeroBigInt({ value }: BigIntLiteralType) {
@@ -24681,16 +24681,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getDefinitelyFalsyPartOfType(type: Type): Type {
-        return type.flags & TypeFlags.String ? emptyStringType :
-            type.flags & TypeFlags.Number ? zeroType :
-            type.flags & TypeFlags.BigInt ? zeroBigIntType :
-            type === regularFalseType ||
-                type === falseType ||
-                type.flags & (TypeFlags.Void | TypeFlags.Undefined | TypeFlags.Null | TypeFlags.AnyOrUnknown) ||
-                type.flags & TypeFlags.StringLiteral && (type as StringLiteralType).value === "" ||
-                type.flags & TypeFlags.NumberLiteral && (type as NumberLiteralType).value === 0 ||
-                type.flags & TypeFlags.BigIntLiteral && isZeroBigInt(type as BigIntLiteralType) ? type :
-            neverType;
+        return type.flags & TypeFlags.String ? emptyStringType
+            : type.flags & TypeFlags.Number ? zeroType
+            : type.flags & TypeFlags.BigInt ? zeroBigIntType
+            : type === regularFalseType
+                    || type === falseType
+                    || type.flags & (TypeFlags.Void | TypeFlags.Undefined | TypeFlags.Null | TypeFlags.AnyOrUnknown)
+                    || type.flags & TypeFlags.StringLiteral && (type as StringLiteralType).value === ""
+                    || type.flags & TypeFlags.NumberLiteral && (type as NumberLiteralType).value === 0
+                    || type.flags & TypeFlags.BigIntLiteral && isZeroBigInt(type as BigIntLiteralType) ? type
+            : neverType;
     }
 
     /**
@@ -24700,10 +24700,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      */
     function getNullableType(type: Type, flags: TypeFlags): Type {
         const missing = (flags & ~type.flags) & (TypeFlags.Undefined | TypeFlags.Null);
-        return missing === 0 ? type :
-            missing === TypeFlags.Undefined ? getUnionType([type, undefinedType]) :
-            missing === TypeFlags.Null ? getUnionType([type, nullType]) :
-            getUnionType([type, undefinedType, nullType]);
+        return missing === 0 ? type
+            : missing === TypeFlags.Undefined ? getUnionType([type, undefinedType])
+            : missing === TypeFlags.Null ? getUnionType([type, nullType])
+            : getUnionType([type, undefinedType, nullType]);
     }
 
     function getOptionalType(type: Type, isProperty = false): Type {
@@ -24716,9 +24716,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!deferredGlobalNonNullableTypeAlias) {
             deferredGlobalNonNullableTypeAlias = getGlobalSymbol("NonNullable" as __String, SymbolFlags.TypeAlias, /*diagnostic*/ undefined) || unknownSymbol;
         }
-        return deferredGlobalNonNullableTypeAlias !== unknownSymbol ?
-            getTypeAliasInstantiation(deferredGlobalNonNullableTypeAlias, [type]) :
-            getIntersectionType([type, emptyObjectType]);
+        return deferredGlobalNonNullableTypeAlias !== unknownSymbol
+            ? getTypeAliasInstantiation(deferredGlobalNonNullableTypeAlias, [type])
+            : getIntersectionType([type, emptyObjectType]);
     }
 
     function getNonNullableType(type: Type): Type {
@@ -24738,9 +24738,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getOptionalExpressionType(exprType: Type, expression: Expression) {
-        return isExpressionOfOptionalChainRoot(expression) ? getNonNullableType(exprType) :
-            isOptionalChain(expression) ? removeOptionalTypeMarker(exprType) :
-            exprType;
+        return isExpressionOfOptionalChainRoot(expression) ? getNonNullableType(exprType)
+            : isOptionalChain(expression) ? removeOptionalTypeMarker(exprType)
+            : exprType;
     }
 
     function removeMissingType(type: Type, isOptional: boolean) {
@@ -25028,10 +25028,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (isIdentifier(param.name)) {
                     const originalKeywordKind = identifierToKeywordKind(param.name);
                     if (
-                        (isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent)) &&
-                        param.parent.parameters.includes(param) &&
-                        (resolveName(param, param.name.escapedText, SymbolFlags.Type, /*nameNotFoundMessage*/ undefined, param.name.escapedText, /*isUse*/ true) ||
-                            originalKeywordKind && isTypeNodeKind(originalKeywordKind))
+                        (isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent))
+                        && param.parent.parameters.includes(param)
+                        && (resolveName(param, param.name.escapedText, SymbolFlags.Type, /*nameNotFoundMessage*/ undefined, param.name.escapedText, /*isUse*/ true)
+                            || originalKeywordKind && isTypeNodeKind(originalKeywordKind))
                     ) {
                         const newName = "arg" + param.parent.parameters.indexOf(param);
                         const typeName = declarationNameToString(param.name) + (param.dotDotDotToken ? "[]" : "");
@@ -25039,9 +25039,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return;
                     }
                 }
-                diagnostic = (declaration as ParameterDeclaration).dotDotDotToken ?
-                    noImplicitAny ? Diagnostics.Rest_parameter_0_implicitly_has_an_any_type : Diagnostics.Rest_parameter_0_implicitly_has_an_any_type_but_a_better_type_may_be_inferred_from_usage :
-                    noImplicitAny ? Diagnostics.Parameter_0_implicitly_has_an_1_type : Diagnostics.Parameter_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage;
+                diagnostic = (declaration as ParameterDeclaration).dotDotDotToken
+                    ? noImplicitAny ? Diagnostics.Rest_parameter_0_implicitly_has_an_any_type : Diagnostics.Rest_parameter_0_implicitly_has_an_any_type_but_a_better_type_may_be_inferred_from_usage
+                    : noImplicitAny ? Diagnostics.Parameter_0_implicitly_has_an_1_type : Diagnostics.Parameter_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage;
                 break;
             case SyntaxKind.BindingElement:
                 diagnostic = Diagnostics.Binding_element_0_implicitly_has_an_1_type;
@@ -25074,9 +25074,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     return;
                 }
-                diagnostic = !noImplicitAny ? Diagnostics._0_implicitly_has_an_1_return_type_but_a_better_type_may_be_inferred_from_usage :
-                    wideningKind === WideningKind.GeneratorYield ? Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_yield_type :
-                    Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type;
+                diagnostic = !noImplicitAny ? Diagnostics._0_implicitly_has_an_1_return_type_but_a_better_type_may_be_inferred_from_usage
+                    : wideningKind === WideningKind.GeneratorYield ? Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_yield_type
+                    : Diagnostics._0_which_lacks_return_type_annotation_implicitly_has_an_1_return_type;
                 break;
             case SyntaxKind.MappedType:
                 if (noImplicitAny) {
@@ -25208,9 +25208,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function inferFromIntraExpressionSites(context: InferenceContext) {
         if (context.intraExpressionInferenceSites) {
             for (const { node, type } of context.intraExpressionInferenceSites) {
-                const contextualType = node.kind === SyntaxKind.MethodDeclaration ?
-                    getContextualTypeForObjectLiteralMethod(node as MethodDeclaration, ContextFlags.NoConstraints) :
-                    getContextualType(node, ContextFlags.NoConstraints);
+                const contextualType = node.kind === SyntaxKind.MethodDeclaration
+                    ? getContextualTypeForObjectLiteralMethod(node as MethodDeclaration, ContextFlags.NoConstraints)
+                    : getContextualType(node, ContextFlags.NoConstraints);
                 if (contextualType) {
                     inferTypes(context.inferences, type, contextualType);
                 }
@@ -25247,9 +25247,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function cloneInferredPartOfContext(context: InferenceContext): InferenceContext | undefined {
         const inferences = filter(context.inferences, hasInferenceCandidates);
-        return inferences.length ?
-            createInferenceContextWorker(map(inferences, cloneInferenceInfo), context.signature, context.flags, context.compareTypes) :
-            undefined;
+        return inferences.length
+            ? createInferenceContextWorker(map(inferences, cloneInferenceInfo), context.signature, context.flags, context.compareTypes)
+            : undefined;
     }
 
     function getMapperFromContext<T extends InferenceContext | undefined>(context: T): TypeMapper | T & undefined {
@@ -25264,13 +25264,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (objectFlags & ObjectFlags.CouldContainTypeVariablesComputed) {
             return !!(objectFlags & ObjectFlags.CouldContainTypeVariables);
         }
-        const result = !!(type.flags & TypeFlags.Instantiable ||
-            type.flags & TypeFlags.Object && !isNonGenericTopLevelType(type) && (
-                    objectFlags & ObjectFlags.Reference && ((type as TypeReference).node || some(getTypeArguments(type as TypeReference), couldContainTypeVariables)) ||
-                    objectFlags & ObjectFlags.Anonymous && type.symbol && type.symbol.flags & (SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.TypeLiteral | SymbolFlags.ObjectLiteral) && type.symbol.declarations ||
-                    objectFlags & (ObjectFlags.Mapped | ObjectFlags.ReverseMapped | ObjectFlags.ObjectRestType | ObjectFlags.InstantiationExpressionType)
-                ) ||
-            type.flags & TypeFlags.UnionOrIntersection && !(type.flags & TypeFlags.EnumLiteral) && !isNonGenericTopLevelType(type) && some((type as UnionOrIntersectionType).types, couldContainTypeVariables));
+        const result = !!(type.flags & TypeFlags.Instantiable
+            || type.flags & TypeFlags.Object && !isNonGenericTopLevelType(type) && (
+                    objectFlags & ObjectFlags.Reference && ((type as TypeReference).node || some(getTypeArguments(type as TypeReference), couldContainTypeVariables))
+                    || objectFlags & ObjectFlags.Anonymous && type.symbol && type.symbol.flags & (SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.TypeLiteral | SymbolFlags.ObjectLiteral) && type.symbol.declarations
+                    || objectFlags & (ObjectFlags.Mapped | ObjectFlags.ReverseMapped | ObjectFlags.ObjectRestType | ObjectFlags.InstantiationExpressionType)
+                )
+            || type.flags & TypeFlags.UnionOrIntersection && !(type.flags & TypeFlags.EnumLiteral) && !isNonGenericTopLevelType(type) && some((type as UnionOrIntersectionType).types, couldContainTypeVariables));
         if (type.flags & TypeFlags.ObjectFlagsType) {
             (type as ObjectFlagsType).objectFlags |= ObjectFlags.CouldContainTypeVariablesComputed | (result ? ObjectFlags.CouldContainTypeVariables : 0);
         }
@@ -25286,18 +25286,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTypeParameterAtTopLevel(type: Type, tp: TypeParameter, depth = 0): boolean {
-        return !!(type === tp ||
-            type.flags & TypeFlags.UnionOrIntersection && some((type as UnionOrIntersectionType).types, t => isTypeParameterAtTopLevel(t, tp, depth)) ||
-            depth < 3 && type.flags & TypeFlags.Conditional && (
-                    isTypeParameterAtTopLevel(getTrueTypeFromConditionalType(type as ConditionalType), tp, depth + 1) ||
-                    isTypeParameterAtTopLevel(getFalseTypeFromConditionalType(type as ConditionalType), tp, depth + 1)
+        return !!(type === tp
+            || type.flags & TypeFlags.UnionOrIntersection && some((type as UnionOrIntersectionType).types, t => isTypeParameterAtTopLevel(t, tp, depth))
+            || depth < 3 && type.flags & TypeFlags.Conditional && (
+                    isTypeParameterAtTopLevel(getTrueTypeFromConditionalType(type as ConditionalType), tp, depth + 1)
+                    || isTypeParameterAtTopLevel(getFalseTypeFromConditionalType(type as ConditionalType), tp, depth + 1)
                 ));
     }
 
     function isTypeParameterAtTopLevelInReturnType(signature: Signature, typeParameter: TypeParameter) {
         const typePredicate = getTypePredicateOfSignature(signature);
-        return typePredicate ? !!typePredicate.type && isTypeParameterAtTopLevel(typePredicate.type, typeParameter) :
-            isTypeParameterAtTopLevel(getReturnTypeOfSignature(signature), typeParameter);
+        return typePredicate ? !!typePredicate.type && isTypeParameterAtTopLevel(typePredicate.type, typeParameter)
+            : isTypeParameterAtTopLevel(getReturnTypeOfSignature(signature), typeParameter);
     }
 
     /** Create an object with properties named in the string literal type. Every property has type `any` */
@@ -25347,9 +25347,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // literal { a: 123, b: x => true } is marked non-inferable because it contains a context sensitive
     // arrow function, but is considered partially inferable because property 'a' has an inferable type.
     function isPartiallyInferableType(type: Type): boolean {
-        return !(getObjectFlags(type) & ObjectFlags.NonInferrableType) ||
-            isObjectLiteralType(type) && some(getPropertiesOfType(type), prop => isPartiallyInferableType(getTypeOfSymbol(prop))) ||
-            isTupleType(type) && some(getElementTypes(type), isPartiallyInferableType);
+        return !(getObjectFlags(type) & ObjectFlags.NonInferrableType)
+            || isObjectLiteralType(type) && some(getPropertiesOfType(type), prop => isPartiallyInferableType(getTypeOfSymbol(prop)))
+            || isTupleType(type) && some(getElementTypes(type), isPartiallyInferableType);
     }
 
     function createReverseMappedType(source: Type, target: MappedType, constraint: IndexType) {
@@ -25365,9 +25365,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (isTupleType(source)) {
             const elementTypes = map(getElementTypes(source), t => inferReverseMappedType(t, target, constraint));
-            const elementFlags = getMappedTypeModifiers(target) & MappedTypeModifiers.IncludeOptional ?
-                sameMap(source.target.elementFlags, f => f & ElementFlags.Optional ? ElementFlags.Required : f) :
-                source.target.elementFlags;
+            const elementFlags = getMappedTypeModifiers(target) & MappedTypeModifiers.IncludeOptional
+                ? sameMap(source.target.elementFlags, f => f & ElementFlags.Optional ? ElementFlags.Required : f)
+                : source.target.elementFlags;
             return createTupleType(elementTypes, elementFlags, source.target.readonly, source.target.labeledElementDeclarations);
         }
         // For all other object types we infer a new object type where the reverse mapping has been
@@ -25425,22 +25425,22 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function tupleTypesDefinitelyUnrelated(source: TupleTypeReference, target: TupleTypeReference) {
-        return !(target.target.combinedFlags & ElementFlags.Variadic) && target.target.minLength > source.target.minLength ||
-            !target.target.hasRestElement && (source.target.hasRestElement || target.target.fixedLength < source.target.fixedLength);
+        return !(target.target.combinedFlags & ElementFlags.Variadic) && target.target.minLength > source.target.minLength
+            || !target.target.hasRestElement && (source.target.hasRestElement || target.target.fixedLength < source.target.fixedLength);
     }
 
     function typesDefinitelyUnrelated(source: Type, target: Type) {
         // Two tuple types with incompatible arities are definitely unrelated.
         // Two object types that each have a property that is unmatched in the other are definitely unrelated.
-        return isTupleType(source) && isTupleType(target) ? tupleTypesDefinitelyUnrelated(source, target) :
-            !!getUnmatchedProperty(source, target, /*requireOptionalProperties*/ false, /*matchDiscriminantProperties*/ true) &&
-            !!getUnmatchedProperty(target, source, /*requireOptionalProperties*/ false, /*matchDiscriminantProperties*/ false);
+        return isTupleType(source) && isTupleType(target) ? tupleTypesDefinitelyUnrelated(source, target)
+            : !!getUnmatchedProperty(source, target, /*requireOptionalProperties*/ false, /*matchDiscriminantProperties*/ true)
+                && !!getUnmatchedProperty(target, source, /*requireOptionalProperties*/ false, /*matchDiscriminantProperties*/ false);
     }
 
     function getTypeFromInference(inference: InferenceInfo) {
-        return inference.candidates ? getUnionType(inference.candidates, UnionReduction.Subtype) :
-            inference.contraCandidates ? getIntersectionType(inference.contraCandidates) :
-            undefined;
+        return inference.candidates ? getUnionType(inference.candidates, UnionReduction.Subtype)
+            : inference.contraCandidates ? getIntersectionType(inference.contraCandidates)
+            : undefined;
     }
 
     function hasSkipDirectInferenceFlag(node: Node) {
@@ -25459,8 +25459,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const targetEnd = target.texts[target.texts.length - 1];
         const startLen = Math.min(sourceStart.length, targetStart.length);
         const endLen = Math.min(sourceEnd.length, targetEnd.length);
-        return sourceStart.slice(0, startLen) !== targetStart.slice(0, startLen) ||
-            sourceEnd.slice(sourceEnd.length - endLen) !== targetEnd.slice(targetEnd.length - endLen);
+        return sourceStart.slice(0, startLen) !== targetStart.slice(0, startLen)
+            || sourceEnd.slice(sourceEnd.length - endLen) !== targetEnd.slice(targetEnd.length - endLen);
     }
 
     /**
@@ -25516,11 +25516,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (source.flags & TypeFlags.StringLiteral) {
             const value = (source as StringLiteralType).value;
-            return !!(target.flags & TypeFlags.Number && isValidNumberString(value, /*roundTripOnly*/ false) ||
-                target.flags & TypeFlags.BigInt && isValidBigIntString(value, /*roundTripOnly*/ false) ||
-                target.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) && value === (target as IntrinsicType).intrinsicName ||
-                target.flags & TypeFlags.StringMapping && isMemberOfStringMapping(getStringLiteralType(value), target) ||
-                target.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, target as TemplateLiteralType));
+            return !!(target.flags & TypeFlags.Number && isValidNumberString(value, /*roundTripOnly*/ false)
+                || target.flags & TypeFlags.BigInt && isValidBigIntString(value, /*roundTripOnly*/ false)
+                || target.flags & (TypeFlags.BooleanLiteral | TypeFlags.Nullable) && value === (target as IntrinsicType).intrinsicName
+                || target.flags & TypeFlags.StringMapping && isMemberOfStringMapping(getStringLiteralType(value), target)
+                || target.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, target as TemplateLiteralType));
         }
         if (source.flags & TypeFlags.TemplateLiteral) {
             const texts = (source as TemplateLiteralType).texts;
@@ -25530,13 +25530,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function inferTypesFromTemplateLiteralType(source: Type, target: TemplateLiteralType): Type[] | undefined {
-        return source.flags & TypeFlags.StringLiteral ? inferFromLiteralPartsToTemplateLiteral([(source as StringLiteralType).value], emptyArray, target) :
-            source.flags & TypeFlags.TemplateLiteral ?
-            arraysEqual((source as TemplateLiteralType).texts, target.texts) ? map((source as TemplateLiteralType).types, (s, i) => {
+        return source.flags & TypeFlags.StringLiteral ? inferFromLiteralPartsToTemplateLiteral([(source as StringLiteralType).value], emptyArray, target)
+            : source.flags & TypeFlags.TemplateLiteral
+            ? arraysEqual((source as TemplateLiteralType).texts, target.texts) ? map((source as TemplateLiteralType).types, (s, i) => {
                 return isTypeAssignableTo(getBaseConstraintOrType(s), getBaseConstraintOrType(target.types[i])) ? s : getStringLikeTypeForType(s);
-            }) :
-                inferFromLiteralPartsToTemplateLiteral((source as TemplateLiteralType).texts, (source as TemplateLiteralType).types, target) :
-            undefined;
+            })
+                : inferFromLiteralPartsToTemplateLiteral((source as TemplateLiteralType).texts, (source as TemplateLiteralType).types, target)
+            : undefined;
     }
 
     function isTypeMatchedByTemplateLiteralType(source: Type, target: TemplateLiteralType): boolean {
@@ -25576,8 +25576,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const targetStartText = targetTexts[0];
         const targetEndText = targetTexts[lastTargetIndex];
         if (
-            lastSourceIndex === 0 && sourceStartText.length < targetStartText.length + targetEndText.length ||
-            !sourceStartText.startsWith(targetStartText) || !sourceEndText.endsWith(targetEndText)
+            lastSourceIndex === 0 && sourceStartText.length < targetStartText.length + targetEndText.length
+            || !sourceStartText.startsWith(targetStartText) || !sourceEndText.endsWith(targetEndText)
         ) return undefined;
         const remainingEndText = sourceEndText.slice(0, sourceEndText.length - targetEndText.length);
         const matches: Type[] = [];
@@ -25614,9 +25614,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return index < lastSourceIndex ? sourceTexts[index] : remainingEndText;
         }
         function addMatch(s: number, p: number) {
-            const matchType = s === seg ?
-                getStringLiteralType(getSourceText(s).slice(pos, p)) :
-                getTemplateLiteralType(
+            const matchType = s === seg
+                ? getStringLiteralType(getSourceText(s).slice(pos, p))
+                : getTemplateLiteralType(
                     [sourceTexts[seg].slice(pos), ...sourceTexts.slice(seg + 1, s), getSourceText(s).slice(0, p)],
                     sourceTypes.slice(seg, s),
                 );
@@ -25795,8 +25795,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (
                 getObjectFlags(source) & ObjectFlags.Reference && getObjectFlags(target) & ObjectFlags.Reference && (
                     (source as TypeReference).target === (target as TypeReference).target || isArrayType(source) && isArrayType(target)
-                ) &&
-                !((source as TypeReference).node && (target as TypeReference).node)
+                )
+                && !((source as TypeReference).node && (target as TypeReference).node)
             ) {
                 // If source and target are references to the same generic type, infer from type arguments
                 inferFromTypeArguments(getTypeArguments(source as TypeReference), getTypeArguments(target as TypeReference), getVariances((source as TypeReference).target));
@@ -26088,9 +26088,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         inferWithPriority(
                             inferredType,
                             inference.typeParameter,
-                            getObjectFlags(source) & ObjectFlags.NonInferrableType ?
-                                InferencePriority.PartialHomomorphicMappedType :
-                                InferencePriority.HomomorphicMappedType,
+                            getObjectFlags(source) & ObjectFlags.NonInferrableType
+                                ? InferencePriority.PartialHomomorphicMappedType
+                                : InferencePriority.HomomorphicMappedType,
                         );
                     }
                 }
@@ -26170,21 +26170,21 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                                 // for each type in the constraint, find the highest priority matching type
                                 const matchingType = reduceLeft(constraintTypes, (left, right) =>
-                                    !(right.flags & allTypeFlags) ? left :
-                                        left.flags & TypeFlags.String ? left : right.flags & TypeFlags.String ? source :
-                                        left.flags & TypeFlags.TemplateLiteral ? left : right.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, right as TemplateLiteralType) ? source :
-                                        left.flags & TypeFlags.StringMapping ? left : right.flags & TypeFlags.StringMapping && str === applyStringMapping(right.symbol, str) ? source :
-                                        left.flags & TypeFlags.StringLiteral ? left : right.flags & TypeFlags.StringLiteral && (right as StringLiteralType).value === str ? right :
-                                        left.flags & TypeFlags.Number ? left : right.flags & TypeFlags.Number ? getNumberLiteralType(+str) :
-                                        left.flags & TypeFlags.Enum ? left : right.flags & TypeFlags.Enum ? getNumberLiteralType(+str) :
-                                        left.flags & TypeFlags.NumberLiteral ? left : right.flags & TypeFlags.NumberLiteral && (right as NumberLiteralType).value === +str ? right :
-                                        left.flags & TypeFlags.BigInt ? left : right.flags & TypeFlags.BigInt ? parseBigIntLiteralType(str) :
-                                        left.flags & TypeFlags.BigIntLiteral ? left : right.flags & TypeFlags.BigIntLiteral && pseudoBigIntToString((right as BigIntLiteralType).value) === str ? right :
-                                        left.flags & TypeFlags.Boolean ? left : right.flags & TypeFlags.Boolean ? str === "true" ? trueType : str === "false" ? falseType : booleanType :
-                                        left.flags & TypeFlags.BooleanLiteral ? left : right.flags & TypeFlags.BooleanLiteral && (right as IntrinsicType).intrinsicName === str ? right :
-                                        left.flags & TypeFlags.Undefined ? left : right.flags & TypeFlags.Undefined && (right as IntrinsicType).intrinsicName === str ? right :
-                                        left.flags & TypeFlags.Null ? left : right.flags & TypeFlags.Null && (right as IntrinsicType).intrinsicName === str ? right :
-                                        left, neverType as Type);
+                                    !(right.flags & allTypeFlags) ? left
+                                        : left.flags & TypeFlags.String ? left : right.flags & TypeFlags.String ? source
+                                        : left.flags & TypeFlags.TemplateLiteral ? left : right.flags & TypeFlags.TemplateLiteral && isTypeMatchedByTemplateLiteralType(source, right as TemplateLiteralType) ? source
+                                        : left.flags & TypeFlags.StringMapping ? left : right.flags & TypeFlags.StringMapping && str === applyStringMapping(right.symbol, str) ? source
+                                        : left.flags & TypeFlags.StringLiteral ? left : right.flags & TypeFlags.StringLiteral && (right as StringLiteralType).value === str ? right
+                                        : left.flags & TypeFlags.Number ? left : right.flags & TypeFlags.Number ? getNumberLiteralType(+str)
+                                        : left.flags & TypeFlags.Enum ? left : right.flags & TypeFlags.Enum ? getNumberLiteralType(+str)
+                                        : left.flags & TypeFlags.NumberLiteral ? left : right.flags & TypeFlags.NumberLiteral && (right as NumberLiteralType).value === +str ? right
+                                        : left.flags & TypeFlags.BigInt ? left : right.flags & TypeFlags.BigInt ? parseBigIntLiteralType(str)
+                                        : left.flags & TypeFlags.BigIntLiteral ? left : right.flags & TypeFlags.BigIntLiteral && pseudoBigIntToString((right as BigIntLiteralType).value) === str ? right
+                                        : left.flags & TypeFlags.Boolean ? left : right.flags & TypeFlags.Boolean ? str === "true" ? trueType : str === "false" ? falseType : booleanType
+                                        : left.flags & TypeFlags.BooleanLiteral ? left : right.flags & TypeFlags.BooleanLiteral && (right as IntrinsicType).intrinsicName === str ? right
+                                        : left.flags & TypeFlags.Undefined ? left : right.flags & TypeFlags.Undefined && (right as IntrinsicType).intrinsicName === str ? right
+                                        : left.flags & TypeFlags.Null ? left : right.flags & TypeFlags.Null && (right as IntrinsicType).intrinsicName === str ? right
+                                        : left, neverType as Type);
 
                                 if (!(matchingType.flags & TypeFlags.Never)) {
                                     inferFromTypes(matchingType, target);
@@ -26402,13 +26402,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTypeOrBaseIdenticalTo(s: Type, t: Type) {
-        return t === missingType ? s === t :
-            (isTypeIdenticalTo(s, t) || !!(t.flags & TypeFlags.String && s.flags & TypeFlags.StringLiteral || t.flags & TypeFlags.Number && s.flags & TypeFlags.NumberLiteral));
+        return t === missingType ? s === t
+            : (isTypeIdenticalTo(s, t) || !!(t.flags & TypeFlags.String && s.flags & TypeFlags.StringLiteral || t.flags & TypeFlags.Number && s.flags & TypeFlags.NumberLiteral));
     }
 
     function isTypeCloselyMatchedBy(s: Type, t: Type) {
-        return !!(s.flags & TypeFlags.Object && t.flags & TypeFlags.Object && s.symbol && s.symbol === t.symbol ||
-            s.aliasSymbol && s.aliasTypeArguments && s.aliasSymbol === t.aliasSymbol);
+        return !!(s.flags & TypeFlags.Object && t.flags & TypeFlags.Object && s.symbol && s.symbol === t.symbol
+            || s.aliasSymbol && s.aliasTypeArguments && s.aliasSymbol === t.aliasSymbol);
     }
 
     function hasPrimitiveConstraint(type: TypeParameter): boolean {
@@ -26447,16 +26447,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // the type parameter has no constraint or its constraint includes no primitive or literal types, and
         // the type parameter was fixed during inference or does not occur at top-level in the return type.
         const primitiveConstraint = hasPrimitiveConstraint(inference.typeParameter) || isConstTypeVariable(inference.typeParameter);
-        const widenLiteralTypes = !primitiveConstraint && inference.topLevel &&
-            (inference.isFixed || !isTypeParameterAtTopLevelInReturnType(signature, inference.typeParameter));
-        const baseCandidates = primitiveConstraint ? sameMap(candidates, getRegularTypeOfLiteralType) :
-            widenLiteralTypes ? sameMap(candidates, getWidenedLiteralType) :
-            candidates;
+        const widenLiteralTypes = !primitiveConstraint && inference.topLevel
+            && (inference.isFixed || !isTypeParameterAtTopLevelInReturnType(signature, inference.typeParameter));
+        const baseCandidates = primitiveConstraint ? sameMap(candidates, getRegularTypeOfLiteralType)
+            : widenLiteralTypes ? sameMap(candidates, getWidenedLiteralType)
+            : candidates;
         // If all inferences were made from a position that implies a combined result, infer a union type.
         // Otherwise, infer a common supertype.
-        const unwidenedType = inference.priority! & InferencePriority.PriorityImpliesCombination ?
-            getUnionType(baseCandidates, UnionReduction.Subtype) :
-            getCommonSupertype(baseCandidates);
+        const unwidenedType = inference.priority! & InferencePriority.PriorityImpliesCombination
+            ? getUnionType(baseCandidates, UnionReduction.Subtype)
+            : getCommonSupertype(baseCandidates);
         return getWidenedType(unwidenedType);
     }
 
@@ -26473,12 +26473,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // all co-variant inferences are subtypes of it (i.e. it isn't one of a conflicting set of candidates), it is
                     // a subtype of some contra-variant inference, and no other type parameter is constrained to this type parameter
                     // and has inferences that would conflict. Otherwise, we prefer the contra-variant inference.
-                    const preferCovariantType = inferredCovariantType && (!inferredContravariantType ||
-                        !(inferredCovariantType.flags & TypeFlags.Never) &&
-                            some(inference.contraCandidates, t => isTypeSubtypeOf(inferredCovariantType, t)) &&
-                            every(context.inferences, other =>
-                                other !== inference && getConstraintOfTypeParameter(other.typeParameter) !== inference.typeParameter ||
-                                every(other.candidates, t => isTypeSubtypeOf(t, inferredCovariantType))));
+                    const preferCovariantType = inferredCovariantType && (!inferredContravariantType
+                        || !(inferredCovariantType.flags & TypeFlags.Never)
+                            && some(inference.contraCandidates, t => isTypeSubtypeOf(inferredCovariantType, t))
+                            && every(context.inferences, other =>
+                                other !== inference && getConstraintOfTypeParameter(other.typeParameter) !== inference.typeParameter
+                                || every(other.candidates, t => isTypeSubtypeOf(t, inferredCovariantType))));
                     inferredType = preferCovariantType ? inferredCovariantType : inferredContravariantType;
                     fallbackType = preferCovariantType ? inferredContravariantType : inferredCovariantType;
                 }
@@ -26597,8 +26597,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getResolvedSymbol(node: Identifier): Symbol {
         const links = getNodeLinks(node);
         if (!links.resolvedSymbol) {
-            links.resolvedSymbol = !nodeIsMissing(node) &&
-                    resolveName(
+            links.resolvedSymbol = !nodeIsMissing(node)
+                    && resolveName(
                         node,
                         node.escapedText,
                         SymbolFlags.Value | SymbolFlags.ExportValue,
@@ -26661,8 +26661,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.NonNullExpression:
                 return isMatchingReference(source, (target as NonNullExpression | ParenthesizedExpression).expression);
             case SyntaxKind.BinaryExpression:
-                return (isAssignmentExpression(target) && isMatchingReference(source, target.left)) ||
-                    (isBinaryExpression(target) && target.operatorToken.kind === SyntaxKind.CommaToken && isMatchingReference(source, target.right));
+                return (isAssignmentExpression(target) && isMatchingReference(source, target.left))
+                    || (isBinaryExpression(target) && target.operatorToken.kind === SyntaxKind.CommaToken && isMatchingReference(source, target.right));
         }
         switch (source.kind) {
             case SyntaxKind.MetaProperty:
@@ -26671,11 +26671,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     && (source as MetaProperty).name.escapedText === (target as MetaProperty).name.escapedText;
             case SyntaxKind.Identifier:
             case SyntaxKind.PrivateIdentifier:
-                return isThisInTypeQuery(source) ?
-                    target.kind === SyntaxKind.ThisKeyword :
-                    target.kind === SyntaxKind.Identifier && getResolvedSymbol(source as Identifier) === getResolvedSymbol(target as Identifier) ||
-                    (isVariableDeclaration(target) || isBindingElement(target)) &&
-                        getExportSymbolOfValueSymbolIfExported(getResolvedSymbol(source as Identifier)) === getSymbolOfDeclaration(target);
+                return isThisInTypeQuery(source)
+                    ? target.kind === SyntaxKind.ThisKeyword
+                    : target.kind === SyntaxKind.Identifier && getResolvedSymbol(source as Identifier) === getResolvedSymbol(target as Identifier)
+                        || (isVariableDeclaration(target) || isBindingElement(target))
+                            && getExportSymbolOfValueSymbolIfExported(getResolvedSymbol(source as Identifier)) === getSymbolOfDeclaration(target);
             case SyntaxKind.ThisKeyword:
                 return target.kind === SyntaxKind.ThisKeyword;
             case SyntaxKind.SuperKeyword:
@@ -26687,12 +26687,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.ElementAccessExpression:
                 const sourcePropertyName = getAccessedPropertyName(source as AccessExpression);
                 const targetPropertyName = isAccessExpression(target) ? getAccessedPropertyName(target) : undefined;
-                return sourcePropertyName !== undefined && targetPropertyName !== undefined && targetPropertyName === sourcePropertyName &&
-                    isMatchingReference((source as AccessExpression).expression, (target as AccessExpression).expression);
+                return sourcePropertyName !== undefined && targetPropertyName !== undefined && targetPropertyName === sourcePropertyName
+                    && isMatchingReference((source as AccessExpression).expression, (target as AccessExpression).expression);
             case SyntaxKind.QualifiedName:
-                return isAccessExpression(target) &&
-                    (source as QualifiedName).right.escapedText === getAccessedPropertyName(target) &&
-                    isMatchingReference((source as QualifiedName).left, target.expression);
+                return isAccessExpression(target)
+                    && (source as QualifiedName).right.escapedText === getAccessedPropertyName(target)
+                    && isMatchingReference((source as QualifiedName).left, target.expression);
             case SyntaxKind.BinaryExpression:
                 return (isBinaryExpression(source) && source.operatorToken.kind === SyntaxKind.CommaToken && isMatchingReference(source.right, target));
         }
@@ -26717,13 +26717,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function tryGetNameFromType(type: Type) {
-        return type.flags & TypeFlags.UniqueESSymbol ? (type as UniqueESSymbolType).escapedName :
-            type.flags & TypeFlags.StringOrNumberLiteral ? escapeLeadingUnderscores("" + (type as StringLiteralType | NumberLiteralType).value) : undefined;
+        return type.flags & TypeFlags.UniqueESSymbol ? (type as UniqueESSymbolType).escapedName
+            : type.flags & TypeFlags.StringOrNumberLiteral ? escapeLeadingUnderscores("" + (type as StringLiteralType | NumberLiteralType).value) : undefined;
     }
 
     function tryGetElementAccessExpressionName(node: ElementAccessExpression) {
-        return isStringOrNumericLiteralLike(node.argumentExpression) ? escapeLeadingUnderscores(node.argumentExpression.text) :
-            isEntityNameExpression(node.argumentExpression) ? tryGetNameFromEntityNameExpression(node.argumentExpression) : undefined;
+        return isStringOrNumericLiteralLike(node.argumentExpression) ? escapeLeadingUnderscores(node.argumentExpression.text)
+            : isEntityNameExpression(node.argumentExpression) ? tryGetNameFromEntityNameExpression(node.argumentExpression) : undefined;
     }
 
     function tryGetNameFromEntityNameExpression(node: EntityNameOrEntityNameExpression) {
@@ -26779,8 +26779,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (prop && getCheckFlags(prop) & CheckFlags.SyntheticProperty) {
                 // NOTE: cast to TransientSymbol should be safe because only TransientSymbols can have CheckFlags.SyntheticProperty
                 if ((prop as TransientSymbol).links.isDiscriminantProperty === undefined) {
-                    (prop as TransientSymbol).links.isDiscriminantProperty = ((prop as TransientSymbol).links.checkFlags & CheckFlags.Discriminant) === CheckFlags.Discriminant &&
-                        !isGenericType(getTypeOfSymbol(prop));
+                    (prop as TransientSymbol).links.isDiscriminantProperty = ((prop as TransientSymbol).links.checkFlags & CheckFlags.Discriminant) === CheckFlags.Discriminant
+                        && !isGenericType(getTypeOfSymbol(prop));
                 }
                 return !!(prop as TransientSymbol).links.isDiscriminantProperty;
             }
@@ -26841,8 +26841,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const types = unionType.types;
         // We only construct maps for unions with many non-primitive constituents.
         if (
-            types.length < 10 || getObjectFlags(unionType) & ObjectFlags.PrimitiveUnion ||
-            countWhere(types, t => !!(t.flags & (TypeFlags.Object | TypeFlags.InstantiableNonPrimitive))) < 10
+            types.length < 10 || getObjectFlags(unionType) & ObjectFlags.PrimitiveUnion
+            || countWhere(types, t => !!(t.flags & (TypeFlags.Object | TypeFlags.InstantiableNonPrimitive))) < 10
         ) {
             return undefined;
         }
@@ -26850,9 +26850,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // The candidate key property name is the name of the first property with a unit type in one of the
             // constituent types.
             const keyPropertyName = forEach(types, t =>
-                t.flags & (TypeFlags.Object | TypeFlags.InstantiableNonPrimitive) ?
-                    forEach(getPropertiesOfType(t), p => isUnitType(getTypeOfSymbol(p)) ? p.escapedName : undefined) :
-                    undefined);
+                t.flags & (TypeFlags.Object | TypeFlags.InstantiableNonPrimitive)
+                    ? forEach(getPropertiesOfType(t), p => isUnitType(getTypeOfSymbol(p)) ? p.escapedName : undefined)
+                    : undefined);
             const mapByKeyProperty = keyPropertyName && mapTypesByKeyProperty(types, keyPropertyName);
             unionType.keyPropertyName = mapByKeyProperty ? keyPropertyName : "" as __String;
             unionType.constituentMap = mapByKeyProperty;
@@ -26876,8 +26876,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getMatchingUnionConstituentForObjectLiteral(unionType: UnionType, node: ObjectLiteralExpression) {
         const keyPropertyName = getKeyPropertyName(unionType);
         const propNode = keyPropertyName && find(node.properties, p =>
-            p.symbol && p.kind === SyntaxKind.PropertyAssignment &&
-            p.symbol.escapedName === keyPropertyName && isPossiblyDiscriminantValue(p.initializer));
+            p.symbol && p.kind === SyntaxKind.PropertyAssignment
+            && p.symbol.escapedName === keyPropertyName && isPossiblyDiscriminantValue(p.initializer));
         const propType = propNode && getContextFreeTypeOfExpression((propNode as PropertyAssignment).initializer);
         return propType && getConstituentTypeForKeyType(unionType, propType);
     }
@@ -26895,8 +26895,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
         if (
-            expression.expression.kind === SyntaxKind.PropertyAccessExpression &&
-            isOrContainsMatchingReference(reference, (expression.expression as PropertyAccessExpression).expression)
+            expression.expression.kind === SyntaxKind.PropertyAccessExpression
+            && isOrContainsMatchingReference(reference, (expression.expression as PropertyAccessExpression).expression)
         ) {
             return true;
         }
@@ -26952,8 +26952,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // We do a quick check for a "bind" property before performing the more expensive subtype
         // check. This gives us a quicker out in the common case where an object type is not a function.
         const resolved = resolveStructuredTypeMembers(type);
-        return !!(resolved.callSignatures.length || resolved.constructSignatures.length ||
-            resolved.members.get("bind" as __String) && isTypeSubtypeOf(type, globalFunctionType));
+        return !!(resolved.callSignatures.length || resolved.constructSignatures.length
+            || resolved.members.get("bind" as __String) && isTypeSubtypeOf(type, globalFunctionType));
     }
 
     function getTypeFacts(type: Type, mask: TypeFacts): TypeFacts {
@@ -26974,35 +26974,35 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral)) {
             const isEmpty = flags & TypeFlags.StringLiteral && (type as StringLiteralType).value === "";
-            return strictNullChecks ?
-                isEmpty ? TypeFacts.EmptyStringStrictFacts : TypeFacts.NonEmptyStringStrictFacts :
-                isEmpty ? TypeFacts.EmptyStringFacts : TypeFacts.NonEmptyStringFacts;
+            return strictNullChecks
+                ? isEmpty ? TypeFacts.EmptyStringStrictFacts : TypeFacts.NonEmptyStringStrictFacts
+                : isEmpty ? TypeFacts.EmptyStringFacts : TypeFacts.NonEmptyStringFacts;
         }
         if (flags & (TypeFlags.Number | TypeFlags.Enum)) {
             return strictNullChecks ? TypeFacts.NumberStrictFacts : TypeFacts.NumberFacts;
         }
         if (flags & TypeFlags.NumberLiteral) {
             const isZero = (type as NumberLiteralType).value === 0;
-            return strictNullChecks ?
-                isZero ? TypeFacts.ZeroNumberStrictFacts : TypeFacts.NonZeroNumberStrictFacts :
-                isZero ? TypeFacts.ZeroNumberFacts : TypeFacts.NonZeroNumberFacts;
+            return strictNullChecks
+                ? isZero ? TypeFacts.ZeroNumberStrictFacts : TypeFacts.NonZeroNumberStrictFacts
+                : isZero ? TypeFacts.ZeroNumberFacts : TypeFacts.NonZeroNumberFacts;
         }
         if (flags & TypeFlags.BigInt) {
             return strictNullChecks ? TypeFacts.BigIntStrictFacts : TypeFacts.BigIntFacts;
         }
         if (flags & TypeFlags.BigIntLiteral) {
             const isZero = isZeroBigInt(type as BigIntLiteralType);
-            return strictNullChecks ?
-                isZero ? TypeFacts.ZeroBigIntStrictFacts : TypeFacts.NonZeroBigIntStrictFacts :
-                isZero ? TypeFacts.ZeroBigIntFacts : TypeFacts.NonZeroBigIntFacts;
+            return strictNullChecks
+                ? isZero ? TypeFacts.ZeroBigIntStrictFacts : TypeFacts.NonZeroBigIntStrictFacts
+                : isZero ? TypeFacts.ZeroBigIntFacts : TypeFacts.NonZeroBigIntFacts;
         }
         if (flags & TypeFlags.Boolean) {
             return strictNullChecks ? TypeFacts.BooleanStrictFacts : TypeFacts.BooleanFacts;
         }
         if (flags & TypeFlags.BooleanLike) {
-            return strictNullChecks ?
-                (type === falseType || type === regularFalseType) ? TypeFacts.FalseStrictFacts : TypeFacts.TrueStrictFacts :
-                (type === falseType || type === regularFalseType) ? TypeFacts.FalseFacts : TypeFacts.TrueFacts;
+            return strictNullChecks
+                ? (type === falseType || type === regularFalseType) ? TypeFacts.FalseStrictFacts : TypeFacts.TrueStrictFacts
+                : (type === falseType || type === regularFalseType) ? TypeFacts.FalseFacts : TypeFacts.TrueFacts;
         }
         if (flags & TypeFlags.Object) {
             const possibleFacts = strictNullChecks
@@ -27015,11 +27015,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return 0;
             }
 
-            return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type as ObjectType) ?
-                strictNullChecks ? TypeFacts.EmptyObjectStrictFacts : TypeFacts.EmptyObjectFacts :
-                isFunctionObjectType(type as ObjectType) ?
-                strictNullChecks ? TypeFacts.FunctionStrictFacts : TypeFacts.FunctionFacts :
-                strictNullChecks ? TypeFacts.ObjectStrictFacts : TypeFacts.ObjectFacts;
+            return getObjectFlags(type) & ObjectFlags.Anonymous && isEmptyObjectType(type as ObjectType)
+                ? strictNullChecks ? TypeFacts.EmptyObjectStrictFacts : TypeFacts.EmptyObjectFacts
+                : isFunctionObjectType(type as ObjectType)
+                ? strictNullChecks ? TypeFacts.FunctionStrictFacts : TypeFacts.FunctionFacts
+                : strictNullChecks ? TypeFacts.ObjectStrictFacts : TypeFacts.ObjectFacts;
         }
         if (flags & TypeFlags.Void) {
             return TypeFacts.VoidFacts;
@@ -27108,9 +27108,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeWithDefault(type: Type, defaultExpression: Expression) {
-        return defaultExpression ?
-            getUnionType([getNonUndefinedType(type), getTypeOfExpression(defaultExpression)]) :
-            type;
+        return defaultExpression
+            ? getUnionType([getNonUndefinedType(type), getTypeOfExpression(defaultExpression)])
+            : type;
     }
 
     function getTypeOfDestructuredProperty(type: Type, name: PropertyName) {
@@ -27121,16 +27121,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getTypeOfDestructuredArrayElement(type: Type, index: number) {
-        return everyType(type, isTupleLikeType) && getTupleElementType(type, index) ||
-            includeUndefinedInIndexSignature(checkIteratedTypeOrElementType(IterationUse.Destructuring, type, undefinedType, /*errorNode*/ undefined)) ||
-            errorType;
+        return everyType(type, isTupleLikeType) && getTupleElementType(type, index)
+            || includeUndefinedInIndexSignature(checkIteratedTypeOrElementType(IterationUse.Destructuring, type, undefinedType, /*errorNode*/ undefined))
+            || errorType;
     }
 
     function includeUndefinedInIndexSignature(type: Type | undefined): Type | undefined {
         if (!type) return type;
-        return compilerOptions.noUncheckedIndexedAccess ?
-            getUnionType([type, missingType]) :
-            type;
+        return compilerOptions.noUncheckedIndexedAccess
+            ? getUnionType([type, missingType])
+            : type;
     }
 
     function getTypeOfDestructuredSpreadExpression(type: Type) {
@@ -27138,16 +27138,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getAssignedTypeOfBinaryExpression(node: BinaryExpression): Type {
-        const isDestructuringDefaultAssignment = node.parent.kind === SyntaxKind.ArrayLiteralExpression && isDestructuringAssignmentTarget(node.parent) ||
-            node.parent.kind === SyntaxKind.PropertyAssignment && isDestructuringAssignmentTarget(node.parent.parent);
-        return isDestructuringDefaultAssignment ?
-            getTypeWithDefault(getAssignedType(node), node.right) :
-            getTypeOfExpression(node.right);
+        const isDestructuringDefaultAssignment = node.parent.kind === SyntaxKind.ArrayLiteralExpression && isDestructuringAssignmentTarget(node.parent)
+            || node.parent.kind === SyntaxKind.PropertyAssignment && isDestructuringAssignmentTarget(node.parent.parent);
+        return isDestructuringDefaultAssignment
+            ? getTypeWithDefault(getAssignedType(node), node.right)
+            : getTypeOfExpression(node.right);
     }
 
     function isDestructuringAssignmentTarget(parent: Node) {
-        return parent.parent.kind === SyntaxKind.BinaryExpression && (parent.parent as BinaryExpression).left === parent ||
-            parent.parent.kind === SyntaxKind.ForOfStatement && (parent.parent as ForOfStatement).initializer === parent;
+        return parent.parent.kind === SyntaxKind.BinaryExpression && (parent.parent as BinaryExpression).left === parent
+            || parent.parent.kind === SyntaxKind.ForOfStatement && (parent.parent as ForOfStatement).initializer === parent;
     }
 
     function getAssignedTypeOfArrayLiteralElement(node: ArrayLiteralExpression, element: Expression): Type {
@@ -27192,11 +27192,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getInitialTypeOfBindingElement(node: BindingElement): Type {
         const pattern = node.parent;
         const parentType = getInitialType(pattern.parent as VariableDeclaration | BindingElement);
-        const type = pattern.kind === SyntaxKind.ObjectBindingPattern ?
-            getTypeOfDestructuredProperty(parentType, node.propertyName || node.name as Identifier) :
-            !node.dotDotDotToken ?
-            getTypeOfDestructuredArrayElement(parentType, pattern.elements.indexOf(node)) :
-            getTypeOfDestructuredSpreadExpression(parentType);
+        const type = pattern.kind === SyntaxKind.ObjectBindingPattern
+            ? getTypeOfDestructuredProperty(parentType, node.propertyName || node.name as Identifier)
+            : !node.dotDotDotToken
+            ? getTypeOfDestructuredArrayElement(parentType, pattern.elements.indexOf(node))
+            : getTypeOfDestructuredSpreadExpression(parentType);
         return getTypeWithDefault(type, node.initializer!);
     }
 
@@ -27222,16 +27222,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getInitialType(node: VariableDeclaration | BindingElement) {
-        return node.kind === SyntaxKind.VariableDeclaration ?
-            getInitialTypeOfVariableDeclaration(node) :
-            getInitialTypeOfBindingElement(node);
+        return node.kind === SyntaxKind.VariableDeclaration
+            ? getInitialTypeOfVariableDeclaration(node)
+            : getInitialTypeOfBindingElement(node);
     }
 
     function isEmptyArrayAssignment(node: VariableDeclaration | BindingElement | Expression) {
-        return node.kind === SyntaxKind.VariableDeclaration && (node as VariableDeclaration).initializer &&
-                isEmptyArrayLiteral((node as VariableDeclaration).initializer!) ||
-            node.kind !== SyntaxKind.BindingElement && node.parent.kind === SyntaxKind.BinaryExpression &&
-                isEmptyArrayLiteral((node.parent as BinaryExpression).right);
+        return node.kind === SyntaxKind.VariableDeclaration && (node as VariableDeclaration).initializer
+                && isEmptyArrayLiteral((node as VariableDeclaration).initializer!)
+            || node.kind !== SyntaxKind.BindingElement && node.parent.kind === SyntaxKind.BinaryExpression
+                && isEmptyArrayLiteral((node.parent as BinaryExpression).right);
     }
 
     function getReferenceCandidate(node: Expression): Expression {
@@ -27254,10 +27254,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getReferenceRoot(node: Node): Node {
         const { parent } = node;
-        return parent.kind === SyntaxKind.ParenthesizedExpression ||
-                parent.kind === SyntaxKind.BinaryExpression && (parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken && (parent as BinaryExpression).left === node ||
-                parent.kind === SyntaxKind.BinaryExpression && (parent as BinaryExpression).operatorToken.kind === SyntaxKind.CommaToken && (parent as BinaryExpression).right === node ?
-            getReferenceRoot(parent) : node;
+        return parent.kind === SyntaxKind.ParenthesizedExpression
+                || parent.kind === SyntaxKind.BinaryExpression && (parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken && (parent as BinaryExpression).left === node
+                || parent.kind === SyntaxKind.BinaryExpression && (parent as BinaryExpression).operatorToken.kind === SyntaxKind.CommaToken && (parent as BinaryExpression).right === node
+            ? getReferenceRoot(parent) : node;
     }
 
     function getTypeOfSwitchClause(clause: CaseClause | DefaultClause) {
@@ -27402,9 +27402,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function mapTypeWithAlias(type: Type, mapper: (t: Type) => Type, aliasSymbol: Symbol | undefined, aliasTypeArguments: readonly Type[] | undefined) {
-        return type.flags & TypeFlags.Union && aliasSymbol ?
-            getUnionType(map((type as UnionType).types, mapper), UnionReduction.Literal, aliasSymbol, aliasTypeArguments) :
-            mapType(type, mapper);
+        return type.flags & TypeFlags.Union && aliasSymbol
+            ? getUnionType(map((type as UnionType).types, mapper), UnionReduction.Literal, aliasSymbol, aliasTypeArguments)
+            : mapType(type, mapper);
     }
 
     function extractTypesOfKind(type: Type, kind: TypeFlags) {
@@ -27418,14 +27418,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // types we don't actually care about.
     function replacePrimitivesWithLiterals(typeWithPrimitives: Type, typeWithLiterals: Type) {
         if (
-            maybeTypeOfKind(typeWithPrimitives, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.Number | TypeFlags.BigInt) &&
-            maybeTypeOfKind(typeWithLiterals, TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping | TypeFlags.NumberLiteral | TypeFlags.BigIntLiteral)
+            maybeTypeOfKind(typeWithPrimitives, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.Number | TypeFlags.BigInt)
+            && maybeTypeOfKind(typeWithLiterals, TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping | TypeFlags.NumberLiteral | TypeFlags.BigIntLiteral)
         ) {
             return mapType(typeWithPrimitives, t =>
-                t.flags & TypeFlags.String ? extractTypesOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) :
-                    isPatternLiteralType(t) && !maybeTypeOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? extractTypesOfKind(typeWithLiterals, TypeFlags.StringLiteral) :
-                    t.flags & TypeFlags.Number ? extractTypesOfKind(typeWithLiterals, TypeFlags.Number | TypeFlags.NumberLiteral) :
-                    t.flags & TypeFlags.BigInt ? extractTypesOfKind(typeWithLiterals, TypeFlags.BigInt | TypeFlags.BigIntLiteral) : t);
+                t.flags & TypeFlags.String ? extractTypesOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.StringLiteral | TypeFlags.TemplateLiteral | TypeFlags.StringMapping)
+                    : isPatternLiteralType(t) && !maybeTypeOfKind(typeWithLiterals, TypeFlags.String | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) ? extractTypesOfKind(typeWithLiterals, TypeFlags.StringLiteral)
+                    : t.flags & TypeFlags.Number ? extractTypesOfKind(typeWithLiterals, TypeFlags.Number | TypeFlags.NumberLiteral)
+                    : t.flags & TypeFlags.BigInt ? extractTypesOfKind(typeWithLiterals, TypeFlags.BigInt | TypeFlags.BigIntLiteral) : t);
         }
         return typeWithPrimitives;
     }
@@ -27465,12 +27465,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function createFinalArrayType(elementType: Type) {
-        return elementType.flags & TypeFlags.Never ?
-            autoArrayType :
-            createArrayType(
-                elementType.flags & TypeFlags.Union ?
-                    getUnionType((elementType as UnionType).types, UnionReduction.Subtype) :
-                    elementType,
+        return elementType.flags & TypeFlags.Never
+            ? autoArrayType
+            : createArrayType(
+                elementType.flags & TypeFlags.Union
+                    ? getUnionType((elementType as UnionType).types, UnionReduction.Subtype)
+                    : elementType,
             );
     }
 
@@ -27506,25 +27506,25 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const root = getReferenceRoot(node);
         const parent = root.parent;
         const isLengthPushOrUnshift = isPropertyAccessExpression(parent) && (
-            parent.name.escapedText === "length" ||
-            parent.parent.kind === SyntaxKind.CallExpression
+            parent.name.escapedText === "length"
+            || parent.parent.kind === SyntaxKind.CallExpression
                 && isIdentifier(parent.name)
                 && isPushOrUnshiftIdentifier(parent.name)
         );
-        const isElementAssignment = parent.kind === SyntaxKind.ElementAccessExpression &&
-            (parent as ElementAccessExpression).expression === root &&
-            parent.parent.kind === SyntaxKind.BinaryExpression &&
-            (parent.parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken &&
-            (parent.parent as BinaryExpression).left === parent &&
-            !isAssignmentTarget(parent.parent) &&
-            isTypeAssignableToKind(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression), TypeFlags.NumberLike);
+        const isElementAssignment = parent.kind === SyntaxKind.ElementAccessExpression
+            && (parent as ElementAccessExpression).expression === root
+            && parent.parent.kind === SyntaxKind.BinaryExpression
+            && (parent.parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken
+            && (parent.parent as BinaryExpression).left === parent
+            && !isAssignmentTarget(parent.parent)
+            && isTypeAssignableToKind(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression), TypeFlags.NumberLike);
         return isLengthPushOrUnshift || isElementAssignment;
     }
 
     function isDeclarationWithExplicitTypeAnnotation(node: Declaration) {
-        return (isVariableDeclaration(node) || isPropertyDeclaration(node) || isPropertySignature(node) || isParameter(node)) &&
-            !!(getEffectiveTypeAnnotationNode(node) ||
-                isInJSFile(node) && hasInitializer(node) && node.initializer && isFunctionExpressionOrArrowFunction(node.initializer) && getEffectiveReturnTypeNode(node.initializer));
+        return (isVariableDeclaration(node) || isPropertyDeclaration(node) || isPropertySignature(node) || isParameter(node))
+            && !!(getEffectiveTypeAnnotationNode(node)
+                || isInJSFile(node) && hasInitializer(node) && node.initializer && isFunctionExpressionOrArrowFunction(node.initializer) && getEffectiveReturnTypeNode(node.initializer));
     }
 
     function getExplicitTypeOfSymbol(symbol: Symbol, diagnostic?: Diagnostic) {
@@ -27625,17 +27625,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
             const signatures = getSignaturesOfType(funcType && getApparentType(funcType) || unknownType, SignatureKind.Call);
-            const candidate = signatures.length === 1 && !signatures[0].typeParameters ? signatures[0] :
-                some(signatures, hasTypePredicateOrNeverReturnType) ? getResolvedSignature(node) :
-                undefined;
+            const candidate = signatures.length === 1 && !signatures[0].typeParameters ? signatures[0]
+                : some(signatures, hasTypePredicateOrNeverReturnType) ? getResolvedSignature(node)
+                : undefined;
             signature = links.effectsSignature = candidate && hasTypePredicateOrNeverReturnType(candidate) ? candidate : unknownSignature;
         }
         return signature === unknownSignature ? undefined : signature;
     }
 
     function hasTypePredicateOrNeverReturnType(signature: Signature) {
-        return !!(getTypePredicateOfSignature(signature) ||
-            signature.declaration && (getReturnTypeFromAnnotation(signature.declaration) || unknownType).flags & TypeFlags.Never);
+        return !!(getTypePredicateOfSignature(signature)
+            || signature.declaration && (getReturnTypeFromAnnotation(signature.declaration) || unknownType).flags & TypeFlags.Never);
     }
 
     function getTypePredicateArgument(predicate: TypePredicate, callExpression: CallExpression) {
@@ -27663,8 +27663,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function isFalseExpression(expr: Expression): boolean {
         const node = skipParentheses(expr, /*excludeJSDocTypeAssertions*/ true);
         return node.kind === SyntaxKind.FalseKeyword || node.kind === SyntaxKind.BinaryExpression && (
-                    (node as BinaryExpression).operatorToken.kind === SyntaxKind.AmpersandAmpersandToken && (isFalseExpression((node as BinaryExpression).left) || isFalseExpression((node as BinaryExpression).right)) ||
-                    (node as BinaryExpression).operatorToken.kind === SyntaxKind.BarBarToken && isFalseExpression((node as BinaryExpression).left) && isFalseExpression((node as BinaryExpression).right)
+                    (node as BinaryExpression).operatorToken.kind === SyntaxKind.AmpersandAmpersandToken && (isFalseExpression((node as BinaryExpression).left) || isFalseExpression((node as BinaryExpression).right))
+                    || (node as BinaryExpression).operatorToken.kind === SyntaxKind.BarBarToken && isFalseExpression((node as BinaryExpression).left) && isFalseExpression((node as BinaryExpression).right)
                 );
     }
 
@@ -27889,9 +27889,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         flow = (flow as FlowLabel).antecedents![0];
                         continue;
                     }
-                    type = flags & FlowFlags.BranchLabel ?
-                        getTypeAtFlowBranchLabel(flow as FlowLabel) :
-                        getTypeAtFlowLoopLabel(flow as FlowLabel);
+                    type = flags & FlowFlags.BranchLabel
+                        ? getTypeAtFlowBranchLabel(flow as FlowLabel)
+                        : getTypeAtFlowLoopLabel(flow as FlowLabel);
                 }
                 else if (flags & FlowFlags.ArrayMutation) {
                     type = getTypeAtFlowArrayMutation(flow as FlowArrayMutation);
@@ -27911,10 +27911,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // Check if we should continue with the control flow of the containing function.
                     const container = (flow as FlowStart).node;
                     if (
-                        container && container !== flowContainer &&
-                        reference.kind !== SyntaxKind.PropertyAccessExpression &&
-                        reference.kind !== SyntaxKind.ElementAccessExpression &&
-                        !(reference.kind === SyntaxKind.ThisKeyword && container.kind !== SyntaxKind.ArrowFunction)
+                        container && container !== flowContainer
+                        && reference.kind !== SyntaxKind.PropertyAccessExpression
+                        && reference.kind !== SyntaxKind.ElementAccessExpression
+                        && !(reference.kind === SyntaxKind.ThisKeyword && container.kind !== SyntaxKind.ArrowFunction)
                     ) {
                         flow = container.flowNode!;
                         continue;
@@ -27941,9 +27941,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function getInitialOrAssignedType(flow: FlowAssignment) {
             const node = flow.node;
             return getNarrowableTypeForReference(
-                node.kind === SyntaxKind.VariableDeclaration || node.kind === SyntaxKind.BindingElement ?
-                    getInitialType(node as VariableDeclaration | BindingElement) :
-                    getAssignedType(node),
+                node.kind === SyntaxKind.VariableDeclaration || node.kind === SyntaxKind.BindingElement
+                    ? getInitialType(node as VariableDeclaration | BindingElement)
+                    : getAssignedType(node),
                 reference,
             );
         }
@@ -27993,9 +27993,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             // for (const _ in ref) acts as a nonnull on ref
             if (
-                isVariableDeclaration(node) &&
-                node.parent.parent.kind === SyntaxKind.ForInStatement &&
-                (isMatchingReference(reference, node.parent.parent.expression) || optionalChainContainsReference(node.parent.parent.expression, reference))
+                isVariableDeclaration(node)
+                && node.parent.parent.kind === SyntaxKind.ForInStatement
+                && (isMatchingReference(reference, node.parent.parent.expression) || optionalChainContainsReference(node.parent.parent.expression, reference))
             ) {
                 return getNonNullableTypeIfNeeded(finalizeEvolvingArrayType(getTypeFromFlowType(getTypeAtFlowNode(flow.antecedent))));
             }
@@ -28026,9 +28026,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (predicate && (predicate.kind === TypePredicateKind.AssertsThis || predicate.kind === TypePredicateKind.AssertsIdentifier)) {
                     const flowType = getTypeAtFlowNode(flow.antecedent);
                     const type = finalizeEvolvingArrayType(getTypeFromFlowType(flowType));
-                    const narrowedType = predicate.type ? narrowTypeByTypePredicate(type, predicate, flow.node, /*assumeTrue*/ true) :
-                        predicate.kind === TypePredicateKind.AssertsIdentifier && predicate.parameterIndex >= 0 && predicate.parameterIndex < flow.node.arguments.length ? narrowTypeByAssertion(type, flow.node.arguments[predicate.parameterIndex]) :
-                        type;
+                    const narrowedType = predicate.type ? narrowTypeByTypePredicate(type, predicate, flow.node, /*assumeTrue*/ true)
+                        : predicate.kind === TypePredicateKind.AssertsIdentifier && predicate.parameterIndex >= 0 && predicate.parameterIndex < flow.node.arguments.length ? narrowTypeByAssertion(type, flow.node.arguments[predicate.parameterIndex])
+                        : type;
                     return narrowedType === type ? flowType : createFlowType(narrowedType, isIncomplete(flowType));
                 }
                 if (getReturnTypeOfSignature(signature).flags & TypeFlags.Never) {
@@ -28041,9 +28041,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function getTypeAtFlowArrayMutation(flow: FlowArrayMutation): FlowType | undefined {
             if (declaredType === autoType || declaredType === autoArrayType) {
                 const node = flow.node;
-                const expr = node.kind === SyntaxKind.CallExpression ?
-                    (node.expression as PropertyAccessExpression).expression :
-                    (node.left as ElementAccessExpression).expression;
+                const expr = node.kind === SyntaxKind.CallExpression
+                    ? (node.expression as PropertyAccessExpression).expression
+                    : (node.left as ElementAccessExpression).expression;
                 if (isMatchingReference(reference, getReferenceCandidate(expr))) {
                     const flowType = getTypeAtFlowNode(flow.antecedent);
                     const type = getTypeFromFlowType(flowType);
@@ -28297,8 +28297,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const declaration = symbol.valueDeclaration!;
                     // Given 'const x = obj.kind', allow 'x' as an alias for 'obj.kind'
                     if (
-                        isVariableDeclaration(declaration) && !declaration.type && declaration.initializer && isAccessExpression(declaration.initializer) &&
-                        isMatchingReference(reference, declaration.initializer.expression)
+                        isVariableDeclaration(declaration) && !declaration.type && declaration.initializer && isAccessExpression(declaration.initializer)
+                        && isMatchingReference(reference, declaration.initializer.expression)
                     ) {
                         return declaration.initializer;
                     }
@@ -28306,8 +28306,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (isBindingElement(declaration) && !declaration.initializer) {
                         const parent = declaration.parent.parent;
                         if (
-                            isVariableDeclaration(parent) && !parent.type && parent.initializer && (isIdentifier(parent.initializer) || isAccessExpression(parent.initializer)) &&
-                            isMatchingReference(reference, parent.initializer)
+                            isVariableDeclaration(parent) && !parent.type && parent.initializer && (isIdentifier(parent.initializer) || isAccessExpression(parent.initializer))
+                            && isMatchingReference(reference, parent.initializer)
                         ) {
                             return declaration;
                         }
@@ -28361,9 +28361,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (keyPropertyName && keyPropertyName === getAccessedPropertyName(access)) {
                     const candidate = getConstituentTypeForKeyType(type as UnionType, getTypeOfExpression(value));
                     if (candidate) {
-                        return operator === (assumeTrue ? SyntaxKind.EqualsEqualsEqualsToken : SyntaxKind.ExclamationEqualsEqualsToken) ? candidate :
-                            isUnitType(getTypeOfPropertyOfType(candidate, keyPropertyName) || unknownType) ? removeType(type, candidate) :
-                            type;
+                        return operator === (assumeTrue ? SyntaxKind.EqualsEqualsEqualsToken : SyntaxKind.ExclamationEqualsEqualsToken) ? candidate
+                            : isUnitType(getTypeOfPropertyOfType(candidate, keyPropertyName) || unknownType) ? removeType(type, candidate)
+                            : type;
                     }
                 }
             }
@@ -28397,9 +28397,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function isTypePresencePossible(type: Type, propName: __String, assumeTrue: boolean) {
             const prop = getPropertyOfType(type, propName);
-            return prop ?
-                !!(prop.flags & SymbolFlags.Optional || getCheckFlags(prop) & CheckFlags.Partial) || assumeTrue :
-                !!getApplicableIndexInfoForName(type, propName) || !assumeTrue;
+            return prop
+                ? !!(prop.flags & SymbolFlags.Optional || getCheckFlags(prop) & CheckFlags.Partial) || assumeTrue
+                : !!getApplicableIndexInfoForName(type, propName) || !assumeTrue;
         }
 
         function narrowTypeByInKeyword(type: Type, nameType: StringLiteralType | NumberLiteralType | UniqueESSymbolType, assumeTrue: boolean) {
@@ -28507,13 +28507,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // expressions down to individual conditional control flows. However, we may encounter them when analyzing
                 // aliased conditional expressions.
                 case SyntaxKind.AmpersandAmpersandToken:
-                    return assumeTrue ?
-                        narrowType(narrowType(type, expr.left, /*assumeTrue*/ true), expr.right, /*assumeTrue*/ true) :
-                        getUnionType([narrowType(type, expr.left, /*assumeTrue*/ false), narrowType(type, expr.right, /*assumeTrue*/ false)]);
+                    return assumeTrue
+                        ? narrowType(narrowType(type, expr.left, /*assumeTrue*/ true), expr.right, /*assumeTrue*/ true)
+                        : getUnionType([narrowType(type, expr.left, /*assumeTrue*/ false), narrowType(type, expr.right, /*assumeTrue*/ false)]);
                 case SyntaxKind.BarBarToken:
-                    return assumeTrue ?
-                        getUnionType([narrowType(type, expr.left, /*assumeTrue*/ true), narrowType(type, expr.right, /*assumeTrue*/ true)]) :
-                        narrowType(narrowType(type, expr.left, /*assumeTrue*/ false), expr.right, /*assumeTrue*/ false);
+                    return assumeTrue
+                        ? getUnionType([narrowType(type, expr.left, /*assumeTrue*/ true), narrowType(type, expr.right, /*assumeTrue*/ true)])
+                        : narrowType(narrowType(type, expr.left, /*assumeTrue*/ false), expr.right, /*assumeTrue*/ false);
             }
             return type;
         }
@@ -28550,8 +28550,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const nullableFlags = operator === SyntaxKind.EqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsToken ? TypeFlags.Nullable : TypeFlags.Undefined;
             const valueType = getTypeOfExpression(value);
             // Note that we include any and unknown in the exclusion test because their domain includes null and undefined.
-            const removeNullable = equalsOperator !== assumeTrue && everyType(valueType, t => !!(t.flags & nullableFlags)) ||
-                equalsOperator === assumeTrue && everyType(valueType, t => !(t.flags & (TypeFlags.AnyOrUnknown | nullableFlags)));
+            const removeNullable = equalsOperator !== assumeTrue && everyType(valueType, t => !!(t.flags & nullableFlags))
+                || equalsOperator === assumeTrue && everyType(valueType, t => !(t.flags & (TypeFlags.AnyOrUnknown | nullableFlags)));
             return removeNullable ? getAdjustedTypeWithFacts(type, TypeFacts.NEUndefinedOrNull) : type;
         }
 
@@ -28568,11 +28568,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (!strictNullChecks) {
                     return type;
                 }
-                const facts = doubleEquals ?
-                    assumeTrue ? TypeFacts.EQUndefinedOrNull : TypeFacts.NEUndefinedOrNull :
-                    valueType.flags & TypeFlags.Null ?
-                    assumeTrue ? TypeFacts.EQNull : TypeFacts.NENull :
-                    assumeTrue ? TypeFacts.EQUndefined : TypeFacts.NEUndefined;
+                const facts = doubleEquals
+                    ? assumeTrue ? TypeFacts.EQUndefinedOrNull : TypeFacts.NEUndefinedOrNull
+                    : valueType.flags & TypeFlags.Null
+                    ? assumeTrue ? TypeFacts.EQNull : TypeFacts.NENull
+                    : assumeTrue ? TypeFacts.EQUndefined : TypeFacts.NEUndefined;
                 return getAdjustedTypeWithFacts(type, facts);
             }
             if (assumeTrue) {
@@ -28613,9 +28613,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         function narrowTypeByLiteralExpression(type: Type, literal: LiteralExpression, assumeTrue: boolean) {
-            return assumeTrue ?
-                narrowTypeByTypeName(type, literal.text) :
-                getAdjustedTypeWithFacts(type, typeofNEFacts.get(literal.text) || TypeFacts.TypeofNEHostObject);
+            return assumeTrue
+                ? narrowTypeByTypeName(type, literal.text)
+                : getAdjustedTypeWithFacts(type, typeofNEFacts.get(literal.text) || TypeFacts.TypeofNEHostObject);
         }
 
         function narrowTypeBySwitchOptionalChainContainment(type: Type, switchStatement: SwitchStatement, clauseStart: number, clauseEnd: number, clauseCheck: (type: Type) => boolean) {
@@ -28656,8 +28656,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return getUnionType(groundClauseTypes === undefined ? clauseTypes : groundClauseTypes);
             }
             const discriminantType = getUnionType(clauseTypes);
-            const caseType = discriminantType.flags & TypeFlags.Never ? neverType :
-                replacePrimitivesWithLiterals(filterType(type, t => areTypesComparable(discriminantType, t)), discriminantType);
+            const caseType = discriminantType.flags & TypeFlags.Never ? neverType
+                : replacePrimitivesWithLiterals(filterType(type, t => areTypesComparable(discriminantType, t)), discriminantType);
             if (!hasDefaultClause) {
                 return caseType;
             }
@@ -28693,15 +28693,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // the constituent based on its type facts. We use the strict subtype relation because it treats `object`
                 // as a subtype of `{}`, and we need the type facts check because function types are subtypes of `object`,
                 // but are classified as "function" according to `typeof`.
-                isTypeRelatedTo(t, impliedType, strictSubtypeRelation) ? hasTypeFacts(t, facts) ? t : neverType :
+                isTypeRelatedTo(t, impliedType, strictSubtypeRelation) ? hasTypeFacts(t, facts) ? t : neverType
                     // We next check if the consituent is a supertype of the implied type. If so, we substitute the implied
                     // type. This handles top types like `unknown` and `{}`, and supertypes like `{ toString(): string }`.
-                    isTypeSubtypeOf(impliedType, t) ? impliedType :
+                    : isTypeSubtypeOf(impliedType, t) ? impliedType
                     // Neither the constituent nor the implied type is a subtype of the other, however their domains may still
                     // overlap. For example, an unconstrained type parameter and type `string`. If the type facts indicate
                     // possible overlap, we form an intersection. Otherwise, we eliminate the constituent.
-                    hasTypeFacts(t, facts) ? getIntersectionType([t, impliedType]) :
-                    neverType);
+                    : hasTypeFacts(t, facts) ? getIntersectionType([t, impliedType])
+                    : neverType);
         }
 
         function narrowTypeBySwitchOnTypeOf(type: Type, switchStatement: SwitchStatement, clauseStart: number, clauseEnd: number): Type {
@@ -28753,9 +28753,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         function isMatchingConstructorReference(expr: Expression) {
-            return (isPropertyAccessExpression(expr) && idText(expr.name) === "constructor" ||
-                isElementAccessExpression(expr) && isStringLiteralLike(expr.argumentExpression) && expr.argumentExpression.text === "constructor") &&
-                isMatchingReference(reference, expr.expression);
+            return (isPropertyAccessExpression(expr) && idText(expr.name) === "constructor"
+                || isElementAccessExpression(expr) && isStringLiteralLike(expr.argumentExpression) && expr.argumentExpression.text === "constructor")
+                && isMatchingReference(reference, expr.expression);
         }
 
         function narrowTypeByConstructor(type: Type, operator: SyntaxKind, identifier: Expression, assumeTrue: boolean): Type {
@@ -28797,8 +28797,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // that defines the same set of properties as class `A`, in that case they are structurally the same
                 // type, but when you do something like `instanceOfA.constructor === B` it will return false.
                 if (
-                    source.flags & TypeFlags.Object && getObjectFlags(source) & ObjectFlags.Class ||
-                    target.flags & TypeFlags.Object && getObjectFlags(target) & ObjectFlags.Class
+                    source.flags & TypeFlags.Object && getObjectFlags(source) & ObjectFlags.Class
+                    || target.flags & TypeFlags.Object && getObjectFlags(target) & ObjectFlags.Class
                 ) {
                     return source.symbol === target.symbol;
                 }
@@ -28837,8 +28837,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Don't narrow from `any` if the target type is exactly `Object` or `Function`, and narrow
             // in the false branch only if the target is a non-empty object type.
             if (
-                isTypeAny(type) && (instanceType === globalObjectType || instanceType === globalFunctionType) ||
-                !assumeTrue && !(instanceType.flags & TypeFlags.Object && !isEmptyAnonymousObjectType(instanceType))
+                isTypeAny(type) && (instanceType === globalObjectType || instanceType === globalFunctionType)
+                || !assumeTrue && !(instanceType.flags & TypeFlags.Object && !isEmptyAnonymousObjectType(instanceType))
             ) {
                 return type;
             }
@@ -28896,23 +28896,23 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // prototype object types.
                 const directlyRelated = mapType(
                     matching || type,
-                    checkDerived ?
-                        t => isTypeDerivedFrom(t, c) ? t : isTypeDerivedFrom(c, t) ? c : neverType :
-                        t => isTypeStrictSubtypeOf(t, c) ? t : isTypeStrictSubtypeOf(c, t) ? c : isTypeSubtypeOf(t, c) ? t : isTypeSubtypeOf(c, t) ? c : neverType,
+                    checkDerived
+                        ? t => isTypeDerivedFrom(t, c) ? t : isTypeDerivedFrom(c, t) ? c : neverType
+                        : t => isTypeStrictSubtypeOf(t, c) ? t : isTypeStrictSubtypeOf(c, t) ? c : isTypeSubtypeOf(t, c) ? t : isTypeSubtypeOf(c, t) ? c : neverType,
                 );
                 // If no constituents are directly related, create intersections for any generic constituents that
                 // are related by constraint.
-                return directlyRelated.flags & TypeFlags.Never ?
-                    mapType(type, t => maybeTypeOfKind(t, TypeFlags.Instantiable) && isRelated(c, getBaseConstraintOfType(t) || unknownType) ? getIntersectionType([t, c]) : neverType) :
-                    directlyRelated;
+                return directlyRelated.flags & TypeFlags.Never
+                    ? mapType(type, t => maybeTypeOfKind(t, TypeFlags.Instantiable) && isRelated(c, getBaseConstraintOfType(t) || unknownType) ? getIntersectionType([t, c]) : neverType)
+                    : directlyRelated;
             });
             // If filtering produced a non-empty type, return that. Otherwise, pick the most specific of the two
             // based on assignability, or as a last resort produce an intersection.
-            return !(narrowedType.flags & TypeFlags.Never) ? narrowedType :
-                isTypeSubtypeOf(candidate, type) ? candidate :
-                isTypeAssignableTo(type, candidate) ? type :
-                isTypeAssignableTo(candidate, type) ? candidate :
-                getIntersectionType([type, candidate]);
+            return !(narrowedType.flags & TypeFlags.Never) ? narrowedType
+                : isTypeSubtypeOf(candidate, type) ? candidate
+                : isTypeAssignableTo(type, candidate) ? type
+                : isTypeAssignableTo(candidate, type) ? candidate
+                : getIntersectionType([type, candidate]);
         }
 
         function narrowTypeByCallExpression(type: Type, callExpression: CallExpression, assumeTrue: boolean): Type {
@@ -28926,8 +28926,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (containsMissingType(type) && isAccessExpression(reference) && isPropertyAccessExpression(callExpression.expression)) {
                 const callAccess = callExpression.expression;
                 if (
-                    isMatchingReference(reference.expression, getReferenceCandidate(callAccess.expression)) &&
-                    isIdentifier(callAccess.name) && callAccess.name.escapedText === "hasOwnProperty" && callExpression.arguments.length === 1
+                    isMatchingReference(reference.expression, getReferenceCandidate(callAccess.expression))
+                    && isIdentifier(callAccess.name) && callAccess.name.escapedText === "hasOwnProperty" && callExpression.arguments.length === 1
                 ) {
                     const argument = callExpression.arguments[0];
                     if (isStringLiteralLike(argument) && getAccessedPropertyName(reference) === escapeLeadingUnderscores(argument.text)) {
@@ -28947,10 +28947,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         return getNarrowedType(type, predicate.type, assumeTrue, /*checkDerived*/ false);
                     }
                     if (
-                        strictNullChecks && optionalChainContainsReference(predicateArgument, reference) &&
-                        (
-                            assumeTrue && !(hasTypeFacts(predicate.type, TypeFacts.EQUndefined)) ||
-                            !assumeTrue && everyType(predicate.type, isNullableType)
+                        strictNullChecks && optionalChainContainsReference(predicateArgument, reference)
+                        && (
+                            assumeTrue && !(hasTypeFacts(predicate.type, TypeFacts.EQUndefined))
+                            || !assumeTrue && everyType(predicate.type, isNullableType)
                         )
                     ) {
                         type = getAdjustedTypeWithFacts(type, TypeFacts.NEUndefinedOrNull);
@@ -28969,8 +28969,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function narrowType(type: Type, expr: Expression, assumeTrue: boolean): Type {
             // for `a?.b`, we emulate a synthetic `a !== null && a !== undefined` condition for `a`
             if (
-                isExpressionOfOptionalChainRoot(expr) ||
-                isBinaryExpression(expr.parent) && (expr.parent.operatorToken.kind === SyntaxKind.QuestionQuestionToken || expr.parent.operatorToken.kind === SyntaxKind.QuestionQuestionEqualsToken) && expr.parent.left === expr
+                isExpressionOfOptionalChainRoot(expr)
+                || isBinaryExpression(expr.parent) && (expr.parent.operatorToken.kind === SyntaxKind.QuestionQuestionToken || expr.parent.operatorToken.kind === SyntaxKind.QuestionQuestionEqualsToken) && expr.parent.left === expr
             ) {
                 return narrowTypeByOptionality(type, expr, assumeTrue);
             }
@@ -29037,9 +29037,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             if (isExpressionNode(location) && (!isAssignmentTarget(location) || isWriteAccess(location))) {
                 const type = removeOptionalTypeMarker(
-                    isWriteAccess(location) && location.kind === SyntaxKind.PropertyAccessExpression ?
-                        checkPropertyAccessExpression(location as PropertyAccessExpression, /*checkMode*/ undefined, /*writeOnly*/ true) :
-                        getTypeOfExpression(location as Expression),
+                    isWriteAccess(location) && location.kind === SyntaxKind.PropertyAccessExpression
+                        ? checkPropertyAccessExpression(location as PropertyAccessExpression, /*checkMode*/ undefined, /*writeOnly*/ true)
+                        : getTypeOfExpression(location as Expression),
                 );
                 if (getExportSymbolOfValueSymbolIfExported(getNodeLinks(location).resolvedSymbol) === symbol) {
                     return type;
@@ -29059,10 +29059,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getControlFlowContainer(node: Node): Node {
         return findAncestor(node.parent, node =>
-            isFunctionLike(node) && !getImmediatelyInvokedFunctionExpression(node) ||
-            node.kind === SyntaxKind.ModuleBlock ||
-            node.kind === SyntaxKind.SourceFile ||
-            node.kind === SyntaxKind.PropertyDeclaration)!;
+            isFunctionLike(node) && !getImmediatelyInvokedFunctionExpression(node)
+            || node.kind === SyntaxKind.ModuleBlock
+            || node.kind === SyntaxKind.SourceFile
+            || node.kind === SyntaxKind.PropertyDeclaration)!;
     }
 
     // Check if a parameter or catch variable is assigned anywhere
@@ -29181,16 +29181,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Return true if symbol is a parameter, a catch clause variable, or a mutable local variable
         const declaration = symbol.valueDeclaration && getRootDeclaration(symbol.valueDeclaration);
         return !!declaration && (
-            isParameter(declaration) ||
-            isVariableDeclaration(declaration) && (isCatchClause(declaration.parent) || isMutableLocalVariableDeclaration(declaration))
+            isParameter(declaration)
+            || isVariableDeclaration(declaration) && (isCatchClause(declaration.parent) || isMutableLocalVariableDeclaration(declaration))
         );
     }
 
     function isMutableLocalVariableDeclaration(declaration: VariableDeclaration) {
         // Return true if symbol is a non-exported and non-global `let` variable
         return !!(declaration.parent.flags & NodeFlags.Let) && !(
-            getCombinedModifierFlags(declaration) & ModifierFlags.Export ||
-            declaration.parent.parent.kind === SyntaxKind.VariableStatement && isGlobalSourceFile(declaration.parent.parent.parent)
+            getCombinedModifierFlags(declaration) & ModifierFlags.Export
+            || declaration.parent.parent.kind === SyntaxKind.VariableStatement && isGlobalSourceFile(declaration.parent.parent.parent)
         );
     }
 
@@ -29218,11 +29218,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     /** remove undefined from the annotated type of a parameter when there is an initializer (that doesn't include undefined) */
     function removeOptionalityFromDeclaredType(declaredType: Type, declaration: VariableLikeDeclaration): Type {
-        const removeUndefined = strictNullChecks &&
-            declaration.kind === SyntaxKind.Parameter &&
-            declaration.initializer &&
-            hasTypeFacts(declaredType, TypeFacts.IsUndefined) &&
-            !parameterInitializerContainsUndefined(declaration);
+        const removeUndefined = strictNullChecks
+            && declaration.kind === SyntaxKind.Parameter
+            && declaration.initializer
+            && hasTypeFacts(declaredType, TypeFacts.IsUndefined)
+            && !parameterInitializerContainsUndefined(declaration);
 
         return removeUndefined ? getTypeWithFacts(declaredType, TypeFacts.NEUndefined) : declaredType;
     }
@@ -29232,24 +29232,24 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // In an element access obj[x], we consider obj to be in a constraint position, except when obj is of
         // a generic type without a nullable constraint and x is a generic type. This is because when both obj
         // and x are of generic types T and K, we want the resulting type to be T[K].
-        return parent.kind === SyntaxKind.PropertyAccessExpression ||
-            parent.kind === SyntaxKind.QualifiedName ||
-            parent.kind === SyntaxKind.CallExpression && (parent as CallExpression).expression === node ||
-            parent.kind === SyntaxKind.NewExpression && (parent as NewExpression).expression === node ||
-            parent.kind === SyntaxKind.ElementAccessExpression && (parent as ElementAccessExpression).expression === node &&
-                !(someType(type, isGenericTypeWithoutNullableConstraint) && isGenericIndexType(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression)));
+        return parent.kind === SyntaxKind.PropertyAccessExpression
+            || parent.kind === SyntaxKind.QualifiedName
+            || parent.kind === SyntaxKind.CallExpression && (parent as CallExpression).expression === node
+            || parent.kind === SyntaxKind.NewExpression && (parent as NewExpression).expression === node
+            || parent.kind === SyntaxKind.ElementAccessExpression && (parent as ElementAccessExpression).expression === node
+                && !(someType(type, isGenericTypeWithoutNullableConstraint) && isGenericIndexType(getTypeOfExpression((parent as ElementAccessExpression).argumentExpression)));
     }
 
     function isGenericTypeWithUnionConstraint(type: Type): boolean {
-        return type.flags & TypeFlags.Intersection ?
-            some((type as IntersectionType).types, isGenericTypeWithUnionConstraint) :
-            !!(type.flags & TypeFlags.Instantiable && getBaseConstraintOrType(type).flags & (TypeFlags.Nullable | TypeFlags.Union));
+        return type.flags & TypeFlags.Intersection
+            ? some((type as IntersectionType).types, isGenericTypeWithUnionConstraint)
+            : !!(type.flags & TypeFlags.Instantiable && getBaseConstraintOrType(type).flags & (TypeFlags.Nullable | TypeFlags.Union));
     }
 
     function isGenericTypeWithoutNullableConstraint(type: Type): boolean {
-        return type.flags & TypeFlags.Intersection ?
-            some((type as IntersectionType).types, isGenericTypeWithoutNullableConstraint) :
-            !!(type.flags & TypeFlags.Instantiable && !maybeTypeOfKind(getBaseConstraintOrType(type), TypeFlags.Nullable));
+        return type.flags & TypeFlags.Intersection
+            ? some((type as IntersectionType).types, isGenericTypeWithoutNullableConstraint)
+            : !!(type.flags & TypeFlags.Instantiable && !maybeTypeOfKind(getBaseConstraintOrType(type), TypeFlags.Nullable));
     }
 
     function hasContextualTypeWithNoGenericTypes(node: Node, checkMode: CheckMode | undefined) {
@@ -29257,10 +29257,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // element's tag name, so we exclude that here to avoid circularities.
         // If check mode has `CheckMode.RestBindingElement`, we skip binding pattern contextual types,
         // as we want the type of a rest element to be generic when possible.
-        const contextualType = (isIdentifier(node) || isPropertyAccessExpression(node) || isElementAccessExpression(node)) &&
-            !((isJsxOpeningElement(node.parent) || isJsxSelfClosingElement(node.parent)) && node.parent.tagName === node) &&
-            (checkMode && checkMode & CheckMode.RestBindingElement ?
-                getContextualType(node, ContextFlags.SkipBindingPatterns)
+        const contextualType = (isIdentifier(node) || isPropertyAccessExpression(node) || isElementAccessExpression(node))
+            && !((isJsxOpeningElement(node.parent) || isJsxSelfClosingElement(node.parent)) && node.parent.tagName === node)
+            && (checkMode && checkMode & CheckMode.RestBindingElement
+                ? getContextualType(node, ContextFlags.SkipBindingPatterns)
                 : getContextualType(node, /*contextFlags*/ undefined));
         return contextualType && !isGenericType(contextualType);
     }
@@ -29273,9 +29273,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // control flow analysis an opportunity to narrow it further. For example, for a reference of a type
         // parameter type 'T extends string | undefined' with a contextual type 'string', we substitute
         // 'string | undefined' to give control flow analysis the opportunity to narrow to type 'string'.
-        const substituteConstraints = !(checkMode && checkMode & CheckMode.Inferential) &&
-            someType(type, isGenericTypeWithUnionConstraint) &&
-            (isConstraintPosition(type, reference) || hasContextualTypeWithNoGenericTypes(reference, checkMode));
+        const substituteConstraints = !(checkMode && checkMode & CheckMode.Inferential)
+            && someType(type, isGenericTypeWithUnionConstraint)
+            && (isConstraintPosition(type, reference) || hasContextualTypeWithNoGenericTypes(reference, checkMode));
         return substituteConstraints ? mapType(type, getBaseConstraintOrType) : type;
     }
 
@@ -29306,9 +29306,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // (because the const enum value will not be inlined), or if (2) the alias is an export
                 // of a const enum declaration that will be preserved.
                 if (
-                    getIsolatedModules(compilerOptions) ||
-                    shouldPreserveConstEnums(compilerOptions) && isExportOrExportExpression(location) ||
-                    !isConstEnumOrConstEnumOnlyModule(getExportSymbolOfValueSymbolIfExported(target))
+                    getIsolatedModules(compilerOptions)
+                    || shouldPreserveConstEnums(compilerOptions) && isExportOrExportExpression(location)
+                    || !isConstEnumOrConstEnumOnlyModule(getExportSymbolOfValueSymbolIfExported(target))
                 ) {
                     markAliasSymbolAsReferenced(symbol);
                 }
@@ -29488,8 +29488,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         if (assignmentKind) {
             if (
-                !(localOrExportSymbol.flags & SymbolFlags.Variable) &&
-                !(isInJSFile(node) && localOrExportSymbol.flags & SymbolFlags.ValueModule)
+                !(localOrExportSymbol.flags & SymbolFlags.Variable)
+                && !(isInJSFile(node) && localOrExportSymbol.flags & SymbolFlags.ValueModule)
             ) {
                 const assignmentError = localOrExportSymbol.flags & SymbolFlags.Enum ? Diagnostics.Cannot_assign_to_0_because_it_is_an_enum
                     : localOrExportSymbol.flags & SymbolFlags.Class ? Diagnostics.Cannot_assign_to_0_because_it_is_a_class
@@ -29551,12 +29551,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // control flow container.
         while (
             flowContainer !== declarationContainer && (
-                flowContainer.kind === SyntaxKind.FunctionExpression ||
-                flowContainer.kind === SyntaxKind.ArrowFunction ||
-                isObjectLiteralOrClassExpressionMethodOrAccessor(flowContainer)
+                flowContainer.kind === SyntaxKind.FunctionExpression
+                || flowContainer.kind === SyntaxKind.ArrowFunction
+                || isObjectLiteralOrClassExpressionMethodOrAccessor(flowContainer)
             ) && (
-                isConstantVariable(localOrExportSymbol) && type !== autoArrayType ||
-                isParameterOrMutableLocalVariable(localOrExportSymbol) && isPastLastAssignment(localOrExportSymbol, node)
+                isConstantVariable(localOrExportSymbol) && type !== autoArrayType
+                || isParameterOrMutableLocalVariable(localOrExportSymbol) && isPastLastAssignment(localOrExportSymbol, node)
             )
         ) {
             flowContainer = getControlFlowContainer(flowContainer);
@@ -29564,17 +29564,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // We only look for uninitialized variables in strict null checking mode, and only when we can analyze
         // the entire control flow graph from the variable's declaration (i.e. when the flow container and
         // declaration container are the same).
-        const assumeInitialized = isParameter || isAlias || isOuterVariable || isSpreadDestructuringAssignmentTarget || isModuleExports || isSameScopedBindingElement(node, declaration) ||
-            type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void)) !== 0 ||
-                    isInTypeQuery(node) || isInAmbientOrTypeNode(node) || node.parent.kind === SyntaxKind.ExportSpecifier) ||
-            node.parent.kind === SyntaxKind.NonNullExpression ||
-            declaration.kind === SyntaxKind.VariableDeclaration && (declaration as VariableDeclaration).exclamationToken ||
-            declaration.flags & NodeFlags.Ambient;
-        const initialType = isAutomaticTypeInNonNull ? undefinedType :
-            assumeInitialized ? (isParameter ? removeOptionalityFromDeclaredType(type, declaration as VariableLikeDeclaration) : type) :
-            typeIsAutomatic ? undefinedType : getOptionalType(type);
-        const flowType = isAutomaticTypeInNonNull ? getNonNullableType(getFlowTypeOfReference(node, type, initialType, flowContainer)) :
-            getFlowTypeOfReference(node, type, initialType, flowContainer);
+        const assumeInitialized = isParameter || isAlias || isOuterVariable || isSpreadDestructuringAssignmentTarget || isModuleExports || isSameScopedBindingElement(node, declaration)
+            || type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void)) !== 0
+                    || isInTypeQuery(node) || isInAmbientOrTypeNode(node) || node.parent.kind === SyntaxKind.ExportSpecifier)
+            || node.parent.kind === SyntaxKind.NonNullExpression
+            || declaration.kind === SyntaxKind.VariableDeclaration && (declaration as VariableDeclaration).exclamationToken
+            || declaration.flags & NodeFlags.Ambient;
+        const initialType = isAutomaticTypeInNonNull ? undefinedType
+            : assumeInitialized ? (isParameter ? removeOptionalityFromDeclaredType(type, declaration as VariableLikeDeclaration) : type)
+            : typeIsAutomatic ? undefinedType : getOptionalType(type);
+        const flowType = isAutomaticTypeInNonNull ? getNonNullableType(getFlowTypeOfReference(node, type, initialType, flowContainer))
+            : getFlowTypeOfReference(node, type, initialType, flowContainer);
         // A variable is considered uninitialized when it is possible to analyze the entire control flow graph
         // from declaration to use, and when the variable's declared type doesn't include undefined but the
         // control flow based type does include undefined.
@@ -29638,11 +29638,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkNestedBlockScopedBinding(node: Identifier, symbol: Symbol): void {
         if (
-            languageVersion >= ScriptTarget.ES2015 ||
-            (symbol.flags & (SymbolFlags.BlockScopedVariable | SymbolFlags.Class)) === 0 ||
-            !symbol.valueDeclaration ||
-            isSourceFile(symbol.valueDeclaration) ||
-            symbol.valueDeclaration.parent.kind === SyntaxKind.CatchClause
+            languageVersion >= ScriptTarget.ES2015
+            || (symbol.flags & (SymbolFlags.BlockScopedVariable | SymbolFlags.Class)) === 0
+            || !symbol.valueDeclaration
+            || isSourceFile(symbol.valueDeclaration)
+            || symbol.valueDeclaration.parent.kind === SyntaxKind.CatchClause
         ) {
             return;
         }
@@ -29743,9 +29743,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function findFirstSuperCall(node: Node): SuperCall | undefined {
-        return isSuperCall(node) ? node :
-            isFunctionLike(node) ? undefined :
-            forEachChild(node, findFirstSuperCall);
+        return isSuperCall(node) ? node
+            : isFunctionLike(node) ? undefined
+            : forEachChild(node, findFirstSuperCall);
     }
 
     /**
@@ -29776,8 +29776,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkThisInStaticClassFieldInitializerInDecoratedClass(thisExpression: Node, container: Node) {
         if (
-            isPropertyDeclaration(container) && hasStaticModifier(container) && legacyDecorators &&
-            container.initializer && textRangeContainsPositionInclusive(container.initializer, thisExpression.pos) && hasDecorators(container.parent)
+            isPropertyDeclaration(container) && hasStaticModifier(container) && legacyDecorators
+            && container.initializer && textRangeContainsPositionInclusive(container.initializer, thisExpression.pos) && hasDecorators(container.parent)
         ) {
             error(thisExpression, Diagnostics.Cannot_use_this_in_a_static_property_initializer_of_a_decorated_class);
         }
@@ -29862,8 +29862,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function tryGetThisTypeAt(node: Node, includeGlobalThis = true, container = getThisContainer(node, /*includeArrowFunctions*/ false, /*includeClassComputedPropertyName*/ false)): Type | undefined {
         const isInJS = isInJSFile(node);
         if (
-            isFunctionLike(container) &&
-            (!isInParameterInitializerBeforeContainingFunction(node) || getThisParameter(container))
+            isFunctionLike(container)
+            && (!isInParameterInitializerBeforeContainingFunction(node) || getThisParameter(container))
         ) {
             let thisType = getThisTypeOfDeclaration(container) || isInJS && getTypeForThisExpressionFromJSDoc(container);
             // Note: a parameter initializer should refer to class-this unless function-this is explicitly annotated.
@@ -29926,9 +29926,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getClassNameFromPrototypeMethod(container: Node) {
         // Check if it's the RHS of a x.prototype.y = function [name]() { .... }
         if (
-            container.kind === SyntaxKind.FunctionExpression &&
-            isBinaryExpression(container.parent) &&
-            getAssignmentDeclarationKind(container.parent) === AssignmentDeclarationKind.PrototypeProperty
+            container.kind === SyntaxKind.FunctionExpression
+            && isBinaryExpression(container.parent)
+            && getAssignmentDeclarationKind(container.parent) === AssignmentDeclarationKind.PrototypeProperty
         ) {
             // Get the 'x' of 'x.prototype.y = container'
             return ((container.parent // x.prototype.y = container
@@ -29938,20 +29938,20 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         // x.prototype = { method() { } }
         else if (
-            container.kind === SyntaxKind.MethodDeclaration &&
-            container.parent.kind === SyntaxKind.ObjectLiteralExpression &&
-            isBinaryExpression(container.parent.parent) &&
-            getAssignmentDeclarationKind(container.parent.parent) === AssignmentDeclarationKind.Prototype
+            container.kind === SyntaxKind.MethodDeclaration
+            && container.parent.kind === SyntaxKind.ObjectLiteralExpression
+            && isBinaryExpression(container.parent.parent)
+            && getAssignmentDeclarationKind(container.parent.parent) === AssignmentDeclarationKind.Prototype
         ) {
             return (container.parent.parent.left as PropertyAccessExpression).expression;
         }
         // x.prototype = { method: function() { } }
         else if (
-            container.kind === SyntaxKind.FunctionExpression &&
-            container.parent.kind === SyntaxKind.PropertyAssignment &&
-            container.parent.parent.kind === SyntaxKind.ObjectLiteralExpression &&
-            isBinaryExpression(container.parent.parent.parent) &&
-            getAssignmentDeclarationKind(container.parent.parent.parent) === AssignmentDeclarationKind.Prototype
+            container.kind === SyntaxKind.FunctionExpression
+            && container.parent.kind === SyntaxKind.PropertyAssignment
+            && container.parent.parent.kind === SyntaxKind.ObjectLiteralExpression
+            && isBinaryExpression(container.parent.parent.parent)
+            && getAssignmentDeclarationKind(container.parent.parent.parent) === AssignmentDeclarationKind.Prototype
         ) {
             return (container.parent.parent.parent.left as PropertyAccessExpression).expression;
         }
@@ -29959,14 +29959,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Object.defineProperty(x, "method", { set: (x: () => void) => void });
         // Object.defineProperty(x, "method", { get: () => function() { }) });
         else if (
-            container.kind === SyntaxKind.FunctionExpression &&
-            isPropertyAssignment(container.parent) &&
-            isIdentifier(container.parent.name) &&
-            (container.parent.name.escapedText === "value" || container.parent.name.escapedText === "get" || container.parent.name.escapedText === "set") &&
-            isObjectLiteralExpression(container.parent.parent) &&
-            isCallExpression(container.parent.parent.parent) &&
-            container.parent.parent.parent.arguments[2] === container.parent.parent &&
-            getAssignmentDeclarationKind(container.parent.parent.parent) === AssignmentDeclarationKind.ObjectDefinePrototypeProperty
+            container.kind === SyntaxKind.FunctionExpression
+            && isPropertyAssignment(container.parent)
+            && isIdentifier(container.parent.name)
+            && (container.parent.name.escapedText === "value" || container.parent.name.escapedText === "get" || container.parent.name.escapedText === "set")
+            && isObjectLiteralExpression(container.parent.parent)
+            && isCallExpression(container.parent.parent.parent)
+            && container.parent.parent.parent.arguments[2] === container.parent.parent
+            && getAssignmentDeclarationKind(container.parent.parent.parent) === AssignmentDeclarationKind.ObjectDefinePrototypeProperty
         ) {
             return (container.parent.parent.parent.arguments[0] as PropertyAccessExpression).expression;
         }
@@ -29974,13 +29974,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Object.defineProperty(x, "method", { set(x: () => void) {} });
         // Object.defineProperty(x, "method", { get() { return () => {} } });
         else if (
-            isMethodDeclaration(container) &&
-            isIdentifier(container.name) &&
-            (container.name.escapedText === "value" || container.name.escapedText === "get" || container.name.escapedText === "set") &&
-            isObjectLiteralExpression(container.parent) &&
-            isCallExpression(container.parent.parent) &&
-            container.parent.parent.arguments[2] === container.parent &&
-            getAssignmentDeclarationKind(container.parent.parent) === AssignmentDeclarationKind.ObjectDefinePrototypeProperty
+            isMethodDeclaration(container)
+            && isIdentifier(container.name)
+            && (container.name.escapedText === "value" || container.name.escapedText === "get" || container.name.escapedText === "set")
+            && isObjectLiteralExpression(container.parent)
+            && isCallExpression(container.parent.parent)
+            && container.parent.parent.arguments[2] === container.parent
+            && getAssignmentDeclarationKind(container.parent.parent) === AssignmentDeclarationKind.ObjectDefinePrototypeProperty
         ) {
             return (container.parent.parent.arguments[0] as PropertyAccessExpression).expression;
         }
@@ -30050,9 +30050,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isStatic(container) || isCallExpression) {
             nodeCheckFlag = NodeCheckFlags.SuperStatic;
             if (
-                !isCallExpression &&
-                languageVersion >= ScriptTarget.ES2015 && languageVersion <= ScriptTarget.ES2021 &&
-                (isPropertyDeclaration(container) || isClassStaticBlockDeclaration(container))
+                !isCallExpression
+                && languageVersion >= ScriptTarget.ES2015 && languageVersion <= ScriptTarget.ES2021
+                && (isPropertyDeclaration(container) || isClassStaticBlockDeclaration(container))
             ) {
                 // for `super.x` or `super[x]` in a static initializer, mark all enclosing
                 // block scope containers so that we can report potential collisions with
@@ -30198,21 +30198,21 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // topmost container must be something that is directly nested in the class declaration\object literal expression
                 if (isClassLike(container.parent) || container.parent.kind === SyntaxKind.ObjectLiteralExpression) {
                     if (isStatic(container)) {
-                        return container.kind === SyntaxKind.MethodDeclaration ||
-                            container.kind === SyntaxKind.MethodSignature ||
-                            container.kind === SyntaxKind.GetAccessor ||
-                            container.kind === SyntaxKind.SetAccessor ||
-                            container.kind === SyntaxKind.PropertyDeclaration ||
-                            container.kind === SyntaxKind.ClassStaticBlockDeclaration;
+                        return container.kind === SyntaxKind.MethodDeclaration
+                            || container.kind === SyntaxKind.MethodSignature
+                            || container.kind === SyntaxKind.GetAccessor
+                            || container.kind === SyntaxKind.SetAccessor
+                            || container.kind === SyntaxKind.PropertyDeclaration
+                            || container.kind === SyntaxKind.ClassStaticBlockDeclaration;
                     }
                     else {
-                        return container.kind === SyntaxKind.MethodDeclaration ||
-                            container.kind === SyntaxKind.MethodSignature ||
-                            container.kind === SyntaxKind.GetAccessor ||
-                            container.kind === SyntaxKind.SetAccessor ||
-                            container.kind === SyntaxKind.PropertyDeclaration ||
-                            container.kind === SyntaxKind.PropertySignature ||
-                            container.kind === SyntaxKind.Constructor;
+                        return container.kind === SyntaxKind.MethodDeclaration
+                            || container.kind === SyntaxKind.MethodSignature
+                            || container.kind === SyntaxKind.GetAccessor
+                            || container.kind === SyntaxKind.SetAccessor
+                            || container.kind === SyntaxKind.PropertyDeclaration
+                            || container.kind === SyntaxKind.PropertySignature
+                            || container.kind === SyntaxKind.Constructor;
                     }
                 }
             }
@@ -30222,11 +30222,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getContainingObjectLiteral(func: SignatureDeclaration): ObjectLiteralExpression | undefined {
-        return (func.kind === SyntaxKind.MethodDeclaration ||
-                func.kind === SyntaxKind.GetAccessor ||
-                func.kind === SyntaxKind.SetAccessor) && func.parent.kind === SyntaxKind.ObjectLiteralExpression ? func.parent :
-            func.kind === SyntaxKind.FunctionExpression && func.parent.kind === SyntaxKind.PropertyAssignment ? func.parent.parent as ObjectLiteralExpression :
-            undefined;
+        return (func.kind === SyntaxKind.MethodDeclaration
+                || func.kind === SyntaxKind.GetAccessor
+                || func.kind === SyntaxKind.SetAccessor) && func.parent.kind === SyntaxKind.ObjectLiteralExpression ? func.parent
+            : func.kind === SyntaxKind.FunctionExpression && func.parent.kind === SyntaxKind.PropertyAssignment ? func.parent.parent as ObjectLiteralExpression
+            : undefined;
     }
 
     function getThisTypeArgument(type: Type): Type | undefined {
@@ -30323,18 +30323,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const links = getNodeLinks(iife);
             const cached = links.resolvedSignature;
             links.resolvedSignature = anySignature;
-            const type = indexOfParameter < args.length ?
-                getWidenedLiteralType(checkExpression(args[indexOfParameter])) :
-                parameter.initializer ? undefined : undefinedWideningType;
+            const type = indexOfParameter < args.length
+                ? getWidenedLiteralType(checkExpression(args[indexOfParameter]))
+                : parameter.initializer ? undefined : undefinedWideningType;
             links.resolvedSignature = cached;
             return type;
         }
         const contextualSignature = getContextualSignature(func);
         if (contextualSignature) {
             const index = func.parameters.indexOf(parameter) - (getThisParameter(func) ? 1 : 0);
-            return parameter.dotDotDotToken && lastOrUndefined(func.parameters) === parameter ?
-                getRestTypeAtPosition(contextualSignature, index) :
-                tryGetTypeAtPosition(contextualSignature, index);
+            return parameter.dotDotDotToken && lastOrUndefined(func.parameters) === parameter
+                ? getRestTypeAtPosition(contextualSignature, index)
+                : tryGetTypeAtPosition(contextualSignature, index);
         }
     }
 
@@ -30359,8 +30359,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getContextualTypeForBindingElement(declaration: BindingElement, contextFlags: ContextFlags | undefined): Type | undefined {
         const parent = declaration.parent.parent;
         const name = declaration.propertyName || declaration.name;
-        const parentType = getContextualTypeForVariableLikeDeclaration(parent, contextFlags) ||
-            parent.kind !== SyntaxKind.BindingElement && parent.initializer && checkDeclarationInitializer(parent, declaration.dotDotDotToken ? CheckMode.RestBindingElement : CheckMode.Normal);
+        const parentType = getContextualTypeForVariableLikeDeclaration(parent, contextFlags)
+            || parent.kind !== SyntaxKind.BindingElement && parent.initializer && checkDeclarationInitializer(parent, declaration.dotDotDotToken ? CheckMode.RestBindingElement : CheckMode.Normal);
         if (!parentType || isBindingPattern(name) || isComputedNonLiteralName(name)) return undefined;
         if (parent.name.kind === SyntaxKind.ArrayBindingPattern) {
             const index = indexOfNode(declaration.parent.elements, declaration);
@@ -30529,9 +30529,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getContextualTypeForArgumentAtIndex(callTarget: CallLikeExpression, argIndex: number): Type {
         if (isImportCall(callTarget)) {
-            return argIndex === 0 ? stringType :
-                argIndex === 1 ? getGlobalImportCallOptionsType(/*reportErrors*/ false) :
-                anyType;
+            return argIndex === 0 ? stringType
+                : argIndex === 1 ? getGlobalImportCallOptionsType(/*reportErrors*/ false)
+                : anyType;
         }
 
         // If we're already in the process of resolving the given signature, don't resolve again as
@@ -30542,9 +30542,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return getEffectiveFirstArgumentForJsxSignature(signature, callTarget);
         }
         const restIndex = signature.parameters.length - 1;
-        return signatureHasRestParameter(signature) && argIndex >= restIndex ?
-            getIndexedAccessType(getTypeOfSymbol(signature.parameters[restIndex]), getNumberLiteralType(argIndex - restIndex), AccessFlags.Contextual) :
-            getTypeAtPosition(signature, argIndex);
+        return signatureHasRestParameter(signature) && argIndex >= restIndex
+            ? getIndexedAccessType(getTypeOfSymbol(signature.parameters[restIndex]), getNumberLiteralType(argIndex - restIndex), AccessFlags.Contextual)
+            : getTypeAtPosition(signature, argIndex);
     }
 
     function getContextualTypeForDecorator(decorator: Decorator): Type | undefined {
@@ -30577,8 +30577,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // by the type of the left operand, except for the special case of Javascript declarations of the form
                 // `namespace.prop = namespace.prop || {}`.
                 const type = getContextualType(binaryExpression, contextFlags);
-                return node === right && (type && type.pattern || !type && !isDefaultedExpandoInitializer(binaryExpression)) ?
-                    getTypeOfExpression(left) : type;
+                return node === right && (type && type.pattern || !type && !isDefaultedExpandoInitializer(binaryExpression))
+                    ? getTypeOfExpression(left) : type;
             case SyntaxKind.AmpersandAmpersandToken:
             case SyntaxKind.CommaToken:
                 return node === right ? getContextualType(binaryExpression, contextFlags) : undefined;
@@ -30631,8 +30631,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // We avoid calling back into `getTypeOfExpression` and reentering contextual typing to avoid a bogus circularity error in that case.
                 if (decl && (isPropertyDeclaration(decl) || isPropertySignature(decl))) {
                     const overallAnnotation = getEffectiveTypeAnnotationNode(decl);
-                    return (overallAnnotation && instantiateType(getTypeFromTypeNode(overallAnnotation), getSymbolLinks(lhsSymbol).mapper)) ||
-                        (isPropertyDeclaration(decl) ? decl.initializer && getTypeOfExpression(binaryExpression.left) : undefined);
+                    return (overallAnnotation && instantiateType(getTypeFromTypeNode(overallAnnotation), getSymbolLinks(lhsSymbol).mapper))
+                        || (isPropertyDeclaration(decl) ? decl.initializer && getTypeOfExpression(binaryExpression.left) : undefined);
                 }
                 if (kind === AssignmentDeclarationKind.None) {
                     return getTypeOfExpression(binaryExpression.left);
@@ -30835,8 +30835,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             // If element index is known and a contextual property with that name exists, return it. Otherwise return the
             // iterated or element type of the contextual type.
-            return (!firstSpreadIndex || index < firstSpreadIndex) && getTypeOfPropertyOfContextualType(t, "" + index as __String) ||
-                getIteratedTypeOrElementType(IterationUse.Element, t, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false);
+            return (!firstSpreadIndex || index < firstSpreadIndex) && getTypeOfPropertyOfContextualType(t, "" + index as __String)
+                || getIteratedTypeOrElementType(IterationUse.Element, t, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false);
         }, /*noReductions*/ true);
     }
 
@@ -30974,9 +30974,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     // Return the contextual type for a given expression node. During overload resolution, a contextual type may temporarily
     // be "pushed" onto a node using the contextualType property.
     function getApparentTypeOfContextualType(node: Expression | MethodDeclaration, contextFlags: ContextFlags | undefined): Type | undefined {
-        const contextualType = isObjectLiteralMethod(node) ?
-            getContextualTypeForObjectLiteralMethod(node, contextFlags) :
-            getContextualType(node, contextFlags);
+        const contextualType = isObjectLiteralMethod(node)
+            ? getContextualTypeForObjectLiteralMethod(node, contextFlags)
+            : getContextualType(node, contextFlags);
         const instantiatedType = instantiateContextualType(contextualType, node, contextFlags);
         if (instantiatedType && !(contextFlags && contextFlags & ContextFlags.NoConstraints && instantiatedType.flags & TypeFlags.TypeVariable)) {
             const apparentType = mapType(
@@ -30988,9 +30988,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 t => getObjectFlags(t) & ObjectFlags.Mapped ? t : getApparentType(t),
                 /*noReductions*/ true,
             );
-            return apparentType.flags & TypeFlags.Union && isObjectLiteralExpression(node) ? discriminateContextualTypeByObjectMembers(node, apparentType as UnionType) :
-                apparentType.flags & TypeFlags.Union && isJsxAttributes(node) ? discriminateContextualTypeByJSXAttributes(node, apparentType as UnionType) :
-                apparentType;
+            return apparentType.flags & TypeFlags.Union && isObjectLiteralExpression(node) ? discriminateContextualTypeByObjectMembers(node, apparentType as UnionType)
+                : apparentType.flags & TypeFlags.Union && isJsxAttributes(node) ? discriminateContextualTypeByJSXAttributes(node, apparentType as UnionType)
+                : apparentType;
         }
     }
 
@@ -31013,9 +31013,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // the 'boolean' type from the contextual type such that contextually typed boolean
                 // literals actually end up widening to 'boolean' (see #48363).
                 const type = instantiateInstantiableTypes(contextualType, inferenceContext.returnMapper);
-                return type.flags & TypeFlags.Union && containsType((type as UnionType).types, regularFalseType) && containsType((type as UnionType).types, regularTrueType) ?
-                    filterType(type, t => t !== regularFalseType && t !== regularTrueType) :
-                    type;
+                return type.flags & TypeFlags.Union && containsType((type as UnionType).types, regularFalseType) && containsType((type as UnionType).types, regularTrueType)
+                    ? filterType(type, t => t !== regularFalseType && t !== regularTrueType)
+                    : type;
             }
         }
         return contextualType;
@@ -31370,10 +31370,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const leftName = i >= leftCount ? undefined : getParameterNameAtPosition(left, i);
             const rightName = i >= rightCount ? undefined : getParameterNameAtPosition(right, i);
 
-            const paramName = leftName === rightName ? leftName :
-                !leftName ? rightName :
-                !rightName ? leftName :
-                undefined;
+            const paramName = leftName === rightName ? leftName
+                : !leftName ? rightName
+                : !rightName ? leftName
+                : undefined;
             const paramSymbol = createSymbol(
                 SymbolFlags.FunctionScopedVariable | (isOptional && !isRestParam ? SymbolFlags.Optional : 0),
                 paramName || `arg${i}` as __String,
@@ -31508,8 +31508,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function hasDefaultValue(node: BindingElement | Expression): boolean {
-        return (node.kind === SyntaxKind.BindingElement && !!(node as BindingElement).initializer) ||
-            (node.kind === SyntaxKind.BinaryExpression && (node as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken);
+        return (node.kind === SyntaxKind.BindingElement && !!(node as BindingElement).initializer)
+            || (node.kind === SyntaxKind.BinaryExpression && (node as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken);
     }
 
     function isSpreadIntoCallOrNew(node: ArrayLiteralExpression) {
@@ -31553,9 +31553,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // get the contextual element type from it. So we do something similar to
                     // getContextualTypeForElementExpression, which will crucially not error
                     // if there is no index type / iterated type.
-                    const restElementType = getIndexTypeOfType(spreadType, numberType) ||
-                        getIteratedTypeOrElementType(IterationUse.Destructuring, spreadType, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false) ||
-                        unknownType;
+                    const restElementType = getIndexTypeOfType(spreadType, numberType)
+                        || getIteratedTypeOrElementType(IterationUse.Destructuring, spreadType, undefinedType, /*errorNode*/ undefined, /*checkAssignability*/ false)
+                        || unknownType;
                     elementTypes.push(restElementType);
                     elementFlags.push(ElementFlags.Rest);
                 }
@@ -31588,9 +31588,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return createArrayLiteralType(createTupleType(elementTypes, elementFlags, /*readonly*/ inConstContext && !(contextualType && someType(contextualType, isMutableArrayLikeType))));
         }
         return createArrayLiteralType(createArrayType(
-            elementTypes.length ?
-                getUnionType(sameMap(elementTypes, (t, i) => elementFlags[i] & ElementFlags.Variadic ? getIndexedAccessTypeOrUndefined(t, numberType) || anyType : t), UnionReduction.Subtype) :
-                strictNullChecks ? implicitNeverType : undefinedWideningType,
+            elementTypes.length
+                ? getUnionType(sameMap(elementTypes, (t, i) => elementFlags[i] & ElementFlags.Variadic ? getIndexedAccessTypeOrUndefined(t, numberType) || anyType : t), UnionReduction.Subtype)
+                : strictNullChecks ? implicitNeverType : undefinedWideningType,
             inConstContext,
         ));
     }
@@ -31655,9 +31655,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // This will allow types number, string, symbol or any. It will also allow enums, the unknown
             // type, and any union of these types (like string | number).
             if (
-                links.resolvedType.flags & TypeFlags.Nullable ||
-                !isTypeAssignableToKind(links.resolvedType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbolLike) &&
-                    !isTypeAssignableTo(links.resolvedType, stringNumberSymbolType)
+                links.resolvedType.flags & TypeFlags.Nullable
+                || !isTypeAssignableToKind(links.resolvedType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbolLike)
+                    && !isTypeAssignableTo(links.resolvedType, stringNumberSymbolType)
             ) {
                 error(node, Diagnostics.A_computed_property_name_must_be_of_type_string_number_symbol_or_any);
             }
@@ -31673,8 +31673,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isSymbolWithSymbolName(symbol: Symbol) {
         const firstDecl = symbol.declarations?.[0];
-        return isKnownSymbol(symbol) || (firstDecl && isNamedDeclaration(firstDecl) && isComputedPropertyName(firstDecl.name) &&
-            isTypeAssignableToKind(checkComputedPropertyName(firstDecl.name), TypeFlags.ESSymbol));
+        return isKnownSymbol(symbol) || (firstDecl && isNamedDeclaration(firstDecl) && isComputedPropertyName(firstDecl.name)
+            && isTypeAssignableToKind(checkComputedPropertyName(firstDecl.name), TypeFlags.ESSymbol));
     }
 
     function getObjectLiteralIndexInfo(node: ObjectLiteralExpression, offset: number, properties: Symbol[], keyType: Type): IndexInfo {
@@ -31682,9 +31682,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         for (let i = offset; i < properties.length; i++) {
             const prop = properties[i];
             if (
-                keyType === stringType && !isSymbolWithSymbolName(prop) ||
-                keyType === numberType && isSymbolWithNumericName(prop) ||
-                keyType === esSymbolType && isSymbolWithSymbolName(prop)
+                keyType === stringType && !isSymbolWithSymbolName(prop)
+                || keyType === numberType && isSymbolWithNumericName(prop)
+                || keyType === esSymbolType && isSymbolWithSymbolName(prop)
             ) {
                 propTypes.push(getTypeOfSymbol(properties[i]));
             }
@@ -31717,8 +31717,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         pushCachedContextualType(node);
         const contextualType = getApparentTypeOfContextualType(node, /*contextFlags*/ undefined);
-        const contextualTypeHasPattern = contextualType && contextualType.pattern &&
-            (contextualType.pattern.kind === SyntaxKind.ObjectBindingPattern || contextualType.pattern.kind === SyntaxKind.ObjectLiteralExpression);
+        const contextualTypeHasPattern = contextualType && contextualType.pattern
+            && (contextualType.pattern.kind === SyntaxKind.ObjectBindingPattern || contextualType.pattern.kind === SyntaxKind.ObjectLiteralExpression);
         const inConstContext = isConstContext(node);
         const checkFlags = inConstContext ? CheckFlags.Readonly : 0;
         const isInJavascript = isInJSFile(node) && !isInJsonFile(node);
@@ -31742,19 +31742,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let offset = 0;
         for (const memberDecl of node.properties) {
             let member = getSymbolOfDeclaration(memberDecl);
-            const computedNameType = memberDecl.name && memberDecl.name.kind === SyntaxKind.ComputedPropertyName ?
-                checkComputedPropertyName(memberDecl.name) : undefined;
+            const computedNameType = memberDecl.name && memberDecl.name.kind === SyntaxKind.ComputedPropertyName
+                ? checkComputedPropertyName(memberDecl.name) : undefined;
             if (
-                memberDecl.kind === SyntaxKind.PropertyAssignment ||
-                memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ||
-                isObjectLiteralMethod(memberDecl)
+                memberDecl.kind === SyntaxKind.PropertyAssignment
+                || memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment
+                || isObjectLiteralMethod(memberDecl)
             ) {
-                let type = memberDecl.kind === SyntaxKind.PropertyAssignment ? checkPropertyAssignment(memberDecl, checkMode) :
+                let type = memberDecl.kind === SyntaxKind.PropertyAssignment ? checkPropertyAssignment(memberDecl, checkMode)
                     // avoid resolving the left side of the ShorthandPropertyAssignment outside of the destructuring
                     // for error recovery purposes. For example, if a user wrote `{ a = 100 }` instead of `{ a: 100 }`.
                     // we don't want to say "could not find 'a'".
-                    memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ? checkExpressionForMutableLocation(!inDestructuringPattern && memberDecl.objectAssignmentInitializer ? memberDecl.objectAssignmentInitializer : memberDecl.name, checkMode) :
-                    checkObjectLiteralMethod(memberDecl, checkMode);
+                    : memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment ? checkExpressionForMutableLocation(!inDestructuringPattern && memberDecl.objectAssignmentInitializer ? memberDecl.objectAssignmentInitializer : memberDecl.name, checkMode)
+                    : checkObjectLiteralMethod(memberDecl, checkMode);
                 if (isInJavascript) {
                     const jsDocType = getTypeForDeclarationFromJSDocComment(memberDecl);
                     if (jsDocType) {
@@ -31767,9 +31767,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 objectFlags |= getObjectFlags(type) & ObjectFlags.PropagatingFlags;
                 const nameType = computedNameType && isTypeUsableAsPropertyName(computedNameType) ? computedNameType : undefined;
-                const prop = nameType ?
-                    createSymbol(SymbolFlags.Property | member.flags, getPropertyNameFromType(nameType), checkFlags | CheckFlags.Late) :
-                    createSymbol(SymbolFlags.Property | member.flags, member.escapedName, checkFlags);
+                const prop = nameType
+                    ? createSymbol(SymbolFlags.Property | member.flags, getPropertyNameFromType(nameType), checkFlags | CheckFlags.Late)
+                    : createSymbol(SymbolFlags.Property | member.flags, member.escapedName, checkFlags);
                 if (nameType) {
                     prop.links.nameType = nameType;
                 }
@@ -31777,8 +31777,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (inDestructuringPattern) {
                     // If object literal is an assignment pattern and if the assignment pattern specifies a default value
                     // for the property, make the property optional.
-                    const isOptional = (memberDecl.kind === SyntaxKind.PropertyAssignment && hasDefaultValue(memberDecl.initializer)) ||
-                        (memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment && memberDecl.objectAssignmentInitializer);
+                    const isOptional = (memberDecl.kind === SyntaxKind.PropertyAssignment && hasDefaultValue(memberDecl.initializer))
+                        || (memberDecl.kind === SyntaxKind.ShorthandPropertyAssignment && memberDecl.objectAssignmentInitializer);
                     if (isOptional) {
                         prop.flags |= SymbolFlags.Optional;
                     }
@@ -31807,8 +31807,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 allPropertiesTable?.set(prop.escapedName, prop);
 
                 if (
-                    contextualType && checkMode & CheckMode.Inferential && !(checkMode & CheckMode.SkipContextSensitive) &&
-                    (memberDecl.kind === SyntaxKind.PropertyAssignment || memberDecl.kind === SyntaxKind.MethodDeclaration) && isContextSensitive(memberDecl)
+                    contextualType && checkMode & CheckMode.Inferential && !(checkMode & CheckMode.SkipContextSensitive)
+                    && (memberDecl.kind === SyntaxKind.PropertyAssignment || memberDecl.kind === SyntaxKind.MethodDeclaration) && isContextSensitive(memberDecl)
                 ) {
                     const inferenceContext = getInferenceContext(node);
                     Debug.assert(inferenceContext); // In CheckMode.Inferential we should always have an inference context
@@ -31888,12 +31888,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // since the type flows in non-obvious ways through conditional expressions, IIFEs and more.
         if (contextualTypeHasPattern) {
             const rootPatternParent = findAncestor(contextualType.pattern!.parent, n =>
-                n.kind === SyntaxKind.VariableDeclaration ||
-                n.kind === SyntaxKind.BinaryExpression ||
-                n.kind === SyntaxKind.Parameter);
+                n.kind === SyntaxKind.VariableDeclaration
+                || n.kind === SyntaxKind.BinaryExpression
+                || n.kind === SyntaxKind.Parameter);
             const spreadOrOutsideRootObject = findAncestor(node, n =>
-                n === rootPatternParent ||
-                n.kind === SyntaxKind.SpreadAssignment)!;
+                n === rootPatternParent
+                || n.kind === SyntaxKind.SpreadAssignment)!;
 
             if (spreadOrOutsideRootObject.kind !== SyntaxKind.SpreadAssignment) {
                 for (const prop of getPropertiesOfType(contextualType)) {
@@ -31948,8 +31948,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isValidSpreadType(type: Type): boolean {
         const t = removeDefinitelyFalsyTypes(mapType(type, getBaseConstraintOrType));
-        return !!(t.flags & (TypeFlags.Any | TypeFlags.NonPrimitive | TypeFlags.Object | TypeFlags.InstantiableNonPrimitive) ||
-            t.flags & TypeFlags.UnionOrIntersection && every((t as UnionOrIntersectionType).types, isValidSpreadType));
+        return !!(t.flags & (TypeFlags.Any | TypeFlags.NonPrimitive | TypeFlags.Object | TypeFlags.InstantiableNonPrimitive)
+            || t.flags & TypeFlags.UnionOrIntersection && every((t as UnionOrIntersectionType).types, isValidSpreadType));
     }
 
     function checkJsxSelfClosingElementDeferred(node: JsxSelfClosingElement) {
@@ -32121,9 +32121,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const childrenContextualType = contextualType && getTypeOfPropertyOfContextualType(contextualType, jsxChildrenPropertyName);
                 // If there are children in the body of JSX element, create dummy attribute "children" with the union of children types so that it will pass the attribute checking process
                 const childrenPropSymbol = createSymbol(SymbolFlags.Property, jsxChildrenPropertyName);
-                childrenPropSymbol.links.type = childrenTypes.length === 1 ? childrenTypes[0] :
-                    childrenContextualType && someType(childrenContextualType, isTupleLikeType) ? createTupleType(childrenTypes) :
-                    createArrayType(getUnionType(childrenTypes));
+                childrenPropSymbol.links.type = childrenTypes.length === 1 ? childrenTypes[0]
+                    : childrenContextualType && someType(childrenContextualType, isTupleLikeType) ? createTupleType(childrenTypes)
+                    : createArrayType(getUnionType(childrenTypes));
                 // Fake up a property declaration for the children
                 childrenPropSymbol.valueDeclaration = factory.createPropertySignature(/*modifiers*/ undefined, unescapeLeadingUnderscores(jsxChildrenPropertyName), /*questionToken*/ undefined, /*type*/ undefined);
                 setParent(childrenPropSymbol.valueDeclaration, attributes);
@@ -32622,10 +32622,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // is incorrect and inconsistent with element access expressions, where it is an error, so eventually
             // we should remove this exception.
             if (
-                getPropertyOfObjectType(targetType, name) ||
-                getApplicableIndexInfoForName(targetType, name) ||
-                isLateBoundName(name) && getIndexInfoOfType(targetType, stringType) ||
-                isComparingJsxAttributes && isHyphenatedJsxName(name)
+                getPropertyOfObjectType(targetType, name)
+                || getApplicableIndexInfoForName(targetType, name)
+                || isLateBoundName(name) && getIndexInfoOfType(targetType, stringType)
+                || isComparingJsxAttributes && isHyphenatedJsxName(name)
             ) {
                 // For JSXAttributes, if the attribute has a hyphenated name, consider that the attribute to be known.
                 return true;
@@ -32642,10 +32642,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isExcessPropertyCheckTarget(type: Type): boolean {
-        return !!(type.flags & TypeFlags.Object && !(getObjectFlags(type) & ObjectFlags.ObjectLiteralPatternWithComputedProperties) ||
-            type.flags & TypeFlags.NonPrimitive ||
-            type.flags & TypeFlags.Union && some((type as UnionType).types, isExcessPropertyCheckTarget) ||
-            type.flags & TypeFlags.Intersection && every((type as IntersectionType).types, isExcessPropertyCheckTarget));
+        return !!(type.flags & TypeFlags.Object && !(getObjectFlags(type) & ObjectFlags.ObjectLiteralPatternWithComputedProperties)
+            || type.flags & TypeFlags.NonPrimitive
+            || type.flags & TypeFlags.Union && some((type as UnionType).types, isExcessPropertyCheckTarget)
+            || type.flags & TypeFlags.Intersection && every((type as IntersectionType).types, isExcessPropertyCheckTarget));
     }
 
     function checkJsxExpression(node: JsxExpression, checkMode?: CheckMode) {
@@ -32676,8 +32676,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (isInJSFile(symbol.valueDeclaration)) {
             const parent = symbol.valueDeclaration!.parent;
-            return parent && isBinaryExpression(parent) &&
-                getAssignmentDeclarationKind(parent) === AssignmentDeclarationKind.PrototypeProperty;
+            return parent && isBinaryExpression(parent)
+                && getAssignmentDeclarationKind(parent) === AssignmentDeclarationKind.PrototypeProperty;
         }
     }
 
@@ -32697,10 +32697,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         prop: Symbol,
         reportError = true,
     ): boolean {
-        const errorNode = !reportError ? undefined :
-            node.kind === SyntaxKind.QualifiedName ? node.right :
-            node.kind === SyntaxKind.ImportType ? node :
-            node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
+        const errorNode = !reportError ? undefined
+            : node.kind === SyntaxKind.QualifiedName ? node.right
+            : node.kind === SyntaxKind.ImportType ? node
+            : node.kind === SyntaxKind.BindingElement && node.propertyName ? node.propertyName : node.name;
 
         return checkPropertyAccessibilityAtLocation(node, isSuper, writing, type, prop, errorNode);
     }
@@ -32756,8 +32756,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         // Referencing abstract properties within their own constructors is not allowed
         if (
-            (flags & ModifierFlags.Abstract) && symbolHasNonMethodDeclaration(prop) &&
-            (isThisProperty(location) || isThisInitializedObjectBindingExpression(location) || isObjectBindingPattern(location.parent) && isThisInitializedDeclaration(location.parent.parent))
+            (flags & ModifierFlags.Abstract) && symbolHasNonMethodDeclaration(prop)
+            && (isThisProperty(location) || isThisInitializedObjectBindingExpression(location) || isObjectBindingPattern(location.parent) && isThisInitializedDeclaration(location.parent.parent))
         ) {
             const declaringClassDeclaration = getClassLikeDeclarationOfSymbol(getParentOfSymbol(prop)!);
             if (declaringClassDeclaration && isNodeUsedDuringClassInitialization(location)) {
@@ -32876,20 +32876,20 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             error(
                 node,
-                facts & TypeFacts.IsUndefined ? facts & TypeFacts.IsNull ?
-                    Diagnostics._0_is_possibly_null_or_undefined :
-                    Diagnostics._0_is_possibly_undefined :
-                    Diagnostics._0_is_possibly_null,
+                facts & TypeFacts.IsUndefined ? facts & TypeFacts.IsNull
+                    ? Diagnostics._0_is_possibly_null_or_undefined
+                    : Diagnostics._0_is_possibly_undefined
+                    : Diagnostics._0_is_possibly_null,
                 nodeText,
             );
         }
         else {
             error(
                 node,
-                facts & TypeFacts.IsUndefined ? facts & TypeFacts.IsNull ?
-                    Diagnostics.Object_is_possibly_null_or_undefined :
-                    Diagnostics.Object_is_possibly_undefined :
-                    Diagnostics.Object_is_possibly_null,
+                facts & TypeFacts.IsUndefined ? facts & TypeFacts.IsNull
+                    ? Diagnostics.Object_is_possibly_null_or_undefined
+                    : Diagnostics.Object_is_possibly_undefined
+                    : Diagnostics.Object_is_possibly_null,
             );
         }
     }
@@ -32897,10 +32897,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function reportCannotInvokePossiblyNullOrUndefinedError(node: Node, facts: TypeFacts) {
         error(
             node,
-            facts & TypeFacts.IsUndefined ? facts & TypeFacts.IsNull ?
-                Diagnostics.Cannot_invoke_an_object_which_is_possibly_null_or_undefined :
-                Diagnostics.Cannot_invoke_an_object_which_is_possibly_undefined :
-                Diagnostics.Cannot_invoke_an_object_which_is_possibly_null,
+            facts & TypeFacts.IsUndefined ? facts & TypeFacts.IsNull
+                ? Diagnostics.Cannot_invoke_an_object_which_is_possibly_null_or_undefined
+                : Diagnostics.Cannot_invoke_an_object_which_is_possibly_undefined
+                : Diagnostics.Cannot_invoke_an_object_which_is_possibly_null,
         );
     }
 
@@ -32953,8 +32953,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkPropertyAccessExpression(node: PropertyAccessExpression, checkMode: CheckMode | undefined, writeOnly?: boolean) {
-        return node.flags & NodeFlags.OptionalChain ? checkPropertyAccessChain(node as PropertyAccessChain, checkMode) :
-            checkPropertyAccessExpressionOrQualifiedName(node, node.expression, checkNonNullExpression(node.expression), node.name, checkMode, writeOnly);
+        return node.flags & NodeFlags.OptionalChain ? checkPropertyAccessChain(node as PropertyAccessChain, checkMode)
+            : checkPropertyAccessExpressionOrQualifiedName(node, node.expression, checkNonNullExpression(node.expression), node.name, checkMode, writeOnly);
     }
 
     function checkPropertyAccessChain(node: PropertyAccessChain, checkMode: CheckMode | undefined) {
@@ -33105,9 +33105,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let prop: Symbol | undefined;
         if (isPrivateIdentifier(right)) {
             if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
+                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks
+                || languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators
+                || !useDefineForClassFields
             ) {
                 if (assignmentKind !== AssignmentKind.None) {
                     checkExternalEmitHelpers(node, ExternalEmitHelpers.ClassPrivateFieldSet);
@@ -33167,9 +33167,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         //   2. if 'preserveConstEnums' is enabled and the expression is itself an export, e.g. `export = Foo.Bar.Baz`.
         if (
             isIdentifier(left) && parentSymbol && (
-                getIsolatedModules(compilerOptions) ||
-                !(prop && (isConstEnumOrConstEnumOnlyModule(prop) || prop.flags & SymbolFlags.EnumMember && node.parent.kind === SyntaxKind.EnumMember)) ||
-                shouldPreserveConstEnums(compilerOptions) && isExportOrExportExpression(node)
+                getIsolatedModules(compilerOptions)
+                || !(prop && (isConstEnumOrConstEnumOnlyModule(prop) || prop.flags & SymbolFlags.EnumMember && node.parent.kind === SyntaxKind.EnumMember))
+                || shouldPreserveConstEnums(compilerOptions) && isExportOrExportExpression(node)
             )
         ) {
             markAliasReferenced(parentSymbol, node);
@@ -33177,8 +33177,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         let propType: Type;
         if (!prop) {
-            const indexInfo = !isPrivateIdentifier(right) && (assignmentKind === AssignmentKind.None || !isGenericObjectType(leftType) || isThisTypeParameter(leftType)) ?
-                getApplicableIndexInfoForName(apparentType, right.escapedText) : undefined;
+            const indexInfo = !isPrivateIdentifier(right) && (assignmentKind === AssignmentKind.None || !isGenericObjectType(leftType) || isThisTypeParameter(leftType))
+                ? getApplicableIndexInfoForName(apparentType, right.escapedText) : undefined;
             if (!(indexInfo && indexInfo.type)) {
                 const isUncheckedJS = isUncheckedJSSuggestion(node, leftType.symbol, /*excludeClasses*/ true);
                 if (!isUncheckedJS && isJSLiteralType(leftType)) {
@@ -33263,8 +33263,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return removeMissingType(propType, !!(prop && prop.flags & SymbolFlags.Optional));
         }
         if (
-            prop &&
-            !(prop.flags & (SymbolFlags.Variable | SymbolFlags.Property | SymbolFlags.Accessor))
+            prop
+            && !(prop.flags & (SymbolFlags.Variable | SymbolFlags.Property | SymbolFlags.Accessor))
             && !(prop.flags & SymbolFlags.Method && propType.flags & TypeFlags.Union)
             && !isDuplicatedCommonJSExport(prop.declarations)
         ) {
@@ -33291,10 +33291,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
         else if (
-            strictNullChecks && prop && prop.valueDeclaration &&
-            isPropertyAccessExpression(prop.valueDeclaration) &&
-            getAssignmentDeclarationPropertyAccessKind(prop.valueDeclaration) &&
-            getControlFlowContainer(node) === getControlFlowContainer(prop.valueDeclaration)
+            strictNullChecks && prop && prop.valueDeclaration
+            && isPropertyAccessExpression(prop.valueDeclaration)
+            && getAssignmentDeclarationPropertyAccessKind(prop.valueDeclaration)
+            && getControlFlowContainer(node) === getControlFlowContainer(prop.valueDeclaration)
         ) {
             assumeUninitialized = true;
         }
@@ -33326,10 +33326,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             diagnosticMessage = error(right, Diagnostics.Property_0_is_used_before_its_initialization, declarationName);
         }
         else if (
-            valueDeclaration.kind === SyntaxKind.ClassDeclaration &&
-            node.parent.kind !== SyntaxKind.TypeReference &&
-            !(valueDeclaration.flags & NodeFlags.Ambient) &&
-            !isBlockScopedNameDeclaredBeforeUse(valueDeclaration, right)
+            valueDeclaration.kind === SyntaxKind.ClassDeclaration
+            && node.parent.kind !== SyntaxKind.TypeReference
+            && !(valueDeclaration.flags & NodeFlags.Ambient)
+            && !isBlockScopedNameDeclaredBeforeUse(valueDeclaration, right)
         ) {
             diagnosticMessage = error(right, Diagnostics.Class_0_used_before_its_declaration, declarationName);
         }
@@ -33451,9 +33451,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function containerSeemsToBeEmptyDomElement(containingType: Type) {
-        return (compilerOptions.lib && !compilerOptions.lib.includes("dom")) &&
-            everyContainedType(containingType, type => type.symbol && /^(EventTarget|Node|((HTML[a-zA-Z]*)?Element))$/.test(unescapeLeadingUnderscores(type.symbol.escapedName))) &&
-            isEmptyObjectType(containingType);
+        return (compilerOptions.lib && !compilerOptions.lib.includes("dom"))
+            && everyContainedType(containingType, type => type.symbol && /^(EventTarget|Node|((HTML[a-zA-Z]*)?Element))$/.test(unescapeLeadingUnderscores(type.symbol.escapedName)))
+            && isEmptyObjectType(containingType);
     }
 
     function typeHasStaticProperty(propName: __String, containingType: Type): boolean {
@@ -33766,10 +33766,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 let node = expr.parent;
                 while (node) {
                     if (
-                        node.kind === SyntaxKind.ForInStatement &&
-                        child === (node as ForInStatement).statement &&
-                        getForInVariableSymbol(node as ForInStatement) === symbol &&
-                        hasNumericPropertyNames(getTypeOfExpression((node as ForInStatement).expression))
+                        node.kind === SyntaxKind.ForInStatement
+                        && child === (node as ForInStatement).statement
+                        && getForInVariableSymbol(node as ForInStatement) === symbol
+                        && hasNumericPropertyNames(getTypeOfExpression((node as ForInStatement).expression))
                     ) {
                         return true;
                     }
@@ -33782,8 +33782,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkIndexedAccess(node: ElementAccessExpression, checkMode: CheckMode | undefined): Type {
-        return node.flags & NodeFlags.OptionalChain ? checkElementAccessChain(node as ElementAccessChain, checkMode) :
-            checkElementAccessExpression(node, checkNonNullExpression(node.expression), checkMode);
+        return node.flags & NodeFlags.OptionalChain ? checkElementAccessChain(node as ElementAccessChain, checkMode)
+            : checkElementAccessExpression(node, checkNonNullExpression(node.expression), checkMode);
     }
 
     function checkElementAccessChain(node: ElementAccessChain, checkMode: CheckMode | undefined) {
@@ -33807,9 +33807,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         const effectiveIndexType = isForInVariableForNumericPropertyNames(indexExpression) ? numberType : indexType;
-        const accessFlags = isAssignmentTarget(node) ?
-            AccessFlags.Writing | (isGenericObjectType(objectType) && !isThisTypeParameter(objectType) ? AccessFlags.NoIndexSignatures : 0) :
-            AccessFlags.ExpressionPosition;
+        const accessFlags = isAssignmentTarget(node)
+            ? AccessFlags.Writing | (isGenericObjectType(objectType) && !isThisTypeParameter(objectType) ? AccessFlags.NoIndexSignatures : 0)
+            : AccessFlags.ExpressionPosition;
         const indexedAccessType = getIndexedAccessTypeOrUndefined(objectType, effectiveIndexType, accessFlags, node) || errorType;
         return checkIndexedAccessIndexType(getFlowTypeOfAccessExpression(node, getNodeLinks(node).resolvedSymbol, indexedAccessType, indexExpression, checkMode), node);
     }
@@ -33997,8 +33997,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // the declared number of type parameters, the call has an incorrect arity.
         const numTypeParameters = length(signature.typeParameters);
         const minTypeArgumentCount = getMinTypeArgumentCount(signature.typeParameters);
-        return !some(typeArguments) ||
-            (typeArguments.length >= minTypeArgumentCount && typeArguments.length <= numTypeParameters);
+        return !some(typeArguments)
+            || (typeArguments.length >= minTypeArgumentCount && typeArguments.length <= numTypeParameters);
     }
 
     function isInstantiatedGenericParameter(signature: Signature, pos: number) {
@@ -34012,8 +34012,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getSingleCallOrConstructSignature(type: Type): Signature | undefined {
-        return getSingleSignature(type, SignatureKind.Call, /*allowMembers*/ false) ||
-            getSingleSignature(type, SignatureKind.Construct, /*allowMembers*/ false);
+        return getSingleSignature(type, SignatureKind.Call, /*allowMembers*/ false)
+            || getSingleSignature(type, SignatureKind.Construct, /*allowMembers*/ false);
     }
 
     function getSingleSignature(type: Type, kind: SignatureKind, allowMembers: boolean): Signature | undefined {
@@ -34064,10 +34064,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return voidType;
         }
         const thisArgumentType = checkExpression(thisArgumentNode);
-        return isRightSideOfInstanceofExpression(thisArgumentNode) ? thisArgumentType :
-            isOptionalChainRoot(thisArgumentNode.parent) ? getNonNullableType(thisArgumentType) :
-            isOptionalChain(thisArgumentNode.parent) ? removeOptionalTypeMarker(thisArgumentType) :
-            thisArgumentType;
+        return isRightSideOfInstanceofExpression(thisArgumentNode) ? thisArgumentType
+            : isOptionalChainRoot(thisArgumentNode.parent) ? getNonNullableType(thisArgumentType)
+            : isOptionalChain(thisArgumentNode.parent) ? removeOptionalTypeMarker(thisArgumentType)
+            : thisArgumentType;
     }
 
     function inferTypeArguments(node: CallLikeExpression, signature: Signature, args: readonly Expression[], checkMode: CheckMode, context: InferenceContext): Type[] {
@@ -34111,9 +34111,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         //   const boxElements: <A>(a: A[]) => { value: A }[] = arrayMap(value => ({ value }));
                         // Above, the type of the 'value' parameter is inferred to be 'A'.
                         const contextualSignature = getSingleCallSignature(instantiatedType);
-                        const inferenceSourceType = contextualSignature && contextualSignature.typeParameters ?
-                            getOrCreateTypeFromSignature(getSignatureInstantiationWithoutFillingInTypeArguments(contextualSignature, contextualSignature.typeParameters)) :
-                            instantiatedType;
+                        const inferenceSourceType = contextualSignature && contextualSignature.typeParameters
+                            ? getOrCreateTypeFromSignature(getSignatureInstantiationWithoutFillingInTypeArguments(contextualSignature, contextualSignature.typeParameters))
+                            : instantiatedType;
                         // Inferences made from return types have lower priority than all other inferences.
                         inferTypes(context.inferences, inferenceSourceType, inferenceTargetType, InferencePriority.ReturnType);
                     }
@@ -34164,10 +34164,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getMutableArrayOrTupleType(type: Type) {
-        return type.flags & TypeFlags.Union ? mapType(type, getMutableArrayOrTupleType) :
-            type.flags & TypeFlags.Any || isMutableArrayOrTuple(getBaseConstraintOfType(type) || type) ? type :
-            isTupleType(type) ? createTupleType(getElementTypes(type), type.target.elementFlags, /*readonly*/ false, type.target.labeledElementDeclarations) :
-            createTupleType([type], [ElementFlags.Variadic]);
+        return type.flags & TypeFlags.Union ? mapType(type, getMutableArrayOrTupleType)
+            : type.flags & TypeFlags.Any || isMutableArrayOrTuple(getBaseConstraintOfType(type) || type) ? type
+            : isTupleType(type) ? createTupleType(getElementTypes(type), type.target.elementFlags, /*readonly*/ false, type.target.labeledElementDeclarations)
+            : createTupleType([type], [ElementFlags.Variadic]);
     }
 
     function getSpreadArgumentType(args: readonly Expression[], index: number, argCount: number, restType: Type, context: InferenceContext | undefined, checkMode: CheckMode) {
@@ -34178,8 +34178,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isSpreadArgument(arg)) {
                 // We are inferring from a spread expression in the last argument position, i.e. both the parameter
                 // and the argument are ...x forms.
-                const spreadType = arg.kind === SyntaxKind.SyntheticExpression ? (arg as SyntheticExpression).type :
-                    checkExpressionWithContextualType((arg as SpreadElement).expression, restType, context, checkMode);
+                const spreadType = arg.kind === SyntaxKind.SyntheticExpression ? (arg as SyntheticExpression).type
+                    : checkExpressionWithContextualType((arg as SpreadElement).expression, restType, context, checkMode);
 
                 if (isArrayLikeType(spreadType)) {
                     return getMutableArrayOrTupleType(spreadType);
@@ -34205,9 +34205,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
             else {
-                const contextualType = isTupleType(restType) ?
-                    getContextualTypeForElementExpression(restType, i - index, argCount - index) || unknownType :
-                    getIndexedAccessType(restType, getNumberLiteralType(i - index), AccessFlags.Contextual);
+                const contextualType = isTupleType(restType)
+                    ? getContextualTypeForElementExpression(restType, i - index, argCount - index) || unknownType
+                    : getIndexedAccessType(restType, getNumberLiteralType(i - index), AccessFlags.Contextual);
                 const argType = checkExpressionWithContextualType(arg, contextualType, context, checkMode);
                 const hasPrimitiveContextualType = inConstContext || maybeTypeOfKind(contextualType, TypeFlags.Primitive | TypeFlags.Index | TypeFlags.TemplateLiteral | TypeFlags.StringMapping);
                 types.push(hasPrimitiveContextualType ? getRegularTypeOfLiteralType(argType) : getWidenedLiteralType(argType));
@@ -34437,10 +34437,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (restType) {
             const spreadType = getSpreadArgumentType(args, argCount, args.length, restType, /*context*/ undefined, checkMode);
             const restArgCount = args.length - argCount;
-            const errorNode = !reportErrors ? undefined :
-                restArgCount === 0 ? node :
-                restArgCount === 1 ? getEffectiveCheckNode(args[argCount]) :
-                setTextRangePosEnd(createSyntheticExpression(node, spreadType), args[argCount].pos, args[args.length - 1].end);
+            const errorNode = !reportErrors ? undefined
+                : restArgCount === 0 ? node
+                : restArgCount === 1 ? getEffectiveCheckNode(args[argCount])
+                : setTextRangePosEnd(createSyntheticExpression(node, spreadType), args[argCount].pos, args[args.length - 1].end);
             if (!checkTypeRelatedTo(spreadType, restType, relation, errorNode, headMessage, /*containingMessageChain*/ undefined, errorOutputContainer)) {
                 Debug.assert(!reportErrors || !!errorOutputContainer.errors, "rest parameter should have errors when reporting errors");
                 maybeAddMissingAwaitInfo(errorNode, spreadType, restType);
@@ -34471,10 +34471,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return node.right;
         }
 
-        const expression = node.kind === SyntaxKind.CallExpression ? node.expression :
-            node.kind === SyntaxKind.TaggedTemplateExpression ? node.tag :
-            node.kind === SyntaxKind.Decorator && !legacyDecorators ? node.expression :
-            undefined;
+        const expression = node.kind === SyntaxKind.CallExpression ? node.expression
+            : node.kind === SyntaxKind.TaggedTemplateExpression ? node.tag
+            : node.kind === SyntaxKind.Decorator && !legacyDecorators ? node.expression
+            : undefined;
         if (expression) {
             const callee = skipOuterExpressions(expression);
             if (isAccessExpression(callee)) {
@@ -34559,10 +34559,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * Returns the argument count for a decorator node that works like a function invocation.
      */
     function getDecoratorArgumentCount(node: Decorator, signature: Signature) {
-        return compilerOptions.experimentalDecorators ?
-            getLegacyDecoratorArgumentCount(node, signature) :
+        return compilerOptions.experimentalDecorators
+            ? getLegacyDecoratorArgumentCount(node, signature)
             // Allow the runtime to oversupply arguments to an ES decorator as long as there's at least one parameter.
-            Math.min(Math.max(getParameterCount(signature), 1), 2);
+            : Math.min(Math.max(getParameterCount(signature), 1), 2);
     }
 
     /**
@@ -34670,12 +34670,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isVoidPromiseError && isInJSFile(node)) {
             return getDiagnosticForCallNode(node, Diagnostics.Expected_1_argument_but_got_0_new_Promise_needs_a_JSDoc_hint_to_produce_a_resolve_that_can_be_called_without_arguments);
         }
-        const error = isDecorator(node) ?
-            hasRestParameter ? Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_at_least_0 :
-                Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0 :
-            hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1 :
-            isVoidPromiseError ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise :
-            Diagnostics.Expected_0_arguments_but_got_1;
+        const error = isDecorator(node)
+            ? hasRestParameter ? Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_at_least_0
+                : Diagnostics.The_runtime_will_invoke_the_decorator_with_1_arguments_but_the_decorator_expects_0
+            : hasRestParameter ? Diagnostics.Expected_at_least_0_arguments_but_got_1
+            : isVoidPromiseError ? Diagnostics.Expected_0_arguments_but_got_1_Did_you_forget_to_include_void_in_your_type_argument_to_Promise
+            : Diagnostics.Expected_0_arguments_but_got_1;
 
         if (min < args.length && args.length < max) {
             // between min and max, but with no matching overload
@@ -35104,9 +35104,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const parameters: Symbol[] = [];
         for (let i = 0; i < maxNonRestParam; i++) {
             const symbols = mapDefined(candidates, s =>
-                signatureHasRestParameter(s) ?
-                    i < s.parameters.length - 1 ? s.parameters[i] : last(s.parameters) :
-                    i < s.parameters.length ? s.parameters[i] : undefined);
+                signatureHasRestParameter(s)
+                    ? i < s.parameters.length - 1 ? s.parameters[i] : last(s.parameters)
+                    : i < s.parameters.length ? s.parameters[i] : undefined);
             Debug.assert(symbols.length !== 0);
             parameters.push(createCombinedSymbolFromTypes(symbols, mapDefined(candidates, candidate => tryGetTypeAtPosition(candidate, i))));
         }
@@ -35229,9 +35229,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let funcType = checkExpression(node.expression);
         if (isCallChain(node)) {
             const nonOptionalType = getOptionalExpressionType(funcType, node.expression);
-            callChainFlags = nonOptionalType === funcType ? SignatureFlags.None :
-                isOutermostOptionalChain(node) ? SignatureFlags.IsOuterCallChain :
-                SignatureFlags.IsInnerCallChain;
+            callChainFlags = nonOptionalType === funcType ? SignatureFlags.None
+                : isOutermostOptionalChain(node) ? SignatureFlags.IsOuterCallChain
+                : SignatureFlags.IsInnerCallChain;
             funcType = nonOptionalType;
         }
         else {
@@ -35327,8 +35327,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      */
     function isUntypedFunctionCall(funcType: Type, apparentFuncType: Type, numCallSignatures: number, numConstructSignatures: number): boolean {
         // We exclude union types because we may have a union of function types that happen to have no common signatures.
-        return isTypeAny(funcType) || isTypeAny(apparentFuncType) && !!(funcType.flags & TypeFlags.TypeParameter) ||
-            !numCallSignatures && !numConstructSignatures && !(apparentFuncType.flags & TypeFlags.Union) && !(getReducedType(apparentFuncType).flags & TypeFlags.Never) && isTypeAssignableTo(funcType, globalFunctionType);
+        return isTypeAny(funcType) || isTypeAny(apparentFuncType) && !!(funcType.flags & TypeFlags.TypeParameter)
+            || !numCallSignatures && !numConstructSignatures && !(apparentFuncType.flags & TypeFlags.Union) && !(getReducedType(apparentFuncType).flags & TypeFlags.Never) && isTypeAssignableTo(funcType, globalFunctionType);
     }
 
     function resolveNewExpression(node: NewExpression, candidatesOutArray: Signature[] | undefined, checkMode: CheckMode): Signature {
@@ -35504,16 +35504,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (!errorInfo) {
                         errorInfo = chainDiagnosticMessages(
                             errorInfo,
-                            isCall ?
-                                Diagnostics.Type_0_has_no_call_signatures :
-                                Diagnostics.Type_0_has_no_construct_signatures,
+                            isCall
+                                ? Diagnostics.Type_0_has_no_call_signatures
+                                : Diagnostics.Type_0_has_no_construct_signatures,
                             typeToString(constituent),
                         );
                         errorInfo = chainDiagnosticMessages(
                             errorInfo,
-                            isCall ?
-                                Diagnostics.Not_all_constituents_of_type_0_are_callable :
-                                Diagnostics.Not_all_constituents_of_type_0_are_constructable,
+                            isCall
+                                ? Diagnostics.Not_all_constituents_of_type_0_are_callable
+                                : Diagnostics.Not_all_constituents_of_type_0_are_constructable,
                             typeToString(apparentType),
                         );
                     }
@@ -35526,18 +35526,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!hasSignatures) {
                 errorInfo = chainDiagnosticMessages(
                     /*details*/ undefined,
-                    isCall ?
-                        Diagnostics.No_constituent_of_type_0_is_callable :
-                        Diagnostics.No_constituent_of_type_0_is_constructable,
+                    isCall
+                        ? Diagnostics.No_constituent_of_type_0_is_callable
+                        : Diagnostics.No_constituent_of_type_0_is_constructable,
                     typeToString(apparentType),
                 );
             }
             if (!errorInfo) {
                 errorInfo = chainDiagnosticMessages(
                     errorInfo,
-                    isCall ?
-                        Diagnostics.Each_member_of_the_union_type_0_has_signatures_but_none_of_those_signatures_are_compatible_with_each_other :
-                        Diagnostics.Each_member_of_the_union_type_0_has_construct_signatures_but_none_of_those_signatures_are_compatible_with_each_other,
+                    isCall
+                        ? Diagnostics.Each_member_of_the_union_type_0_has_signatures_but_none_of_those_signatures_are_compatible_with_each_other
+                        : Diagnostics.Each_member_of_the_union_type_0_has_construct_signatures_but_none_of_those_signatures_are_compatible_with_each_other,
                     typeToString(apparentType),
                 );
             }
@@ -35545,9 +35545,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         else {
             errorInfo = chainDiagnosticMessages(
                 errorInfo,
-                isCall ?
-                    Diagnostics.Type_0_has_no_call_signatures :
-                    Diagnostics.Type_0_has_no_construct_signatures,
+                isCall
+                    ? Diagnostics.Type_0_has_no_call_signatures
+                    : Diagnostics.Type_0_has_no_construct_signatures,
                 typeToString(apparentType),
             );
         }
@@ -35783,9 +35783,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      */
     function isPotentiallyUncalledDecorator(decorator: Decorator, signatures: readonly Signature[]) {
         return signatures.length && every(signatures, signature =>
-            signature.minArgumentCount === 0 &&
-            !signatureHasRestParameter(signature) &&
-            signature.parameters.length < getDecoratorArgumentCount(decorator, signature));
+            signature.minArgumentCount === 0
+            && !signatureHasRestParameter(signature)
+            && signature.parameters.length < getDecoratorArgumentCount(decorator, signature));
     }
 
     function resolveSignature(node: CallLikeExpression, candidatesOutArray: Signature[] | undefined, checkMode: CheckMode): Signature {
@@ -35853,9 +35853,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!node || !isInJSFile(node)) {
             return false;
         }
-        const func = isFunctionDeclaration(node) || isFunctionExpression(node) ? node :
-            (isVariableDeclaration(node) || isPropertyAssignment(node)) && node.initializer && isFunctionExpression(node.initializer) ? node.initializer :
-            undefined;
+        const func = isFunctionDeclaration(node) || isFunctionExpression(node) ? node
+            : (isVariableDeclaration(node) || isPropertyAssignment(node)) && node.initializer && isFunctionExpression(node.initializer) ? node.initializer
+            : undefined;
         if (func) {
             // If the node has a @class or @constructor tag, treat it like a constructor.
             if (getJSDocClassTag(node)) return true;
@@ -35983,13 +35983,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const declaration = signature.declaration;
 
             if (
-                declaration &&
-                declaration.kind !== SyntaxKind.Constructor &&
-                declaration.kind !== SyntaxKind.ConstructSignature &&
-                declaration.kind !== SyntaxKind.ConstructorType &&
-                !(isJSDocSignature(declaration) && getJSDocRoot(declaration)?.parent?.kind === SyntaxKind.Constructor) &&
-                !isJSDocConstructSignature(declaration) &&
-                !isJSConstructor(declaration)
+                declaration
+                && declaration.kind !== SyntaxKind.Constructor
+                && declaration.kind !== SyntaxKind.ConstructSignature
+                && declaration.kind !== SyntaxKind.ConstructorType
+                && !(isJSDocSignature(declaration) && getJSDocRoot(declaration)?.parent?.kind === SyntaxKind.Constructor)
+                && !isJSDocConstructSignature(declaration)
+                && !isJSConstructor(declaration)
             ) {
                 // When resolved signature is a call signature (and not a construct signature) the result type is any
                 if (noImplicitAny) {
@@ -36011,8 +36011,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return getESSymbolLikeTypeForNode(walkUpParenthesizedExpressions(node.parent));
         }
         if (
-            node.kind === SyntaxKind.CallExpression && !node.questionDotToken && node.parent.kind === SyntaxKind.ExpressionStatement &&
-            returnType.flags & TypeFlags.Void && getTypePredicateOfSignature(signature)
+            node.kind === SyntaxKind.CallExpression && !node.questionDotToken && node.parent.kind === SyntaxKind.ExpressionStatement
+            && returnType.flags & TypeFlags.Void && getTypePredicateOfSignature(signature)
         ) {
             if (!isDottedName(node.expression)) {
                 error(node.expression, Diagnostics.Assertions_require_the_call_target_to_be_an_identifier_or_qualified_name);
@@ -36121,8 +36121,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (esModuleSymbol) {
                 return createPromiseReturnType(
                     node,
-                    getTypeWithSyntheticDefaultOnly(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier) ||
-                        getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier),
+                    getTypeWithSyntheticDefaultOnly(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier)
+                        || getTypeWithSyntheticDefaultImportType(getTypeOfSymbol(esModuleSymbol), esModuleSymbol, moduleSymbol, specifier),
                 );
             }
         }
@@ -36239,8 +36239,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.PrefixUnaryExpression:
                 const op = (node as PrefixUnaryExpression).operator;
                 const arg = (node as PrefixUnaryExpression).operand;
-                return op === SyntaxKind.MinusToken && (arg.kind === SyntaxKind.NumericLiteral || arg.kind === SyntaxKind.BigIntLiteral) ||
-                    op === SyntaxKind.PlusToken && arg.kind === SyntaxKind.NumericLiteral;
+                return op === SyntaxKind.MinusToken && (arg.kind === SyntaxKind.NumericLiteral || arg.kind === SyntaxKind.BigIntLiteral)
+                    || op === SyntaxKind.PlusToken && arg.kind === SyntaxKind.NumericLiteral;
             case SyntaxKind.PropertyAccessExpression:
             case SyntaxKind.ElementAccessExpression:
                 const expr = skipParentheses((node as PropertyAccessExpression | ElementAccessExpression).expression);
@@ -36308,8 +36308,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkNonNullAssertion(node: NonNullExpression) {
-        return node.flags & NodeFlags.OptionalChain ? checkNonNullChain(node as NonNullChain) :
-            getNonNullableType(checkExpression(node.expression));
+        return node.flags & NodeFlags.OptionalChain ? checkNonNullChain(node as NonNullChain)
+            : getNonNullableType(checkExpression(node.expression));
     }
 
     function checkExpressionWithTypeArguments(node: ExpressionWithTypeArguments | TypeQueryNode) {
@@ -36321,9 +36321,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 error(node, Diagnostics.The_right_hand_side_of_an_instanceof_expression_must_not_be_an_instantiation_expression);
             }
         }
-        const exprType = node.kind === SyntaxKind.ExpressionWithTypeArguments ? checkExpression(node.expression) :
-            isThisIdentifier(node.exprName) ? checkThisExpression(node.exprName) :
-            checkExpression(node.exprName);
+        const exprType = node.kind === SyntaxKind.ExpressionWithTypeArguments ? checkExpression(node.expression)
+            : isThisIdentifier(node.exprName) ? checkThisExpression(node.exprName)
+            : checkExpression(node.exprName);
         return getInstantiationExpressionType(exprType, node);
     }
 
@@ -36859,12 +36859,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const isStatic = hasStaticModifier(node);
         const isPrivate = isPrivateIdentifier(node.name);
         const nameType = isPrivate ? getStringLiteralType(idText(node.name)) : getLiteralTypeFromPropertyName(node.name);
-        const contextType = isMethodDeclaration(node) ? createClassMethodDecoratorContextType(thisType, valueType) :
-            isGetAccessorDeclaration(node) ? createClassGetterDecoratorContextType(thisType, valueType) :
-            isSetAccessorDeclaration(node) ? createClassSetterDecoratorContextType(thisType, valueType) :
-            isAutoAccessorPropertyDeclaration(node) ? createClassAccessorDecoratorContextType(thisType, valueType) :
-            isPropertyDeclaration(node) ? createClassFieldDecoratorContextType(thisType, valueType) :
-            Debug.failBadSyntaxKind(node);
+        const contextType = isMethodDeclaration(node) ? createClassMethodDecoratorContextType(thisType, valueType)
+            : isGetAccessorDeclaration(node) ? createClassGetterDecoratorContextType(thisType, valueType)
+            : isSetAccessorDeclaration(node) ? createClassSetterDecoratorContextType(thisType, valueType)
+            : isAutoAccessorPropertyDeclaration(node) ? createClassAccessorDecoratorContextType(thisType, valueType)
+            : isPropertyDeclaration(node) ? createClassFieldDecoratorContextType(thisType, valueType)
+            : Debug.failBadSyntaxKind(node);
         const overrideType = getClassMemberDecoratorContextOverrideType(nameType, isPrivate, isStatic);
         return getIntersectionType([contextType, overrideType]);
     }
@@ -37017,26 +37017,26 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // In all three cases, the `This` type argument is the "final type" of either the class or
                     // instance, depending on whether the member was `static`.
 
-                    const valueType = isMethodDeclaration(node) ? getOrCreateTypeFromSignature(getSignatureFromDeclaration(node)) :
-                        getTypeOfNode(node);
+                    const valueType = isMethodDeclaration(node) ? getOrCreateTypeFromSignature(getSignatureFromDeclaration(node))
+                        : getTypeOfNode(node);
 
-                    const thisType = hasStaticModifier(node) ?
-                        getTypeOfSymbol(getSymbolOfDeclaration(node.parent)) :
-                        getDeclaredTypeOfClassOrInterface(getSymbolOfDeclaration(node.parent));
+                    const thisType = hasStaticModifier(node)
+                        ? getTypeOfSymbol(getSymbolOfDeclaration(node.parent))
+                        : getDeclaredTypeOfClassOrInterface(getSymbolOfDeclaration(node.parent));
 
                     // We wrap the "input type", if necessary, to match the decoration target. For getters this is
                     // something like `() => inputType`, for setters it's `(value: inputType) => void` and for
                     // methods it is just the input type.
-                    const targetType = isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType) :
-                        isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
-                        valueType;
+                    const targetType = isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType)
+                        : isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType)
+                        : valueType;
 
                     const contextType = createClassMemberDecoratorContextTypeForNode(node, thisType, valueType);
 
                     // We also wrap the "output type", as needed.
-                    const returnType = isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType) :
-                        isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType) :
-                        valueType;
+                    const returnType = isGetAccessorDeclaration(node) ? createGetterFunctionType(valueType)
+                        : isSetAccessorDeclaration(node) ? createSetterFunctionType(valueType)
+                        : valueType;
 
                     links.decoratorSignature = createESDecoratorCallSignature(targetType, contextType, returnType);
                     break;
@@ -37053,15 +37053,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // the "final type" of the value stored in the field.
 
                     const valueType = getTypeOfNode(node);
-                    const thisType = hasStaticModifier(node) ?
-                        getTypeOfSymbol(getSymbolOfDeclaration(node.parent)) :
-                        getDeclaredTypeOfClassOrInterface(getSymbolOfDeclaration(node.parent));
+                    const thisType = hasStaticModifier(node)
+                        ? getTypeOfSymbol(getSymbolOfDeclaration(node.parent))
+                        : getDeclaredTypeOfClassOrInterface(getSymbolOfDeclaration(node.parent));
 
                     // The `target` of an auto-accessor decorator is a `{ get, set }` object, representing the
                     // runtime-generated getter and setter that are added to the class/prototype. The `target` of a
                     // regular field decorator is always `undefined` as it isn't installed until it is initialized.
-                    const targetType = hasAccessorModifier(node) ? createClassAccessorDecoratorTargetType(thisType, valueType) :
-                        undefinedType;
+                    const targetType = hasAccessorModifier(node) ? createClassAccessorDecoratorTargetType(thisType, valueType)
+                        : undefinedType;
 
                     const contextType = createClassMemberDecoratorContextTypeForNode(node, thisType, valueType);
 
@@ -37069,8 +37069,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // "output type" in a `ClassAccessorDecoratorResult<This, In, Out>` type, which allows for
                     // mutation of the runtime-generated getter and setter, as well as the injection of an
                     // initializer mutator. For regular fields, we wrap the "output type" in an initializer mutator.
-                    const returnType = hasAccessorModifier(node) ? createClassAccessorDecoratorResultType(thisType, valueType) :
-                        createClassFieldDecoratorInitializerMutatorType(thisType, valueType);
+                    const returnType = hasAccessorModifier(node) ? createClassAccessorDecoratorResultType(thisType, valueType)
+                        : createClassFieldDecoratorInitializerMutatorType(thisType, valueType);
 
                     links.decoratorSignature = createESDecoratorCallSignature(targetType, contextType, returnType);
                     break;
@@ -37104,8 +37104,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.Parameter: {
                     const node = parent as ParameterDeclaration;
                     if (
-                        !isConstructorDeclaration(node.parent) &&
-                        !(isMethodDeclaration(node.parent) || isSetAccessorDeclaration(node.parent) && isClassLike(node.parent.parent))
+                        !isConstructorDeclaration(node.parent)
+                        && !(isMethodDeclaration(node.parent) || isSetAccessorDeclaration(node.parent) && isClassLike(node.parent.parent))
                     ) {
                         break;
                     }
@@ -37114,19 +37114,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         break;
                     }
 
-                    const index = getThisParameter(node.parent) ?
-                        node.parent.parameters.indexOf(node) - 1 :
-                        node.parent.parameters.indexOf(node);
+                    const index = getThisParameter(node.parent)
+                        ? node.parent.parameters.indexOf(node) - 1
+                        : node.parent.parameters.indexOf(node);
                     Debug.assert(index >= 0);
 
                     // A parameter declaration decorator will have three arguments (see `ParameterDecorator` in
                     // core.d.ts).
 
-                    const targetType = isConstructorDeclaration(node.parent) ? getTypeOfSymbol(getSymbolOfDeclaration(node.parent.parent)) :
-                        getParentTypeOfClassElement(node.parent);
+                    const targetType = isConstructorDeclaration(node.parent) ? getTypeOfSymbol(getSymbolOfDeclaration(node.parent.parent))
+                        : getParentTypeOfClassElement(node.parent);
 
-                    const keyType = isConstructorDeclaration(node.parent) ? undefinedType :
-                        getClassElementPropertyKeyType(node.parent);
+                    const keyType = isConstructorDeclaration(node.parent) ? undefinedType
+                        : getClassElementPropertyKeyType(node.parent);
 
                     const indexType = getNumberLiteralType(index);
 
@@ -37157,8 +37157,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const keyType = getClassElementPropertyKeyType(node);
                     const keyParam = createParameter("propertyKey" as __String, keyType);
 
-                    const returnType = isPropertyDeclaration(node) ? voidType :
-                        createTypedPropertyDescriptorType(getTypeOfNode(node));
+                    const returnType = isPropertyDeclaration(node) ? voidType
+                        : createTypedPropertyDescriptorType(getTypeOfNode(node));
 
                     const hasPropDesc = !isPropertyDeclaration(parent) || hasAccessorModifier(parent);
                     if (hasPropDesc) {
@@ -37187,8 +37187,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getDecoratorCallSignature(decorator: Decorator) {
-        return legacyDecorators ? getLegacyDecoratorCallSignature(decorator) :
-            getESDecoratorCallSignature(decorator);
+        return legacyDecorators ? getLegacyDecoratorCallSignature(decorator)
+            : getESDecoratorCallSignature(decorator);
     }
 
     function createPromiseType(promisedType: Type): Type {
@@ -37222,18 +37222,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (promiseType === unknownType) {
             error(
                 func,
-                isImportCall(func) ?
-                    Diagnostics.A_dynamic_import_call_returns_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES2015_in_your_lib_option :
-                    Diagnostics.An_async_function_or_method_must_return_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES2015_in_your_lib_option,
+                isImportCall(func)
+                    ? Diagnostics.A_dynamic_import_call_returns_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES2015_in_your_lib_option
+                    : Diagnostics.An_async_function_or_method_must_return_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES2015_in_your_lib_option,
             );
             return errorType;
         }
         else if (!getGlobalPromiseConstructorSymbol(/*reportErrors*/ true)) {
             error(
                 func,
-                isImportCall(func) ?
-                    Diagnostics.A_dynamic_import_call_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_the_Promise_constructor_or_include_ES2015_in_your_lib_option :
-                    Diagnostics.An_async_function_or_method_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_the_Promise_constructor_or_include_ES2015_in_your_lib_option,
+                isImportCall(func)
+                    ? Diagnostics.A_dynamic_import_call_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_the_Promise_constructor_or_include_ES2015_in_your_lib_option
+                    : Diagnostics.An_async_function_or_method_in_ES5_requires_the_Promise_constructor_Make_sure_you_have_a_declaration_for_the_Promise_constructor_or_include_ES2015_in_your_lib_option,
             );
         }
 
@@ -37300,8 +37300,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // For an async function, the return type will not be void/undefined, but rather a Promise for void/undefined.
                 const contextualReturnType = getContextualReturnType(func, /*contextFlags*/ undefined);
                 const returnType = contextualReturnType && (unwrapReturnType(contextualReturnType, functionFlags) || voidType).flags & TypeFlags.Undefined ? undefinedType : voidType;
-                return functionFlags & FunctionFlags.Async ? createPromiseReturnType(func, returnType) : // Async function
-                    returnType; // Normal function
+                return functionFlags & FunctionFlags.Async ? createPromiseReturnType(func, returnType) // Async function
+                    : returnType; // Normal function
             }
 
             // Return a union of the return expression types.
@@ -37313,14 +37313,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (returnType) reportErrorsFromWidening(func, returnType, WideningKind.FunctionReturn);
             if (nextType) reportErrorsFromWidening(func, nextType, WideningKind.GeneratorNext);
             if (
-                returnType && isUnitType(returnType) ||
-                yieldType && isUnitType(yieldType) ||
-                nextType && isUnitType(nextType)
+                returnType && isUnitType(returnType)
+                || yieldType && isUnitType(yieldType)
+                || nextType && isUnitType(nextType)
             ) {
                 const contextualSignature = getContextualSignatureForFunctionLikeDeclaration(func);
-                const contextualType = !contextualSignature ? undefined :
-                    contextualSignature === getSignatureFromDeclaration(func) ? isGenerator ? undefined : returnType :
-                    instantiateContextualType(getReturnTypeOfSignature(contextualSignature), func, /*contextFlags*/ undefined);
+                const contextualType = !contextualSignature ? undefined
+                    : contextualSignature === getSignatureFromDeclaration(func) ? isGenerator ? undefined : returnType
+                    : instantiateContextualType(getReturnTypeOfSignature(contextualSignature), func, /*contextFlags*/ undefined);
                 if (isGenerator) {
                     yieldType = getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded(yieldType, contextualType, IterationTypeKind.Yield, isAsync);
                     returnType = getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded(returnType, contextualType, IterationTypeKind.Return, isAsync);
@@ -37369,8 +37369,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const iterableIteratorReturnType = iterationTypes ? iterationTypes.returnType : anyType;
             const iterableIteratorNextType = iterationTypes ? iterationTypes.nextType : undefinedType;
             if (
-                isTypeAssignableTo(returnType, iterableIteratorReturnType) &&
-                isTypeAssignableTo(iterableIteratorNextType, nextType)
+                isTypeAssignableTo(returnType, iterableIteratorReturnType)
+                && isTypeAssignableTo(iterableIteratorNextType, nextType)
             ) {
                 if (globalType !== emptyGenericType) {
                     return createTypeFromGenericGlobalType(globalType, [yieldType]);
@@ -37498,9 +37498,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     expr = skipParentheses((expr as AwaitExpression).expression, /*excludeJSDocTypeAssertions*/ true);
                 }
                 if (
-                    expr.kind === SyntaxKind.CallExpression &&
-                    (expr as CallExpression).expression.kind === SyntaxKind.Identifier &&
-                    checkExpressionCached((expr as CallExpression).expression).symbol === func.symbol
+                    expr.kind === SyntaxKind.CallExpression
+                    && (expr as CallExpression).expression.kind === SyntaxKind.Identifier
+                    && checkExpressionCached((expr as CallExpression).expression).symbol === func.symbol
                 ) {
                     hasReturnOfTypeNever = true;
                     return;
@@ -37527,8 +37527,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return undefined;
         }
         if (
-            strictNullChecks && aggregatedTypes.length && hasReturnWithNoExpression &&
-            !(isJSConstructor(func) && aggregatedTypes.some(t => t.symbol === func.symbol))
+            strictNullChecks && aggregatedTypes.length && hasReturnWithNoExpression
+            && !(isJSConstructor(func) && aggregatedTypes.some(t => t.symbol === func.symbol))
         ) {
             // Javascript "callable constructors", containing eg `if (!(this instanceof A)) return new A()` should not add undefined
             pushIfUnique(aggregatedTypes, undefinedType);
@@ -37591,9 +37591,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkIfExpressionRefinesParameter(func: FunctionLikeDeclaration, expr: Expression, param: ParameterDeclaration, initType: Type): Type | undefined {
-        const antecedent = (expr as Expression & { flowNode?: FlowNode; }).flowNode ||
-            expr.parent.kind === SyntaxKind.ReturnStatement && (expr.parent as ReturnStatement).flowNode ||
-            { flags: FlowFlags.Start };
+        const antecedent = (expr as Expression & { flowNode?: FlowNode; }).flowNode
+            || expr.parent.kind === SyntaxKind.ReturnStatement && (expr.parent as ReturnStatement).flowNode
+            || { flags: FlowFlags.Start };
         const trueCondition: FlowCondition = {
             flags: FlowFlags.TrueCondition,
             node: expr,
@@ -37739,8 +37739,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 instantiatedContextualSignature = instantiateSignature(contextualSignature, inferenceContext!.nonFixingMapper);
                             }
                         }
-                        instantiatedContextualSignature ||= inferenceContext ?
-                            instantiateSignature(contextualSignature, inferenceContext.mapper) : contextualSignature;
+                        instantiatedContextualSignature ||= inferenceContext
+                            ? instantiateSignature(contextualSignature, inferenceContext.mapper) : contextualSignature;
                         assignContextualParameterTypes(signature, instantiatedContextualSignature);
                     }
                     else {
@@ -37859,12 +37859,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Enum members
         // Object.defineProperty assignments with writable false or no setter
         // Unions and intersections of the above (unions and intersections eagerly set isReadonly on creation)
-        return !!(getCheckFlags(symbol) & CheckFlags.Readonly ||
-            symbol.flags & SymbolFlags.Property && getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.Readonly ||
-            symbol.flags & SymbolFlags.Variable && getDeclarationNodeFlagsFromSymbol(symbol) & NodeFlags.Constant ||
-            symbol.flags & SymbolFlags.Accessor && !(symbol.flags & SymbolFlags.SetAccessor) ||
-            symbol.flags & SymbolFlags.EnumMember ||
-            some(symbol.declarations, isReadonlyAssignmentDeclaration));
+        return !!(getCheckFlags(symbol) & CheckFlags.Readonly
+            || symbol.flags & SymbolFlags.Property && getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.Readonly
+            || symbol.flags & SymbolFlags.Variable && getDeclarationNodeFlagsFromSymbol(symbol) & NodeFlags.Constant
+            || symbol.flags & SymbolFlags.Accessor && !(symbol.flags & SymbolFlags.SetAccessor)
+            || symbol.flags & SymbolFlags.EnumMember
+            || some(symbol.declarations, isReadonlyAssignmentDeclaration));
     }
 
     function isAssignmentToReadonlyEntity(expr: Expression, symbol: Symbol, assignmentKind: AssignmentKind) {
@@ -37875,9 +37875,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (isReadonlySymbol(symbol)) {
             // Allow assignments to readonly properties within constructors of the same class declaration.
             if (
-                symbol.flags & SymbolFlags.Property &&
-                isAccessExpression(expr) &&
-                expr.expression.kind === SyntaxKind.ThisKeyword
+                symbol.flags & SymbolFlags.Property
+                && isAccessExpression(expr)
+                && expr.expression.kind === SyntaxKind.ThisKeyword
             ) {
                 // Look for if this is the constructor for the class that `symbol` is a property of.
                 const ctor = getContainingFunction(expr);
@@ -37953,9 +37953,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkDeleteExpressionMustBeOptional(expr: AccessExpression, symbol: Symbol) {
         const type = getTypeOfSymbol(symbol);
         if (
-            strictNullChecks &&
-            !(type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Never)) &&
-            !(exactOptionalPropertyTypes ? symbol.flags & SymbolFlags.Optional : hasTypeFacts(type, TypeFacts.IsUndefined))
+            strictNullChecks
+            && !(type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Never))
+            && !(exactOptionalPropertyTypes ? symbol.flags & SymbolFlags.Optional : hasTypeFacts(type, TypeFacts.IsUndefined))
         ) {
             error(expr, Diagnostics.The_operand_of_a_delete_operator_must_be_optional);
         }
@@ -37977,8 +37977,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const container = getContainingFunctionOrClassStaticBlock(node);
         if (container && isClassStaticBlockDeclaration(container)) {
             // NOTE: We report this regardless as to whether there are parse diagnostics.
-            const message = isAwaitExpression(node) ? Diagnostics.await_expression_cannot_be_used_inside_a_class_static_block :
-                Diagnostics.await_using_statements_cannot_be_used_inside_a_class_static_block;
+            const message = isAwaitExpression(node) ? Diagnostics.await_expression_cannot_be_used_inside_a_class_static_block
+                : Diagnostics.await_using_statements_cannot_be_used_inside_a_class_static_block;
             error(node, message);
             hasError = true;
         }
@@ -37989,8 +37989,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     let span: TextSpan | undefined;
                     if (!isEffectiveExternalModule(sourceFile, compilerOptions)) {
                         span ??= getSpanOfTokenAtPosition(sourceFile, node.pos);
-                        const message = isAwaitExpression(node) ? Diagnostics.await_expressions_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_has_no_imports_or_exports_Consider_adding_an_empty_export_to_make_this_file_a_module :
-                            Diagnostics.await_using_statements_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_has_no_imports_or_exports_Consider_adding_an_empty_export_to_make_this_file_a_module;
+                        const message = isAwaitExpression(node) ? Diagnostics.await_expressions_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_has_no_imports_or_exports_Consider_adding_an_empty_export_to_make_this_file_a_module
+                            : Diagnostics.await_using_statements_are_only_allowed_at_the_top_level_of_a_file_when_that_file_is_a_module_but_this_file_has_no_imports_or_exports_Consider_adding_an_empty_export_to_make_this_file_a_module;
                         const diagnostic = createFileDiagnostic(sourceFile, span.start, span.length, message);
                         diagnostics.add(diagnostic);
                         hasError = true;
@@ -38017,8 +38017,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             // fallthrough
                         default:
                             span ??= getSpanOfTokenAtPosition(sourceFile, node.pos);
-                            const message = isAwaitExpression(node) ? Diagnostics.Top_level_await_expressions_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_nodenext_or_preserve_and_the_target_option_is_set_to_es2017_or_higher :
-                                Diagnostics.Top_level_await_using_statements_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_nodenext_or_preserve_and_the_target_option_is_set_to_es2017_or_higher;
+                            const message = isAwaitExpression(node) ? Diagnostics.Top_level_await_expressions_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_nodenext_or_preserve_and_the_target_option_is_set_to_es2017_or_higher
+                                : Diagnostics.Top_level_await_using_statements_are_only_allowed_when_the_module_option_is_set_to_es2022_esnext_system_node16_nodenext_or_preserve_and_the_target_option_is_set_to_es2017_or_higher;
                             diagnostics.add(createFileDiagnostic(sourceFile, span.start, span.length, message));
                             hasError = true;
                             break;
@@ -38030,8 +38030,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const sourceFile = getSourceFileOfNode(node);
                 if (!hasParseDiagnostics(sourceFile)) {
                     const span = getSpanOfTokenAtPosition(sourceFile, node.pos);
-                    const message = isAwaitExpression(node) ? Diagnostics.await_expressions_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules :
-                        Diagnostics.await_using_statements_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules;
+                    const message = isAwaitExpression(node) ? Diagnostics.await_expressions_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules
+                        : Diagnostics.await_using_statements_are_only_allowed_within_async_functions_and_at_the_top_levels_of_modules;
                     const diagnostic = createFileDiagnostic(sourceFile, span.start, span.length, message);
                     if (container && container.kind !== SyntaxKind.Constructor && (getFunctionFlags(container) & FunctionFlags.Async) === 0) {
                         const relatedInfo = createDiagnosticForNode(container, Diagnostics.Did_you_mean_to_mark_this_function_as_async);
@@ -38103,9 +38103,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.ExclamationToken:
                 checkTruthinessOfType(operandType, node.operand);
                 const facts = getTypeFacts(operandType, TypeFacts.Truthy | TypeFacts.Falsy);
-                return facts === TypeFacts.Truthy ? falseType :
-                    facts === TypeFacts.Falsy ? trueType :
-                    booleanType;
+                return facts === TypeFacts.Truthy ? falseType
+                    : facts === TypeFacts.Falsy ? trueType
+                    : booleanType;
             case SyntaxKind.PlusPlusToken:
             case SyntaxKind.MinusMinusToken:
                 const ok = checkArithmeticOperandType(node.operand, checkNonNullType(operandType, node.operand), Diagnostics.An_arithmetic_operand_must_be_of_type_any_number_bigint_or_an_enum_type);
@@ -38186,22 +38186,22 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (strict && source.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void | TypeFlags.Undefined | TypeFlags.Null)) {
             return false;
         }
-        return !!(kind & TypeFlags.NumberLike) && isTypeAssignableTo(source, numberType) ||
-            !!(kind & TypeFlags.BigIntLike) && isTypeAssignableTo(source, bigintType) ||
-            !!(kind & TypeFlags.StringLike) && isTypeAssignableTo(source, stringType) ||
-            !!(kind & TypeFlags.BooleanLike) && isTypeAssignableTo(source, booleanType) ||
-            !!(kind & TypeFlags.Void) && isTypeAssignableTo(source, voidType) ||
-            !!(kind & TypeFlags.Never) && isTypeAssignableTo(source, neverType) ||
-            !!(kind & TypeFlags.Null) && isTypeAssignableTo(source, nullType) ||
-            !!(kind & TypeFlags.Undefined) && isTypeAssignableTo(source, undefinedType) ||
-            !!(kind & TypeFlags.ESSymbol) && isTypeAssignableTo(source, esSymbolType) ||
-            !!(kind & TypeFlags.NonPrimitive) && isTypeAssignableTo(source, nonPrimitiveType);
+        return !!(kind & TypeFlags.NumberLike) && isTypeAssignableTo(source, numberType)
+            || !!(kind & TypeFlags.BigIntLike) && isTypeAssignableTo(source, bigintType)
+            || !!(kind & TypeFlags.StringLike) && isTypeAssignableTo(source, stringType)
+            || !!(kind & TypeFlags.BooleanLike) && isTypeAssignableTo(source, booleanType)
+            || !!(kind & TypeFlags.Void) && isTypeAssignableTo(source, voidType)
+            || !!(kind & TypeFlags.Never) && isTypeAssignableTo(source, neverType)
+            || !!(kind & TypeFlags.Null) && isTypeAssignableTo(source, nullType)
+            || !!(kind & TypeFlags.Undefined) && isTypeAssignableTo(source, undefinedType)
+            || !!(kind & TypeFlags.ESSymbol) && isTypeAssignableTo(source, esSymbolType)
+            || !!(kind & TypeFlags.NonPrimitive) && isTypeAssignableTo(source, nonPrimitiveType);
     }
 
     function allTypesAssignableToKind(source: Type, kind: TypeFlags, strict?: boolean): boolean {
-        return source.flags & TypeFlags.Union ?
-            every((source as UnionType).types, subType => allTypesAssignableToKind(subType, kind, strict)) :
-            isTypeAssignableToKind(source, kind, strict);
+        return source.flags & TypeFlags.Union
+            ? every((source as UnionType).types, subType => allTypesAssignableToKind(subType, kind, strict))
+            : isTypeAssignableToKind(source, kind, strict);
     }
 
     function isConstEnumObjectType(type: Type): boolean {
@@ -38239,8 +38239,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // The result is always of the Boolean primitive type.
         // NOTE: do not raise error if leftType is unknown as related error was already reported
         if (
-            !isTypeAny(leftType) &&
-            allTypesAssignableToKind(leftType, TypeFlags.Primitive)
+            !isTypeAny(leftType)
+            && allTypesAssignableToKind(leftType, TypeFlags.Primitive)
         ) {
             error(left, Diagnostics.The_left_hand_side_of_an_instanceof_expression_must_be_of_type_any_an_object_type_or_a_type_parameter);
         }
@@ -38277,9 +38277,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         if (isPrivateIdentifier(left)) {
             if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
+                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks
+                || languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators
+                || !useDefineForClassFields
             ) {
                 checkExternalEmitHelpers(left, ExternalEmitHelpers.ClassPrivateFieldIn);
             }
@@ -38411,9 +38411,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 else {
                     checkGrammarForDisallowedTrailingComma(node.elements, Diagnostics.A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma);
-                    const type = everyType(sourceType, isTupleType) ?
-                        mapType(sourceType, t => sliceTupleType(t as TupleTypeReference, elementIndex)) :
-                        createArrayType(elementType);
+                    const type = everyType(sourceType, isTupleType)
+                        ? mapType(sourceType, t => sliceTupleType(t as TupleTypeReference, elementIndex))
+                        : createArrayType(elementType);
                     return checkDestructuringAssignment(restExpression, type, checkMode);
                 }
             }
@@ -38429,8 +38429,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // In strict null checking mode, if a default value of a non-undefined type is specified, remove
                 // undefined from the final type.
                 if (
-                    strictNullChecks &&
-                    !(hasTypeFacts(checkExpression(prop.objectAssignmentInitializer), TypeFacts.IsUndefined))
+                    strictNullChecks
+                    && !(hasTypeFacts(checkExpression(prop.objectAssignmentInitializer), TypeFacts.IsUndefined))
                 ) {
                     sourceType = getTypeWithFacts(sourceType, TypeFacts.NEUndefined);
                 }
@@ -38461,12 +38461,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkReferenceAssignment(target: Expression, sourceType: Type, checkMode?: CheckMode): Type {
         const targetType = checkExpression(target, checkMode);
-        const error = target.parent.kind === SyntaxKind.SpreadAssignment ?
-            Diagnostics.The_target_of_an_object_rest_assignment_must_be_a_variable_or_a_property_access :
-            Diagnostics.The_left_hand_side_of_an_assignment_expression_must_be_a_variable_or_a_property_access;
-        const optionalError = target.parent.kind === SyntaxKind.SpreadAssignment ?
-            Diagnostics.The_target_of_an_object_rest_assignment_may_not_be_an_optional_property_access :
-            Diagnostics.The_left_hand_side_of_an_assignment_expression_may_not_be_an_optional_property_access;
+        const error = target.parent.kind === SyntaxKind.SpreadAssignment
+            ? Diagnostics.The_target_of_an_object_rest_assignment_must_be_a_variable_or_a_property_access
+            : Diagnostics.The_left_hand_side_of_an_assignment_expression_must_be_a_variable_or_a_property_access;
+        const optionalError = target.parent.kind === SyntaxKind.SpreadAssignment
+            ? Diagnostics.The_target_of_an_object_rest_assignment_may_not_be_an_optional_property_access
+            : Diagnostics.The_left_hand_side_of_an_assignment_expression_may_not_be_an_optional_property_access;
         if (checkReferenceExpression(target, error, optionalError)) {
             checkTypeAssignableToAndOptionallyElaborate(sourceType, targetType, target, target);
         }
@@ -38512,15 +38512,15 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return true;
 
             case SyntaxKind.ConditionalExpression:
-                return isSideEffectFree((node as ConditionalExpression).whenTrue) &&
-                    isSideEffectFree((node as ConditionalExpression).whenFalse);
+                return isSideEffectFree((node as ConditionalExpression).whenTrue)
+                    && isSideEffectFree((node as ConditionalExpression).whenFalse);
 
             case SyntaxKind.BinaryExpression:
                 if (isAssignmentOperator((node as BinaryExpression).operatorToken.kind)) {
                     return false;
                 }
-                return isSideEffectFree((node as BinaryExpression).left) &&
-                    isSideEffectFree((node as BinaryExpression).right);
+                return isSideEffectFree((node as BinaryExpression).left)
+                    && isSideEffectFree((node as BinaryExpression).right);
 
             case SyntaxKind.PrefixUnaryExpression:
             case SyntaxKind.PostfixUnaryExpression:
@@ -38765,9 +38765,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // if a user tries to apply a bitwise operator to 2 boolean operands
                 // try and return them a helpful suggestion
                 if (
-                    (leftType.flags & TypeFlags.BooleanLike) &&
-                    (rightType.flags & TypeFlags.BooleanLike) &&
-                    (suggestedOperator = getSuggestedBooleanOperator(operatorToken.kind)) !== undefined
+                    (leftType.flags & TypeFlags.BooleanLike)
+                    && (rightType.flags & TypeFlags.BooleanLike)
+                    && (suggestedOperator = getSuggestedBooleanOperator(operatorToken.kind)) !== undefined
                 ) {
                     error(errorNode || operatorToken, Diagnostics.The_0_operator_is_not_allowed_for_boolean_types_Consider_using_1_instead, tokenToString(operatorToken.kind), tokenToString(suggestedOperator));
                     return numberType;
@@ -38779,9 +38779,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     let resultType: Type;
                     // If both are any or unknown, allow operation; assume it will resolve to number
                     if (
-                        (isTypeAssignableToKind(leftType, TypeFlags.AnyOrUnknown) && isTypeAssignableToKind(rightType, TypeFlags.AnyOrUnknown)) ||
+                        (isTypeAssignableToKind(leftType, TypeFlags.AnyOrUnknown) && isTypeAssignableToKind(rightType, TypeFlags.AnyOrUnknown))
                         // Or, if neither could be bigint, implicit coercion results in a number result
-                        !(maybeTypeOfKind(leftType, TypeFlags.BigIntLike) || maybeTypeOfKind(rightType, TypeFlags.BigIntLike))
+                        || !(maybeTypeOfKind(leftType, TypeFlags.BigIntLike) || maybeTypeOfKind(rightType, TypeFlags.BigIntLike))
                     ) {
                         resultType = numberType;
                     }
@@ -38853,8 +38853,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // await(s) will actually be a completely valid binary expression.
                     const closeEnoughKind = TypeFlags.NumberLike | TypeFlags.BigIntLike | TypeFlags.StringLike | TypeFlags.AnyOrUnknown;
                     reportOperatorError((left, right) =>
-                        isTypeAssignableToKind(left, closeEnoughKind) &&
-                        isTypeAssignableToKind(right, closeEnoughKind)
+                        isTypeAssignableToKind(left, closeEnoughKind)
+                        && isTypeAssignableToKind(right, closeEnoughKind)
                     );
                     return anyType;
                 }
@@ -38876,8 +38876,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         }
                         const leftAssignableToNumber = isTypeAssignableTo(left, numberOrBigIntType);
                         const rightAssignableToNumber = isTypeAssignableTo(right, numberOrBigIntType);
-                        return leftAssignableToNumber && rightAssignableToNumber ||
-                            !leftAssignableToNumber && !rightAssignableToNumber && areTypesComparable(left, right);
+                        return leftAssignableToNumber && rightAssignableToNumber
+                            || !leftAssignableToNumber && !rightAssignableToNumber && areTypesComparable(left, right);
                     });
                 }
                 return booleanType;
@@ -38890,9 +38890,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // types may cause the operands to not be comparable. We don't want such errors reported (see #46475).
                 if (!(checkMode && checkMode & CheckMode.TypeOnly)) {
                     if (
-                        (isLiteralExpressionOfObject(left) || isLiteralExpressionOfObject(right)) &&
+                        (isLiteralExpressionOfObject(left) || isLiteralExpressionOfObject(right))
                         // only report for === and !== in JS, not == or !=
-                        (!isInJSFile(left) || (operator === SyntaxKind.EqualsEqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsEqualsToken))
+                        && (!isInJSFile(left) || (operator === SyntaxKind.EqualsEqualsEqualsToken || operator === SyntaxKind.ExclamationEqualsEqualsToken))
                     ) {
                         const eqType = operator === SyntaxKind.EqualsEqualsToken || operator === SyntaxKind.EqualsEqualsEqualsToken;
                         error(errorNode, Diagnostics.This_condition_will_always_return_0_since_JavaScript_compares_objects_by_reference_not_value, eqType ? "false" : "true");
@@ -38907,9 +38907,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return checkInExpression(left, right, leftType, rightType);
             case SyntaxKind.AmpersandAmpersandToken:
             case SyntaxKind.AmpersandAmpersandEqualsToken: {
-                const resultType = hasTypeFacts(leftType, TypeFacts.Truthy) ?
-                    getUnionType([extractDefinitelyFalsyTypes(strictNullChecks ? leftType : getBaseTypeOfLiteralType(rightType)), rightType]) :
-                    leftType;
+                const resultType = hasTypeFacts(leftType, TypeFacts.Truthy)
+                    ? getUnionType([extractDefinitelyFalsyTypes(strictNullChecks ? leftType : getBaseTypeOfLiteralType(rightType)), rightType])
+                    : leftType;
                 if (operator === SyntaxKind.AmpersandAmpersandEqualsToken) {
                     checkAssignmentOperator(rightType);
                 }
@@ -38917,9 +38917,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             case SyntaxKind.BarBarToken:
             case SyntaxKind.BarBarEqualsToken: {
-                const resultType = hasTypeFacts(leftType, TypeFacts.Falsy) ?
-                    getUnionType([getNonNullableType(removeDefinitelyFalsyTypes(leftType)), rightType], UnionReduction.Subtype) :
-                    leftType;
+                const resultType = hasTypeFacts(leftType, TypeFacts.Falsy)
+                    ? getUnionType([getNonNullableType(removeDefinitelyFalsyTypes(leftType)), rightType], UnionReduction.Subtype)
+                    : leftType;
                 if (operator === SyntaxKind.BarBarEqualsToken) {
                     checkAssignmentOperator(rightType);
                 }
@@ -38927,9 +38927,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             case SyntaxKind.QuestionQuestionToken:
             case SyntaxKind.QuestionQuestionEqualsToken: {
-                const resultType = hasTypeFacts(leftType, TypeFacts.EQUndefinedOrNull) ?
-                    getUnionType([getNonNullableType(leftType), rightType], UnionReduction.Subtype) :
-                    leftType;
+                const resultType = hasTypeFacts(leftType, TypeFacts.EQUndefinedOrNull)
+                    ? getUnionType([getNonNullableType(leftType), rightType], UnionReduction.Subtype)
+                    : leftType;
                 if (operator === SyntaxKind.QuestionQuestionEqualsToken) {
                     checkAssignmentOperator(rightType);
                 }
@@ -38940,12 +38940,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 checkAssignmentDeclaration(declKind, rightType);
                 if (isAssignmentDeclaration(declKind)) {
                     if (
-                        !(rightType.flags & TypeFlags.Object) ||
-                        declKind !== AssignmentDeclarationKind.ModuleExports &&
-                            declKind !== AssignmentDeclarationKind.Prototype &&
-                            !isEmptyObjectType(rightType) &&
-                            !isFunctionObjectType(rightType as ObjectType) &&
-                            !(getObjectFlags(rightType) & ObjectFlags.Class)
+                        !(rightType.flags & TypeFlags.Object)
+                        || declKind !== AssignmentDeclarationKind.ModuleExports
+                            && declKind !== AssignmentDeclarationKind.Prototype
+                            && !isEmptyObjectType(rightType)
+                            && !isFunctionObjectType(rightType as ObjectType)
+                            && !(getObjectFlags(rightType) & ObjectFlags.Class)
                     ) {
                         // don't check assignability of module.exports=, C.prototype=, or expando types because they will necessarily be incomplete
                         checkAssignmentOperator(rightType);
@@ -38995,19 +38995,19 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         // Return true for "indirect calls", (i.e. `(0, x.f)(...)` or `(0, eval)(...)`), which prevents passing `this`.
         function isIndirectCall(node: BinaryExpression): boolean {
-            return node.parent.kind === SyntaxKind.ParenthesizedExpression &&
-                isNumericLiteral(node.left) &&
-                node.left.text === "0" &&
-                (isCallExpression(node.parent.parent) && node.parent.parent.expression === node.parent || node.parent.parent.kind === SyntaxKind.TaggedTemplateExpression) &&
+            return node.parent.kind === SyntaxKind.ParenthesizedExpression
+                && isNumericLiteral(node.left)
+                && node.left.text === "0"
+                && (isCallExpression(node.parent.parent) && node.parent.parent.expression === node.parent || node.parent.parent.kind === SyntaxKind.TaggedTemplateExpression)
                 // special-case for "eval" because it's the only non-access case where an indirect call actually affects behavior.
-                (isAccessExpression(node.right) || isIdentifier(node.right) && node.right.escapedText === "eval");
+                && (isAccessExpression(node.right) || isIdentifier(node.right) && node.right.escapedText === "eval");
         }
 
         // Return true if there was no error, false if there was an error.
         function checkForDisallowedESSymbolOperand(operator: PunctuationSyntaxKind): boolean {
-            const offendingSymbolOperand = maybeTypeOfKindConsideringBaseConstraint(leftType, TypeFlags.ESSymbolLike) ? left :
-                maybeTypeOfKindConsideringBaseConstraint(rightType, TypeFlags.ESSymbolLike) ? right :
-                undefined;
+            const offendingSymbolOperand = maybeTypeOfKindConsideringBaseConstraint(leftType, TypeFlags.ESSymbolLike) ? left
+                : maybeTypeOfKindConsideringBaseConstraint(rightType, TypeFlags.ESSymbolLike) ? right
+                : undefined;
 
             if (offendingSymbolOperand) {
                 error(offendingSymbolOperand, Diagnostics.The_0_operator_cannot_be_applied_to_type_symbol, tokenToString(operator));
@@ -39078,8 +39078,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case AssignmentDeclarationKind.ThisProperty:
                     const symbol = getSymbolOfNode(left);
                     const init = getAssignedExpandoInitializer(right);
-                    return !!init && isObjectLiteralExpression(init) &&
-                        !!symbol?.exports?.size;
+                    return !!init && isObjectLiteralExpression(init)
+                        && !!symbol?.exports?.size;
                 default:
                     return false;
             }
@@ -39264,8 +39264,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isTemplateLiteralContext(node: Node): boolean {
         const parent = node.parent;
-        return isParenthesizedExpression(parent) && isTemplateLiteralContext(parent) ||
-            isElementAccessExpression(parent) && parent.argumentExpression === node;
+        return isParenthesizedExpression(parent) && isTemplateLiteralContext(parent)
+            || isElementAccessExpression(parent) && parent.argumentExpression === node;
     }
 
     function checkTemplateExpression(node: TemplateExpression): Type {
@@ -39287,8 +39287,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTemplateLiteralContextualType(type: Type): boolean {
-        return !!(type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral) ||
-            type.flags & TypeFlags.InstantiableNonPrimitive && maybeTypeOfKind(getBaseConstraintOfType(type) || unknownType, TypeFlags.StringLike));
+        return !!(type.flags & (TypeFlags.StringLiteral | TypeFlags.TemplateLiteral)
+            || type.flags & TypeFlags.InstantiableNonPrimitive && maybeTypeOfKind(getBaseConstraintOfType(type) || unknownType, TypeFlags.StringLike));
     }
 
     function getContextNode(node: Expression): Expression {
@@ -39311,8 +39311,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // We strip literal freshness when an appropriate contextual type is present such that contextually typed
         // literals always preserve their literal types (otherwise they might widen during type inference). An alternative
         // here would be to not mark contextually typed literals as fresh in the first place.
-        const result = maybeTypeOfKind(type, TypeFlags.Literal) && isLiteralOfContextualType(type, instantiateContextualType(contextualType, node, /*contextFlags*/ undefined)) ?
-            getRegularTypeOfLiteralType(type) : type;
+        const result = maybeTypeOfKind(type, TypeFlags.Literal) && isLiteralOfContextualType(type, instantiateContextualType(contextualType, node, /*contextFlags*/ undefined))
+            ? getRegularTypeOfLiteralType(type) : type;
         popInferenceContext();
         popContextualType();
         return result;
@@ -39340,9 +39340,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isTypeAssertion(node: Expression) {
         node = skipParentheses(node, /*excludeJSDocTypeAssertions*/ true);
-        return node.kind === SyntaxKind.TypeAssertionExpression ||
-            node.kind === SyntaxKind.AsExpression ||
-            isJSDocTypeAssertion(node);
+        return node.kind === SyntaxKind.TypeAssertionExpression
+            || node.kind === SyntaxKind.AsExpression
+            || isJSDocTypeAssertion(node);
     }
 
     function checkDeclarationInitializer(
@@ -39357,13 +39357,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return checkSatisfiesExpressionWorker(initializer, typeNode, checkMode);
             }
         }
-        const type = getQuickTypeOfExpression(initializer) ||
-            (contextualType ?
-                checkExpressionWithContextualType(initializer, contextualType, /*inferenceContext*/ undefined, checkMode || CheckMode.Normal)
+        const type = getQuickTypeOfExpression(initializer)
+            || (contextualType
+                ? checkExpressionWithContextualType(initializer, contextualType, /*inferenceContext*/ undefined, checkMode || CheckMode.Normal)
                 : checkExpressionCached(initializer, checkMode));
-        return isParameter(declaration) && declaration.name.kind === SyntaxKind.ArrayBindingPattern &&
-                isTupleType(type) && !type.target.hasRestElement && getTypeReferenceArity(type) < declaration.name.elements.length ?
-            padTupleType(type, declaration.name) : type;
+        return isParameter(declaration) && declaration.name.kind === SyntaxKind.ArrayBindingPattern
+                && isTupleType(type) && !type.target.hasRestElement && getTypeReferenceArity(type) < declaration.name.elements.length
+            ? padTupleType(type, declaration.name) : type;
     }
 
     function padTupleType(type: TupleTypeReference, pattern: ArrayBindingPattern) {
@@ -39409,37 +39409,37 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // this a literal context for literals of that primitive type. For example, given a
                 // type parameter 'T extends string', infer string literal types for T.
                 const constraint = getBaseConstraintOfType(contextualType) || unknownType;
-                return maybeTypeOfKind(constraint, TypeFlags.String) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
-                    maybeTypeOfKind(constraint, TypeFlags.Number) && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral) ||
-                    maybeTypeOfKind(constraint, TypeFlags.BigInt) && maybeTypeOfKind(candidateType, TypeFlags.BigIntLiteral) ||
-                    maybeTypeOfKind(constraint, TypeFlags.ESSymbol) && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol) ||
-                    isLiteralOfContextualType(candidateType, constraint);
+                return maybeTypeOfKind(constraint, TypeFlags.String) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral)
+                    || maybeTypeOfKind(constraint, TypeFlags.Number) && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral)
+                    || maybeTypeOfKind(constraint, TypeFlags.BigInt) && maybeTypeOfKind(candidateType, TypeFlags.BigIntLiteral)
+                    || maybeTypeOfKind(constraint, TypeFlags.ESSymbol) && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol)
+                    || isLiteralOfContextualType(candidateType, constraint);
             }
             // If the contextual type is a literal of a particular primitive type, we consider this a
             // literal context for all literals of that primitive type.
-            return !!(contextualType.flags & (TypeFlags.StringLiteral | TypeFlags.Index | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral) ||
-                contextualType.flags & TypeFlags.NumberLiteral && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral) ||
-                contextualType.flags & TypeFlags.BigIntLiteral && maybeTypeOfKind(candidateType, TypeFlags.BigIntLiteral) ||
-                contextualType.flags & TypeFlags.BooleanLiteral && maybeTypeOfKind(candidateType, TypeFlags.BooleanLiteral) ||
-                contextualType.flags & TypeFlags.UniqueESSymbol && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol));
+            return !!(contextualType.flags & (TypeFlags.StringLiteral | TypeFlags.Index | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) && maybeTypeOfKind(candidateType, TypeFlags.StringLiteral)
+                || contextualType.flags & TypeFlags.NumberLiteral && maybeTypeOfKind(candidateType, TypeFlags.NumberLiteral)
+                || contextualType.flags & TypeFlags.BigIntLiteral && maybeTypeOfKind(candidateType, TypeFlags.BigIntLiteral)
+                || contextualType.flags & TypeFlags.BooleanLiteral && maybeTypeOfKind(candidateType, TypeFlags.BooleanLiteral)
+                || contextualType.flags & TypeFlags.UniqueESSymbol && maybeTypeOfKind(candidateType, TypeFlags.UniqueESSymbol));
         }
         return false;
     }
 
     function isConstContext(node: Expression): boolean {
         const parent = node.parent;
-        return isAssertionExpression(parent) && isConstTypeReference(parent.type) ||
-            isJSDocTypeAssertion(parent) && isConstTypeReference(getJSDocTypeAssertionType(parent)) ||
-            isValidConstAssertionArgument(node) && isConstTypeVariable(getContextualType(node, ContextFlags.None)) ||
-            (isParenthesizedExpression(parent) || isArrayLiteralExpression(parent) || isSpreadElement(parent)) && isConstContext(parent) ||
-            (isPropertyAssignment(parent) || isShorthandPropertyAssignment(parent) || isTemplateSpan(parent)) && isConstContext(parent.parent);
+        return isAssertionExpression(parent) && isConstTypeReference(parent.type)
+            || isJSDocTypeAssertion(parent) && isConstTypeReference(getJSDocTypeAssertionType(parent))
+            || isValidConstAssertionArgument(node) && isConstTypeVariable(getContextualType(node, ContextFlags.None))
+            || (isParenthesizedExpression(parent) || isArrayLiteralExpression(parent) || isSpreadElement(parent)) && isConstContext(parent)
+            || (isPropertyAssignment(parent) || isShorthandPropertyAssignment(parent) || isTemplateSpan(parent)) && isConstContext(parent.parent);
     }
 
     function checkExpressionForMutableLocation(node: Expression, checkMode: CheckMode | undefined, forceTuple?: boolean): Type {
         const type = checkExpression(node, checkMode, forceTuple);
-        return isConstContext(node) || isCommonJsExportedExpression(node) ? getRegularTypeOfLiteralType(type) :
-            isTypeAssertion(node) ? type :
-            getWidenedLiteralLikeTypeForContextualType(type, instantiateContextualType(getContextualType(node, /*contextFlags*/ undefined), node, /*contextFlags*/ undefined));
+        return isConstContext(node) || isCommonJsExportedExpression(node) ? getRegularTypeOfLiteralType(type)
+            : isTypeAssertion(node) ? type
+            : getWidenedLiteralLikeTypeForContextualType(type, instantiateContextualType(getContextualType(node, /*contextFlags*/ undefined), node, /*contextFlags*/ undefined));
     }
 
     function checkPropertyAssignment(node: PropertyAssignment, checkMode?: CheckMode): Type {
@@ -39662,8 +39662,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Optimize for the common case of a call to a function with a single non-generic call
         // signature where we can just fetch the return type without checking the arguments.
         if (isCallExpression(expr) && expr.expression.kind !== SyntaxKind.SuperKeyword && !isRequireCall(expr, /*requireStringLiteralLikeArgument*/ true) && !isSymbolOrSymbolForCall(expr)) {
-            return isCallChain(expr) ? getReturnTypeOfSingleNonGenericSignatureOfCallChain(expr) :
-                getReturnTypeOfSingleNonGenericCallSignature(checkNonNullExpression(expr.expression));
+            return isCallChain(expr) ? getReturnTypeOfSingleNonGenericSignatureOfCallChain(expr)
+                : getReturnTypeOfSingleNonGenericCallSignature(checkNonNullExpression(expr.expression));
         }
         else if (isAssertionExpression(expr) && !isConstTypeReference(expr.type)) {
             return getTypeFromTypeNode((expr as TypeAssertion).type);
@@ -39712,11 +39712,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // - 'left' in property access
         // - 'object' in indexed access
         // - target in rhs of import statement
-        const ok = (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).expression === node) ||
-            (node.parent.kind === SyntaxKind.ElementAccessExpression && (node.parent as ElementAccessExpression).expression === node) ||
-            ((node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.QualifiedName) && isInRightSideOfImportOrExportAssignment(node as Identifier) ||
-                (node.parent.kind === SyntaxKind.TypeQuery && (node.parent as TypeQueryNode).exprName === node)) ||
-            (node.parent.kind === SyntaxKind.ExportSpecifier); // We allow reexporting const enums
+        const ok = (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).expression === node)
+            || (node.parent.kind === SyntaxKind.ElementAccessExpression && (node.parent as ElementAccessExpression).expression === node)
+            || ((node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.QualifiedName) && isInRightSideOfImportOrExportAssignment(node as Identifier)
+                || (node.parent.kind === SyntaxKind.TypeQuery && (node.parent as TypeQueryNode).exprName === node))
+            || (node.parent.kind === SyntaxKind.ExportSpecifier); // We allow reexporting const enums
 
         if (!ok) {
             error(node, Diagnostics.const_enums_can_only_be_used_in_property_or_index_access_expressions_or_the_right_hand_side_of_an_import_declaration_or_export_assignment_or_type_query);
@@ -39768,9 +39768,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return nullWideningType;
             case SyntaxKind.NoSubstitutionTemplateLiteral:
             case SyntaxKind.StringLiteral:
-                return hasSkipDirectInferenceFlag(node) ?
-                    blockedStringType :
-                    getFreshTypeOfLiteralType(getStringLiteralType((node as StringLiteralLike).text));
+                return hasSkipDirectInferenceFlag(node)
+                    ? blockedStringType
+                    : getFreshTypeOfLiteralType(getStringLiteralType((node as StringLiteralLike).text));
             case SyntaxKind.NumericLiteral:
                 checkGrammarNumericLiteral(node as NumericLiteral);
                 return getFreshTypeOfLiteralType(getNumberLiteralType(+(node as NumericLiteral).text));
@@ -39992,8 +39992,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 let hasReportedError = false;
                 for (const { name } of parent.parameters) {
                     if (
-                        isBindingPattern(name) &&
-                        checkIfTypePredicateVariableIsDeclaredInBindingPattern(name, parameterName, typePredicate.parameterName)
+                        isBindingPattern(name)
+                        && checkIfTypePredicateVariableIsDeclaredInBindingPattern(name, parameterName, typePredicate.parameterName)
                     ) {
                         hasReportedError = true;
                         break;
@@ -40058,9 +40058,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         // TODO (yuisu): Remove this check in else-if when SyntaxKind.Construct is moved and ambient context is handled
         else if (
-            node.kind === SyntaxKind.FunctionType || node.kind === SyntaxKind.FunctionDeclaration || node.kind === SyntaxKind.ConstructorType ||
-            node.kind === SyntaxKind.CallSignature || node.kind === SyntaxKind.Constructor ||
-            node.kind === SyntaxKind.ConstructSignature
+            node.kind === SyntaxKind.FunctionType || node.kind === SyntaxKind.FunctionDeclaration || node.kind === SyntaxKind.ConstructorType
+            || node.kind === SyntaxKind.CallSignature || node.kind === SyntaxKind.Constructor
+            || node.kind === SyntaxKind.ConstructSignature
         ) {
             checkGrammarFunctionLikeDeclaration(node as FunctionLikeDeclaration);
         }
@@ -40181,9 +40181,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 const isPrivate = isPrivateIdentifier(name);
                 const privateStaticFlags = isPrivate && isStaticMember ? DeclarationMeaning.PrivateStatic : 0;
-                const names = isPrivate ? privateIdentifiers :
-                    isStaticMember ? staticNames :
-                    instanceNames;
+                const names = isPrivate ? privateIdentifiers
+                    : isStaticMember ? staticNames
+                    : instanceNames;
 
                 const memberName = name && getEffectivePropertyNameForPropertyNameNode(name);
                 if (memberName) {
@@ -40389,9 +40389,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function setNodeLinksForPrivateIdentifierScope(node: PropertyDeclaration | PropertySignature | MethodDeclaration | MethodSignature | AccessorDeclaration) {
         if (isPrivateIdentifier(node.name)) {
             if (
-                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-                languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators ||
-                !useDefineForClassFields
+                languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks
+                || languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators
+                || !useDefineForClassFields
             ) {
                 for (let lexicalScope = getEnclosingBlockScopeContainer(node); !!lexicalScope; lexicalScope = getEnclosingBlockScopeContainer(lexicalScope)) {
                     getNodeLinks(lexicalScope).flags |= NodeCheckFlags.ContainsClassWithPrivateIdentifiers;
@@ -40446,9 +40446,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isPrivateIdentifierClassElementDeclaration(n)) {
                 return true;
             }
-            return n.kind === SyntaxKind.PropertyDeclaration &&
-                !isStatic(n) &&
-                !!(n as PropertyDeclaration).initializer;
+            return n.kind === SyntaxKind.PropertyDeclaration
+                && !isStatic(n)
+                && !!(n as PropertyDeclaration).initializer;
         }
 
         function checkConstructorDeclarationDiagnostics() {
@@ -40470,9 +40470,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // - The constructor declares parameter properties
                     //   or the containing class declares instance member variables with initializers.
 
-                    const superCallShouldBeRootLevel = !emitStandardClassFields &&
-                        (some(node.parent.members, isInstancePropertyWithInitializerOrPrivateIdentifierProperty) ||
-                            some(node.parameters, p => hasSyntacticModifier(p, ModifierFlags.ParameterPropertyModifier)));
+                    const superCallShouldBeRootLevel = !emitStandardClassFields
+                        && (some(node.parent.members, isInstancePropertyWithInitializerOrPrivateIdentifierProperty)
+                            || some(node.parameters, p => hasSyntacticModifier(p, ModifierFlags.ParameterPropertyModifier)));
 
                     if (superCallShouldBeRootLevel) {
                         // Until we have better flow analysis, it is an error to place the super call within any kind of block or conditional
@@ -40569,8 +40569,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         error(setter.name, Diagnostics.Accessors_must_both_be_abstract_or_non_abstract);
                     }
                     if (
-                        ((getterFlags & ModifierFlags.Protected) && !(setterFlags & (ModifierFlags.Protected | ModifierFlags.Private))) ||
-                        ((getterFlags & ModifierFlags.Private) && !(setterFlags & ModifierFlags.Private))
+                        ((getterFlags & ModifierFlags.Protected) && !(setterFlags & (ModifierFlags.Protected | ModifierFlags.Private)))
+                        || ((getterFlags & ModifierFlags.Private) && !(setterFlags & ModifierFlags.Private))
                     ) {
                         error(getter.name, Diagnostics.A_get_accessor_must_be_at_least_as_accessible_as_the_setter);
                         error(setter.name, Diagnostics.A_get_accessor_must_be_at_least_as_accessible_as_the_setter);
@@ -40623,8 +40623,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getTypeParametersForTypeAndSymbol(type: Type, symbol: Symbol) {
         if (!isErrorType(type)) {
-            return symbol.flags & SymbolFlags.TypeAlias && getSymbolLinks(symbol).typeParameters ||
-                (getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).target.localTypeParameters : undefined);
+            return symbol.flags & SymbolFlags.TypeAlias && getSymbolLinks(symbol).typeParameters
+                || (getObjectFlags(type) & ObjectFlags.Reference ? (type as TypeReference).target.localTypeParameters : undefined);
         }
         return undefined;
     }
@@ -40763,8 +40763,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const hasNumberIndexInfo = !!getIndexInfoOfType(objectType, numberType);
         if (everyType(indexType, t => isTypeAssignableTo(t, objectIndexType) || hasNumberIndexInfo && isApplicableIndexType(t, numberType))) {
             if (
-                accessNode.kind === SyntaxKind.ElementAccessExpression && isAssignmentTarget(accessNode) &&
-                getObjectFlags(objectType) & ObjectFlags.Mapped && getMappedTypeModifiers(objectType as MappedType) & MappedTypeModifiers.IncludeReadonly
+                accessNode.kind === SyntaxKind.ElementAccessExpression && isAssignmentTarget(accessNode)
+                && getObjectFlags(objectType) & ObjectFlags.Mapped && getMappedTypeModifiers(objectType as MappedType) & MappedTypeModifiers.IncludeReadonly
             ) {
                 error(accessNode, Diagnostics.Index_signature_in_type_0_only_permits_reading, typeToString(objectType));
             }
@@ -40896,10 +40896,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // children of classes (even ambient classes) should not be marked as ambient or export
         // because those flags have no useful semantics there.
         if (
-            n.parent.kind !== SyntaxKind.InterfaceDeclaration &&
-            n.parent.kind !== SyntaxKind.ClassDeclaration &&
-            n.parent.kind !== SyntaxKind.ClassExpression &&
-            n.flags & NodeFlags.Ambient
+            n.parent.kind !== SyntaxKind.InterfaceDeclaration
+            && n.parent.kind !== SyntaxKind.ClassDeclaration
+            && n.parent.kind !== SyntaxKind.ClassExpression
+            && n.flags & NodeFlags.Ambient
         ) {
             const container = getEnclosingContainer(n);
             if ((container && container.flags & NodeFlags.ExportContext) && !(flags & ModifierFlags.Ambient) && !(isModuleBlock(n.parent) && isModuleDeclaration(n.parent.parent) && isGlobalScopeAugmentation(n.parent.parent))) {
@@ -40999,16 +40999,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (
                         node.name && subsequentName && (
                             // both are private identifiers
-                            isPrivateIdentifier(node.name) && isPrivateIdentifier(subsequentName) && node.name.escapedText === subsequentName.escapedText ||
+                            isPrivateIdentifier(node.name) && isPrivateIdentifier(subsequentName) && node.name.escapedText === subsequentName.escapedText
                             // Both are computed property names
-                            isComputedPropertyName(node.name) && isComputedPropertyName(subsequentName) && isTypeIdenticalTo(checkComputedPropertyName(node.name), checkComputedPropertyName(subsequentName)) ||
+                            || isComputedPropertyName(node.name) && isComputedPropertyName(subsequentName) && isTypeIdenticalTo(checkComputedPropertyName(node.name), checkComputedPropertyName(subsequentName))
                             // Both are literal property names that are the same.
-                            isPropertyNameLiteral(node.name) && isPropertyNameLiteral(subsequentName) &&
-                                getEscapedTextOfIdentifierOrLiteral(node.name) === getEscapedTextOfIdentifierOrLiteral(subsequentName)
+                            || isPropertyNameLiteral(node.name) && isPropertyNameLiteral(subsequentName)
+                                && getEscapedTextOfIdentifierOrLiteral(node.name) === getEscapedTextOfIdentifierOrLiteral(subsequentName)
                         )
                     ) {
-                        const reportError = (node.kind === SyntaxKind.MethodDeclaration || node.kind === SyntaxKind.MethodSignature) &&
-                            isStatic(node) !== isStatic(subsequentNode);
+                        const reportError = (node.kind === SyntaxKind.MethodDeclaration || node.kind === SyntaxKind.MethodSignature)
+                            && isStatic(node) !== isStatic(subsequentNode);
                         // we can get here in two cases
                         // 1. mixed static and instance class members
                         // 2. something with the same name was defined before the set of overloads that prevents them from merging
@@ -41140,8 +41140,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         // Abstract methods can't have an implementation -- in particular, they don't need one.
         if (
-            lastSeenNonAmbientDeclaration && !lastSeenNonAmbientDeclaration.body &&
-            !hasSyntacticModifier(lastSeenNonAmbientDeclaration, ModifierFlags.Abstract) && !lastSeenNonAmbientDeclaration.questionToken
+            lastSeenNonAmbientDeclaration && !lastSeenNonAmbientDeclaration.body
+            && !hasSyntacticModifier(lastSeenNonAmbientDeclaration, ModifierFlags.Abstract) && !lastSeenNonAmbientDeclaration.questionToken
         ) {
             reportImplementationExpectedError(lastSeenNonAmbientDeclaration);
         }
@@ -41399,9 +41399,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * The runtime behavior of the `await` keyword.
      */
     function checkAwaitedType(type: Type, withAlias: boolean, errorNode: Node, diagnosticMessage: DiagnosticMessage, ...args: DiagnosticArguments): Type {
-        const awaitedType = withAlias ?
-            getAwaitedType(type, errorNode, diagnosticMessage, ...args) :
-            getAwaitedTypeNoAlias(type, errorNode, diagnosticMessage, ...args);
+        const awaitedType = withAlias
+            ? getAwaitedType(type, errorNode, diagnosticMessage, ...args)
+            : getAwaitedTypeNoAlias(type, errorNode, diagnosticMessage, ...args);
         return awaitedType || errorType;
     }
 
@@ -41436,9 +41436,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
      * For a generic `Awaited<T>`, gets `T`.
      */
     function unwrapAwaitedType(type: Type) {
-        return type.flags & TypeFlags.Union ? mapType(type, unwrapAwaitedType) :
-            isAwaitedTypeInstantiation(type) ? type.aliasTypeArguments[0] :
-            type;
+        return type.flags & TypeFlags.Union ? mapType(type, unwrapAwaitedType)
+            : isAwaitedTypeInstantiation(type) ? type.aliasTypeArguments[0]
+            : type;
     }
 
     function isAwaitedTypeNeeded(type: Type) {
@@ -41453,9 +41453,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // We only need `Awaited<T>` if `T` is a type variable that has no base constraint, or the base constraint of `T` is `any`, `unknown`, `{}`, `object`,
             // or is promise-like.
             if (
-                baseConstraint ?
-                    baseConstraint.flags & TypeFlags.AnyOrUnknown || isEmptyObjectType(baseConstraint) || someType(baseConstraint, isThenableType) :
-                    maybeTypeOfKind(type, TypeFlags.TypeVariable)
+                baseConstraint
+                    ? baseConstraint.flags & TypeFlags.AnyOrUnknown || isEmptyObjectType(baseConstraint) || someType(baseConstraint, isThenableType)
+                    : maybeTypeOfKind(type, TypeFlags.TypeVariable)
             ) {
                 return true;
             }
@@ -42013,9 +42013,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // Verify if they refer to same entity and is identifier
                 // return undefined if they dont match because we would emit object
                 if (
-                    !isIdentifier(commonEntityName) ||
-                    !isIdentifier(individualEntityName) ||
-                    commonEntityName.escapedText !== individualEntityName.escapedText
+                    !isIdentifier(commonEntityName)
+                    || !isIdentifier(individualEntityName)
+                    || commonEntityName.escapedText !== individualEntityName.escapedText
                 ) {
                     return undefined;
                 }
@@ -42513,8 +42513,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             return isIdentifierThatStartsWithUnderscore(declaration.name);
         }
-        return isAmbientModule(declaration) ||
-            (isVariableDeclaration(declaration) && isForInOrOfStatement(declaration.parent.parent) || isImportedDeclaration(declaration)) && isIdentifierThatStartsWithUnderscore(declaration.name!);
+        return isAmbientModule(declaration)
+            || (isVariableDeclaration(declaration) && isForInOrOfStatement(declaration.parent.parent) || isImportedDeclaration(declaration)) && isIdentifierThatStartsWithUnderscore(declaration.name!);
     }
 
     function checkUnusedLocalsAndParameters(nodeWithLocals: HasLocals, addDiagnostic: AddUnusedDiagnostic): void {
@@ -42574,9 +42574,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         });
         unusedImports.forEach(([importClause, unuseds]) => {
             const importDecl = importClause.parent;
-            const nDeclarations = (importClause.name ? 1 : 0) +
-                (importClause.namedBindings ?
-                    (importClause.namedBindings.kind === SyntaxKind.NamespaceImport ? 1 : importClause.namedBindings.elements.length)
+            const nDeclarations = (importClause.name ? 1 : 0)
+                + (importClause.namedBindings
+                    ? (importClause.namedBindings.kind === SyntaxKind.NamespaceImport ? 1 : importClause.namedBindings.elements.length)
                     : 0);
             if (nDeclarations === unuseds.length) {
                 addDiagnostic(
@@ -42711,13 +42711,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (
-            node.kind === SyntaxKind.PropertyDeclaration ||
-            node.kind === SyntaxKind.PropertySignature ||
-            node.kind === SyntaxKind.MethodDeclaration ||
-            node.kind === SyntaxKind.MethodSignature ||
-            node.kind === SyntaxKind.GetAccessor ||
-            node.kind === SyntaxKind.SetAccessor ||
-            node.kind === SyntaxKind.PropertyAssignment
+            node.kind === SyntaxKind.PropertyDeclaration
+            || node.kind === SyntaxKind.PropertySignature
+            || node.kind === SyntaxKind.MethodDeclaration
+            || node.kind === SyntaxKind.MethodSignature
+            || node.kind === SyntaxKind.GetAccessor
+            || node.kind === SyntaxKind.SetAccessor
+            || node.kind === SyntaxKind.PropertyAssignment
         ) {
             // it is ok to have member named '_super', '_this', `Promise`, etc. - member access is always qualified
             return false;
@@ -42929,9 +42929,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!isIdentifier(node.name)) return Debug.fail();
             const localDeclarationSymbol = resolveName(node, node.name.escapedText, SymbolFlags.Variable, /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined, /*isUse*/ false);
             if (
-                localDeclarationSymbol &&
-                localDeclarationSymbol !== symbol &&
-                localDeclarationSymbol.flags & SymbolFlags.BlockScopedVariable
+                localDeclarationSymbol
+                && localDeclarationSymbol !== symbol
+                && localDeclarationSymbol.flags & SymbolFlags.BlockScopedVariable
             ) {
                 if (getDeclarationNodeFlagsFromSymbol(localDeclarationSymbol) & NodeFlags.BlockScoped) {
                     const varDeclList = getAncestor(localDeclarationSymbol.valueDeclaration, SyntaxKind.VariableDeclarationList)!;
@@ -42941,11 +42941,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     // names of block-scoped and function scoped variables can collide only
                     // if block scoped variable is defined in the function\module\source file scope (because of variable hoisting)
-                    const namesShareScope = container &&
-                        (container.kind === SyntaxKind.Block && isFunctionLike(container.parent) ||
-                            container.kind === SyntaxKind.ModuleBlock ||
-                            container.kind === SyntaxKind.ModuleDeclaration ||
-                            container.kind === SyntaxKind.SourceFile);
+                    const namesShareScope = container
+                        && (container.kind === SyntaxKind.Block && isFunctionLike(container.parent)
+                            || container.kind === SyntaxKind.ModuleBlock
+                            || container.kind === SyntaxKind.ModuleDeclaration
+                            || container.kind === SyntaxKind.SourceFile);
 
                     // here we know that function scoped variable is "shadowed" by block scoped one
                     // a var declatation can't hoist past a lexical declaration and it results in a SyntaxError at runtime
@@ -42987,10 +42987,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         if (isBindingElement(node)) {
             if (
-                node.propertyName &&
-                isIdentifier(node.name) &&
-                isParameterDeclaration(node) &&
-                nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)
+                node.propertyName
+                && isIdentifier(node.name)
+                && isParameterDeclaration(node)
+                && nodeIsMissing((getContainingFunction(node) as FunctionLikeDeclaration).body)
             ) {
                 // type F = ({a: string}) => void;
                 //               ^^^^^^
@@ -43083,10 +43083,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // Don't validate for-in initializer as it is already an error
             const initializer = hasOnlyExpressionInitializer(node) && getEffectiveInitializer(node);
             if (initializer) {
-                const isJSObjectLiteralInitializer = isInJSFile(node) &&
-                    isObjectLiteralExpression(initializer) &&
-                    (initializer.properties.length === 0 || isPrototypeAccess(node.name)) &&
-                    !!symbol.exports?.size;
+                const isJSObjectLiteralInitializer = isInJSFile(node)
+                    && isObjectLiteralExpression(initializer)
+                    && (initializer.properties.length === 0 || isPrototypeAccess(node.name))
+                    && !!symbol.exports?.size;
                 if (!isJSObjectLiteralInitializer && node.parent.parent.kind !== SyntaxKind.ForInStatement) {
                     const initializerType = checkExpressionCached(initializer);
                     checkTypeAssignableToAndOptionallyElaborate(initializerType, type, node, initializer, /*headMessage*/ undefined);
@@ -43120,9 +43120,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const declarationType = convertAutoToAny(getWidenedTypeForVariableLikeDeclaration(node));
 
             if (
-                !isErrorType(type) && !isErrorType(declarationType) &&
-                !isTypeIdenticalTo(type, declarationType) &&
-                !(symbol.flags & SymbolFlags.Assignment)
+                !isErrorType(type) && !isErrorType(declarationType)
+                && !isTypeIdenticalTo(type, declarationType)
+                && !(symbol.flags & SymbolFlags.Assignment)
             ) {
                 errorNextVariableOrPropertyDeclarationMustHaveSameType(symbol.valueDeclaration, type, node, declarationType);
             }
@@ -43163,8 +43163,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function areDeclarationFlagsIdentical(left: Declaration, right: Declaration) {
         if (
-            (left.kind === SyntaxKind.Parameter && right.kind === SyntaxKind.VariableDeclaration) ||
-            (left.kind === SyntaxKind.VariableDeclaration && right.kind === SyntaxKind.Parameter)
+            (left.kind === SyntaxKind.Parameter && right.kind === SyntaxKind.VariableDeclaration)
+            || (left.kind === SyntaxKind.VariableDeclaration && right.kind === SyntaxKind.Parameter)
         ) {
             // Differences in optionality between parameters and variables are allowed.
             return true;
@@ -43174,12 +43174,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return false;
         }
 
-        const interestingFlags = ModifierFlags.Private |
-            ModifierFlags.Protected |
-            ModifierFlags.Async |
-            ModifierFlags.Abstract |
-            ModifierFlags.Readonly |
-            ModifierFlags.Static;
+        const interestingFlags = ModifierFlags.Private
+            | ModifierFlags.Protected
+            | ModifierFlags.Async
+            | ModifierFlags.Abstract
+            | ModifierFlags.Readonly
+            | ModifierFlags.Static;
 
         return getSelectedEffectiveModifierFlags(left, interestingFlags) === getSelectedEffectiveModifierFlags(right, interestingFlags);
     }
@@ -43311,8 +43311,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     let childExpression = childNode.parent;
                     while (testedExpression && childExpression) {
                         if (
-                            isIdentifier(testedExpression) && isIdentifier(childExpression) ||
-                            testedExpression.kind === SyntaxKind.ThisKeyword && childExpression.kind === SyntaxKind.ThisKeyword
+                            isIdentifier(testedExpression) && isIdentifier(childExpression)
+                            || testedExpression.kind === SyntaxKind.ThisKeyword && childExpression.kind === SyntaxKind.ThisKeyword
                         ) {
                             return getSymbolAtLocation(testedExpression) === getSymbolAtLocation(childExpression);
                         }
@@ -43562,11 +43562,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const iterationTypes = getIterationTypesOfIterable(inputType, use, uplevelIteration ? errorNode : undefined);
             if (checkAssignability) {
                 if (iterationTypes) {
-                    const diagnostic = use & IterationUse.ForOfFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_for_of_will_always_send_0 :
-                        use & IterationUse.SpreadFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_always_send_0 :
-                        use & IterationUse.DestructuringFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring_will_always_send_0 :
-                        use & IterationUse.YieldStarFlag ? Diagnostics.Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_containing_generator_will_always_send_0 :
-                        undefined;
+                    const diagnostic = use & IterationUse.ForOfFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_for_of_will_always_send_0
+                        : use & IterationUse.SpreadFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_spread_will_always_send_0
+                        : use & IterationUse.DestructuringFlag ? Diagnostics.Cannot_iterate_value_because_the_next_method_of_its_iterator_expects_type_1_but_array_destructuring_will_always_send_0
+                        : use & IterationUse.YieldStarFlag ? Diagnostics.Cannot_delegate_iteration_to_value_because_the_next_method_of_its_iterator_expects_type_1_but_the_containing_generator_will_always_send_0
+                        : undefined;
                     if (diagnostic) {
                         checkTypeAssignableTo(sentType, iterationTypes.nextType, errorNode, diagnostic);
                     }
@@ -43700,9 +43700,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // are also cached on the type they are requested for, so we shouldn't need to maintain
         // the cache for less-frequently used types.
         if (
-            yieldType.flags & TypeFlags.Intrinsic &&
-            returnType.flags & (TypeFlags.Any | TypeFlags.Never | TypeFlags.Unknown | TypeFlags.Void | TypeFlags.Undefined) &&
-            nextType.flags & (TypeFlags.Any | TypeFlags.Never | TypeFlags.Unknown | TypeFlags.Void | TypeFlags.Undefined)
+            yieldType.flags & TypeFlags.Intrinsic
+            && returnType.flags & (TypeFlags.Any | TypeFlags.Never | TypeFlags.Unknown | TypeFlags.Void | TypeFlags.Undefined)
+            && nextType.flags & (TypeFlags.Any | TypeFlags.Never | TypeFlags.Unknown | TypeFlags.Void | TypeFlags.Undefined)
         ) {
             const id = getTypeListId([yieldType, returnType, nextType]);
             let iterationTypes = iterationTypesCache.get(id);
@@ -43868,24 +43868,24 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         let noCache = false;
 
         if (use & IterationUse.AllowsAsyncIterablesFlag) {
-            const iterationTypes = getIterationTypesOfIterableCached(type, asyncIterationTypesResolver) ||
-                getIterationTypesOfIterableFast(type, asyncIterationTypesResolver);
+            const iterationTypes = getIterationTypesOfIterableCached(type, asyncIterationTypesResolver)
+                || getIterationTypesOfIterableFast(type, asyncIterationTypesResolver);
             if (iterationTypes) {
                 if (iterationTypes === noIterationTypes && errorNode) {
                     // ignore the cached value
                     noCache = true;
                 }
                 else {
-                    return use & IterationUse.ForOfFlag ?
-                        getAsyncFromSyncIterationTypes(iterationTypes, errorNode) :
-                        iterationTypes;
+                    return use & IterationUse.ForOfFlag
+                        ? getAsyncFromSyncIterationTypes(iterationTypes, errorNode)
+                        : iterationTypes;
                 }
             }
         }
 
         if (use & IterationUse.AllowsSyncIterablesFlag) {
-            let iterationTypes = getIterationTypesOfIterableCached(type, syncIterationTypesResolver) ||
-                getIterationTypesOfIterableFast(type, syncIterationTypesResolver);
+            let iterationTypes = getIterationTypesOfIterableCached(type, syncIterationTypesResolver)
+                || getIterationTypesOfIterableFast(type, syncIterationTypesResolver);
             if (iterationTypes) {
                 if (iterationTypes === noIterationTypes && errorNode) {
                     // ignore the cached value
@@ -43941,8 +43941,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getIterationTypesOfGlobalIterableType(globalType: Type, resolver: IterationTypesResolver) {
-        const globalIterationTypes = getIterationTypesOfIterableCached(globalType, resolver) ||
-            getIterationTypesOfIterableSlow(globalType, resolver, /*errorNode*/ undefined, /*errorOutputContainer*/ undefined, /*noCache*/ false);
+        const globalIterationTypes = getIterationTypesOfIterableCached(globalType, resolver)
+            || getIterationTypesOfIterableSlow(globalType, resolver, /*errorNode*/ undefined, /*errorOutputContainer*/ undefined, /*noCache*/ false);
         return globalIterationTypes === noIterationTypes ? defaultIterationTypes : globalIterationTypes;
     }
 
@@ -43965,8 +43965,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // - `IterableIterator<T>` or `AsyncIterableIterator<T>`
         let globalType: Type;
         if (
-            isReferenceToType(type, globalType = resolver.getGlobalIterableType(/*reportErrors*/ false)) ||
-            isReferenceToType(type, globalType = resolver.getGlobalIterableIteratorType(/*reportErrors*/ false))
+            isReferenceToType(type, globalType = resolver.getGlobalIterableType(/*reportErrors*/ false))
+            || isReferenceToType(type, globalType = resolver.getGlobalIterableIteratorType(/*reportErrors*/ false))
         ) {
             const [yieldType] = getTypeArguments(type as GenericType);
             // The "return" and "next" types of `Iterable` and `IterableIterator` are defined by the
@@ -44028,11 +44028,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             !!getAwaitedTypeOfPromise(type)
             // for (const x of AsyncIterable<...>)
             || (
-                !allowAsyncIterables &&
-                isForOfStatement(errorNode.parent) &&
-                errorNode.parent.expression === errorNode &&
-                getGlobalAsyncIterableType(/*reportErrors*/ false) !== emptyGenericType &&
-                isTypeAssignableTo(type, getGlobalAsyncIterableType(/*reportErrors*/ false))
+                !allowAsyncIterables
+                && isForOfStatement(errorNode.parent)
+                && errorNode.parent.expression === errorNode
+                && getGlobalAsyncIterableType(/*reportErrors*/ false) !== emptyGenericType
+                && isTypeAssignableTo(type, getGlobalAsyncIterableType(/*reportErrors*/ false))
             );
         return errorAndMaybeSuggestAwait(errorNode, suggestAwait, message, typeToString(type));
     }
@@ -44061,8 +44061,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return anyIterationTypes;
         }
 
-        let iterationTypes = getIterationTypesOfIteratorCached(type, resolver) ||
-            getIterationTypesOfIteratorFast(type, resolver);
+        let iterationTypes = getIterationTypesOfIteratorCached(type, resolver)
+            || getIterationTypesOfIteratorFast(type, resolver);
 
         if (iterationTypes === noIterationTypes && errorNode) {
             iterationTypes = undefined;
@@ -44108,14 +44108,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // The "return" and "next" types of `IterableIterator` and `AsyncIterableIterator` are defined by the
             // iteration types of their `next`, `return`, and `throw` methods. While we define these as `any`
             // and `undefined` in our libs by default, a custom lib *could* use different definitions.
-            const globalIterationTypes = getIterationTypesOfIteratorCached(globalType, resolver) ||
-                getIterationTypesOfIteratorSlow(globalType, resolver, /*errorNode*/ undefined, /*errorOutputContainer*/ undefined, /*noCache*/ false);
+            const globalIterationTypes = getIterationTypesOfIteratorCached(globalType, resolver)
+                || getIterationTypesOfIteratorSlow(globalType, resolver, /*errorNode*/ undefined, /*errorOutputContainer*/ undefined, /*noCache*/ false);
             const { returnType, nextType } = globalIterationTypes === noIterationTypes ? defaultIterationTypes : globalIterationTypes;
             return setCachedIterationTypes(type, resolver.iteratorCacheKey, createIterationTypes(yieldType, returnType, nextType));
         }
         if (
-            isReferenceToType(type, resolver.getGlobalIteratorType(/*reportErrors*/ false)) ||
-            isReferenceToType(type, resolver.getGlobalGeneratorType(/*reportErrors*/ false))
+            isReferenceToType(type, resolver.getGlobalIteratorType(/*reportErrors*/ false))
+            || isReferenceToType(type, resolver.getGlobalGeneratorType(/*reportErrors*/ false))
         ) {
             const [yieldType, returnType, nextType] = getTypeArguments(type as GenericType);
             return setCachedIterationTypes(type, resolver.iteratorCacheKey, createIterationTypes(yieldType, returnType, nextType));
@@ -44343,8 +44343,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         const use = isAsyncGenerator ? IterationUse.AsyncGeneratorReturnType : IterationUse.GeneratorReturnType;
         const resolver = isAsyncGenerator ? asyncIterationTypesResolver : syncIterationTypesResolver;
-        return getIterationTypesOfIterable(type, use, /*errorNode*/ undefined) ||
-            getIterationTypesOfIterator(type, resolver, /*errorNode*/ undefined, /*errorOutputContainer*/ undefined);
+        return getIterationTypesOfIterable(type, use, /*errorNode*/ undefined)
+            || getIterationTypesOfIterator(type, resolver, /*errorNode*/ undefined, /*errorOutputContainer*/ undefined);
     }
 
     function checkBreakOrContinueStatement(node: BreakOrContinueStatement) {
@@ -44599,16 +44599,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         const indexInfos = getApplicableIndexInfos(type, propNameType);
         const interfaceDeclaration = getObjectFlags(type) & ObjectFlags.Interface ? getDeclarationOfKind(type.symbol, SyntaxKind.InterfaceDeclaration) : undefined;
-        const propDeclaration = declaration && declaration.kind === SyntaxKind.BinaryExpression ||
-                name && name.kind === SyntaxKind.ComputedPropertyName ? declaration : undefined;
+        const propDeclaration = declaration && declaration.kind === SyntaxKind.BinaryExpression
+                || name && name.kind === SyntaxKind.ComputedPropertyName ? declaration : undefined;
         const localPropDeclaration = getParentOfSymbol(prop) === type.symbol ? declaration : undefined;
         for (const info of indexInfos) {
             const localIndexDeclaration = info.declaration && getParentOfSymbol(getSymbolOfDeclaration(info.declaration)) === type.symbol ? info.declaration : undefined;
             // We check only when (a) the property is declared in the containing type, or (b) the applicable index signature is declared
             // in the containing type, or (c) the containing type is an interface and no base interface contains both the property and
             // the index signature (i.e. property and index signature are declared in separate inherited interfaces).
-            const errorNode = localPropDeclaration || localIndexDeclaration ||
-                (interfaceDeclaration && !some(getBaseTypes(type as InterfaceType), base => !!getPropertyOfObjectType(base, prop.escapedName) && !!getIndexTypeOfType(base, info.keyType)) ? interfaceDeclaration : undefined);
+            const errorNode = localPropDeclaration || localIndexDeclaration
+                || (interfaceDeclaration && !some(getBaseTypes(type as InterfaceType), base => !!getPropertyOfObjectType(base, prop.escapedName) && !!getIndexTypeOfType(base, info.keyType)) ? interfaceDeclaration : undefined);
             if (errorNode && !isTypeAssignableTo(propType, info.type)) {
                 const diagnostic = createError(errorNode, Diagnostics.Property_0_of_type_1_is_not_assignable_to_2_index_type_3, symbolToString(prop), typeToString(propType), typeToString(info.keyType), typeToString(info.type));
                 if (propDeclaration && errorNode !== propDeclaration) {
@@ -44630,8 +44630,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             // We check only when (a) the check index signature is declared in the containing type, or (b) the applicable index
             // signature is declared in the containing type, or (c) the containing type is an interface and no base interface contains
             // both index signatures (i.e. the index signatures are declared in separate inherited interfaces).
-            const errorNode = localCheckDeclaration || localIndexDeclaration ||
-                (interfaceDeclaration && !some(getBaseTypes(type as InterfaceType), base => !!getIndexInfoOfType(base, checkInfo.keyType) && !!getIndexTypeOfType(base, info.keyType)) ? interfaceDeclaration : undefined);
+            const errorNode = localCheckDeclaration || localIndexDeclaration
+                || (interfaceDeclaration && !some(getBaseTypes(type as InterfaceType), base => !!getIndexInfoOfType(base, checkInfo.keyType) && !!getIndexTypeOfType(base, info.keyType)) ? interfaceDeclaration : undefined);
             if (errorNode && !isTypeAssignableTo(checkInfo.type, info.type)) {
                 error(errorNode, Diagnostics._0_index_type_1_is_not_assignable_to_2_index_type_3, typeToString(checkInfo.keyType), typeToString(checkInfo.type), typeToString(info.keyType), typeToString(info.type));
             }
@@ -44690,8 +44690,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const lastJSDocParamIndex = jsdocParameters.length - 1;
             const lastJSDocParam = jsdocParameters[lastJSDocParamIndex];
             if (
-                isJs && lastJSDocParam && isIdentifier(lastJSDocParam.name) && lastJSDocParam.typeExpression &&
-                lastJSDocParam.typeExpression.type && !parameters.has(lastJSDocParam.name.escapedText) && !excludedParameters.has(lastJSDocParamIndex) && !isArrayType(getTypeFromTypeNode(lastJSDocParam.typeExpression.type))
+                isJs && lastJSDocParam && isIdentifier(lastJSDocParam.name) && lastJSDocParam.typeExpression
+                && lastJSDocParam.typeExpression.type && !parameters.has(lastJSDocParam.name.escapedText) && !excludedParameters.has(lastJSDocParamIndex) && !isArrayType(getTypeFromTypeNode(lastJSDocParam.typeExpression.type))
             ) {
                 error(lastJSDocParam.name, Diagnostics.JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name_It_would_match_arguments_if_it_had_an_array_type, idText(lastJSDocParam.name));
             }
@@ -44837,10 +44837,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getFirstTransformableStaticClassElement(node: ClassLikeDeclaration) {
-        const willTransformStaticElementsOfDecoratedClass = !legacyDecorators && languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators &&
-            classOrConstructorParameterIsDecorated(/*useLegacyDecorators*/ false, node);
-        const willTransformPrivateElementsOrClassStaticBlocks = languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks ||
-            languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators;
+        const willTransformStaticElementsOfDecoratedClass = !legacyDecorators && languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators
+            && classOrConstructorParameterIsDecorated(/*useLegacyDecorators*/ false, node);
+        const willTransformPrivateElementsOrClassStaticBlocks = languageVersion < LanguageFeatureMinimumTarget.PrivateNamesAndClassStaticBlocks
+            || languageVersion < LanguageFeatureMinimumTarget.ClassAndClassElementDecorators;
         const willTransformInitializers = !emitStandardClassFields;
         if (willTransformStaticElementsOfDecoratedClass || willTransformPrivateElementsOrClassStaticBlocks) {
             for (const member of node.members) {
@@ -44853,8 +44853,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                     else if (isStatic(member)) {
                         if (
-                            isPrivateIdentifierClassElementDeclaration(member) ||
-                            willTransformInitializers && isInitializedProperty(member)
+                            isPrivateIdentifierClassElementDeclaration(member)
+                            || willTransformInitializers && isInitializedProperty(member)
                         ) {
                             return member;
                         }
@@ -45019,9 +45019,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const t = getReducedType(getTypeFromTypeNode(typeRefNode));
                 if (!isErrorType(t)) {
                     if (isValidBaseType(t)) {
-                        const genericDiag = t.symbol && t.symbol.flags & SymbolFlags.Class ?
-                            Diagnostics.Class_0_incorrectly_implements_class_1_Did_you_mean_to_extend_1_and_inherit_its_members_as_a_subclass :
-                            Diagnostics.Class_0_incorrectly_implements_interface_1;
+                        const genericDiag = t.symbol && t.symbol.flags & SymbolFlags.Class
+                            ? Diagnostics.Class_0_incorrectly_implements_class_1_Did_you_mean_to_extend_1_and_inherit_its_members_as_a_subclass
+                            : Diagnostics.Class_0_incorrectly_implements_interface_1;
                         const baseWithThis = getTypeWithThisArgument(t, type.thisType);
                         if (!checkTypeAssignableTo(typeWithThis, baseWithThis, /*errorNode*/ undefined)) {
                             issueMemberSpecificError(node, typeWithThis, baseWithThis, genericDiag);
@@ -45148,20 +45148,20 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (prop && !baseProp && memberHasOverrideModifier) {
                 if (errorNode) {
                     const suggestion = getSuggestedSymbolForNonexistentClassMember(memberName, baseType); // Again, using symbol name: note that's different from `symbol.escapedName`
-                    suggestion ?
-                        error(
+                    suggestion
+                        ? error(
                             errorNode,
-                            isJs ?
-                                Diagnostics.This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base_class_0_Did_you_mean_1 :
-                                Diagnostics.This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0_Did_you_mean_1,
+                            isJs
+                                ? Diagnostics.This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base_class_0_Did_you_mean_1
+                                : Diagnostics.This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0_Did_you_mean_1,
                             baseClassName,
                             symbolToString(suggestion),
-                        ) :
-                        error(
+                        )
+                        : error(
                             errorNode,
-                            isJs ?
-                                Diagnostics.This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base_class_0 :
-                                Diagnostics.This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0,
+                            isJs
+                                ? Diagnostics.This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_it_is_not_declared_in_the_base_class_0
+                                : Diagnostics.This_member_cannot_have_an_override_modifier_because_it_is_not_declared_in_the_base_class_0,
                             baseClassName,
                         );
                 }
@@ -45175,13 +45175,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                 if (!baseHasAbstract) {
                     if (errorNode) {
-                        const diag = memberIsParameterProperty ?
-                            isJs ?
-                                Diagnostics.This_parameter_property_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_in_the_base_class_0 :
-                                Diagnostics.This_parameter_property_must_have_an_override_modifier_because_it_overrides_a_member_in_base_class_0 :
-                            isJs ?
-                            Diagnostics.This_member_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_in_the_base_class_0 :
-                            Diagnostics.This_member_must_have_an_override_modifier_because_it_overrides_a_member_in_the_base_class_0;
+                        const diag = memberIsParameterProperty
+                            ? isJs
+                                ? Diagnostics.This_parameter_property_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_in_the_base_class_0
+                                : Diagnostics.This_parameter_property_must_have_an_override_modifier_because_it_overrides_a_member_in_base_class_0
+                            : isJs
+                            ? Diagnostics.This_member_must_have_a_JSDoc_comment_with_an_override_tag_because_it_overrides_a_member_in_the_base_class_0
+                            : Diagnostics.This_member_must_have_an_override_modifier_because_it_overrides_a_member_in_the_base_class_0;
                         error(errorNode, diag, baseClassName);
                     }
                     return MemberOverrideStatus.NeedsOverride;
@@ -45199,9 +45199,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const className = typeToString(type);
                 error(
                     errorNode,
-                    isJs ?
-                        Diagnostics.This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_its_containing_class_0_does_not_extend_another_class :
-                        Diagnostics.This_member_cannot_have_an_override_modifier_because_its_containing_class_0_does_not_extend_another_class,
+                    isJs
+                        ? Diagnostics.This_member_cannot_have_a_JSDoc_comment_with_an_override_tag_because_its_containing_class_0_does_not_extend_another_class
+                        : Diagnostics.This_member_cannot_have_an_override_modifier_because_its_containing_class_0_does_not_extend_another_class,
                     className,
                 );
             }
@@ -45406,9 +45406,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const overriddenInstanceProperty = basePropertyFlags !== SymbolFlags.Property && derivedPropertyFlags === SymbolFlags.Property;
                     const overriddenInstanceAccessor = basePropertyFlags === SymbolFlags.Property && derivedPropertyFlags !== SymbolFlags.Property;
                     if (overriddenInstanceProperty || overriddenInstanceAccessor) {
-                        const errorMessage = overriddenInstanceProperty ?
-                            Diagnostics._0_is_defined_as_an_accessor_in_class_1_but_is_overridden_here_in_2_as_an_instance_property :
-                            Diagnostics._0_is_defined_as_a_property_in_class_1_but_is_overridden_here_in_2_as_an_accessor;
+                        const errorMessage = overriddenInstanceProperty
+                            ? Diagnostics._0_is_defined_as_an_accessor_in_class_1_but_is_overridden_here_in_2_as_an_instance_property
+                            : Diagnostics._0_is_defined_as_a_property_in_class_1_but_is_overridden_here_in_2_as_an_accessor;
                         error(getNameOfDeclaration(derived.valueDeclaration) || derived.valueDeclaration, errorMessage, symbolToString(base), typeToString(baseType), typeToString(type));
                     }
                     else if (useDefineForClassFields) {
@@ -45583,10 +45583,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isPropertyWithoutInitializer(node: Node) {
-        return node.kind === SyntaxKind.PropertyDeclaration &&
-            !hasAbstractModifier(node) &&
-            !(node as PropertyDeclaration).exclamationToken &&
-            !(node as PropertyDeclaration).initializer;
+        return node.kind === SyntaxKind.PropertyDeclaration
+            && !hasAbstractModifier(node)
+            && !(node as PropertyDeclaration).exclamationToken
+            && !(node as PropertyDeclaration).initializer;
     }
 
     function isPropertyInitializedInStaticBlocks(propName: Identifier | PrivateIdentifier, propType: Type, staticBlocks: readonly ClassStaticBlockDeclaration[], startPos: number, endPos: number) {
@@ -45726,9 +45726,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (isConstEnum && typeof value === "number" && !isFinite(value)) {
                 error(
                     initializer,
-                    isNaN(value) ?
-                        Diagnostics.const_enum_member_initializer_was_evaluated_to_disallowed_value_NaN :
-                        Diagnostics.const_enum_member_initializer_was_evaluated_to_a_non_finite_value,
+                    isNaN(value)
+                        ? Diagnostics.const_enum_member_initializer_was_evaluated_to_disallowed_value_NaN
+                        : Diagnostics.const_enum_member_initializer_was_evaluated_to_a_non_finite_value,
                 );
             }
         }
@@ -45791,9 +45791,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 else if (
-                    (typeof left === "string" || typeof left === "number") &&
-                    (typeof right === "string" || typeof right === "number") &&
-                    (expr as BinaryExpression).operatorToken.kind === SyntaxKind.PlusToken
+                    (typeof left === "string" || typeof left === "number")
+                    && (typeof right === "string" || typeof right === "number")
+                    && (expr as BinaryExpression).operatorToken.kind === SyntaxKind.PlusToken
                 ) {
                     return "" + left + right;
                 }
@@ -45946,9 +45946,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (declarations) {
             for (const declaration of declarations) {
                 if (
-                    (declaration.kind === SyntaxKind.ClassDeclaration ||
-                        (declaration.kind === SyntaxKind.FunctionDeclaration && nodeIsPresent((declaration as FunctionLikeDeclaration).body))) &&
-                    !(declaration.flags & NodeFlags.Ambient)
+                    (declaration.kind === SyntaxKind.ClassDeclaration
+                        || (declaration.kind === SyntaxKind.FunctionDeclaration && nodeIsPresent((declaration as FunctionLikeDeclaration).body)))
+                    && !(declaration.flags & NodeFlags.Ambient)
                 ) {
                     return declaration;
                 }
@@ -46038,16 +46038,16 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     // we need to track this to ensure the correct emit.
                     const mergedClass = getDeclarationOfKind(symbol, SyntaxKind.ClassDeclaration);
                     if (
-                        mergedClass &&
-                        inSameLexicalScope(node, mergedClass)
+                        mergedClass
+                        && inSameLexicalScope(node, mergedClass)
                     ) {
                         getNodeLinks(node).flags |= NodeCheckFlags.LexicalModuleMergesWithClass;
                     }
                 }
                 if (
-                    compilerOptions.verbatimModuleSyntax &&
-                    node.parent.kind === SyntaxKind.SourceFile &&
-                    (moduleKind === ModuleKind.CommonJS || node.parent.impliedNodeFormat === ModuleKind.CommonJS)
+                    compilerOptions.verbatimModuleSyntax
+                    && node.parent.kind === SyntaxKind.SourceFile
+                    && (moduleKind === ModuleKind.CommonJS || node.parent.impliedNodeFormat === ModuleKind.CommonJS)
                 ) {
                     const exportModifier = node.modifiers?.find(m => m.kind === SyntaxKind.ExportKeyword);
                     if (exportModifier) {
@@ -46168,9 +46168,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (node.parent.kind !== SyntaxKind.SourceFile && !inAmbientExternalModule) {
             error(
                 moduleName,
-                node.kind === SyntaxKind.ExportDeclaration ?
-                    Diagnostics.Export_declarations_are_not_permitted_in_a_namespace :
-                    Diagnostics.Import_declarations_in_a_namespace_cannot_reference_a_module,
+                node.kind === SyntaxKind.ExportDeclaration
+                    ? Diagnostics.Export_declarations_are_not_permitted_in_a_namespace
+                    : Diagnostics.Import_declarations_in_a_namespace_cannot_reference_a_module,
             );
             return false;
         }
@@ -46215,9 +46215,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             // A type-only import/export will already have a grammar error in a JS file, so no need to issue more errors within
             if (isInJSFile(node) && !(target.flags & SymbolFlags.Value) && !isTypeOnlyImportOrExportDeclaration(node)) {
-                const errorNode = isImportOrExportSpecifier(node) ? node.propertyName || node.name :
-                    isNamedDeclaration(node) ? node.name :
-                    node;
+                const errorNode = isImportOrExportSpecifier(node) ? node.propertyName || node.name
+                    : isNamedDeclaration(node) ? node.name
+                    : node;
 
                 Debug.assert(node.kind !== SyntaxKind.NamespaceExport);
                 if (node.kind === SyntaxKind.ExportSpecifier) {
@@ -46253,13 +46253,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             const targetFlags = getSymbolFlags(target);
-            const excludedMeanings = (symbol.flags & (SymbolFlags.Value | SymbolFlags.ExportValue) ? SymbolFlags.Value : 0) |
-                (symbol.flags & SymbolFlags.Type ? SymbolFlags.Type : 0) |
-                (symbol.flags & SymbolFlags.Namespace ? SymbolFlags.Namespace : 0);
+            const excludedMeanings = (symbol.flags & (SymbolFlags.Value | SymbolFlags.ExportValue) ? SymbolFlags.Value : 0)
+                | (symbol.flags & SymbolFlags.Type ? SymbolFlags.Type : 0)
+                | (symbol.flags & SymbolFlags.Namespace ? SymbolFlags.Namespace : 0);
             if (targetFlags & excludedMeanings) {
-                const message = node.kind === SyntaxKind.ExportSpecifier ?
-                    Diagnostics.Export_declaration_conflicts_with_exported_declaration_of_0 :
-                    Diagnostics.Import_declaration_conflicts_with_local_declaration_of_0;
+                const message = node.kind === SyntaxKind.ExportSpecifier
+                    ? Diagnostics.Export_declaration_conflicts_with_exported_declaration_of_0
+                    : Diagnostics.Import_declaration_conflicts_with_local_declaration_of_0;
                 error(node, message, symbolToString(symbol));
             }
             else if (node.kind !== SyntaxKind.ExportSpecifier) {
@@ -46324,10 +46324,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
 
                 if (
-                    compilerOptions.verbatimModuleSyntax &&
-                    node.kind !== SyntaxKind.ImportEqualsDeclaration &&
-                    !isInJSFile(node) &&
-                    (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
+                    compilerOptions.verbatimModuleSyntax
+                    && node.kind !== SyntaxKind.ImportEqualsDeclaration
+                    && !isInJSFile(node)
+                    && (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
                 ) {
                     error(node, Diagnostics.ESM_syntax_is_not_allowed_in_a_CommonJS_module_when_verbatimModuleSyntax_is_enabled);
                 }
@@ -46376,10 +46376,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         checkCollisionsForDeclarationName(node, node.name);
         checkAliasSymbol(node);
         if (
-            node.kind === SyntaxKind.ImportSpecifier &&
-            idText(node.propertyName || node.name) === "default" &&
-            getESModuleInterop(compilerOptions) &&
-            moduleKind !== ModuleKind.System && (moduleKind < ModuleKind.ES2015 || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
+            node.kind === SyntaxKind.ImportSpecifier
+            && idText(node.propertyName || node.name) === "default"
+            && getESModuleInterop(compilerOptions)
+            && moduleKind !== ModuleKind.System && (moduleKind < ModuleKind.ES2015 || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
         ) {
             checkExternalEmitHelpers(node, ExternalEmitHelpers.ImportDefault);
         }
@@ -46517,8 +46517,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // export { x, y } from "foo"
                 forEach(node.exportClause.elements, checkExportSpecifier);
                 const inAmbientExternalModule = node.parent.kind === SyntaxKind.ModuleBlock && isAmbientModule(node.parent.parent);
-                const inAmbientNamespaceDeclaration = !inAmbientExternalModule && node.parent.kind === SyntaxKind.ModuleBlock &&
-                    !node.moduleSpecifier && node.flags & NodeFlags.Ambient;
+                const inAmbientNamespaceDeclaration = !inAmbientExternalModule && node.parent.kind === SyntaxKind.ModuleBlock
+                    && !node.moduleSpecifier && node.flags & NodeFlags.Ambient;
                 if (node.parent.kind !== SyntaxKind.SourceFile && !inAmbientExternalModule && !inAmbientNamespaceDeclaration) {
                     error(node, Diagnostics.Export_declarations_are_not_permitted_in_a_namespace);
                 }
@@ -46591,10 +46591,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         else {
             if (
-                getESModuleInterop(compilerOptions) &&
-                moduleKind !== ModuleKind.System &&
-                (moduleKind < ModuleKind.ES2015 || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS) &&
-                idText(node.propertyName || node.name) === "default"
+                getESModuleInterop(compilerOptions)
+                && moduleKind !== ModuleKind.System
+                && (moduleKind < ModuleKind.ES2015 || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
+                && idText(node.propertyName || node.name) === "default"
             ) {
                 checkExternalEmitHelpers(node, ExternalEmitHelpers.ImportDefault);
             }
@@ -46631,10 +46631,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             checkTypeAssignableTo(checkExpressionCached(node.expression), getTypeFromTypeNode(typeAnnotationNode), node.expression);
         }
 
-        const isIllegalExportDefaultInCJS = !node.isExportEquals &&
-            !(node.flags & NodeFlags.Ambient) &&
-            compilerOptions.verbatimModuleSyntax &&
-            (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS);
+        const isIllegalExportDefaultInCJS = !node.isExportEquals
+            && !(node.flags & NodeFlags.Ambient)
+            && compilerOptions.verbatimModuleSyntax
+            && (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS);
 
         if (node.expression.kind === SyntaxKind.Identifier) {
             const id = node.expression as Identifier;
@@ -46679,8 +46679,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         // export = SomeType;
                         error(
                             id,
-                            node.isExportEquals ?
-                                Diagnostics._0_resolves_to_a_type_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_import_type_where_0_is_imported
+                            node.isExportEquals
+                                ? Diagnostics._0_resolves_to_a_type_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_import_type_where_0_is_imported
                                 : Diagnostics._0_resolves_to_a_type_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_export_type_0_as_default,
                             idText(id),
                             isolatedModulesLikeFlagName,
@@ -46693,8 +46693,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         addTypeOnlyDeclarationRelatedInfo(
                             error(
                                 id,
-                                node.isExportEquals ?
-                                    Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_import_type_where_0_is_imported
+                                node.isExportEquals
+                                    ? Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_import_type_where_0_is_imported
                                     : Diagnostics._0_resolves_to_a_type_only_declaration_and_must_be_marked_type_only_in_this_file_before_re_exporting_when_1_is_enabled_Consider_using_export_type_0_as_default,
                                 idText(id),
                                 isolatedModulesLikeFlagName,
@@ -46730,10 +46730,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (node.isExportEquals) {
             // Forbid export= in esm implementation files, and esm mode declaration files
             if (
-                moduleKind >= ModuleKind.ES2015 &&
-                moduleKind !== ModuleKind.Preserve &&
-                ((node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext) ||
-                    (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))
+                moduleKind >= ModuleKind.ES2015
+                && moduleKind !== ModuleKind.Preserve
+                && ((node.flags & NodeFlags.Ambient && getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.ESNext)
+                    || (!(node.flags & NodeFlags.Ambient) && getSourceFileOfNode(node).impliedNodeFormat !== ModuleKind.CommonJS))
             ) {
                 // export assignment is not supported in es6 modules
                 grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_targeting_ECMAScript_modules_Consider_using_export_default_or_another_module_format_instead);
@@ -47102,8 +47102,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     : lastOrUndefined(host!.parameters);
                 const symbol = getParameterSymbolFromJSDoc(paramTag);
                 if (
-                    !lastParamDeclaration ||
-                    symbol && lastParamDeclaration.symbol === symbol && isRestParameter(lastParamDeclaration)
+                    !lastParamDeclaration
+                    || symbol && lastParamDeclaration.symbol === symbol && isRestParameter(lastParamDeclaration)
                 ) {
                     return createArrayType(type);
                 }
@@ -47478,9 +47478,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isTypeDeclarationName(name: Node): boolean {
-        return name.kind === SyntaxKind.Identifier &&
-            isTypeDeclaration(name.parent) &&
-            getNameOfDeclaration(name.parent) === name;
+        return name.kind === SyntaxKind.Identifier
+            && isTypeDeclaration(name.parent)
+            && getNameOfDeclaration(name.parent) === name;
     }
 
     // True if the given identifier is part of a type reference
@@ -47597,9 +47597,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (
-            isInJSFile(name) &&
-            name.parent.kind === SyntaxKind.PropertyAccessExpression &&
-            name.parent === (name.parent.parent as BinaryExpression).left
+            isInJSFile(name)
+            && name.parent.kind === SyntaxKind.PropertyAccessExpression
+            && name.parent === (name.parent.parent as BinaryExpression).left
         ) {
             // Check if this is a special property assignment
             if (!isPrivateIdentifier(name) && !isJSDocMemberName(name) && !isThisPropertyAndThisTyped(name.parent as PropertyAccessExpression)) {
@@ -47822,9 +47822,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return getSymbolOfNameOrPropertyAccessExpression(node as Identifier);
             }
             else if (
-                parent.kind === SyntaxKind.BindingElement &&
-                grandParent.kind === SyntaxKind.ObjectBindingPattern &&
-                node === (parent as BindingElement).propertyName
+                parent.kind === SyntaxKind.BindingElement
+                && grandParent.kind === SyntaxKind.ObjectBindingPattern
+                && node === (parent as BindingElement).propertyName
             ) {
                 const typeOfPattern = getTypeOfNode(grandParent);
                 const propertyDeclaration = getPropertyOfType(typeOfPattern, (node as Identifier).escapedText);
@@ -47894,10 +47894,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // 3). Dynamic import call or require in javascript
                 // 4). type A = import("./f/*gotToDefinitionHere*/oo")
                 if (
-                    (isExternalModuleImportEqualsDeclaration(node.parent.parent) && getExternalModuleImportEqualsDeclarationExpression(node.parent.parent) === node) ||
-                    ((node.parent.kind === SyntaxKind.ImportDeclaration || node.parent.kind === SyntaxKind.ExportDeclaration) && (node.parent as ImportDeclaration).moduleSpecifier === node) ||
-                    ((isInJSFile(node) && isRequireCall(node.parent, /*requireStringLiteralLikeArgument*/ false)) || isImportCall(node.parent)) ||
-                    (isLiteralTypeNode(node.parent) && isLiteralImportTypeNode(node.parent.parent) && node.parent.parent.argument === node.parent)
+                    (isExternalModuleImportEqualsDeclaration(node.parent.parent) && getExternalModuleImportEqualsDeclarationExpression(node.parent.parent) === node)
+                    || ((node.parent.kind === SyntaxKind.ImportDeclaration || node.parent.kind === SyntaxKind.ExportDeclaration) && (node.parent as ImportDeclaration).moduleSpecifier === node)
+                    || ((isInJSFile(node) && isRequireCall(node.parent, /*requireStringLiteralLikeArgument*/ false)) || isImportCall(node.parent))
+                    || (isLiteralTypeNode(node.parent) && isLiteralImportTypeNode(node.parent.parent) && node.parent.parent.argument === node.parent)
                 ) {
                     return resolveExternalModuleName(node, node as LiteralExpression, ignoreErrors);
                 }
@@ -47970,9 +47970,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     /** Returns the target of an export specifier without following aliases */
     function getExportSpecifierLocalTargetSymbol(node: ExportSpecifier | Identifier): Symbol | undefined {
         if (isExportSpecifier(node)) {
-            return node.parent.parent.moduleSpecifier ?
-                getExternalModuleMember(node.parent.parent, node) :
-                resolveEntityName(node.propertyName || node.name, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias);
+            return node.parent.parent.moduleSpecifier
+                ? getExternalModuleMember(node.parent.parent, node)
+                : resolveEntityName(node.propertyName || node.name, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias);
         }
         else {
             return resolveEntityName(node, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias);
@@ -48147,9 +48147,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function getAugmentedPropertiesOfType(type: Type): Symbol[] {
         type = getApparentType(type);
         const propsByName = createSymbolTable(getPropertiesOfType(type));
-        const functionType = getSignaturesOfType(type, SignatureKind.Call).length ? globalCallableFunctionType :
-            getSignaturesOfType(type, SignatureKind.Construct).length ? globalNewableFunctionType :
-            undefined;
+        const functionType = getSignaturesOfType(type, SignatureKind.Call).length ? globalCallableFunctionType
+            : getSignaturesOfType(type, SignatureKind.Construct).length ? globalNewableFunctionType
+            : undefined;
         if (functionType) {
             forEach(getPropertiesOfType(functionType), p => {
                 if (!propsByName.has(p.escapedName)) {
@@ -48388,13 +48388,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case SyntaxKind.ExportDeclaration:
                 const exportClause = (node as ExportDeclaration).exportClause;
                 return !!exportClause && (
-                    isNamespaceExport(exportClause) ||
-                    some(exportClause.elements, isValueAliasDeclaration)
+                    isNamespaceExport(exportClause)
+                    || some(exportClause.elements, isValueAliasDeclaration)
                 );
             case SyntaxKind.ExportAssignment:
-                return (node as ExportAssignment).expression && (node as ExportAssignment).expression.kind === SyntaxKind.Identifier ?
-                    isAliasResolvedToValue(getSymbolOfDeclaration(node as ExportAssignment), /*excludeTypeOnlyValues*/ true) :
-                    true;
+                return (node as ExportAssignment).expression && (node as ExportAssignment).expression.kind === SyntaxKind.Identifier
+                    ? isAliasResolvedToValue(getSymbolOfDeclaration(node as ExportAssignment), /*excludeTypeOnlyValues*/ true)
+                    : true;
         }
         return false;
     }
@@ -48420,8 +48420,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         // const enums and modules that contain only const enums are not considered values from the emit perspective
         // unless 'preserveConstEnums' option is set to true
-        return !!(getSymbolFlags(symbol, excludeTypeOnlyValues, /*excludeLocalMeanings*/ true) & SymbolFlags.Value) &&
-            (shouldPreserveConstEnums(compilerOptions) || !isConstEnumOrConstEnumOnlyModule(target));
+        return !!(getSymbolFlags(symbol, excludeTypeOnlyValues, /*excludeLocalMeanings*/ true) & SymbolFlags.Value)
+            && (shouldPreserveConstEnums(compilerOptions) || !isConstEnumOrConstEnumOnlyModule(target));
     }
 
     function isConstEnumOrConstEnumOnlyModule(s: Symbol): boolean {
@@ -48438,9 +48438,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const target = getSymbolLinks(symbol).aliasTarget;
             if (
-                target && getEffectiveModifierFlags(node) & ModifierFlags.Export &&
-                getSymbolFlags(target) & SymbolFlags.Value &&
-                (shouldPreserveConstEnums(compilerOptions) || !isConstEnumOrConstEnumOnlyModule(target))
+                target && getEffectiveModifierFlags(node) & ModifierFlags.Export
+                && getSymbolFlags(target) & SymbolFlags.Value
+                && (shouldPreserveConstEnums(compilerOptions) || !isConstEnumOrConstEnumOnlyModule(target))
             ) {
                 // An `export import ... =` of a value symbol is always considered referenced
                 return true;
@@ -48464,13 +48464,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             //       function foo(a: any) { // This is implementation of the overloads
             //           return a;
             //       }
-            return signaturesOfSymbol.length > 1 ||
+            return signaturesOfSymbol.length > 1
                 // If there is single signature for the symbol, it is overload if that signature isn't coming from the node
                 // e.g.: function foo(a: string): string;
                 //       function foo(a: any) { // This is implementation of the overloads
                 //           return a;
                 //       }
-                (signaturesOfSymbol.length === 1 && signaturesOfSymbol[0].declaration !== node);
+                || (signaturesOfSymbol.length === 1 && signaturesOfSymbol[0].declaration !== node);
         }
         return false;
     }
@@ -48485,18 +48485,18 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isRequiredInitializedParameter(parameter: ParameterDeclaration | JSDocParameterTag): boolean {
-        return !!strictNullChecks &&
-            !isOptionalParameter(parameter) &&
-            !isJSDocParameterTag(parameter) &&
-            !!parameter.initializer &&
-            !hasSyntacticModifier(parameter, ModifierFlags.ParameterPropertyModifier);
+        return !!strictNullChecks
+            && !isOptionalParameter(parameter)
+            && !isJSDocParameterTag(parameter)
+            && !!parameter.initializer
+            && !hasSyntacticModifier(parameter, ModifierFlags.ParameterPropertyModifier);
     }
 
     function isOptionalUninitializedParameterProperty(parameter: ParameterDeclaration) {
-        return strictNullChecks &&
-            isOptionalParameter(parameter) &&
-            !parameter.initializer &&
-            hasSyntacticModifier(parameter, ModifierFlags.ParameterPropertyModifier);
+        return strictNullChecks
+            && isOptionalParameter(parameter)
+            && !parameter.initializer
+            && hasSyntacticModifier(parameter, ModifierFlags.ParameterPropertyModifier);
     }
 
     function isExpandoFunctionDeclaration(node: Declaration): boolean {
@@ -48839,10 +48839,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             : type === trueType ? factory.createTrue() : type === falseType && factory.createFalse();
         if (enumResult) return enumResult;
         const literalValue = (type as LiteralType).value;
-        return typeof literalValue === "object" ? factory.createBigIntLiteral(literalValue) :
-            typeof literalValue === "string" ? factory.createStringLiteral(literalValue) :
-            literalValue < 0 ? factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, factory.createNumericLiteral(-literalValue)) :
-            factory.createNumericLiteral(literalValue);
+        return typeof literalValue === "object" ? factory.createBigIntLiteral(literalValue)
+            : typeof literalValue === "string" ? factory.createStringLiteral(literalValue)
+            : literalValue < 0 ? factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, factory.createNumericLiteral(-literalValue))
+            : factory.createNumericLiteral(literalValue);
     }
 
     function createLiteralConstValue(node: VariableDeclaration | PropertyDeclaration | PropertySignature | ParameterDeclaration, tracker: SymbolTracker) {
@@ -49450,8 +49450,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         }
                         const parent = (isJSDocTemplateTag(node.parent) && getEffectiveJSDocHost(node.parent)) || node.parent;
                         if (
-                            node.kind === SyntaxKind.TypeParameter && !(isFunctionLikeDeclaration(parent) || isClassLike(parent) || isFunctionTypeNode(parent) ||
-                                isConstructorTypeNode(parent) || isCallSignatureDeclaration(parent) || isConstructSignatureDeclaration(parent) || isMethodSignature(parent))
+                            node.kind === SyntaxKind.TypeParameter && !(isFunctionLikeDeclaration(parent) || isClassLike(parent) || isFunctionTypeNode(parent)
+                                || isConstructorTypeNode(parent) || isCallSignatureDeclaration(parent) || isConstructSignatureDeclaration(parent) || isMethodSignature(parent))
                         ) {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_can_only_appear_on_a_type_parameter_of_a_function_method_or_class, tokenToString(modifier.kind));
                         }
@@ -49580,14 +49580,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                     case SyntaxKind.ExportKeyword:
                         if (
-                            compilerOptions.verbatimModuleSyntax &&
-                            !(node.flags & NodeFlags.Ambient) &&
-                            node.kind !== SyntaxKind.TypeAliasDeclaration &&
-                            node.kind !== SyntaxKind.InterfaceDeclaration &&
+                            compilerOptions.verbatimModuleSyntax
+                            && !(node.flags & NodeFlags.Ambient)
+                            && node.kind !== SyntaxKind.TypeAliasDeclaration
+                            && node.kind !== SyntaxKind.InterfaceDeclaration
                             // ModuleDeclaration needs to be checked that it is uninstantiated later
-                            node.kind !== SyntaxKind.ModuleDeclaration &&
-                            node.parent.kind === SyntaxKind.SourceFile &&
-                            (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
+                            && node.kind !== SyntaxKind.ModuleDeclaration
+                            && node.parent.kind === SyntaxKind.SourceFile
+                            && (moduleKind === ModuleKind.CommonJS || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS)
                         ) {
                             return grammarErrorOnNode(modifier, Diagnostics.A_top_level_export_modifier_cannot_be_used_on_value_declarations_in_a_CommonJS_module_when_verbatimModuleSyntax_is_enabled);
                         }
@@ -49677,14 +49677,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                             return grammarErrorOnNode(modifier, Diagnostics._0_modifier_already_seen, "abstract");
                         }
                         if (
-                            node.kind !== SyntaxKind.ClassDeclaration &&
-                            node.kind !== SyntaxKind.ConstructorType
+                            node.kind !== SyntaxKind.ClassDeclaration
+                            && node.kind !== SyntaxKind.ConstructorType
                         ) {
                             if (
-                                node.kind !== SyntaxKind.MethodDeclaration &&
-                                node.kind !== SyntaxKind.PropertyDeclaration &&
-                                node.kind !== SyntaxKind.GetAccessor &&
-                                node.kind !== SyntaxKind.SetAccessor
+                                node.kind !== SyntaxKind.MethodDeclaration
+                                && node.kind !== SyntaxKind.PropertyDeclaration
+                                && node.kind !== SyntaxKind.GetAccessor
+                                && node.kind !== SyntaxKind.SetAccessor
                             ) {
                                 return grammarErrorOnNode(modifier, Diagnostics.abstract_modifier_can_only_appear_on_a_class_method_or_property_declaration);
                             }
@@ -49839,9 +49839,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     case SyntaxKind.TypeAliasDeclaration:
                         return find(node.modifiers, isModifier);
                     case SyntaxKind.VariableStatement:
-                        return node.declarationList.flags & NodeFlags.Using ?
-                            findFirstModifierExcept(node, SyntaxKind.AwaitKeyword) :
-                            find(node.modifiers, isModifier);
+                        return node.declarationList.flags & NodeFlags.Using
+                            ? findFirstModifierExcept(node, SyntaxKind.AwaitKeyword)
+                            : find(node.modifiers, isModifier);
                     case SyntaxKind.EnumDeclaration:
                         return findFirstModifierExcept(node, SyntaxKind.ConstKeyword);
                     default:
@@ -49952,17 +49952,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkGrammarFunctionLikeDeclaration(node: FunctionLikeDeclaration | MethodSignature): boolean {
         // Prevent cascading error by short-circuit
         const file = getSourceFileOfNode(node);
-        return checkGrammarModifiers(node) ||
-            checkGrammarTypeParameterList(node.typeParameters, file) ||
-            checkGrammarParameterList(node.parameters) ||
-            checkGrammarArrowFunction(node, file) ||
-            (isFunctionLikeDeclaration(node) && checkGrammarForUseStrictSimpleParameterList(node));
+        return checkGrammarModifiers(node)
+            || checkGrammarTypeParameterList(node.typeParameters, file)
+            || checkGrammarParameterList(node.parameters)
+            || checkGrammarArrowFunction(node, file)
+            || (isFunctionLikeDeclaration(node) && checkGrammarForUseStrictSimpleParameterList(node));
     }
 
     function checkGrammarClassLikeDeclaration(node: ClassLikeDeclaration): boolean {
         const file = getSourceFileOfNode(node);
-        return checkGrammarClassDeclarationHeritageClauses(node) ||
-            checkGrammarTypeParameterList(node.typeParameters, file);
+        return checkGrammarClassDeclarationHeritageClauses(node)
+            || checkGrammarTypeParameterList(node.typeParameters, file);
     }
 
     function checkGrammarArrowFunction(node: Node, file: SourceFile): boolean {
@@ -50037,8 +50037,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkGrammarTypeArguments(node: Node, typeArguments: NodeArray<TypeNode> | undefined): boolean {
-        return checkGrammarForDisallowedTrailingComma(typeArguments) ||
-            checkGrammarForAtLeastOneTypeArgument(node, typeArguments);
+        return checkGrammarForDisallowedTrailingComma(typeArguments)
+            || checkGrammarForAtLeastOneTypeArgument(node, typeArguments);
     }
 
     function checkGrammarTaggedTemplateChain(node: TaggedTemplateExpression): boolean {
@@ -50143,9 +50143,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     function checkGrammarForGenerator(node: FunctionLikeDeclaration) {
         if (node.asteriskToken) {
             Debug.assert(
-                node.kind === SyntaxKind.FunctionDeclaration ||
-                    node.kind === SyntaxKind.FunctionExpression ||
-                    node.kind === SyntaxKind.MethodDeclaration,
+                node.kind === SyntaxKind.FunctionDeclaration
+                    || node.kind === SyntaxKind.FunctionExpression
+                    || node.kind === SyntaxKind.MethodDeclaration,
             );
             if (node.flags & NodeFlags.Ambient) {
                 return grammarErrorOnNode(node.asteriskToken, Diagnostics.Generators_are_not_allowed_in_an_ambient_context);
@@ -50373,8 +50373,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (
-            isForOfStatement(forInOrOfStatement) && !(forInOrOfStatement.flags & NodeFlags.AwaitContext) &&
-            isIdentifier(forInOrOfStatement.initializer) && forInOrOfStatement.initializer.escapedText === "async"
+            isForOfStatement(forInOrOfStatement) && !(forInOrOfStatement.flags & NodeFlags.AwaitContext)
+            && isIdentifier(forInOrOfStatement.initializer) && forInOrOfStatement.initializer.escapedText === "async"
         ) {
             grammarErrorOnNode(forInOrOfStatement.initializer, Diagnostics.The_left_hand_side_of_a_for_of_statement_may_not_be_async);
             return false;
@@ -50445,9 +50445,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!doesAccessorHaveCorrectParameterCount(accessor)) {
             return grammarErrorOnNode(
                 accessor.name,
-                accessor.kind === SyntaxKind.GetAccessor ?
-                    Diagnostics.A_get_accessor_cannot_have_parameters :
-                    Diagnostics.A_set_accessor_must_have_exactly_one_parameter,
+                accessor.kind === SyntaxKind.GetAccessor
+                    ? Diagnostics.A_get_accessor_cannot_have_parameters
+                    : Diagnostics.A_set_accessor_must_have_exactly_one_parameter,
             );
         }
         if (accessor.kind === SyntaxKind.SetAccessor) {
@@ -50510,8 +50510,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
                 case SyntaxKind.PropertyDeclaration:
                     if (
-                        !isStatic(parent) ||
-                        !hasEffectiveReadonlyModifier(parent)
+                        !isStatic(parent)
+                        || !hasEffectiveReadonlyModifier(parent)
                     ) {
                         return grammarErrorOnNode((parent as PropertyDeclaration).name, Diagnostics.A_property_of_a_class_whose_type_is_a_unique_symbol_type_must_be_both_static_and_readonly);
                     }
@@ -50664,21 +50664,21 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isStringOrNumberLiteralExpression(expr: Expression) {
-        return isStringOrNumericLiteralLike(expr) ||
-            expr.kind === SyntaxKind.PrefixUnaryExpression && (expr as PrefixUnaryExpression).operator === SyntaxKind.MinusToken &&
-                (expr as PrefixUnaryExpression).operand.kind === SyntaxKind.NumericLiteral;
+        return isStringOrNumericLiteralLike(expr)
+            || expr.kind === SyntaxKind.PrefixUnaryExpression && (expr as PrefixUnaryExpression).operator === SyntaxKind.MinusToken
+                && (expr as PrefixUnaryExpression).operand.kind === SyntaxKind.NumericLiteral;
     }
 
     function isBigIntLiteralExpression(expr: Expression) {
-        return expr.kind === SyntaxKind.BigIntLiteral ||
-            expr.kind === SyntaxKind.PrefixUnaryExpression && (expr as PrefixUnaryExpression).operator === SyntaxKind.MinusToken &&
-                (expr as PrefixUnaryExpression).operand.kind === SyntaxKind.BigIntLiteral;
+        return expr.kind === SyntaxKind.BigIntLiteral
+            || expr.kind === SyntaxKind.PrefixUnaryExpression && (expr as PrefixUnaryExpression).operator === SyntaxKind.MinusToken
+                && (expr as PrefixUnaryExpression).operand.kind === SyntaxKind.BigIntLiteral;
     }
 
     function isSimpleLiteralEnumReference(expr: Expression) {
         if (
-            (isPropertyAccessExpression(expr) || (isElementAccessExpression(expr) && isStringOrNumberLiteralExpression(expr.argumentExpression))) &&
-            isEntityNameExpression(expr.expression)
+            (isPropertyAccessExpression(expr) || (isElementAccessExpression(expr) && isStringOrNumberLiteralExpression(expr.argumentExpression)))
+            && isEntityNameExpression(expr.expression)
         ) {
             return !!(checkExpressionCached(expr).flags & TypeFlags.EnumLike);
         }
@@ -50688,10 +50688,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const initializer = node.initializer;
         if (initializer) {
             const isInvalidInitializer = !(
-                isStringOrNumberLiteralExpression(initializer) ||
-                isSimpleLiteralEnumReference(initializer) ||
-                initializer.kind === SyntaxKind.TrueKeyword || initializer.kind === SyntaxKind.FalseKeyword ||
-                isBigIntLiteralExpression(initializer)
+                isStringOrNumberLiteralExpression(initializer)
+                || isSimpleLiteralEnumReference(initializer)
+                || initializer.kind === SyntaxKind.TrueKeyword || initializer.kind === SyntaxKind.FalseKeyword
+                || isBigIntLiteralExpression(initializer)
             );
             const isConstOrReadonly = isDeclarationReadonly(node) || isVariableDeclaration(node) && (isVarConstLike(node));
             if (isConstOrReadonly && !node.type) {
@@ -50746,8 +50746,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (
-            (moduleKind < ModuleKind.ES2015 || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS) && moduleKind !== ModuleKind.System &&
-            !(node.parent.parent.flags & NodeFlags.Ambient) && hasSyntacticModifier(node.parent.parent, ModifierFlags.Export)
+            (moduleKind < ModuleKind.ES2015 || getSourceFileOfNode(node).impliedNodeFormat === ModuleKind.CommonJS) && moduleKind !== ModuleKind.System
+            && !(node.parent.parent.flags & NodeFlags.Ambient) && hasSyntacticModifier(node.parent.parent, ModifierFlags.Export)
         ) {
             checkESModuleMarker(node.name);
         }
@@ -50810,9 +50810,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if ((blockScopeFlags === NodeFlags.Using || blockScopeFlags === NodeFlags.AwaitUsing) && isForInStatement(declarationList.parent)) {
             return grammarErrorOnNode(
                 declarationList,
-                blockScopeFlags === NodeFlags.Using ?
-                    Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_a_using_declaration :
-                    Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_an_await_using_declaration,
+                blockScopeFlags === NodeFlags.Using
+                    ? Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_a_using_declaration
+                    : Diagnostics.The_left_hand_side_of_a_for_in_statement_cannot_be_an_await_using_declaration,
             );
         }
 
@@ -50844,11 +50844,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (!allowLetAndConstDeclarations(node.parent)) {
             const blockScopeKind = getCombinedNodeFlagsCached(node.declarationList) & NodeFlags.BlockScoped;
             if (blockScopeKind) {
-                const keyword = blockScopeKind === NodeFlags.Let ? "let" :
-                    blockScopeKind === NodeFlags.Const ? "const" :
-                    blockScopeKind === NodeFlags.Using ? "using" :
-                    blockScopeKind === NodeFlags.AwaitUsing ? "await using" :
-                    Debug.fail("Unknown BlockScope flag");
+                const keyword = blockScopeKind === NodeFlags.Let ? "let"
+                    : blockScopeKind === NodeFlags.Const ? "const"
+                    : blockScopeKind === NodeFlags.Using ? "using"
+                    : blockScopeKind === NodeFlags.AwaitUsing ? "await using"
+                    : Debug.fail("Unknown BlockScope flag");
                 return grammarErrorOnNode(node, Diagnostics._0_declarations_can_only_be_declared_inside_a_block, keyword);
             }
         }
@@ -50975,8 +50975,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
 
         if (
-            isPropertyDeclaration(node) && node.exclamationToken && (!isClassLike(node.parent) || !node.type || node.initializer ||
-                node.flags & NodeFlags.Ambient || isStatic(node) || hasAbstractModifier(node))
+            isPropertyDeclaration(node) && node.exclamationToken && (!isClassLike(node.parent) || !node.type || node.initializer
+                || node.flags & NodeFlags.Ambient || isStatic(node) || hasAbstractModifier(node))
         ) {
             const message = node.initializer
                 ? Diagnostics.Declarations_with_initializers_cannot_also_have_definite_assignment_assertions
@@ -51001,14 +51001,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         //
         // TODO: The spec needs to be amended to reflect this grammar.
         if (
-            node.kind === SyntaxKind.InterfaceDeclaration ||
-            node.kind === SyntaxKind.TypeAliasDeclaration ||
-            node.kind === SyntaxKind.ImportDeclaration ||
-            node.kind === SyntaxKind.ImportEqualsDeclaration ||
-            node.kind === SyntaxKind.ExportDeclaration ||
-            node.kind === SyntaxKind.ExportAssignment ||
-            node.kind === SyntaxKind.NamespaceExportDeclaration ||
-            hasSyntacticModifier(node, ModifierFlags.Ambient | ModifierFlags.Export | ModifierFlags.Default)
+            node.kind === SyntaxKind.InterfaceDeclaration
+            || node.kind === SyntaxKind.TypeAliasDeclaration
+            || node.kind === SyntaxKind.ImportDeclaration
+            || node.kind === SyntaxKind.ImportEqualsDeclaration
+            || node.kind === SyntaxKind.ExportDeclaration
+            || node.kind === SyntaxKind.ExportAssignment
+            || node.kind === SyntaxKind.NamespaceExportDeclaration
+            || hasSyntacticModifier(node, ModifierFlags.Ambient | ModifierFlags.Export | ModifierFlags.Default)
         ) {
             return false;
         }
@@ -51087,8 +51087,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkGrammarBigIntLiteral(node: BigIntLiteral): boolean {
-        const literalType = isLiteralTypeNode(node.parent) ||
-            isPrefixUnaryExpression(node.parent) && isLiteralTypeNode(node.parent.parent);
+        const literalType = isLiteralTypeNode(node.parent)
+            || isPrefixUnaryExpression(node.parent) && isLiteralTypeNode(node.parent.parent);
         if (!literalType) {
             if (languageVersion < ScriptTarget.ES2020) {
                 if (grammarErrorOnNode(node, Diagnostics.BigInt_literals_are_not_available_when_targeting_lower_than_ES2020)) {
@@ -51208,8 +51208,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function findBestTypeForInvokable(source: Type, unionTarget: UnionOrIntersectionType) {
         let signatureKind = SignatureKind.Call;
-        const hasSignatures = getSignaturesOfType(source, signatureKind).length > 0 ||
-            (signatureKind = SignatureKind.Construct, getSignaturesOfType(source, signatureKind).length > 0);
+        const hasSignatures = getSignaturesOfType(source, signatureKind).length > 0
+            || (signatureKind = SignatureKind.Construct, getSignaturesOfType(source, signatureKind).length > 0);
         if (hasSignatures) {
             return find(unionTarget.types, t => getSignaturesOfType(t, signatureKind).length > 0);
         }
@@ -51275,8 +51275,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function getEffectivePropertyNameForPropertyNameNode(node: PropertyName) {
         const name = getPropertyNameForPropertyNameNode(node);
-        return name ? name :
-            isComputedPropertyName(node) ? tryGetNameFromType(getTypeOfExpression(node.expression)) : undefined;
+        return name ? name
+            : isComputedPropertyName(node) ? tryGetNameFromType(getTypeOfExpression(node.expression)) : undefined;
     }
 
     function getCombinedModifierFlagsCached(node: Declaration) {
@@ -51302,9 +51302,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isVarConstLike(node: VariableDeclaration | VariableDeclarationList) {
         const blockScopeKind = getCombinedNodeFlagsCached(node) & NodeFlags.BlockScoped;
-        return blockScopeKind === NodeFlags.Const ||
-            blockScopeKind === NodeFlags.Using ||
-            blockScopeKind === NodeFlags.AwaitUsing;
+        return blockScopeKind === NodeFlags.Const
+            || blockScopeKind === NodeFlags.Using
+            || blockScopeKind === NodeFlags.AwaitUsing;
     }
 }
 
@@ -51314,8 +51314,8 @@ function isNotAccessor(declaration: Declaration): boolean {
 }
 
 function isNotOverload(declaration: Declaration): boolean {
-    return (declaration.kind !== SyntaxKind.FunctionDeclaration && declaration.kind !== SyntaxKind.MethodDeclaration) ||
-        !!(declaration as FunctionDeclaration).body;
+    return (declaration.kind !== SyntaxKind.FunctionDeclaration && declaration.kind !== SyntaxKind.MethodDeclaration)
+        || !!(declaration as FunctionDeclaration).body;
 }
 
 /** Like 'isDeclarationName', but returns true for LHS of `import { x as y }` or `export { x as y }`. */

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1782,9 +1782,9 @@ function createUnknownOptionError(
     }
 
     const possibleOption = getSpellingSuggestion(unknownOption, diagnostics.optionDeclarations, getOptionName);
-    return possibleOption ?
-        createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile, node, diagnostics.unknownDidYouMeanDiagnostic, unknownOptionErrorText || unknownOption, possibleOption.name) :
-        createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile, node, diagnostics.unknownOptionDiagnostic, unknownOptionErrorText || unknownOption);
+    return possibleOption
+        ? createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile, node, diagnostics.unknownDidYouMeanDiagnostic, unknownOptionErrorText || unknownOption, possibleOption.name)
+        : createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile, node, diagnostics.unknownOptionDiagnostic, unknownOptionErrorText || unknownOption);
 }
 
 /** @internal */
@@ -2430,11 +2430,11 @@ export function convertToJson(
 }
 
 function getCompilerOptionValueTypeString(option: CommandLineOption): string {
-    return (option.type === "listOrElement") ?
-        `${getCompilerOptionValueTypeString(option.element)} or Array` :
-        option.type === "list" ?
-        "Array" :
-        isString(option.type) ? option.type : "string";
+    return (option.type === "listOrElement")
+        ? `${getCompilerOptionValueTypeString(option.element)} or Array`
+        : option.type === "list"
+        ? "Array"
+        : isString(option.type) ? option.type : "string";
 }
 
 function isCompilerOptionsValue(option: CommandLineOption | undefined, value: any): value is CompilerOptionsValue {
@@ -2890,9 +2890,9 @@ function parseJsonConfigFileContentWorker(
     const parsedConfig = parseConfig(json, sourceFile, host, basePath, configFileName, resolutionStack, errors, extendedConfigCache);
     const { raw } = parsedConfig;
     const options = extend(existingOptions, parsedConfig.options || {});
-    const watchOptions = existingWatchOptions && parsedConfig.watchOptions ?
-        extend(existingWatchOptions, parsedConfig.watchOptions) :
-        parsedConfig.watchOptions || existingWatchOptions;
+    const watchOptions = existingWatchOptions && parsedConfig.watchOptions
+        ? extend(existingWatchOptions, parsedConfig.watchOptions)
+        : parsedConfig.watchOptions || existingWatchOptions;
 
     options.configFilePath = configFileName && normalizeSlashes(configFileName);
     const configFileSpecs = getConfigFileSpecs();
@@ -3122,9 +3122,9 @@ function parseConfig(
         return { raw: json || convertToObject(sourceFile!, errors) };
     }
 
-    const ownConfig = json ?
-        parseOwnConfigOfJson(json, host, basePath, configFileName, errors) :
-        parseOwnConfigOfJsonSourceFile(sourceFile!, host, basePath, configFileName, errors);
+    const ownConfig = json
+        ? parseOwnConfigOfJson(json, host, basePath, configFileName, errors)
+        : parseOwnConfigOfJsonSourceFile(sourceFile!, host, basePath, configFileName, errors);
 
     if (ownConfig.options?.paths) {
         // If we end up needing to resolve relative paths from 'paths' relative to
@@ -3150,9 +3150,9 @@ function parseConfig(
         if (sourceFile && result.extendedSourceFiles) sourceFile.extendedSourceFiles = arrayFrom(result.extendedSourceFiles.keys());
 
         ownConfig.options = assign(result.options, ownConfig.options);
-        ownConfig.watchOptions = ownConfig.watchOptions && result.watchOptions ?
-            assign(result.watchOptions, ownConfig.watchOptions) :
-            ownConfig.watchOptions || result.watchOptions;
+        ownConfig.watchOptions = ownConfig.watchOptions && result.watchOptions
+            ? assign(result.watchOptions, ownConfig.watchOptions)
+            : ownConfig.watchOptions || result.watchOptions;
     }
     return ownConfig;
 
@@ -3177,9 +3177,9 @@ function parseConfig(
                 result.compileOnSave = extendsRaw.compileOnSave;
             }
             assign(result.options, extendedConfig.options);
-            result.watchOptions = result.watchOptions && extendedConfig.watchOptions ?
-                assign({}, result.watchOptions, extendedConfig.watchOptions) :
-                result.watchOptions || extendedConfig.watchOptions;
+            result.watchOptions = result.watchOptions && extendedConfig.watchOptions
+                ? assign({}, result.watchOptions, extendedConfig.watchOptions)
+                : result.watchOptions || extendedConfig.watchOptions;
             // TODO extend type typeAcquisition
         }
     }
@@ -3200,9 +3200,9 @@ function parseOwnConfigOfJson(
     const typeAcquisition = convertTypeAcquisitionFromJsonWorker(json.typeAcquisition, basePath, errors, configFileName);
     const watchOptions = convertWatchOptionsFromJsonWorker(json.watchOptions, basePath, errors);
     json.compileOnSave = convertCompileOnSaveOptionFromJson(json, basePath, errors);
-    const extendedConfigPath = json.extends || json.extends === "" ?
-        getExtendsConfigPathOrArray(json.extends, host, basePath, configFileName, errors) :
-        undefined;
+    const extendedConfigPath = json.extends || json.extends === ""
+        ? getExtendsConfigPathOrArray(json.extends, host, basePath, configFileName, errors)
+        : undefined;
     return { raw: json, options, watchOptions, typeAcquisition, extendedConfigPath };
 }
 
@@ -3484,9 +3484,9 @@ function convertOptionsFromJson(optionsNameMap: Map<string, CommandLineOption>, 
 }
 
 function createDiagnosticForNodeInSourceFileOrCompilerDiagnostic(sourceFile: TsConfigSourceFile | undefined, node: Node | undefined, message: DiagnosticMessage, ...args: DiagnosticArguments) {
-    return sourceFile && node ?
-        createDiagnosticForNodeInSourceFile(sourceFile, node, message, ...args) :
-        createCompilerDiagnostic(message, ...args);
+    return sourceFile && node
+        ? createDiagnosticForNodeInSourceFile(sourceFile, node, message, ...args)
+        : createCompilerDiagnostic(message, ...args);
 }
 
 /** @internal */
@@ -3509,9 +3509,9 @@ export function convertJsonOption(
             return convertJsonOptionOfListType(opt, value, basePath, errors, propertyAssignment, valueExpression as ArrayLiteralExpression | undefined, sourceFile);
         }
         else if (optType === "listOrElement") {
-            return isArray(value) ?
-                convertJsonOptionOfListType(opt, value, basePath, errors, propertyAssignment, valueExpression as ArrayLiteralExpression | undefined, sourceFile) :
-                convertJsonOption(opt.element, value, basePath, errors, propertyAssignment, valueExpression, sourceFile);
+            return isArray(value)
+                ? convertJsonOptionOfListType(opt, value, basePath, errors, propertyAssignment, valueExpression as ArrayLiteralExpression | undefined, sourceFile)
+                : convertJsonOption(opt.element, value, basePath, errors, propertyAssignment, valueExpression, sourceFile);
         }
         else if (!isString(opt.type)) {
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -766,10 +766,10 @@ function deduplicateEquality<T>(array: readonly T[], equalityComparer: EqualityC
  * @internal
  */
 export function deduplicate<T>(array: readonly T[], equalityComparer: EqualityComparer<T>, comparer?: Comparer<T>): T[] {
-    return array.length === 0 ? [] :
-        array.length === 1 ? array.slice() :
-        comparer ? deduplicateRelational(array, equalityComparer, comparer) :
-        deduplicateEquality(array, equalityComparer);
+    return array.length === 0 ? []
+        : array.length === 1 ? array.slice()
+        : comparer ? deduplicateRelational(array, equalityComparer, comparer)
+        : deduplicateEquality(array, equalityComparer);
 }
 
 /**
@@ -1928,9 +1928,9 @@ const fileNameLowerCaseRegExp = /[^\u0130\u0131\u00DFa-z0-9\\/:\-_. ]+/g;
  * @internal
  */
 export function toFileNameLowerCase(x: string) {
-    return fileNameLowerCaseRegExp.test(x) ?
-        x.replace(fileNameLowerCaseRegExp, toLowerCase) :
-        x;
+    return fileNameLowerCaseRegExp.test(x)
+        ? x.replace(fileNameLowerCaseRegExp, toLowerCase)
+        : x;
 }
 
 /**
@@ -2103,11 +2103,11 @@ export function equateStringsCaseSensitive(a: string, b: string) {
 function compareComparableValues(a: string | undefined, b: string | undefined): Comparison;
 function compareComparableValues(a: number | undefined, b: number | undefined): Comparison;
 function compareComparableValues(a: string | number | undefined, b: string | number | undefined) {
-    return a === b ? Comparison.EqualTo :
-        a === undefined ? Comparison.LessThan :
-        b === undefined ? Comparison.GreaterThan :
-        a < b ? Comparison.LessThan :
-        Comparison.GreaterThan;
+    return a === b ? Comparison.EqualTo
+        : a === undefined ? Comparison.LessThan
+        : b === undefined ? Comparison.GreaterThan
+        : a < b ? Comparison.LessThan
+        : Comparison.GreaterThan;
 }
 
 /**
@@ -2260,10 +2260,10 @@ export function compareStringsCaseSensitiveUI(a: string, b: string) {
 
 /** @internal */
 export function compareProperties<T extends object, K extends keyof T>(a: T | undefined, b: T | undefined, key: K, comparer: Comparer<T[K]>): Comparison {
-    return a === b ? Comparison.EqualTo :
-        a === undefined ? Comparison.LessThan :
-        b === undefined ? Comparison.GreaterThan :
-        comparer(a[key], b[key]);
+    return a === b ? Comparison.EqualTo
+        : a === undefined ? Comparison.LessThan
+        : b === undefined ? Comparison.GreaterThan
+        : comparer(a[key], b[key]);
 }
 
 /**
@@ -2568,9 +2568,9 @@ export function tryRemovePrefix(str: string, prefix: string, getCanonicalFileNam
 
 /** @internal */
 export function isPatternMatch({ prefix, suffix }: Pattern, candidate: string) {
-    return candidate.length >= prefix.length + suffix.length &&
-        startsWith(candidate, prefix) &&
-        endsWith(candidate, suffix);
+    return candidate.length >= prefix.length + suffix.length
+        && startsWith(candidate, prefix)
+        && endsWith(candidate, suffix);
 }
 
 /** @internal */

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -514,18 +514,18 @@ export namespace Debug {
                 // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
                 __tsDebuggerDisplay: {
                     value(this: FlowNodeBase) {
-                        const flowHeader = this.flags & FlowFlags.Start ? "FlowStart" :
-                            this.flags & FlowFlags.BranchLabel ? "FlowBranchLabel" :
-                            this.flags & FlowFlags.LoopLabel ? "FlowLoopLabel" :
-                            this.flags & FlowFlags.Assignment ? "FlowAssignment" :
-                            this.flags & FlowFlags.TrueCondition ? "FlowTrueCondition" :
-                            this.flags & FlowFlags.FalseCondition ? "FlowFalseCondition" :
-                            this.flags & FlowFlags.SwitchClause ? "FlowSwitchClause" :
-                            this.flags & FlowFlags.ArrayMutation ? "FlowArrayMutation" :
-                            this.flags & FlowFlags.Call ? "FlowCall" :
-                            this.flags & FlowFlags.ReduceLabel ? "FlowReduceLabel" :
-                            this.flags & FlowFlags.Unreachable ? "FlowUnreachable" :
-                            "UnknownFlow";
+                        const flowHeader = this.flags & FlowFlags.Start ? "FlowStart"
+                            : this.flags & FlowFlags.BranchLabel ? "FlowBranchLabel"
+                            : this.flags & FlowFlags.LoopLabel ? "FlowLoopLabel"
+                            : this.flags & FlowFlags.Assignment ? "FlowAssignment"
+                            : this.flags & FlowFlags.TrueCondition ? "FlowTrueCondition"
+                            : this.flags & FlowFlags.FalseCondition ? "FlowFalseCondition"
+                            : this.flags & FlowFlags.SwitchClause ? "FlowSwitchClause"
+                            : this.flags & FlowFlags.ArrayMutation ? "FlowArrayMutation"
+                            : this.flags & FlowFlags.Call ? "FlowCall"
+                            : this.flags & FlowFlags.ReduceLabel ? "FlowReduceLabel"
+                            : this.flags & FlowFlags.Unreachable ? "FlowUnreachable"
+                            : "UnknownFlow";
                         const remainingFlags = this.flags & ~(FlowFlags.Referenced - 1);
                         return `${flowHeader}${remainingFlags ? ` (${formatFlowFlags(remainingFlags)})` : ""}`;
                     },
@@ -616,8 +616,8 @@ export namespace Debug {
             // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
             __tsDebuggerDisplay: {
                 value(this: Symbol) {
-                    const symbolHeader = this.flags & SymbolFlags.Transient ? "TransientSymbol" :
-                        "Symbol";
+                    const symbolHeader = this.flags & SymbolFlags.Transient ? "TransientSymbol"
+                        : "Symbol";
                     const remainingSymbolFlags = this.flags & ~SymbolFlags.Transient;
                     return `${symbolHeader} '${symbolName(this)}'${remainingSymbolFlags ? ` (${formatSymbolFlags(remainingSymbolFlags)})` : ""}`;
                 },
@@ -633,29 +633,29 @@ export namespace Debug {
             // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
             __tsDebuggerDisplay: {
                 value(this: Type) {
-                    const typeHeader = this.flags & TypeFlags.Intrinsic ? `IntrinsicType ${(this as IntrinsicType).intrinsicName}${(this as IntrinsicType).debugIntrinsicName ? ` (${(this as IntrinsicType).debugIntrinsicName})` : ""}` :
-                        this.flags & TypeFlags.Nullable ? "NullableType" :
-                        this.flags & TypeFlags.StringOrNumberLiteral ? `LiteralType ${JSON.stringify((this as LiteralType).value)}` :
-                        this.flags & TypeFlags.BigIntLiteral ? `LiteralType ${(this as BigIntLiteralType).value.negative ? "-" : ""}${(this as BigIntLiteralType).value.base10Value}n` :
-                        this.flags & TypeFlags.UniqueESSymbol ? "UniqueESSymbolType" :
-                        this.flags & TypeFlags.Enum ? "EnumType" :
-                        this.flags & TypeFlags.Union ? "UnionType" :
-                        this.flags & TypeFlags.Intersection ? "IntersectionType" :
-                        this.flags & TypeFlags.Index ? "IndexType" :
-                        this.flags & TypeFlags.IndexedAccess ? "IndexedAccessType" :
-                        this.flags & TypeFlags.Conditional ? "ConditionalType" :
-                        this.flags & TypeFlags.Substitution ? "SubstitutionType" :
-                        this.flags & TypeFlags.TypeParameter ? "TypeParameter" :
-                        this.flags & TypeFlags.Object ?
-                        (this as ObjectType).objectFlags & ObjectFlags.ClassOrInterface ? "InterfaceType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Reference ? "TypeReference" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Tuple ? "TupleType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Anonymous ? "AnonymousType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.Mapped ? "MappedType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.ReverseMapped ? "ReverseMappedType" :
-                            (this as ObjectType).objectFlags & ObjectFlags.EvolvingArray ? "EvolvingArrayType" :
-                            "ObjectType" :
-                        "Type";
+                    const typeHeader = this.flags & TypeFlags.Intrinsic ? `IntrinsicType ${(this as IntrinsicType).intrinsicName}${(this as IntrinsicType).debugIntrinsicName ? ` (${(this as IntrinsicType).debugIntrinsicName})` : ""}`
+                        : this.flags & TypeFlags.Nullable ? "NullableType"
+                        : this.flags & TypeFlags.StringOrNumberLiteral ? `LiteralType ${JSON.stringify((this as LiteralType).value)}`
+                        : this.flags & TypeFlags.BigIntLiteral ? `LiteralType ${(this as BigIntLiteralType).value.negative ? "-" : ""}${(this as BigIntLiteralType).value.base10Value}n`
+                        : this.flags & TypeFlags.UniqueESSymbol ? "UniqueESSymbolType"
+                        : this.flags & TypeFlags.Enum ? "EnumType"
+                        : this.flags & TypeFlags.Union ? "UnionType"
+                        : this.flags & TypeFlags.Intersection ? "IntersectionType"
+                        : this.flags & TypeFlags.Index ? "IndexType"
+                        : this.flags & TypeFlags.IndexedAccess ? "IndexedAccessType"
+                        : this.flags & TypeFlags.Conditional ? "ConditionalType"
+                        : this.flags & TypeFlags.Substitution ? "SubstitutionType"
+                        : this.flags & TypeFlags.TypeParameter ? "TypeParameter"
+                        : this.flags & TypeFlags.Object
+                        ? (this as ObjectType).objectFlags & ObjectFlags.ClassOrInterface ? "InterfaceType"
+                            : (this as ObjectType).objectFlags & ObjectFlags.Reference ? "TypeReference"
+                            : (this as ObjectType).objectFlags & ObjectFlags.Tuple ? "TupleType"
+                            : (this as ObjectType).objectFlags & ObjectFlags.Anonymous ? "AnonymousType"
+                            : (this as ObjectType).objectFlags & ObjectFlags.Mapped ? "MappedType"
+                            : (this as ObjectType).objectFlags & ObjectFlags.ReverseMapped ? "ReverseMappedType"
+                            : (this as ObjectType).objectFlags & ObjectFlags.EvolvingArray ? "EvolvingArrayType"
+                            : "ObjectType"
+                        : "Type";
                     const remainingObjectFlags = this.flags & TypeFlags.Object ? (this as ObjectType).objectFlags & ~ObjectFlags.ObjectTypeKindMask : 0;
                     return `${typeHeader}${this.symbol ? ` '${symbolName(this.symbol)}'` : ""}${remainingObjectFlags ? ` (${formatObjectFlags(remainingObjectFlags)})` : ""}`;
                 },
@@ -709,43 +709,43 @@ export namespace Debug {
                     // for use with vscode-js-debug's new customDescriptionGenerator in launch.json
                     __tsDebuggerDisplay: {
                         value(this: Node) {
-                            const nodeHeader = isGeneratedIdentifier(this) ? "GeneratedIdentifier" :
-                                isIdentifier(this) ? `Identifier '${idText(this)}'` :
-                                isPrivateIdentifier(this) ? `PrivateIdentifier '${idText(this)}'` :
-                                isStringLiteral(this) ? `StringLiteral ${JSON.stringify(this.text.length < 10 ? this.text : this.text.slice(10) + "...")}` :
-                                isNumericLiteral(this) ? `NumericLiteral ${this.text}` :
-                                isBigIntLiteral(this) ? `BigIntLiteral ${this.text}n` :
-                                isTypeParameterDeclaration(this) ? "TypeParameterDeclaration" :
-                                isParameter(this) ? "ParameterDeclaration" :
-                                isConstructorDeclaration(this) ? "ConstructorDeclaration" :
-                                isGetAccessorDeclaration(this) ? "GetAccessorDeclaration" :
-                                isSetAccessorDeclaration(this) ? "SetAccessorDeclaration" :
-                                isCallSignatureDeclaration(this) ? "CallSignatureDeclaration" :
-                                isConstructSignatureDeclaration(this) ? "ConstructSignatureDeclaration" :
-                                isIndexSignatureDeclaration(this) ? "IndexSignatureDeclaration" :
-                                isTypePredicateNode(this) ? "TypePredicateNode" :
-                                isTypeReferenceNode(this) ? "TypeReferenceNode" :
-                                isFunctionTypeNode(this) ? "FunctionTypeNode" :
-                                isConstructorTypeNode(this) ? "ConstructorTypeNode" :
-                                isTypeQueryNode(this) ? "TypeQueryNode" :
-                                isTypeLiteralNode(this) ? "TypeLiteralNode" :
-                                isArrayTypeNode(this) ? "ArrayTypeNode" :
-                                isTupleTypeNode(this) ? "TupleTypeNode" :
-                                isOptionalTypeNode(this) ? "OptionalTypeNode" :
-                                isRestTypeNode(this) ? "RestTypeNode" :
-                                isUnionTypeNode(this) ? "UnionTypeNode" :
-                                isIntersectionTypeNode(this) ? "IntersectionTypeNode" :
-                                isConditionalTypeNode(this) ? "ConditionalTypeNode" :
-                                isInferTypeNode(this) ? "InferTypeNode" :
-                                isParenthesizedTypeNode(this) ? "ParenthesizedTypeNode" :
-                                isThisTypeNode(this) ? "ThisTypeNode" :
-                                isTypeOperatorNode(this) ? "TypeOperatorNode" :
-                                isIndexedAccessTypeNode(this) ? "IndexedAccessTypeNode" :
-                                isMappedTypeNode(this) ? "MappedTypeNode" :
-                                isLiteralTypeNode(this) ? "LiteralTypeNode" :
-                                isNamedTupleMember(this) ? "NamedTupleMember" :
-                                isImportTypeNode(this) ? "ImportTypeNode" :
-                                formatSyntaxKind(this.kind);
+                            const nodeHeader = isGeneratedIdentifier(this) ? "GeneratedIdentifier"
+                                : isIdentifier(this) ? `Identifier '${idText(this)}'`
+                                : isPrivateIdentifier(this) ? `PrivateIdentifier '${idText(this)}'`
+                                : isStringLiteral(this) ? `StringLiteral ${JSON.stringify(this.text.length < 10 ? this.text : this.text.slice(10) + "...")}`
+                                : isNumericLiteral(this) ? `NumericLiteral ${this.text}`
+                                : isBigIntLiteral(this) ? `BigIntLiteral ${this.text}n`
+                                : isTypeParameterDeclaration(this) ? "TypeParameterDeclaration"
+                                : isParameter(this) ? "ParameterDeclaration"
+                                : isConstructorDeclaration(this) ? "ConstructorDeclaration"
+                                : isGetAccessorDeclaration(this) ? "GetAccessorDeclaration"
+                                : isSetAccessorDeclaration(this) ? "SetAccessorDeclaration"
+                                : isCallSignatureDeclaration(this) ? "CallSignatureDeclaration"
+                                : isConstructSignatureDeclaration(this) ? "ConstructSignatureDeclaration"
+                                : isIndexSignatureDeclaration(this) ? "IndexSignatureDeclaration"
+                                : isTypePredicateNode(this) ? "TypePredicateNode"
+                                : isTypeReferenceNode(this) ? "TypeReferenceNode"
+                                : isFunctionTypeNode(this) ? "FunctionTypeNode"
+                                : isConstructorTypeNode(this) ? "ConstructorTypeNode"
+                                : isTypeQueryNode(this) ? "TypeQueryNode"
+                                : isTypeLiteralNode(this) ? "TypeLiteralNode"
+                                : isArrayTypeNode(this) ? "ArrayTypeNode"
+                                : isTupleTypeNode(this) ? "TupleTypeNode"
+                                : isOptionalTypeNode(this) ? "OptionalTypeNode"
+                                : isRestTypeNode(this) ? "RestTypeNode"
+                                : isUnionTypeNode(this) ? "UnionTypeNode"
+                                : isIntersectionTypeNode(this) ? "IntersectionTypeNode"
+                                : isConditionalTypeNode(this) ? "ConditionalTypeNode"
+                                : isInferTypeNode(this) ? "InferTypeNode"
+                                : isParenthesizedTypeNode(this) ? "ParenthesizedTypeNode"
+                                : isThisTypeNode(this) ? "ThisTypeNode"
+                                : isTypeOperatorNode(this) ? "TypeOperatorNode"
+                                : isIndexedAccessTypeNode(this) ? "IndexedAccessTypeNode"
+                                : isMappedTypeNode(this) ? "MappedTypeNode"
+                                : isLiteralTypeNode(this) ? "LiteralTypeNode"
+                                : isNamedTupleMember(this) ? "NamedTupleMember"
+                                : isImportTypeNode(this) ? "ImportTypeNode"
+                                : formatSyntaxKind(this.kind);
                             return `${nodeHeader}${this.flags ? ` (${formatNodeFlags(this.flags)})` : ""}`;
                         },
                     },
@@ -802,11 +802,11 @@ export namespace Debug {
 
     export function formatVariance(varianceFlags: VarianceFlags) {
         const variance = varianceFlags & VarianceFlags.VarianceMask;
-        let result = variance === VarianceFlags.Invariant ? "in out" :
-            variance === VarianceFlags.Bivariant ? "[bivariant]" :
-            variance === VarianceFlags.Contravariant ? "in" :
-            variance === VarianceFlags.Covariant ? "out" :
-            variance === VarianceFlags.Independent ? "[independent]" : "";
+        let result = variance === VarianceFlags.Invariant ? "in out"
+            : variance === VarianceFlags.Bivariant ? "[bivariant]"
+            : variance === VarianceFlags.Contravariant ? "in"
+            : variance === VarianceFlags.Covariant ? "out"
+            : variance === VarianceFlags.Independent ? "[independent]" : "";
         if (varianceFlags & VarianceFlags.Unmeasurable) {
             result += " (unmeasurable)";
         }
@@ -922,18 +922,18 @@ m2: ${(this.mapper2 as unknown as DebugTypeMapper).__debugToString().split("\n")
             target: FlowGraphNode;
         }
 
-        const hasAntecedentFlags = FlowFlags.Assignment |
-            FlowFlags.Condition |
-            FlowFlags.SwitchClause |
-            FlowFlags.ArrayMutation |
-            FlowFlags.Call |
-            FlowFlags.ReduceLabel;
+        const hasAntecedentFlags = FlowFlags.Assignment
+            | FlowFlags.Condition
+            | FlowFlags.SwitchClause
+            | FlowFlags.ArrayMutation
+            | FlowFlags.Call
+            | FlowFlags.ReduceLabel;
 
-        const hasNodeFlags = FlowFlags.Start |
-            FlowFlags.Assignment |
-            FlowFlags.Call |
-            FlowFlags.Condition |
-            FlowFlags.ArrayMutation;
+        const hasNodeFlags = FlowFlags.Start
+            | FlowFlags.Assignment
+            | FlowFlags.Call
+            | FlowFlags.Condition
+            | FlowFlags.ArrayMutation;
 
         const links: Record<number, FlowGraphNode> = Object.create(/*o*/ null); // eslint-disable-line no-null/no-null
         const nodes: FlowGraphNode[] = [];

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -486,11 +486,11 @@ export function getTsBuildInfoEmitOutputFilePath(options: CompilerOptions) {
     else {
         if (!configFile) return undefined;
         const configFileExtensionLess = removeFileExtension(configFile);
-        buildInfoExtensionLess = options.outDir ?
-            options.rootDir ?
-                resolvePath(options.outDir, getRelativePathFromDirectory(options.rootDir, configFileExtensionLess, /*ignoreCase*/ true)) :
-                combinePaths(options.outDir, getBaseFileName(configFileExtensionLess)) :
-            configFileExtensionLess;
+        buildInfoExtensionLess = options.outDir
+            ? options.rootDir
+                ? resolvePath(options.outDir, getRelativePathFromDirectory(options.rootDir, configFileExtensionLess, /*ignoreCase*/ true))
+                : combinePaths(options.outDir, getBaseFileName(configFileExtensionLess))
+            : configFileExtensionLess;
     }
     return buildInfoExtensionLess + Extension.TsBuildInfo;
 }
@@ -516,8 +516,8 @@ export function getOutputPathsFor(sourceFile: SourceFile | Bundle, host: EmitHos
         const ownOutputFilePath = getOwnEmitOutputFilePath(sourceFile.fileName, host, getOutputExtension(sourceFile.fileName, options));
         const isJsonFile = isJsonSourceFile(sourceFile);
         // If json file emits to the same location skip writing it, if emitDeclarationOnly skip writing it
-        const isJsonEmittedToSameLocation = isJsonFile &&
-            comparePaths(sourceFile.fileName, ownOutputFilePath, host.getCurrentDirectory(), !host.useCaseSensitiveFileNames()) === Comparison.EqualTo;
+        const isJsonEmittedToSameLocation = isJsonFile
+            && comparePaths(sourceFile.fileName, ownOutputFilePath, host.getCurrentDirectory(), !host.useCaseSensitiveFileNames()) === Comparison.EqualTo;
         const jsFilePath = options.emitDeclarationOnly || isJsonEmittedToSameLocation ? undefined : ownOutputFilePath;
         const sourceMapFilePath = !jsFilePath || isJsonSourceFile(sourceFile) ? undefined : getSourceMapFilePath(jsFilePath, options);
         const declarationFilePath = (forceDtsPaths || (getEmitDeclarations(options) && !isJsonFile)) ? getDeclarationEmitOutputFilePath(sourceFile.fileName, host) : undefined;
@@ -532,11 +532,11 @@ function getSourceMapFilePath(jsFilePath: string, options: CompilerOptions) {
 
 /** @internal */
 export function getOutputExtension(fileName: string, options: CompilerOptions): Extension {
-    return fileExtensionIs(fileName, Extension.Json) ? Extension.Json :
-        options.jsx === JsxEmit.Preserve && fileExtensionIsOneOf(fileName, [Extension.Jsx, Extension.Tsx]) ? Extension.Jsx :
-        fileExtensionIsOneOf(fileName, [Extension.Mts, Extension.Mjs]) ? Extension.Mjs :
-        fileExtensionIsOneOf(fileName, [Extension.Cts, Extension.Cjs]) ? Extension.Cjs :
-        Extension.Js;
+    return fileExtensionIs(fileName, Extension.Json) ? Extension.Json
+        : options.jsx === JsxEmit.Preserve && fileExtensionIsOneOf(fileName, [Extension.Jsx, Extension.Tsx]) ? Extension.Jsx
+        : fileExtensionIsOneOf(fileName, [Extension.Mts, Extension.Mjs]) ? Extension.Mjs
+        : fileExtensionIsOneOf(fileName, [Extension.Cts, Extension.Cjs]) ? Extension.Cjs
+        : Extension.Js;
 }
 
 function getOutputPathWithoutChangingExt(
@@ -545,12 +545,12 @@ function getOutputPathWithoutChangingExt(
     outputDir: string | undefined,
     getCommonSourceDirectory: () => string,
 ): string {
-    return outputDir ?
-        resolvePath(
+    return outputDir
+        ? resolvePath(
             outputDir,
             getRelativePathFromDirectory(getCommonSourceDirectory(), inputFileName, ignoreCase),
-        ) :
-        inputFileName;
+        )
+        : inputFileName;
 }
 
 /** @internal */
@@ -570,9 +570,9 @@ function getOutputJSFileName(inputFileName: string, configFile: ParsedCommandLin
     if (configFile.options.emitDeclarationOnly) return undefined;
     const isJsonFile = fileExtensionIs(inputFileName, Extension.Json);
     const outputFileName = getOutputJSFileNameWorker(inputFileName, configFile.options, ignoreCase, getCommonSourceDirectory);
-    return !isJsonFile || comparePaths(inputFileName, outputFileName, Debug.checkDefined(configFile.options.configFilePath), ignoreCase) !== Comparison.EqualTo ?
-        outputFileName :
-        undefined;
+    return !isJsonFile || comparePaths(inputFileName, outputFileName, Debug.checkDefined(configFile.options.configFilePath), ignoreCase) !== Comparison.EqualTo
+        ? outputFileName
+        : undefined;
 }
 
 /** @internal */
@@ -1425,9 +1425,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     }
 
     function shouldEmitSourceMaps(node: Node) {
-        return !sourceMapsDisabled &&
-            !isSourceFile(node) &&
-            !isInJsonFile(node);
+        return !sourceMapsDisabled
+            && !isSourceFile(node)
+            && !isInJsonFile(node);
     }
 
     function getPipelinePhase(phase: PipelinePhase, emitHint: EmitHint, node: Node) {
@@ -2437,9 +2437,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         writeTokenText(node.operator, writeKeyword);
         writeSpace();
 
-        const parenthesizerRule = node.operator === SyntaxKind.ReadonlyKeyword ?
-            parenthesizer.parenthesizeOperandOfReadonlyTypeOperator :
-            parenthesizer.parenthesizeOperandOfTypeOperator;
+        const parenthesizerRule = node.operator === SyntaxKind.ReadonlyKeyword
+            ? parenthesizer.parenthesizeOperandOfReadonlyTypeOperator
+            : parenthesizer.parenthesizeOperandOfTypeOperator;
         emit(node.type, parenthesizerRule);
     }
 
@@ -2596,10 +2596,10 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
         writeLinesAndIndent(linesBeforeDot, /*writeSpaceIfNotIndenting*/ false);
 
-        const shouldEmitDotDot = token.kind !== SyntaxKind.QuestionDotToken &&
-            mayNeedDotDotForPropertyAccess(node.expression) &&
-            !writer.hasTrailingComment() &&
-            !writer.hasTrailingWhitespace();
+        const shouldEmitDotDot = token.kind !== SyntaxKind.QuestionDotToken
+            && mayNeedDotDotForPropertyAccess(node.expression)
+            && !writer.hasTrailingComment()
+            && !writer.hasTrailingWhitespace();
 
         if (shouldEmitDotDot) {
             writePunctuation(".");
@@ -2859,9 +2859,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         }
 
         function maybeEmitExpression(next: Expression, parent: BinaryExpression, side: "left" | "right") {
-            const parenthesizerRule = side === "left" ?
-                parenthesizer.getParenthesizeLeftSideOfBinaryForOperator(parent.operatorToken.kind) :
-                parenthesizer.getParenthesizeRightSideOfBinaryForOperator(parent.operatorToken.kind);
+            const parenthesizerRule = side === "left"
+                ? parenthesizer.getParenthesizeLeftSideOfBinaryForOperator(parent.operatorToken.kind)
+                : parenthesizer.getParenthesizeRightSideOfBinaryForOperator(parent.operatorToken.kind);
 
             let pipelinePhase = getPipelinePhase(PipelinePhase.Notification, EmitHint.Expression, next);
             if (pipelinePhase === pipelineEmitWithSubstitution) {
@@ -2872,9 +2872,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
             }
 
             if (
-                pipelinePhase === pipelineEmitWithComments ||
-                pipelinePhase === pipelineEmitWithSourceMaps ||
-                pipelinePhase === pipelineEmitWithHint
+                pipelinePhase === pipelineEmitWithComments
+                || pipelinePhase === pipelineEmitWithSourceMaps
+                || pipelinePhase === pipelineEmitWithHint
             ) {
                 if (isBinaryExpression(next)) {
                     return next;
@@ -3283,10 +3283,10 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
             writeKeyword("using");
         }
         else {
-            const head = isLet(node) ? "let" :
-                isVarConst(node) ? "const" :
-                isVarUsing(node) ? "using" :
-                "var";
+            const head = isLet(node) ? "let"
+                : isVarConst(node) ? "const"
+                : isVarUsing(node) ? "using"
+                : "var";
             writeKeyword(head);
         }
         writeSpace();
@@ -3617,9 +3617,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         writeSpace();
         emitExpression(
             node.expression,
-            node.isExportEquals ?
-                parenthesizer.getParenthesizeRightSideOfBinaryForOperator(SyntaxKind.EqualsToken) :
-                parenthesizer.parenthesizeExpressionOfExportDefault,
+            node.isExportEquals
+                ? parenthesizer.getParenthesizeRightSideOfBinaryForOperator(SyntaxKind.EqualsToken)
+                : parenthesizer.parenthesizeExpressionOfExportDefault,
         );
         writeTrailingSemicolon();
     }
@@ -3879,13 +3879,13 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
     }
 
     function emitCaseOrDefaultClauseRest(parentNode: Node, statements: NodeArray<Statement>, colonPos: number) {
-        const emitAsSingleStatement = statements.length === 1 &&
-            (
+        const emitAsSingleStatement = statements.length === 1
+            && (
                 // treat synthesized nodes as located on the same line for emit purposes
-                !currentSourceFile ||
-                nodeIsSynthesized(parentNode) ||
-                nodeIsSynthesized(statements[0]) ||
-                rangeStartPositionsAreOnSameLine(parentNode, statements[0], currentSourceFile)
+                !currentSourceFile
+                || nodeIsSynthesized(parentNode)
+                || nodeIsSynthesized(statements[0])
+                || rangeStartPositionsAreOnSameLine(parentNode, statements[0], currentSourceFile)
             );
 
         let format = ListFormat.CaseOrDefaultClauseStatements;
@@ -4147,9 +4147,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         const statements = node.statements;
         // Emit detached comment if there are no prologue directives or if the first node is synthesized.
         // The synthesized node will have no leading comment so some comments may be missed.
-        const shouldEmitDetachedComment = statements.length === 0 ||
-            !isPrologueDirective(statements[0]) ||
-            nodeIsSynthesized(statements[0]);
+        const shouldEmitDetachedComment = statements.length === 0
+            || !isPrologueDirective(statements[0])
+            || nodeIsSynthesized(statements[0]);
         if (shouldEmitDetachedComment) {
             emitBodyWithDetachedComments(node, statements, emitSourceFileWorker);
             return;
@@ -4426,9 +4426,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
 
     function emitEmbeddedStatement(parent: Node, node: Statement) {
         if (
-            isBlock(node) ||
-            getEmitFlags(parent) & EmitFlags.SingleLine ||
-            preserveSourceNewlines && !getLeadingLineTerminatorCount(parent, node, ListFormat.None)
+            isBlock(node)
+            || getEmitFlags(parent) & EmitFlags.SingleLine
+            || preserveSourceNewlines && !getLeadingLineTerminatorCount(parent, node, ListFormat.None)
         ) {
             writeSpace();
             emit(node);
@@ -4898,10 +4898,10 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
                 return 0;
             }
             if (
-                currentSourceFile && parentNode &&
-                !positionIsSynthesized(parentNode.pos) &&
-                !nodeIsSynthesized(firstChild) &&
-                (!firstChild.parent || getOriginalNode(firstChild.parent) === getOriginalNode(parentNode))
+                currentSourceFile && parentNode
+                && !positionIsSynthesized(parentNode.pos)
+                && !nodeIsSynthesized(firstChild)
+                && (!firstChild.parent || getOriginalNode(firstChild.parent) === getOriginalNode(parentNode))
             ) {
                 if (preserveSourceNewlines) {
                     return getEffectiveLines(
@@ -5130,9 +5130,9 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
             const textSourceNode = (node as StringLiteral).textSourceNode!;
             if (isIdentifier(textSourceNode) || isPrivateIdentifier(textSourceNode) || isNumericLiteral(textSourceNode) || isJsxNamespacedName(textSourceNode)) {
                 const text = isNumericLiteral(textSourceNode) ? textSourceNode.text : getTextOfNode(textSourceNode);
-                return jsxAttributeEscape ? `"${escapeJsxAttributeString(text)}"` :
-                    neverAsciiEscape || (getEmitFlags(node) & EmitFlags.NoAsciiEscaping) ? `"${escapeString(text)}"` :
-                    `"${escapeNonAsciiString(text)}"`;
+                return jsxAttributeEscape ? `"${escapeJsxAttributeString(text)}"`
+                    : neverAsciiEscape || (getEmitFlags(node) & EmitFlags.NoAsciiEscaping) ? `"${escapeString(text)}"`
+                    : `"${escapeNonAsciiString(text)}"`;
             }
             else {
                 return getLiteralTextOfNode(textSourceNode, neverAsciiEscape, jsxAttributeEscape);
@@ -5529,8 +5529,8 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
      */
     function generateNameForImportOrExportDeclaration(node: ImportDeclaration | ExportDeclaration) {
         const expr = getExternalModuleName(node)!; // TODO: GH#18217
-        const baseName = isStringLiteral(expr) ?
-            makeIdentifierFromModuleName(expr.text) : "module";
+        const baseName = isStringLiteral(expr)
+            ? makeIdentifierFromModuleName(expr.text) : "module";
         return makeUniqueName(baseName, isUniqueName, /*optimistic*/ false, /*scoped*/ false, /*privateName*/ false, /*prefix*/ "", /*suffix*/ "");
     }
 
@@ -6215,7 +6215,7 @@ function emitListItemWithParenthesizerRule(node: Node, emit: EmitFunction, paren
 }
 
 function getEmitListItem<T extends Node>(emit: EmitFunction, parenthesizerRule: ParenthesizerRuleOrSelector<T> | undefined): EmitListItemFunction<T> {
-    return emit.length === 1 ? emitListItemNoParenthesizer as EmitListItemFunction<T> :
-        typeof parenthesizerRule === "object" ? emitListItemWithParenthesizerRuleSelector as EmitListItemFunction<T> :
-        emitListItemWithParenthesizerRule as EmitListItemFunction<T>;
+    return emit.length === 1 ? emitListItemNoParenthesizer as EmitListItemFunction<T>
+        : typeof parenthesizerRule === "object" ? emitListItemWithParenthesizerRuleSelector as EmitListItemFunction<T>
+        : emitListItemWithParenthesizerRule as EmitListItemFunction<T>;
 }

--- a/src/compiler/factory/emitHelpers.ts
+++ b/src/compiler/factory/emitHelpers.ts
@@ -260,9 +260,9 @@ export function createEmitHelperFactory(context: TransformationContext): EmitHel
     }
 
     function createESDecorateClassElementAccessGetMethod(elementName: ESDecorateName) {
-        const accessor = elementName.computed ?
-            factory.createElementAccessExpression(factory.createIdentifier("obj"), elementName.name) :
-            factory.createPropertyAccessExpression(factory.createIdentifier("obj"), elementName.name);
+        const accessor = elementName.computed
+            ? factory.createElementAccessExpression(factory.createIdentifier("obj"), elementName.name)
+            : factory.createPropertyAccessExpression(factory.createIdentifier("obj"), elementName.name);
 
         return factory.createPropertyAssignment(
             "get",
@@ -282,9 +282,9 @@ export function createEmitHelperFactory(context: TransformationContext): EmitHel
     }
 
     function createESDecorateClassElementAccessSetMethod(elementName: ESDecorateName) {
-        const accessor = elementName.computed ?
-            factory.createElementAccessExpression(factory.createIdentifier("obj"), elementName.name) :
-            factory.createPropertyAccessExpression(factory.createIdentifier("obj"), elementName.name);
+        const accessor = elementName.computed
+            ? factory.createElementAccessExpression(factory.createIdentifier("obj"), elementName.name)
+            : factory.createPropertyAccessExpression(factory.createIdentifier("obj"), elementName.name);
 
         return factory.createPropertyAssignment(
             "set",
@@ -318,9 +318,9 @@ export function createEmitHelperFactory(context: TransformationContext): EmitHel
     }
 
     function createESDecorateClassElementAccessHasMethod(elementName: ESDecorateName) {
-        const propertyName = elementName.computed ? elementName.name :
-            isIdentifier(elementName.name) ? factory.createStringLiteralFromNode(elementName.name) :
-            elementName.name;
+        const propertyName = elementName.computed ? elementName.name
+            : isIdentifier(elementName.name) ? factory.createStringLiteralFromNode(elementName.name)
+            : elementName.name;
 
         return factory.createPropertyAssignment(
             "has",
@@ -364,8 +364,8 @@ export function createEmitHelperFactory(context: TransformationContext): EmitHel
     }
 
     function createESDecorateContextObject(contextIn: ESDecorateContext) {
-        return contextIn.kind === "class" ? createESDecorateClassContextObject(contextIn) :
-            createESDecorateClassElementContextObject(contextIn);
+        return contextIn.kind === "class" ? createESDecorateClassContextObject(contextIn)
+            : createESDecorateClassElementContextObject(contextIn);
     }
 
     function createESDecorateHelper(ctor: Expression, descriptorIn: Expression, decorators: Expression, contextIn: ESDecorateContext, initializers: Expression, extraInitializers: Expression) {

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -628,13 +628,13 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         updateArrayLiteralExpression,
         createObjectLiteralExpression,
         updateObjectLiteralExpression,
-        createPropertyAccessExpression: flags & NodeFactoryFlags.NoIndentationOnFreshPropertyAccess ?
-            (expression, name) => setEmitFlags(createPropertyAccessExpression(expression, name), EmitFlags.NoIndentation) :
-            createPropertyAccessExpression,
+        createPropertyAccessExpression: flags & NodeFactoryFlags.NoIndentationOnFreshPropertyAccess
+            ? (expression, name) => setEmitFlags(createPropertyAccessExpression(expression, name), EmitFlags.NoIndentation)
+            : createPropertyAccessExpression,
         updatePropertyAccessExpression,
-        createPropertyAccessChain: flags & NodeFactoryFlags.NoIndentationOnFreshPropertyAccess ?
-            (expression, questionDotToken, name: string) => setEmitFlags(createPropertyAccessChain(expression, questionDotToken, name), EmitFlags.NoIndentation) :
-            createPropertyAccessChain,
+        createPropertyAccessChain: flags & NodeFactoryFlags.NoIndentationOnFreshPropertyAccess
+            ? (expression, questionDotToken, name: string) => setEmitFlags(createPropertyAccessChain(expression, questionDotToken, name), EmitFlags.NoIndentation)
+            : createPropertyAccessChain,
         updatePropertyAccessChain,
         createElementAccessExpression,
         updateElementAccessExpression,
@@ -1369,9 +1369,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     // @api
     function getGeneratedNameForNode(node: Node | undefined, flags: GeneratedIdentifierFlags = 0, prefix?: string | GeneratedNamePart, suffix?: string): Identifier {
         Debug.assert(!(flags & GeneratedIdentifierFlags.KindMask), "Argument out of range: flags");
-        const text = !node ? "" :
-            isMemberName(node) ? formatGeneratedName(/*privateName*/ false, prefix, node, suffix, idText) :
-            `generated@${getNodeId(node)}`;
+        const text = !node ? ""
+            : isMemberName(node) ? formatGeneratedName(/*privateName*/ false, prefix, node, suffix, idText)
+            : `generated@${getNodeId(node)}`;
         if (prefix || suffix) flags |= GeneratedIdentifierFlags.Optimistic;
         const name = createBaseGeneratedIdentifier(text, GeneratedIdentifierFlags.Node | flags, prefix, suffix);
         name.original = node;
@@ -1407,15 +1407,15 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     // @api
     function createUniquePrivateName(text?: string, prefix?: string | GeneratedNamePart, suffix?: string): PrivateIdentifier {
         if (text && !startsWith(text, "#")) Debug.fail("First character of private identifier must be #: " + text);
-        const autoGenerateFlags = GeneratedIdentifierFlags.ReservedInNestedScopes |
-            (text ? GeneratedIdentifierFlags.Unique : GeneratedIdentifierFlags.Auto);
+        const autoGenerateFlags = GeneratedIdentifierFlags.ReservedInNestedScopes
+            | (text ? GeneratedIdentifierFlags.Unique : GeneratedIdentifierFlags.Auto);
         return createBaseGeneratedPrivateIdentifier(text ?? "", autoGenerateFlags, prefix, suffix);
     }
 
     // @api
     function getGeneratedPrivateNameForNode(node: Node, prefix?: string | GeneratedNamePart, suffix?: string): PrivateIdentifier {
-        const text = isMemberName(node) ? formatGeneratedName(/*privateName*/ true, prefix, node, suffix, idText) :
-            `#generated@${getNodeId(node)}`;
+        const text = isMemberName(node) ? formatGeneratedName(/*privateName*/ true, prefix, node, suffix, idText)
+            : `#generated@${getNodeId(node)}`;
         const flags = prefix || suffix ? GeneratedIdentifierFlags.Optimistic : GeneratedIdentifierFlags.None;
         const name = createBaseGeneratedPrivateIdentifier(text, GeneratedIdentifierFlags.Node | flags, prefix, suffix);
         name.original = node;
@@ -1453,8 +1453,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         switch (token) {
             case SyntaxKind.AsyncKeyword:
                 // 'async' modifier is ES2017 (async functions) or ES2018 (async generators)
-                transformFlags = TransformFlags.ContainsES2017 |
-                    TransformFlags.ContainsES2018;
+                transformFlags = TransformFlags.ContainsES2017
+                    | TransformFlags.ContainsES2018;
                 break;
 
             case SyntaxKind.UsingKeyword:
@@ -1574,8 +1574,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<QualifiedName>(SyntaxKind.QualifiedName);
         node.left = left;
         node.right = asName(right);
-        node.transformFlags |= propagateChildFlags(node.left) |
-            propagateIdentifierNameFlags(node.right);
+        node.transformFlags |= propagateChildFlags(node.left)
+            | propagateIdentifierNameFlags(node.right);
 
         node.flowNode = undefined; // initialized by binder (FlowContainer)
         return node;
@@ -1593,9 +1593,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createComputedPropertyName(expression: Expression) {
         const node = createBaseNode<ComputedPropertyName>(SyntaxKind.ComputedPropertyName);
         node.expression = parenthesizerRules().parenthesizeExpressionOfComputedPropertyName(expression);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsES2015 |
-            TransformFlags.ContainsComputedPropertyName;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsES2015
+            | TransformFlags.ContainsComputedPropertyName;
         return node;
     }
 
@@ -1655,14 +1655,14 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             node.transformFlags = TransformFlags.ContainsTypeScript;
         }
         else {
-            node.transformFlags = propagateChildrenFlags(node.modifiers) |
-                propagateChildFlags(node.dotDotDotToken) |
-                propagateNameFlags(node.name) |
-                propagateChildFlags(node.questionToken) |
-                propagateChildFlags(node.initializer) |
-                (node.questionToken ?? node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-                (node.dotDotDotToken ?? node.initializer ? TransformFlags.ContainsES2015 : TransformFlags.None) |
-                (modifiersToFlags(node.modifiers) & ModifierFlags.ParameterPropertyModifier ? TransformFlags.ContainsTypeScriptClassSyntax : TransformFlags.None);
+            node.transformFlags = propagateChildrenFlags(node.modifiers)
+                | propagateChildFlags(node.dotDotDotToken)
+                | propagateNameFlags(node.name)
+                | propagateChildFlags(node.questionToken)
+                | propagateChildFlags(node.initializer)
+                | (node.questionToken ?? node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+                | (node.dotDotDotToken ?? node.initializer ? TransformFlags.ContainsES2015 : TransformFlags.None)
+                | (modifiersToFlags(node.modifiers) & ModifierFlags.ParameterPropertyModifier ? TransformFlags.ContainsTypeScriptClassSyntax : TransformFlags.None);
         }
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -1693,10 +1693,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createDecorator(expression: Expression) {
         const node = createBaseNode<Decorator>(SyntaxKind.Decorator);
         node.expression = parenthesizerRules().parenthesizeLeftSideOfAccess(expression, /*optionalChain*/ false);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsTypeScript |
-            TransformFlags.ContainsTypeScriptClassSyntax |
-            TransformFlags.ContainsDecorators;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsTypeScript
+            | TransformFlags.ContainsTypeScriptClassSyntax
+            | TransformFlags.ContainsDecorators;
         return node;
     }
 
@@ -1772,12 +1772,12 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
 
         const isAmbient = node.flags & NodeFlags.Ambient || modifiersToFlags(node.modifiers) & ModifierFlags.Ambient;
 
-        node.transformFlags = propagateChildrenFlags(node.modifiers) |
-            propagateNameFlags(node.name) |
-            propagateChildFlags(node.initializer) |
-            (isAmbient || node.questionToken || node.exclamationToken || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-            (isComputedPropertyName(node.name) || modifiersToFlags(node.modifiers) & ModifierFlags.Static && node.initializer ? TransformFlags.ContainsTypeScriptClassSyntax : TransformFlags.None) |
-            TransformFlags.ContainsClassFields;
+        node.transformFlags = propagateChildrenFlags(node.modifiers)
+            | propagateNameFlags(node.name)
+            | propagateChildFlags(node.initializer)
+            | (isAmbient || node.questionToken || node.exclamationToken || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+            | (isComputedPropertyName(node.name) || modifiersToFlags(node.modifiers) & ModifierFlags.Static && node.initializer ? TransformFlags.ContainsTypeScriptClassSyntax : TransformFlags.None)
+            | TransformFlags.ContainsClassFields;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         return node;
@@ -1877,20 +1877,20 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             const isGenerator = !!node.asteriskToken;
             const isAsyncGenerator = isAsync && isGenerator;
 
-            node.transformFlags = propagateChildrenFlags(node.modifiers) |
-                propagateChildFlags(node.asteriskToken) |
-                propagateNameFlags(node.name) |
-                propagateChildFlags(node.questionToken) |
-                propagateChildrenFlags(node.typeParameters) |
-                propagateChildrenFlags(node.parameters) |
-                propagateChildFlags(node.type) |
-                (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-                (isAsyncGenerator ? TransformFlags.ContainsES2018 :
-                    isAsync ? TransformFlags.ContainsES2017 :
-                    isGenerator ? TransformFlags.ContainsGenerator :
-                    TransformFlags.None) |
-                (node.questionToken || node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-                TransformFlags.ContainsES2015;
+            node.transformFlags = propagateChildrenFlags(node.modifiers)
+                | propagateChildFlags(node.asteriskToken)
+                | propagateNameFlags(node.name)
+                | propagateChildFlags(node.questionToken)
+                | propagateChildrenFlags(node.typeParameters)
+                | propagateChildrenFlags(node.parameters)
+                | propagateChildFlags(node.type)
+                | (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait)
+                | (isAsyncGenerator ? TransformFlags.ContainsES2018
+                    : isAsync ? TransformFlags.ContainsES2017
+                    : isGenerator ? TransformFlags.ContainsGenerator
+                    : TransformFlags.None)
+                | (node.questionToken || node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+                | TransformFlags.ContainsES2015;
         }
 
         node.typeArguments = undefined; // used in quick info
@@ -1981,10 +1981,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.parameters = createNodeArray(parameters);
         node.body = body;
 
-        node.transformFlags = propagateChildrenFlags(node.modifiers) |
-            propagateChildrenFlags(node.parameters) |
-            (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags = propagateChildrenFlags(node.modifiers)
+            | propagateChildrenFlags(node.parameters)
+            | (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait)
+            | TransformFlags.ContainsES2015;
 
         node.typeParameters = undefined; // initialized by parser for grammar errors
         node.type = undefined; // initialized by parser for grammar errors
@@ -2038,12 +2038,12 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             node.transformFlags = TransformFlags.ContainsTypeScript;
         }
         else {
-            node.transformFlags = propagateChildrenFlags(node.modifiers) |
-                propagateNameFlags(node.name) |
-                propagateChildrenFlags(node.parameters) |
-                propagateChildFlags(node.type) |
-                (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-                (node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
+            node.transformFlags = propagateChildrenFlags(node.modifiers)
+                | propagateNameFlags(node.name)
+                | propagateChildrenFlags(node.parameters)
+                | propagateChildFlags(node.type)
+                | (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait)
+                | (node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
         }
 
         node.typeArguments = undefined; // used in quick info
@@ -2100,11 +2100,11 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             node.transformFlags = TransformFlags.ContainsTypeScript;
         }
         else {
-            node.transformFlags = propagateChildrenFlags(node.modifiers) |
-                propagateNameFlags(node.name) |
-                propagateChildrenFlags(node.parameters) |
-                (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-                (node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
+            node.transformFlags = propagateChildrenFlags(node.modifiers)
+                | propagateNameFlags(node.name)
+                | propagateChildrenFlags(node.parameters)
+                | (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait)
+                | (node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
         }
 
         node.typeArguments = undefined; // used in quick info
@@ -2349,9 +2349,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
 
     // @api
     function createConstructorTypeNode(...args: Parameters<typeof createConstructorTypeNode1 | typeof createConstructorTypeNode2>) {
-        return args.length === 4 ? createConstructorTypeNode1(...args) :
-            args.length === 3 ? createConstructorTypeNode2(...args) :
-            Debug.fail("Incorrect number of arguments specified.");
+        return args.length === 4 ? createConstructorTypeNode1(...args)
+            : args.length === 3 ? createConstructorTypeNode2(...args)
+            : Debug.fail("Incorrect number of arguments specified.");
     }
 
     function createConstructorTypeNode1(
@@ -2385,9 +2385,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
 
     // @api
     function updateConstructorTypeNode(...args: Parameters<typeof updateConstructorTypeNode1 | typeof updateConstructorTypeNode2>) {
-        return args.length === 5 ? updateConstructorTypeNode1(...args) :
-            args.length === 4 ? updateConstructorTypeNode2(...args) :
-            Debug.fail("Incorrect number of arguments specified.");
+        return args.length === 5 ? updateConstructorTypeNode1(...args)
+            : args.length === 4 ? updateConstructorTypeNode2(...args)
+            : Debug.fail("Incorrect number of arguments specified.");
     }
 
     function updateConstructorTypeNode1(
@@ -2684,9 +2684,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createTypeOperatorNode(operator: SyntaxKind.KeyOfKeyword | SyntaxKind.UniqueKeyword | SyntaxKind.ReadonlyKeyword, type: TypeNode): TypeOperatorNode {
         const node = createBaseNode<TypeOperatorNode>(SyntaxKind.TypeOperator);
         node.operator = operator;
-        node.type = operator === SyntaxKind.ReadonlyKeyword ?
-            parenthesizerRules().parenthesizeOperandOfReadonlyTypeOperator(type) :
-            parenthesizerRules().parenthesizeOperandOfTypeOperator(type);
+        node.type = operator === SyntaxKind.ReadonlyKeyword
+            ? parenthesizerRules().parenthesizeOperandOfReadonlyTypeOperator(type)
+            : parenthesizerRules().parenthesizeOperandOfTypeOperator(type);
         node.transformFlags = TransformFlags.ContainsTypeScript;
         return node;
     }
@@ -2766,12 +2766,12 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createObjectBindingPattern(elements: readonly BindingElement[]) {
         const node = createBaseNode<ObjectBindingPattern>(SyntaxKind.ObjectBindingPattern);
         node.elements = createNodeArray(elements);
-        node.transformFlags |= propagateChildrenFlags(node.elements) |
-            TransformFlags.ContainsES2015 |
-            TransformFlags.ContainsBindingPattern;
+        node.transformFlags |= propagateChildrenFlags(node.elements)
+            | TransformFlags.ContainsES2015
+            | TransformFlags.ContainsBindingPattern;
         if (node.transformFlags & TransformFlags.ContainsRestOrSpread) {
-            node.transformFlags |= TransformFlags.ContainsES2018 |
-                TransformFlags.ContainsObjectRestOrSpread;
+            node.transformFlags |= TransformFlags.ContainsES2018
+                | TransformFlags.ContainsObjectRestOrSpread;
         }
         return node;
     }
@@ -2787,9 +2787,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createArrayBindingPattern(elements: readonly ArrayBindingElement[]) {
         const node = createBaseNode<ArrayBindingPattern>(SyntaxKind.ArrayBindingPattern);
         node.elements = createNodeArray(elements);
-        node.transformFlags |= propagateChildrenFlags(node.elements) |
-            TransformFlags.ContainsES2015 |
-            TransformFlags.ContainsBindingPattern;
+        node.transformFlags |= propagateChildrenFlags(node.elements)
+            | TransformFlags.ContainsES2015
+            | TransformFlags.ContainsBindingPattern;
         return node;
     }
 
@@ -2807,12 +2807,12 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.propertyName = asName(propertyName);
         node.name = asName(name);
         node.initializer = asInitializer(initializer);
-        node.transformFlags |= propagateChildFlags(node.dotDotDotToken) |
-            propagateNameFlags(node.propertyName) |
-            propagateNameFlags(node.name) |
-            propagateChildFlags(node.initializer) |
-            (node.dotDotDotToken ? TransformFlags.ContainsRestOrSpread : TransformFlags.None) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateChildFlags(node.dotDotDotToken)
+            | propagateNameFlags(node.propertyName)
+            | propagateNameFlags(node.name)
+            | propagateChildFlags(node.initializer)
+            | (node.dotDotDotToken ? TransformFlags.ContainsRestOrSpread : TransformFlags.None)
+            | TransformFlags.ContainsES2015;
 
         node.flowNode = undefined; // initialized by binder (FlowContainer)
         return node;
@@ -2876,11 +2876,11 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.expression = expression;
         node.questionDotToken = questionDotToken;
         node.name = name;
-        node.transformFlags = propagateChildFlags(node.expression) |
-            propagateChildFlags(node.questionDotToken) |
-            (isIdentifier(node.name) ?
-                propagateIdentifierNameFlags(node.name) :
-                propagateChildFlags(node.name) | TransformFlags.ContainsPrivateIdentifierInExpression);
+        node.transformFlags = propagateChildFlags(node.expression)
+            | propagateChildFlags(node.questionDotToken)
+            | (isIdentifier(node.name)
+                ? propagateIdentifierNameFlags(node.name)
+                : propagateChildFlags(node.name) | TransformFlags.ContainsPrivateIdentifierInExpression);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -2897,8 +2897,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         if (isSuperKeyword(expression)) {
             // super method calls require a lexical 'this'
             // super method calls require 'super' hoisting in ES2017 and ES2018 async functions and async generators
-            node.transformFlags |= TransformFlags.ContainsES2017 |
-                TransformFlags.ContainsES2018;
+            node.transformFlags |= TransformFlags.ContainsES2017
+                | TransformFlags.ContainsES2018;
         }
         return node;
     }
@@ -2943,9 +2943,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.expression = expression;
         node.questionDotToken = questionDotToken;
         node.argumentExpression = argumentExpression;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.questionDotToken) |
-            propagateChildFlags(node.argumentExpression);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.questionDotToken)
+            | propagateChildFlags(node.argumentExpression);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -2962,8 +2962,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         if (isSuperKeyword(expression)) {
             // super method calls require a lexical 'this'
             // super method calls require 'super' hoisting in ES2017 and ES2018 async functions and async generators
-            node.transformFlags |= TransformFlags.ContainsES2017 |
-                TransformFlags.ContainsES2018;
+            node.transformFlags |= TransformFlags.ContainsES2017
+                | TransformFlags.ContainsES2018;
         }
         return node;
     }
@@ -3009,10 +3009,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.questionDotToken = questionDotToken;
         node.typeArguments = typeArguments;
         node.arguments = argumentsArray;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.questionDotToken) |
-            propagateChildrenFlags(node.typeArguments) |
-            propagateChildrenFlags(node.arguments);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.questionDotToken)
+            | propagateChildrenFlags(node.typeArguments)
+            | propagateChildrenFlags(node.arguments);
         if (node.typeArguments) {
             node.transformFlags |= TransformFlags.ContainsTypeScript;
         }
@@ -3078,10 +3078,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.expression = parenthesizerRules().parenthesizeExpressionOfNew(expression);
         node.typeArguments = asNodeArray(typeArguments);
         node.arguments = argumentsArray ? parenthesizerRules().parenthesizeExpressionsOfCommaDelimitedList(argumentsArray) : undefined;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildrenFlags(node.typeArguments) |
-            propagateChildrenFlags(node.arguments) |
-            TransformFlags.ContainsES2020;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildrenFlags(node.typeArguments)
+            | propagateChildrenFlags(node.arguments)
+            | TransformFlags.ContainsES2020;
         if (node.typeArguments) {
             node.transformFlags |= TransformFlags.ContainsTypeScript;
         }
@@ -3103,10 +3103,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.tag = parenthesizerRules().parenthesizeLeftSideOfAccess(tag, /*optionalChain*/ false);
         node.typeArguments = asNodeArray(typeArguments);
         node.template = template;
-        node.transformFlags |= propagateChildFlags(node.tag) |
-            propagateChildrenFlags(node.typeArguments) |
-            propagateChildFlags(node.template) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateChildFlags(node.tag)
+            | propagateChildrenFlags(node.typeArguments)
+            | propagateChildFlags(node.template)
+            | TransformFlags.ContainsES2015;
         if (node.typeArguments) {
             node.transformFlags |= TransformFlags.ContainsTypeScript;
         }
@@ -3130,9 +3130,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<TypeAssertion>(SyntaxKind.TypeAssertionExpression);
         node.expression = parenthesizerRules().parenthesizeOperandOfPrefixUnary(expression);
         node.type = type;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.type) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.type)
+            | TransformFlags.ContainsTypeScript;
         return node;
     }
 
@@ -3184,19 +3184,19 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const isGenerator = !!node.asteriskToken;
         const isAsyncGenerator = isAsync && isGenerator;
 
-        node.transformFlags = propagateChildrenFlags(node.modifiers) |
-            propagateChildFlags(node.asteriskToken) |
-            propagateNameFlags(node.name) |
-            propagateChildrenFlags(node.typeParameters) |
-            propagateChildrenFlags(node.parameters) |
-            propagateChildFlags(node.type) |
-            (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-            (isAsyncGenerator ? TransformFlags.ContainsES2018 :
-                isAsync ? TransformFlags.ContainsES2017 :
-                isGenerator ? TransformFlags.ContainsGenerator :
-                TransformFlags.None) |
-            (node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-            TransformFlags.ContainsHoistedDeclarationOrCompletion;
+        node.transformFlags = propagateChildrenFlags(node.modifiers)
+            | propagateChildFlags(node.asteriskToken)
+            | propagateNameFlags(node.name)
+            | propagateChildrenFlags(node.typeParameters)
+            | propagateChildrenFlags(node.parameters)
+            | propagateChildFlags(node.type)
+            | (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait)
+            | (isAsyncGenerator ? TransformFlags.ContainsES2018
+                : isAsync ? TransformFlags.ContainsES2017
+                : isGenerator ? TransformFlags.ContainsGenerator
+                : TransformFlags.None)
+            | (node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+            | TransformFlags.ContainsHoistedDeclarationOrCompletion;
 
         node.typeArguments = undefined; // used in quick info
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -3249,15 +3249,15 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
 
         const isAsync = modifiersToFlags(node.modifiers) & ModifierFlags.Async;
 
-        node.transformFlags = propagateChildrenFlags(node.modifiers) |
-            propagateChildrenFlags(node.typeParameters) |
-            propagateChildrenFlags(node.parameters) |
-            propagateChildFlags(node.type) |
-            propagateChildFlags(node.equalsGreaterThanToken) |
-            (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-            (node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-            (isAsync ? TransformFlags.ContainsES2017 | TransformFlags.ContainsLexicalThis : TransformFlags.None) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags = propagateChildrenFlags(node.modifiers)
+            | propagateChildrenFlags(node.typeParameters)
+            | propagateChildrenFlags(node.parameters)
+            | propagateChildFlags(node.type)
+            | propagateChildFlags(node.equalsGreaterThanToken)
+            | (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait)
+            | (node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+            | (isAsync ? TransformFlags.ContainsES2017 | TransformFlags.ContainsLexicalThis : TransformFlags.None)
+            | TransformFlags.ContainsES2015;
 
         node.typeArguments = undefined; // used in quick info
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -3338,10 +3338,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createAwaitExpression(expression: Expression) {
         const node = createBaseNode<AwaitExpression>(SyntaxKind.AwaitExpression);
         node.expression = parenthesizerRules().parenthesizeOperandOfPrefixUnary(expression);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsES2017 |
-            TransformFlags.ContainsES2018 |
-            TransformFlags.ContainsAwait;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsES2017
+            | TransformFlags.ContainsES2018
+            | TransformFlags.ContainsAwait;
         return node;
     }
 
@@ -3361,10 +3361,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         // Only set this flag for non-generated identifiers and non-"local" names. See the
         // comment in `visitPreOrPostfixUnaryExpression` in module.ts
         if (
-            (operator === SyntaxKind.PlusPlusToken || operator === SyntaxKind.MinusMinusToken) &&
-            isIdentifier(node.operand) &&
-            !isGeneratedIdentifier(node.operand) &&
-            !isLocalName(node.operand)
+            (operator === SyntaxKind.PlusPlusToken || operator === SyntaxKind.MinusMinusToken)
+            && isIdentifier(node.operand)
+            && !isGeneratedIdentifier(node.operand)
+            && !isLocalName(node.operand)
         ) {
             node.transformFlags |= TransformFlags.ContainsUpdateExpressionForIdentifier;
         }
@@ -3387,9 +3387,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         // Only set this flag for non-generated identifiers and non-"local" names. See the
         // comment in `visitPreOrPostfixUnaryExpression` in module.ts
         if (
-            isIdentifier(node.operand) &&
-            !isGeneratedIdentifier(node.operand) &&
-            !isLocalName(node.operand)
+            isIdentifier(node.operand)
+            && !isGeneratedIdentifier(node.operand)
+            && !isLocalName(node.operand)
         ) {
             node.transformFlags |= TransformFlags.ContainsUpdateExpressionForIdentifier;
         }
@@ -3411,23 +3411,23 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.left = parenthesizerRules().parenthesizeLeftSideOfBinary(operatorKind, left);
         node.operatorToken = operatorToken;
         node.right = parenthesizerRules().parenthesizeRightSideOfBinary(operatorKind, node.left, right);
-        node.transformFlags |= propagateChildFlags(node.left) |
-            propagateChildFlags(node.operatorToken) |
-            propagateChildFlags(node.right);
+        node.transformFlags |= propagateChildFlags(node.left)
+            | propagateChildFlags(node.operatorToken)
+            | propagateChildFlags(node.right);
         if (operatorKind === SyntaxKind.QuestionQuestionToken) {
             node.transformFlags |= TransformFlags.ContainsES2020;
         }
         else if (operatorKind === SyntaxKind.EqualsToken) {
             if (isObjectLiteralExpression(node.left)) {
-                node.transformFlags |= TransformFlags.ContainsES2015 |
-                    TransformFlags.ContainsES2018 |
-                    TransformFlags.ContainsDestructuringAssignment |
-                    propagateAssignmentPatternFlags(node.left);
+                node.transformFlags |= TransformFlags.ContainsES2015
+                    | TransformFlags.ContainsES2018
+                    | TransformFlags.ContainsDestructuringAssignment
+                    | propagateAssignmentPatternFlags(node.left);
             }
             else if (isArrayLiteralExpression(node.left)) {
-                node.transformFlags |= TransformFlags.ContainsES2015 |
-                    TransformFlags.ContainsDestructuringAssignment |
-                    propagateAssignmentPatternFlags(node.left);
+                node.transformFlags |= TransformFlags.ContainsES2015
+                    | TransformFlags.ContainsDestructuringAssignment
+                    | propagateAssignmentPatternFlags(node.left);
             }
         }
         else if (operatorKind === SyntaxKind.AsteriskAsteriskToken || operatorKind === SyntaxKind.AsteriskAsteriskEqualsToken) {
@@ -3465,11 +3465,11 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.whenTrue = parenthesizerRules().parenthesizeBranchOfConditionalExpression(whenTrue);
         node.colonToken = colonToken ?? createToken(SyntaxKind.ColonToken);
         node.whenFalse = parenthesizerRules().parenthesizeBranchOfConditionalExpression(whenFalse);
-        node.transformFlags |= propagateChildFlags(node.condition) |
-            propagateChildFlags(node.questionToken) |
-            propagateChildFlags(node.whenTrue) |
-            propagateChildFlags(node.colonToken) |
-            propagateChildFlags(node.whenFalse);
+        node.transformFlags |= propagateChildFlags(node.condition)
+            | propagateChildFlags(node.questionToken)
+            | propagateChildFlags(node.whenTrue)
+            | propagateChildFlags(node.colonToken)
+            | propagateChildFlags(node.whenFalse);
         return node;
     }
 
@@ -3496,9 +3496,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<TemplateExpression>(SyntaxKind.TemplateExpression);
         node.head = head;
         node.templateSpans = createNodeArray(templateSpans);
-        node.transformFlags |= propagateChildFlags(node.head) |
-            propagateChildrenFlags(node.templateSpans) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateChildFlags(node.head)
+            | propagateChildrenFlags(node.templateSpans)
+            | TransformFlags.ContainsES2015;
         return node;
     }
 
@@ -3600,11 +3600,11 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<YieldExpression>(SyntaxKind.YieldExpression);
         node.expression = expression && parenthesizerRules().parenthesizeExpressionForDisallowedComma(expression);
         node.asteriskToken = asteriskToken;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.asteriskToken) |
-            TransformFlags.ContainsES2015 |
-            TransformFlags.ContainsES2018 |
-            TransformFlags.ContainsYield;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.asteriskToken)
+            | TransformFlags.ContainsES2015
+            | TransformFlags.ContainsES2018
+            | TransformFlags.ContainsYield;
         return node;
     }
 
@@ -3620,9 +3620,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createSpreadElement(expression: Expression) {
         const node = createBaseNode<SpreadElement>(SyntaxKind.SpreadElement);
         node.expression = parenthesizerRules().parenthesizeExpressionForDisallowedComma(expression);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsES2015 |
-            TransformFlags.ContainsRestOrSpread;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsES2015
+            | TransformFlags.ContainsRestOrSpread;
         return node;
     }
 
@@ -3647,13 +3647,13 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.typeParameters = asNodeArray(typeParameters);
         node.heritageClauses = asNodeArray(heritageClauses);
         node.members = createNodeArray(members);
-        node.transformFlags |= propagateChildrenFlags(node.modifiers) |
-            propagateNameFlags(node.name) |
-            propagateChildrenFlags(node.typeParameters) |
-            propagateChildrenFlags(node.heritageClauses) |
-            propagateChildrenFlags(node.members) |
-            (node.typeParameters ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateChildrenFlags(node.modifiers)
+            | propagateNameFlags(node.name)
+            | propagateChildrenFlags(node.typeParameters)
+            | propagateChildrenFlags(node.heritageClauses)
+            | propagateChildrenFlags(node.members)
+            | (node.typeParameters ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+            | TransformFlags.ContainsES2015;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         return node;
@@ -3687,9 +3687,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<ExpressionWithTypeArguments>(SyntaxKind.ExpressionWithTypeArguments);
         node.expression = parenthesizerRules().parenthesizeLeftSideOfAccess(expression, /*optionalChain*/ false);
         node.typeArguments = typeArguments && parenthesizerRules().parenthesizeTypeArguments(typeArguments);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildrenFlags(node.typeArguments) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildrenFlags(node.typeArguments)
+            | TransformFlags.ContainsES2015;
         return node;
     }
 
@@ -3706,9 +3706,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<AsExpression>(SyntaxKind.AsExpression);
         node.expression = expression;
         node.type = type;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.type) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.type)
+            | TransformFlags.ContainsTypeScript;
         return node;
     }
 
@@ -3724,8 +3724,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createNonNullExpression(expression: Expression) {
         const node = createBaseNode<NonNullExpression>(SyntaxKind.NonNullExpression);
         node.expression = parenthesizerRules().parenthesizeLeftSideOfAccess(expression, /*optionalChain*/ false);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsTypeScript;
         return node;
     }
 
@@ -3744,9 +3744,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<SatisfiesExpression>(SyntaxKind.SatisfiesExpression);
         node.expression = expression;
         node.type = type;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.type) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.type)
+            | TransformFlags.ContainsTypeScript;
         return node;
     }
 
@@ -3763,8 +3763,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<NonNullChain>(SyntaxKind.NonNullExpression);
         node.flags |= NodeFlags.OptionalChain;
         node.expression = parenthesizerRules().parenthesizeLeftSideOfAccess(expression, /*optionalChain*/ true);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsTypeScript;
         return node;
     }
 
@@ -3813,9 +3813,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<TemplateSpan>(SyntaxKind.TemplateSpan);
         node.expression = expression;
         node.literal = literal;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.literal) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.literal)
+            | TransformFlags.ContainsES2015;
         return node;
     }
 
@@ -3863,8 +3863,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<VariableStatement>(SyntaxKind.VariableStatement);
         node.modifiers = asNodeArray(modifiers);
         node.declarationList = isArray(declarationList) ? createVariableDeclarationList(declarationList) : declarationList;
-        node.transformFlags |= propagateChildrenFlags(node.modifiers) |
-            propagateChildFlags(node.declarationList);
+        node.transformFlags |= propagateChildrenFlags(node.modifiers)
+            | propagateChildFlags(node.declarationList);
         if (modifiersToFlags(node.modifiers) & ModifierFlags.Ambient) {
             node.transformFlags = TransformFlags.ContainsTypeScript;
         }
@@ -3913,9 +3913,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.expression = expression;
         node.thenStatement = asEmbeddedStatement(thenStatement);
         node.elseStatement = asEmbeddedStatement(elseStatement);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.thenStatement) |
-            propagateChildFlags(node.elseStatement);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.thenStatement)
+            | propagateChildFlags(node.elseStatement);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -3936,8 +3936,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<DoStatement>(SyntaxKind.DoStatement);
         node.statement = asEmbeddedStatement(statement);
         node.expression = expression;
-        node.transformFlags |= propagateChildFlags(node.statement) |
-            propagateChildFlags(node.expression);
+        node.transformFlags |= propagateChildFlags(node.statement)
+            | propagateChildFlags(node.expression);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -3957,8 +3957,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<WhileStatement>(SyntaxKind.WhileStatement);
         node.expression = expression;
         node.statement = asEmbeddedStatement(statement);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.statement);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.statement);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -3980,10 +3980,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.condition = condition;
         node.incrementor = incrementor;
         node.statement = asEmbeddedStatement(statement);
-        node.transformFlags |= propagateChildFlags(node.initializer) |
-            propagateChildFlags(node.condition) |
-            propagateChildFlags(node.incrementor) |
-            propagateChildFlags(node.statement);
+        node.transformFlags |= propagateChildFlags(node.initializer)
+            | propagateChildFlags(node.condition)
+            | propagateChildFlags(node.incrementor)
+            | propagateChildFlags(node.statement);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.locals = undefined; // initialized by binder (LocalsContainer)
@@ -4008,9 +4008,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.initializer = initializer;
         node.expression = expression;
         node.statement = asEmbeddedStatement(statement);
-        node.transformFlags |= propagateChildFlags(node.initializer) |
-            propagateChildFlags(node.expression) |
-            propagateChildFlags(node.statement);
+        node.transformFlags |= propagateChildFlags(node.initializer)
+            | propagateChildFlags(node.expression)
+            | propagateChildFlags(node.statement);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.locals = undefined; // initialized by binder (LocalsContainer)
@@ -4035,11 +4035,11 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.initializer = initializer;
         node.expression = parenthesizerRules().parenthesizeExpressionForDisallowedComma(expression);
         node.statement = asEmbeddedStatement(statement);
-        node.transformFlags |= propagateChildFlags(node.awaitModifier) |
-            propagateChildFlags(node.initializer) |
-            propagateChildFlags(node.expression) |
-            propagateChildFlags(node.statement) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateChildFlags(node.awaitModifier)
+            | propagateChildFlags(node.initializer)
+            | propagateChildFlags(node.expression)
+            | propagateChildFlags(node.statement)
+            | TransformFlags.ContainsES2015;
         if (awaitModifier) node.transformFlags |= TransformFlags.ContainsES2018;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -4063,8 +4063,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createContinueStatement(label?: string | Identifier): ContinueStatement {
         const node = createBaseNode<ContinueStatement>(SyntaxKind.ContinueStatement);
         node.label = asName(label);
-        node.transformFlags |= propagateChildFlags(node.label) |
-            TransformFlags.ContainsHoistedDeclarationOrCompletion;
+        node.transformFlags |= propagateChildFlags(node.label)
+            | TransformFlags.ContainsHoistedDeclarationOrCompletion;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -4082,8 +4082,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createBreakStatement(label?: string | Identifier): BreakStatement {
         const node = createBaseNode<BreakStatement>(SyntaxKind.BreakStatement);
         node.label = asName(label);
-        node.transformFlags |= propagateChildFlags(node.label) |
-            TransformFlags.ContainsHoistedDeclarationOrCompletion;
+        node.transformFlags |= propagateChildFlags(node.label)
+            | TransformFlags.ContainsHoistedDeclarationOrCompletion;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -4102,9 +4102,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<ReturnStatement>(SyntaxKind.ReturnStatement);
         node.expression = expression;
         // return in an ES2018 async generator must be awaited
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsES2018 |
-            TransformFlags.ContainsHoistedDeclarationOrCompletion;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsES2018
+            | TransformFlags.ContainsHoistedDeclarationOrCompletion;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -4123,8 +4123,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<WithStatement>(SyntaxKind.WithStatement);
         node.expression = expression;
         node.statement = asEmbeddedStatement(statement);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.statement);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.statement);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -4144,8 +4144,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<SwitchStatement>(SyntaxKind.SwitchStatement);
         node.expression = parenthesizerRules().parenthesizeExpressionForDisallowedComma(expression);
         node.caseBlock = caseBlock;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.caseBlock);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.caseBlock);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -4166,8 +4166,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<LabeledStatement>(SyntaxKind.LabeledStatement);
         node.label = asName(label);
         node.statement = asEmbeddedStatement(statement);
-        node.transformFlags |= propagateChildFlags(node.label) |
-            propagateChildFlags(node.statement);
+        node.transformFlags |= propagateChildFlags(node.label)
+            | propagateChildFlags(node.statement);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -4206,9 +4206,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.tryBlock = tryBlock;
         node.catchClause = catchClause;
         node.finallyBlock = finallyBlock;
-        node.transformFlags |= propagateChildFlags(node.tryBlock) |
-            propagateChildFlags(node.catchClause) |
-            propagateChildFlags(node.finallyBlock);
+        node.transformFlags |= propagateChildFlags(node.tryBlock)
+            | propagateChildFlags(node.catchClause)
+            | propagateChildFlags(node.finallyBlock);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.flowNode = undefined; // initialized by binder (FlowContainer)
@@ -4240,9 +4240,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.exclamationToken = exclamationToken;
         node.type = type;
         node.initializer = asInitializer(initializer);
-        node.transformFlags |= propagateNameFlags(node.name) |
-            propagateChildFlags(node.initializer) |
-            (node.exclamationToken ?? node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
+        node.transformFlags |= propagateNameFlags(node.name)
+            | propagateChildFlags(node.initializer)
+            | (node.exclamationToken ?? node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         return node;
@@ -4263,11 +4263,11 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<VariableDeclarationList>(SyntaxKind.VariableDeclarationList);
         node.flags |= flags & NodeFlags.BlockScoped;
         node.declarations = createNodeArray(declarations);
-        node.transformFlags |= propagateChildrenFlags(node.declarations) |
-            TransformFlags.ContainsHoistedDeclarationOrCompletion;
+        node.transformFlags |= propagateChildrenFlags(node.declarations)
+            | TransformFlags.ContainsHoistedDeclarationOrCompletion;
         if (flags & NodeFlags.BlockScoped) {
-            node.transformFlags |= TransformFlags.ContainsES2015 |
-                TransformFlags.ContainsBlockScopedBinding;
+            node.transformFlags |= TransformFlags.ContainsES2015
+                | TransformFlags.ContainsBlockScopedBinding;
         }
         if (flags & NodeFlags.Using) {
             node.transformFlags |= TransformFlags.ContainsESNext;
@@ -4309,19 +4309,19 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             const isGenerator = !!node.asteriskToken;
             const isAsyncGenerator = isAsync && isGenerator;
 
-            node.transformFlags = propagateChildrenFlags(node.modifiers) |
-                propagateChildFlags(node.asteriskToken) |
-                propagateNameFlags(node.name) |
-                propagateChildrenFlags(node.typeParameters) |
-                propagateChildrenFlags(node.parameters) |
-                propagateChildFlags(node.type) |
-                (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait) |
-                (isAsyncGenerator ? TransformFlags.ContainsES2018 :
-                    isAsync ? TransformFlags.ContainsES2017 :
-                    isGenerator ? TransformFlags.ContainsGenerator :
-                    TransformFlags.None) |
-                (node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-                TransformFlags.ContainsHoistedDeclarationOrCompletion;
+            node.transformFlags = propagateChildrenFlags(node.modifiers)
+                | propagateChildFlags(node.asteriskToken)
+                | propagateNameFlags(node.name)
+                | propagateChildrenFlags(node.typeParameters)
+                | propagateChildrenFlags(node.parameters)
+                | propagateChildFlags(node.type)
+                | (propagateChildFlags(node.body) & ~TransformFlags.ContainsPossibleTopLevelAwait)
+                | (isAsyncGenerator ? TransformFlags.ContainsES2018
+                    : isAsync ? TransformFlags.ContainsES2017
+                    : isGenerator ? TransformFlags.ContainsGenerator
+                    : TransformFlags.None)
+                | (node.typeParameters || node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+                | TransformFlags.ContainsHoistedDeclarationOrCompletion;
         }
 
         node.typeArguments = undefined; // used in quick info
@@ -4384,13 +4384,13 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             node.transformFlags = TransformFlags.ContainsTypeScript;
         }
         else {
-            node.transformFlags |= propagateChildrenFlags(node.modifiers) |
-                propagateNameFlags(node.name) |
-                propagateChildrenFlags(node.typeParameters) |
-                propagateChildrenFlags(node.heritageClauses) |
-                propagateChildrenFlags(node.members) |
-                (node.typeParameters ? TransformFlags.ContainsTypeScript : TransformFlags.None) |
-                TransformFlags.ContainsES2015;
+            node.transformFlags |= propagateChildrenFlags(node.modifiers)
+                | propagateNameFlags(node.name)
+                | propagateChildrenFlags(node.typeParameters)
+                | propagateChildrenFlags(node.heritageClauses)
+                | propagateChildrenFlags(node.members)
+                | (node.typeParameters ? TransformFlags.ContainsTypeScript : TransformFlags.None)
+                | TransformFlags.ContainsES2015;
             if (node.transformFlags & TransformFlags.ContainsTypeScriptClassSyntax) {
                 node.transformFlags |= TransformFlags.ContainsTypeScript;
             }
@@ -4502,10 +4502,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.modifiers = asNodeArray(modifiers);
         node.name = asName(name);
         node.members = createNodeArray(members);
-        node.transformFlags |= propagateChildrenFlags(node.modifiers) |
-            propagateChildFlags(node.name) |
-            propagateChildrenFlags(node.members) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildrenFlags(node.modifiers)
+            | propagateChildFlags(node.name)
+            | propagateChildrenFlags(node.members)
+            | TransformFlags.ContainsTypeScript;
         node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Enum declarations cannot contain `await`
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -4542,10 +4542,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             node.transformFlags = TransformFlags.ContainsTypeScript;
         }
         else {
-            node.transformFlags |= propagateChildrenFlags(node.modifiers) |
-                propagateChildFlags(node.name) |
-                propagateChildFlags(node.body) |
-                TransformFlags.ContainsTypeScript;
+            node.transformFlags |= propagateChildrenFlags(node.modifiers)
+                | propagateChildFlags(node.name)
+                | propagateChildFlags(node.body)
+                | TransformFlags.ContainsTypeScript;
         }
         node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // Module declarations cannot contain `await`.
 
@@ -4608,8 +4608,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createNamespaceExportDeclaration(name: string | Identifier) {
         const node = createBaseDeclaration<NamespaceExportDeclaration>(SyntaxKind.NamespaceExportDeclaration);
         node.name = asName(name);
-        node.transformFlags |= propagateIdentifierNameFlags(node.name) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateIdentifierNameFlags(node.name)
+            | TransformFlags.ContainsTypeScript;
 
         node.modifiers = undefined; // initialized by parser to report grammar errors
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -4643,9 +4643,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.name = asName(name);
         node.isTypeOnly = isTypeOnly;
         node.moduleReference = moduleReference;
-        node.transformFlags |= propagateChildrenFlags(node.modifiers) |
-            propagateIdentifierNameFlags(node.name) |
-            propagateChildFlags(node.moduleReference);
+        node.transformFlags |= propagateChildrenFlags(node.modifiers)
+            | propagateIdentifierNameFlags(node.name)
+            | propagateChildFlags(node.moduleReference);
 
         if (!isExternalModuleReference(node.moduleReference)) {
             node.transformFlags |= TransformFlags.ContainsTypeScript;
@@ -4685,8 +4685,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.importClause = importClause;
         node.moduleSpecifier = moduleSpecifier;
         node.attributes = node.assertClause = attributes;
-        node.transformFlags |= propagateChildFlags(node.importClause) |
-            propagateChildFlags(node.moduleSpecifier);
+        node.transformFlags |= propagateChildFlags(node.importClause)
+            | propagateChildFlags(node.moduleSpecifier);
         node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -4715,8 +4715,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.isTypeOnly = isTypeOnly;
         node.name = name;
         node.namedBindings = namedBindings;
-        node.transformFlags |= propagateChildFlags(node.name) |
-            propagateChildFlags(node.namedBindings);
+        node.transformFlags |= propagateChildFlags(node.name)
+            | propagateChildFlags(node.namedBindings);
         if (isTypeOnly) {
             node.transformFlags |= TransformFlags.ContainsTypeScript;
         }
@@ -4841,8 +4841,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createNamespaceExport(name: Identifier): NamespaceExport {
         const node = createBaseDeclaration<NamespaceExport>(SyntaxKind.NamespaceExport);
         node.name = name;
-        node.transformFlags |= propagateChildFlags(node.name) |
-            TransformFlags.ContainsES2020;
+        node.transformFlags |= propagateChildFlags(node.name)
+            | TransformFlags.ContainsES2020;
         node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
         return node;
     }
@@ -4876,8 +4876,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.isTypeOnly = isTypeOnly;
         node.propertyName = propertyName;
         node.name = name;
-        node.transformFlags |= propagateChildFlags(node.propertyName) |
-            propagateChildFlags(node.name);
+        node.transformFlags |= propagateChildFlags(node.propertyName)
+            | propagateChildFlags(node.name);
         node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
         return node;
     }
@@ -4936,9 +4936,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.exportClause = exportClause;
         node.moduleSpecifier = moduleSpecifier;
         node.attributes = node.assertClause = attributes;
-        node.transformFlags |= propagateChildrenFlags(node.modifiers) |
-            propagateChildFlags(node.exportClause) |
-            propagateChildFlags(node.moduleSpecifier);
+        node.transformFlags |= propagateChildrenFlags(node.modifiers)
+            | propagateChildFlags(node.exportClause)
+            | propagateChildFlags(node.moduleSpecifier);
         node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -4995,8 +4995,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.isTypeOnly = isTypeOnly;
         node.propertyName = asName(propertyName);
         node.name = asName(name);
-        node.transformFlags |= propagateChildFlags(node.propertyName) |
-            propagateChildFlags(node.name);
+        node.transformFlags |= propagateChildFlags(node.propertyName)
+            | propagateChildFlags(node.name);
         node.transformFlags &= ~TransformFlags.ContainsPossibleTopLevelAwait; // always parsed in an Await context
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
@@ -5097,8 +5097,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseDeclaration<JSDocFunctionType>(SyntaxKind.JSDocFunctionType);
         node.parameters = asNodeArray(parameters);
         node.type = type;
-        node.transformFlags = propagateChildrenFlags(node.parameters) |
-            (node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
+        node.transformFlags = propagateChildrenFlags(node.parameters)
+            | (node.type ? TransformFlags.ContainsTypeScript : TransformFlags.None);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         node.locals = undefined; // initialized by binder (LocalsContainer)
@@ -5369,8 +5369,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<JSDocMemberName>(SyntaxKind.JSDocMemberName);
         node.left = left;
         node.right = right;
-        node.transformFlags |= propagateChildFlags(node.left) |
-            propagateChildFlags(node.right);
+        node.transformFlags |= propagateChildFlags(node.left)
+            | propagateChildFlags(node.right);
         return node;
     }
 
@@ -5460,8 +5460,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function updateJSDocSimpleTagWorker<T extends JSDocTag>(kind: T["kind"], node: T, tagName: Identifier = getDefaultTagName(node), comment: string | NodeArray<JSDocComment> | undefined) {
         return node.tagName !== tagName
                 || node.comment !== comment
-            ? update(createJSDocSimpleTagWorker(kind, tagName, comment), node) :
-            node;
+            ? update(createJSDocSimpleTagWorker(kind, tagName, comment), node)
+            : node;
     }
 
     // @api
@@ -5563,10 +5563,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.openingElement = openingElement;
         node.children = createNodeArray(children);
         node.closingElement = closingElement;
-        node.transformFlags |= propagateChildFlags(node.openingElement) |
-            propagateChildrenFlags(node.children) |
-            propagateChildFlags(node.closingElement) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.openingElement)
+            | propagateChildrenFlags(node.children)
+            | propagateChildFlags(node.closingElement)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5585,10 +5585,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.tagName = tagName;
         node.typeArguments = asNodeArray(typeArguments);
         node.attributes = attributes;
-        node.transformFlags |= propagateChildFlags(node.tagName) |
-            propagateChildrenFlags(node.typeArguments) |
-            propagateChildFlags(node.attributes) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.tagName)
+            | propagateChildrenFlags(node.typeArguments)
+            | propagateChildFlags(node.attributes)
+            | TransformFlags.ContainsJsx;
         if (node.typeArguments) {
             node.transformFlags |= TransformFlags.ContainsTypeScript;
         }
@@ -5610,10 +5610,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.tagName = tagName;
         node.typeArguments = asNodeArray(typeArguments);
         node.attributes = attributes;
-        node.transformFlags |= propagateChildFlags(node.tagName) |
-            propagateChildrenFlags(node.typeArguments) |
-            propagateChildFlags(node.attributes) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.tagName)
+            | propagateChildrenFlags(node.typeArguments)
+            | propagateChildFlags(node.attributes)
+            | TransformFlags.ContainsJsx;
         if (typeArguments) {
             node.transformFlags |= TransformFlags.ContainsTypeScript;
         }
@@ -5633,8 +5633,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createJsxClosingElement(tagName: JsxTagNameExpression) {
         const node = createBaseNode<JsxClosingElement>(SyntaxKind.JsxClosingElement);
         node.tagName = tagName;
-        node.transformFlags |= propagateChildFlags(node.tagName) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.tagName)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5651,10 +5651,10 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.openingFragment = openingFragment;
         node.children = createNodeArray(children);
         node.closingFragment = closingFragment;
-        node.transformFlags |= propagateChildFlags(node.openingFragment) |
-            propagateChildrenFlags(node.children) |
-            propagateChildFlags(node.closingFragment) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.openingFragment)
+            | propagateChildrenFlags(node.children)
+            | propagateChildFlags(node.closingFragment)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5703,9 +5703,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseDeclaration<JsxAttribute>(SyntaxKind.JsxAttribute);
         node.name = name;
         node.initializer = initializer;
-        node.transformFlags |= propagateChildFlags(node.name) |
-            propagateChildFlags(node.initializer) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.name)
+            | propagateChildFlags(node.initializer)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5721,8 +5721,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createJsxAttributes(properties: readonly JsxAttributeLike[]) {
         const node = createBaseDeclaration<JsxAttributes>(SyntaxKind.JsxAttributes);
         node.properties = createNodeArray(properties);
-        node.transformFlags |= propagateChildrenFlags(node.properties) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildrenFlags(node.properties)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5737,8 +5737,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createJsxSpreadAttribute(expression: Expression) {
         const node = createBaseNode<JsxSpreadAttribute>(SyntaxKind.JsxSpreadAttribute);
         node.expression = expression;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5754,9 +5754,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<JsxExpression>(SyntaxKind.JsxExpression);
         node.dotDotDotToken = dotDotDotToken;
         node.expression = expression;
-        node.transformFlags |= propagateChildFlags(node.dotDotDotToken) |
-            propagateChildFlags(node.expression) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.dotDotDotToken)
+            | propagateChildFlags(node.expression)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5772,9 +5772,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<JsxNamespacedName>(SyntaxKind.JsxNamespacedName);
         node.namespace = namespace;
         node.name = name;
-        node.transformFlags |= propagateChildFlags(node.namespace) |
-            propagateChildFlags(node.name) |
-            TransformFlags.ContainsJsx;
+        node.transformFlags |= propagateChildFlags(node.namespace)
+            | propagateChildFlags(node.name)
+            | TransformFlags.ContainsJsx;
         return node;
     }
 
@@ -5795,8 +5795,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<CaseClause>(SyntaxKind.CaseClause);
         node.expression = parenthesizerRules().parenthesizeExpressionForDisallowedComma(expression);
         node.statements = createNodeArray(statements);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildrenFlags(node.statements);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildrenFlags(node.statements);
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         return node;
@@ -5857,9 +5857,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.variableDeclaration = asVariableDeclaration(variableDeclaration);
         node.block = block;
 
-        node.transformFlags |= propagateChildFlags(node.variableDeclaration) |
-            propagateChildFlags(node.block) |
-            (!variableDeclaration ? TransformFlags.ContainsES2019 : TransformFlags.None);
+        node.transformFlags |= propagateChildFlags(node.variableDeclaration)
+            | propagateChildFlags(node.block)
+            | (!variableDeclaration ? TransformFlags.ContainsES2019 : TransformFlags.None);
 
         node.locals = undefined; // initialized by binder (LocalsContainer)
         node.nextContainer = undefined; // initialized by binder (LocalsContainer)
@@ -5883,8 +5883,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseDeclaration<PropertyAssignment>(SyntaxKind.PropertyAssignment);
         node.name = asName(name);
         node.initializer = parenthesizerRules().parenthesizeExpressionForDisallowedComma(initializer);
-        node.transformFlags |= propagateNameFlags(node.name) |
-            propagateChildFlags(node.initializer);
+        node.transformFlags |= propagateNameFlags(node.name)
+            | propagateChildFlags(node.initializer);
 
         node.modifiers = undefined; // initialized by parser to report grammar errors
         node.questionToken = undefined; // initialized by parser to report grammar errors
@@ -5917,9 +5917,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseDeclaration<ShorthandPropertyAssignment>(SyntaxKind.ShorthandPropertyAssignment);
         node.name = asName(name);
         node.objectAssignmentInitializer = objectAssignmentInitializer && parenthesizerRules().parenthesizeExpressionForDisallowedComma(objectAssignmentInitializer);
-        node.transformFlags |= propagateIdentifierNameFlags(node.name) |
-            propagateChildFlags(node.objectAssignmentInitializer) |
-            TransformFlags.ContainsES2015;
+        node.transformFlags |= propagateIdentifierNameFlags(node.name)
+            | propagateChildFlags(node.objectAssignmentInitializer)
+            | TransformFlags.ContainsES2015;
 
         node.equalsToken = undefined; // initialized by parser to report grammar errors
         node.modifiers = undefined; // initialized by parser to report grammar errors
@@ -5952,9 +5952,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     function createSpreadAssignment(expression: Expression) {
         const node = createBaseDeclaration<SpreadAssignment>(SyntaxKind.SpreadAssignment);
         node.expression = parenthesizerRules().parenthesizeExpressionForDisallowedComma(expression);
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsES2018 |
-            TransformFlags.ContainsObjectRestOrSpread;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsES2018
+            | TransformFlags.ContainsObjectRestOrSpread;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         return node;
@@ -5976,9 +5976,9 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseDeclaration<EnumMember>(SyntaxKind.EnumMember);
         node.name = asName(name);
         node.initializer = initializer && parenthesizerRules().parenthesizeExpressionForDisallowedComma(initializer);
-        node.transformFlags |= propagateChildFlags(node.name) |
-            propagateChildFlags(node.initializer) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildFlags(node.name)
+            | propagateChildFlags(node.initializer)
+            | TransformFlags.ContainsTypeScript;
 
         node.jsDoc = undefined; // initialized by parser (JsDocContainer)
         return node;
@@ -6017,8 +6017,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.isDeclarationFile = false;
         node.hasNoDefaultLib = false;
 
-        node.transformFlags |= propagateChildrenFlags(node.statements) |
-            propagateChildFlags(node.endOfFileToken);
+        node.transformFlags |= propagateChildrenFlags(node.statements)
+            | propagateChildFlags(node.endOfFileToken);
 
         node.locals = undefined; // initialized by binder (LocalsContainer)
         node.nextContainer = undefined; // initialized by binder (LocalsContainer)
@@ -6128,8 +6128,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.typeReferenceDirectives = typeReferences;
         node.hasNoDefaultLib = hasNoDefaultLib;
         node.libReferenceDirectives = libReferences;
-        node.transformFlags = propagateChildrenFlags(node.statements) |
-            propagateChildFlags(node.endOfFileToken);
+        node.transformFlags = propagateChildrenFlags(node.statements)
+            | propagateChildFlags(node.endOfFileToken);
         return node;
     }
 
@@ -6221,8 +6221,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<PartiallyEmittedExpression>(SyntaxKind.PartiallyEmittedExpression);
         node.expression = expression;
         node.original = original;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            TransformFlags.ContainsTypeScript;
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | TransformFlags.ContainsTypeScript;
         setTextRange(node, original);
         return node;
     }
@@ -6266,8 +6266,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         const node = createBaseNode<SyntheticReferenceExpression>(SyntaxKind.SyntheticReferenceExpression);
         node.expression = expression;
         node.thisArg = thisArg;
-        node.transformFlags |= propagateChildFlags(node.expression) |
-            propagateChildFlags(node.thisArg);
+        node.transformFlags |= propagateChildFlags(node.expression)
+            | propagateChildFlags(node.thisArg);
         return node;
     }
 
@@ -6345,8 +6345,8 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
             return clonePrivateIdentifier(node) as T & PrivateIdentifier;
         }
 
-        const clone = !isNodeKind(node.kind) ? baseFactory.createBaseTokenNode(node.kind) as T :
-            baseFactory.createBaseNode(node.kind) as T;
+        const clone = !isNodeKind(node.kind) ? baseFactory.createBaseTokenNode(node.kind) as T
+            : baseFactory.createBaseNode(node.kind) as T;
 
         (clone as Mutable<T>).flags |= node.flags & ~NodeFlags.Synthesized;
         (clone as Mutable<T>).transformFlags = node.transformFlags;
@@ -6426,15 +6426,15 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     //
 
     function createTypeCheck(value: Expression, tag: TypeOfTag) {
-        return tag === "null" ? factory.createStrictEquality(value, createNull()) :
-            tag === "undefined" ? factory.createStrictEquality(value, createVoidZero()) :
-            factory.createStrictEquality(createTypeOfExpression(value), createStringLiteral(tag));
+        return tag === "null" ? factory.createStrictEquality(value, createNull())
+            : tag === "undefined" ? factory.createStrictEquality(value, createVoidZero())
+            : factory.createStrictEquality(createTypeOfExpression(value), createStringLiteral(tag));
     }
 
     function createIsNotTypeCheck(value: Expression, tag: TypeOfTag) {
-        return tag === "null" ? factory.createStrictInequality(value, createNull()) :
-            tag === "undefined" ? factory.createStrictInequality(value, createVoidZero()) :
-            factory.createStrictInequality(createTypeOfExpression(value), createStringLiteral(tag));
+        return tag === "null" ? factory.createStrictInequality(value, createNull())
+            : tag === "undefined" ? factory.createStrictInequality(value, createVoidZero())
+            : factory.createStrictInequality(createTypeOfExpression(value), createStringLiteral(tag));
     }
 
     function createMethodCall(object: Expression, methodName: string | Identifier, argumentsList: readonly Expression[]) {
@@ -7026,44 +7026,44 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         else {
             modifierArray = modifiers;
         }
-        return isTypeParameterDeclaration(node) ? updateTypeParameterDeclaration(node, modifierArray, node.name, node.constraint, node.default) :
-            isParameter(node) ? updateParameterDeclaration(node, modifierArray, node.dotDotDotToken, node.name, node.questionToken, node.type, node.initializer) :
-            isConstructorTypeNode(node) ? updateConstructorTypeNode1(node, modifierArray, node.typeParameters, node.parameters, node.type) :
-            isPropertySignature(node) ? updatePropertySignature(node, modifierArray, node.name, node.questionToken, node.type) :
-            isPropertyDeclaration(node) ? updatePropertyDeclaration(node, modifierArray, node.name, node.questionToken ?? node.exclamationToken, node.type, node.initializer) :
-            isMethodSignature(node) ? updateMethodSignature(node, modifierArray, node.name, node.questionToken, node.typeParameters, node.parameters, node.type) :
-            isMethodDeclaration(node) ? updateMethodDeclaration(node, modifierArray, node.asteriskToken, node.name, node.questionToken, node.typeParameters, node.parameters, node.type, node.body) :
-            isConstructorDeclaration(node) ? updateConstructorDeclaration(node, modifierArray, node.parameters, node.body) :
-            isGetAccessorDeclaration(node) ? updateGetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.type, node.body) :
-            isSetAccessorDeclaration(node) ? updateSetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.body) :
-            isIndexSignatureDeclaration(node) ? updateIndexSignature(node, modifierArray, node.parameters, node.type) :
-            isFunctionExpression(node) ? updateFunctionExpression(node, modifierArray, node.asteriskToken, node.name, node.typeParameters, node.parameters, node.type, node.body) :
-            isArrowFunction(node) ? updateArrowFunction(node, modifierArray, node.typeParameters, node.parameters, node.type, node.equalsGreaterThanToken, node.body) :
-            isClassExpression(node) ? updateClassExpression(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members) :
-            isVariableStatement(node) ? updateVariableStatement(node, modifierArray, node.declarationList) :
-            isFunctionDeclaration(node) ? updateFunctionDeclaration(node, modifierArray, node.asteriskToken, node.name, node.typeParameters, node.parameters, node.type, node.body) :
-            isClassDeclaration(node) ? updateClassDeclaration(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members) :
-            isInterfaceDeclaration(node) ? updateInterfaceDeclaration(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members) :
-            isTypeAliasDeclaration(node) ? updateTypeAliasDeclaration(node, modifierArray, node.name, node.typeParameters, node.type) :
-            isEnumDeclaration(node) ? updateEnumDeclaration(node, modifierArray, node.name, node.members) :
-            isModuleDeclaration(node) ? updateModuleDeclaration(node, modifierArray, node.name, node.body) :
-            isImportEqualsDeclaration(node) ? updateImportEqualsDeclaration(node, modifierArray, node.isTypeOnly, node.name, node.moduleReference) :
-            isImportDeclaration(node) ? updateImportDeclaration(node, modifierArray, node.importClause, node.moduleSpecifier, node.attributes) :
-            isExportAssignment(node) ? updateExportAssignment(node, modifierArray, node.expression) :
-            isExportDeclaration(node) ? updateExportDeclaration(node, modifierArray, node.isTypeOnly, node.exportClause, node.moduleSpecifier, node.attributes) :
-            Debug.assertNever(node);
+        return isTypeParameterDeclaration(node) ? updateTypeParameterDeclaration(node, modifierArray, node.name, node.constraint, node.default)
+            : isParameter(node) ? updateParameterDeclaration(node, modifierArray, node.dotDotDotToken, node.name, node.questionToken, node.type, node.initializer)
+            : isConstructorTypeNode(node) ? updateConstructorTypeNode1(node, modifierArray, node.typeParameters, node.parameters, node.type)
+            : isPropertySignature(node) ? updatePropertySignature(node, modifierArray, node.name, node.questionToken, node.type)
+            : isPropertyDeclaration(node) ? updatePropertyDeclaration(node, modifierArray, node.name, node.questionToken ?? node.exclamationToken, node.type, node.initializer)
+            : isMethodSignature(node) ? updateMethodSignature(node, modifierArray, node.name, node.questionToken, node.typeParameters, node.parameters, node.type)
+            : isMethodDeclaration(node) ? updateMethodDeclaration(node, modifierArray, node.asteriskToken, node.name, node.questionToken, node.typeParameters, node.parameters, node.type, node.body)
+            : isConstructorDeclaration(node) ? updateConstructorDeclaration(node, modifierArray, node.parameters, node.body)
+            : isGetAccessorDeclaration(node) ? updateGetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.type, node.body)
+            : isSetAccessorDeclaration(node) ? updateSetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.body)
+            : isIndexSignatureDeclaration(node) ? updateIndexSignature(node, modifierArray, node.parameters, node.type)
+            : isFunctionExpression(node) ? updateFunctionExpression(node, modifierArray, node.asteriskToken, node.name, node.typeParameters, node.parameters, node.type, node.body)
+            : isArrowFunction(node) ? updateArrowFunction(node, modifierArray, node.typeParameters, node.parameters, node.type, node.equalsGreaterThanToken, node.body)
+            : isClassExpression(node) ? updateClassExpression(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members)
+            : isVariableStatement(node) ? updateVariableStatement(node, modifierArray, node.declarationList)
+            : isFunctionDeclaration(node) ? updateFunctionDeclaration(node, modifierArray, node.asteriskToken, node.name, node.typeParameters, node.parameters, node.type, node.body)
+            : isClassDeclaration(node) ? updateClassDeclaration(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members)
+            : isInterfaceDeclaration(node) ? updateInterfaceDeclaration(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members)
+            : isTypeAliasDeclaration(node) ? updateTypeAliasDeclaration(node, modifierArray, node.name, node.typeParameters, node.type)
+            : isEnumDeclaration(node) ? updateEnumDeclaration(node, modifierArray, node.name, node.members)
+            : isModuleDeclaration(node) ? updateModuleDeclaration(node, modifierArray, node.name, node.body)
+            : isImportEqualsDeclaration(node) ? updateImportEqualsDeclaration(node, modifierArray, node.isTypeOnly, node.name, node.moduleReference)
+            : isImportDeclaration(node) ? updateImportDeclaration(node, modifierArray, node.importClause, node.moduleSpecifier, node.attributes)
+            : isExportAssignment(node) ? updateExportAssignment(node, modifierArray, node.expression)
+            : isExportDeclaration(node) ? updateExportDeclaration(node, modifierArray, node.isTypeOnly, node.exportClause, node.moduleSpecifier, node.attributes)
+            : Debug.assertNever(node);
     }
 
     function replaceDecoratorsAndModifiers<T extends HasModifiers & HasDecorators>(node: T, modifiers: readonly ModifierLike[]): T;
     function replaceDecoratorsAndModifiers(node: HasModifiers & HasDecorators, modifierArray: readonly ModifierLike[]) {
-        return isParameter(node) ? updateParameterDeclaration(node, modifierArray, node.dotDotDotToken, node.name, node.questionToken, node.type, node.initializer) :
-            isPropertyDeclaration(node) ? updatePropertyDeclaration(node, modifierArray, node.name, node.questionToken ?? node.exclamationToken, node.type, node.initializer) :
-            isMethodDeclaration(node) ? updateMethodDeclaration(node, modifierArray, node.asteriskToken, node.name, node.questionToken, node.typeParameters, node.parameters, node.type, node.body) :
-            isGetAccessorDeclaration(node) ? updateGetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.type, node.body) :
-            isSetAccessorDeclaration(node) ? updateSetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.body) :
-            isClassExpression(node) ? updateClassExpression(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members) :
-            isClassDeclaration(node) ? updateClassDeclaration(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members) :
-            Debug.assertNever(node);
+        return isParameter(node) ? updateParameterDeclaration(node, modifierArray, node.dotDotDotToken, node.name, node.questionToken, node.type, node.initializer)
+            : isPropertyDeclaration(node) ? updatePropertyDeclaration(node, modifierArray, node.name, node.questionToken ?? node.exclamationToken, node.type, node.initializer)
+            : isMethodDeclaration(node) ? updateMethodDeclaration(node, modifierArray, node.asteriskToken, node.name, node.questionToken, node.typeParameters, node.parameters, node.type, node.body)
+            : isGetAccessorDeclaration(node) ? updateGetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.type, node.body)
+            : isSetAccessorDeclaration(node) ? updateSetAccessorDeclaration(node, modifierArray, node.name, node.parameters, node.body)
+            : isClassExpression(node) ? updateClassExpression(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members)
+            : isClassDeclaration(node) ? updateClassDeclaration(node, modifierArray, node.name, node.typeParameters, node.heritageClauses, node.members)
+            : Debug.assertNever(node);
     }
 
     function replacePropertyName<T extends AccessorDeclaration | MethodDeclaration | MethodSignature | PropertyDeclaration | PropertySignature | PropertyAssignment>(node: T, name: T["name"]): T;
@@ -7093,15 +7093,15 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     }
 
     function asName<T extends DeclarationName | Identifier | BindingName | PropertyName | NoSubstitutionTemplateLiteral | EntityName | ThisTypeNode | undefined>(name: string | T): T | Identifier {
-        return typeof name === "string" ? createIdentifier(name) :
-            name;
+        return typeof name === "string" ? createIdentifier(name)
+            : name;
     }
 
     function asExpression<T extends Expression | undefined>(value: string | number | boolean | T): T | StringLiteral | NumericLiteral | BooleanLiteral {
-        return typeof value === "string" ? createStringLiteral(value) :
-            typeof value === "number" ? createNumericLiteral(value) :
-            typeof value === "boolean" ? value ? createTrue() : createFalse() :
-            value;
+        return typeof value === "string" ? createStringLiteral(value)
+            : typeof value === "number" ? createNumericLiteral(value)
+            : typeof value === "boolean" ? value ? createTrue() : createFalse()
+            : value;
     }
 
     function asInitializer(node: Expression | undefined) {

--- a/src/compiler/factory/utilities.ts
+++ b/src/compiler/factory/utilities.ts
@@ -229,18 +229,18 @@ function createJsxFactoryExpressionFromEntityName(factory: NodeFactory, jsxFacto
 
 /** @internal */
 export function createJsxFactoryExpression(factory: NodeFactory, jsxFactoryEntity: EntityName | undefined, reactNamespace: string, parent: JsxOpeningLikeElement | JsxOpeningFragment): Expression {
-    return jsxFactoryEntity ?
-        createJsxFactoryExpressionFromEntityName(factory, jsxFactoryEntity, parent) :
-        factory.createPropertyAccessExpression(
+    return jsxFactoryEntity
+        ? createJsxFactoryExpressionFromEntityName(factory, jsxFactoryEntity, parent)
+        : factory.createPropertyAccessExpression(
             createReactNamespace(reactNamespace, parent),
             "createElement",
         );
 }
 
 function createJsxFragmentFactoryExpression(factory: NodeFactory, jsxFragmentFactoryEntity: EntityName | undefined, reactNamespace: string, parent: JsxOpeningLikeElement | JsxOpeningFragment): Expression {
-    return jsxFragmentFactoryEntity ?
-        createJsxFactoryExpressionFromEntityName(factory, jsxFragmentFactoryEntity, parent) :
-        factory.createPropertyAccessExpression(
+    return jsxFragmentFactoryEntity
+        ? createJsxFactoryExpressionFromEntityName(factory, jsxFragmentFactoryEntity, parent)
+        : factory.createPropertyAccessExpression(
             createReactNamespace(reactNamespace, parent),
             "Fragment",
         );
@@ -534,9 +534,9 @@ export function expandPreOrPostfixIncrementOrDecrementExpression(factory: NodeFa
     expression = factory.createAssignment(temp, expression);
     setTextRange(expression, node.operand);
 
-    let operation: Expression = isPrefixUnaryExpression(node) ?
-        factory.createPrefixUnaryExpression(operator, temp) :
-        factory.createPostfixUnaryExpression(temp, operator);
+    let operation: Expression = isPrefixUnaryExpression(node)
+        ? factory.createPrefixUnaryExpression(operator, temp)
+        : factory.createPostfixUnaryExpression(temp, operator);
     setTextRange(operation, node);
 
     if (resultVariable) {
@@ -1555,9 +1555,9 @@ export function getNodeForGeneratedName(name: GeneratedIdentifier | GeneratedPri
             // if "node" is a different generated name (having a different "autoGenerateId"), use it and stop traversing.
             if (
                 isMemberName(node) && (
-                    autoGenerate === undefined ||
-                    !!(autoGenerate.flags & GeneratedIdentifierFlags.Node) &&
-                        autoGenerate.id !== autoGenerateId
+                    autoGenerate === undefined
+                    || !!(autoGenerate.flags & GeneratedIdentifierFlags.Node)
+                        && autoGenerate.id !== autoGenerateId
                 )
             ) {
                 break;
@@ -1585,21 +1585,21 @@ export function formatGeneratedNamePart(part: string | undefined): string;
 export function formatGeneratedNamePart(part: string | GeneratedNamePart | undefined, generateName: (name: GeneratedIdentifier | GeneratedPrivateIdentifier) => string): string;
 /** @internal */
 export function formatGeneratedNamePart(part: string | GeneratedNamePart | undefined, generateName?: (name: GeneratedIdentifier | GeneratedPrivateIdentifier) => string): string {
-    return typeof part === "object" ? formatGeneratedName(/*privateName*/ false, part.prefix, part.node, part.suffix, generateName!) :
-        typeof part === "string" ? part.length > 0 && part.charCodeAt(0) === CharacterCodes.hash ? part.slice(1) : part :
-        "";
+    return typeof part === "object" ? formatGeneratedName(/*privateName*/ false, part.prefix, part.node, part.suffix, generateName!)
+        : typeof part === "string" ? part.length > 0 && part.charCodeAt(0) === CharacterCodes.hash ? part.slice(1) : part
+        : "";
 }
 
 function formatIdentifier(name: string | Identifier | PrivateIdentifier, generateName?: (name: GeneratedIdentifier | GeneratedPrivateIdentifier) => string) {
-    return typeof name === "string" ? name :
-        formatIdentifierWorker(name, Debug.checkDefined(generateName));
+    return typeof name === "string" ? name
+        : formatIdentifierWorker(name, Debug.checkDefined(generateName));
 }
 
 function formatIdentifierWorker(node: Identifier | PrivateIdentifier, generateName: (name: GeneratedIdentifier | GeneratedPrivateIdentifier) => string) {
-    return isGeneratedPrivateIdentifier(node) ? generateName(node).slice(1) :
-        isGeneratedIdentifier(node) ? generateName(node) :
-        isPrivateIdentifier(node) ? (node.escapedText as string).slice(1) :
-        idText(node);
+    return isGeneratedPrivateIdentifier(node) ? generateName(node).slice(1)
+        : isGeneratedIdentifier(node) ? generateName(node)
+        : isPrivateIdentifier(node) ? (node.escapedText as string).slice(1)
+        : idText(node);
 }
 
 /**

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -229,12 +229,12 @@ function createResolvedModuleWithFailedLookupLocationsHandlingSymlink(
 ): ResolvedModuleWithFailedLookupLocations {
     // If this is from node_modules for non relative name, always respect preserveSymlinks
     if (
-        !state.resultFromCache &&
-        !state.compilerOptions.preserveSymlinks &&
-        resolved &&
-        isExternalLibraryImport &&
-        !resolved.originalPath &&
-        !isExternalModuleNameRelative(moduleName)
+        !state.resultFromCache
+        && !state.compilerOptions.preserveSymlinks
+        && resolved
+        && isExternalLibraryImport
+        && !resolved.originalPath
+        && !isExternalModuleNameRelative(moduleName)
     ) {
         const { resolvedFileName, originalPath } = getOriginalAndResolvedFileName(resolved.path, state.host, state.traceEnabled);
         if (originalPath) resolved = { ...resolved, path: resolvedFileName, originalPath };
@@ -516,9 +516,9 @@ function getOriginalAndResolvedFileName(fileName: string, host: ModuleResolution
 }
 
 function getCandidateFromTypeRoot(typeRoot: string, typeReferenceDirectiveName: string, moduleResolutionState: ModuleResolutionState) {
-    const nameForLookup = endsWith(typeRoot, "/node_modules/@types") || endsWith(typeRoot, "/node_modules/@types/") ?
-        mangleScopedPackageNameWithTrace(typeReferenceDirectiveName, moduleResolutionState) :
-        typeReferenceDirectiveName;
+    const nameForLookup = endsWith(typeRoot, "/node_modules/@types") || endsWith(typeRoot, "/node_modules/@types/")
+        ? mangleScopedPackageNameWithTrace(typeReferenceDirectiveName, moduleResolutionState)
+        : typeReferenceDirectiveName;
     return combinePaths(typeRoot, nameForLookup);
 }
 
@@ -979,15 +979,15 @@ export function createCacheWithRedirects<K, V>(ownOptions: CompilerOptions | und
     };
 
     function getMapOfCacheRedirects(redirectedReference: ResolvedProjectReference | undefined): Map<K, V> | undefined {
-        return redirectedReference ?
-            getOrCreateMap(redirectedReference.commandLine.options, /*create*/ false) :
-            ownMap;
+        return redirectedReference
+            ? getOrCreateMap(redirectedReference.commandLine.options, /*create*/ false)
+            : ownMap;
     }
 
     function getOrCreateMapOfCacheRedirects(redirectedReference: ResolvedProjectReference | undefined): Map<K, V> {
-        return redirectedReference ?
-            getOrCreateMap(redirectedReference.commandLine.options, /*create*/ true) :
-            ownMap;
+        return redirectedReference
+            ? getOrCreateMap(redirectedReference.commandLine.options, /*create*/ true)
+            : ownMap;
     }
 
     function update(newOptions: CompilerOptions) {
@@ -1150,8 +1150,8 @@ function getOriginalOrResolvedModuleFileName(result: ResolvedModuleWithFailedLoo
 }
 
 function getOriginalOrResolvedTypeReferenceFileName(result: ResolvedTypeReferenceDirectiveWithFailedLookupLocations) {
-    return result.resolvedTypeReferenceDirective &&
-        (result.resolvedTypeReferenceDirective.originalPath || result.resolvedTypeReferenceDirective.resolvedFileName);
+    return result.resolvedTypeReferenceDirective
+        && (result.resolvedTypeReferenceDirective.originalPath || result.resolvedTypeReferenceDirective.resolvedFileName);
 }
 
 function createNonRelativeNameResolutionCache<T>(
@@ -1594,8 +1594,8 @@ function tryLoadModuleUsingRootDirs(extensions: Extensions, moduleName: string, 
         if (!endsWith(normalizedRoot, directorySeparator)) {
             normalizedRoot += directorySeparator;
         }
-        const isLongestMatchingPrefix = startsWith(candidate, normalizedRoot) &&
-            (matchedNormalizedPrefix === undefined || matchedNormalizedPrefix.length < normalizedRoot.length);
+        const isLongestMatchingPrefix = startsWith(candidate, normalizedRoot)
+            && (matchedNormalizedPrefix === undefined || matchedNormalizedPrefix.length < normalizedRoot.length);
 
         if (state.traceEnabled) {
             trace(state.host, Diagnostics.Checking_if_0_is_the_longest_matching_prefix_for_1_2, normalizedRoot, candidate, isLongestMatchingPrefix);
@@ -1837,9 +1837,9 @@ function nodeModuleNameResolverWorker(
     if (moduleResolution === ModuleResolutionKind.Node10) {
         const priorityExtensions = extensions & (Extensions.TypeScript | Extensions.Declaration);
         const secondaryExtensions = extensions & ~(Extensions.TypeScript | Extensions.Declaration);
-        result = priorityExtensions && tryResolve(priorityExtensions, state) ||
-            secondaryExtensions && tryResolve(secondaryExtensions, state) ||
-            undefined;
+        result = priorityExtensions && tryResolve(priorityExtensions, state)
+            || secondaryExtensions && tryResolve(secondaryExtensions, state)
+            || undefined;
     }
     else {
         result = tryResolve(extensions, state);
@@ -2094,8 +2094,8 @@ function loadModuleFromFileNoImplicitExtensions(extensions: Extensions, candidat
  */
 function loadFileNameFromPackageJsonField(extensions: Extensions, candidate: string, onlyRecordFailures: boolean, state: ModuleResolutionState): PathAndExtension | undefined {
     if (
-        extensions & Extensions.TypeScript && fileExtensionIsOneOf(candidate, supportedTSImplementationExtensions) ||
-        extensions & Extensions.Declaration && fileExtensionIsOneOf(candidate, supportedDeclarationExtensions)
+        extensions & Extensions.TypeScript && fileExtensionIsOneOf(candidate, supportedTSImplementationExtensions)
+        || extensions & Extensions.Declaration && fileExtensionIsOneOf(candidate, supportedDeclarationExtensions)
     ) {
         const result = tryFile(candidate, onlyRecordFailures, state);
         return result !== undefined ? { path: candidate, ext: tryExtractTSExtension(candidate) as Extension, resolvedUsingTsExtension: undefined } : undefined;
@@ -2413,9 +2413,9 @@ export function getPackageJsonInfo(packageDirectory: string, onlyRecordFailures:
         if (isPackageJsonInfo(existing)) {
             if (traceEnabled) trace(host, Diagnostics.File_0_exists_according_to_earlier_cached_lookups, packageJsonPath);
             state.affectingLocations?.push(packageJsonPath);
-            return existing.packageDirectory === packageDirectory ?
-                existing :
-                { packageDirectory, contents: existing.contents };
+            return existing.packageDirectory === packageDirectory
+                ? existing
+                : { packageDirectory, contents: existing.contents };
         }
         else {
             if (existing.directoryExists && traceEnabled) trace(host, Diagnostics.File_0_does_not_exist_according_to_earlier_cached_lookups, packageJsonPath);
@@ -2451,9 +2451,9 @@ function loadNodeModuleFromDirectoryWorker(extensions: Extensions, candidate: st
             packageFile = readPackageJsonTSConfigField(jsonContent, candidate, state);
         }
         else {
-            packageFile = extensions & Extensions.Declaration && readPackageJsonTypesFields(jsonContent, candidate, state) ||
-                extensions & (Extensions.ImplementationFiles | Extensions.Declaration) && readPackageJsonMainField(jsonContent, candidate, state) ||
-                undefined;
+            packageFile = extensions & Extensions.Declaration && readPackageJsonTypesFields(jsonContent, candidate, state)
+                || extensions & (Extensions.ImplementationFiles | Extensions.Declaration) && readPackageJsonMainField(jsonContent, candidate, state)
+                || undefined;
         }
     }
 
@@ -3020,8 +3020,8 @@ function loadModuleFromSpecificNodeModulesDirectory(extensions: Extensions, modu
     // But only if we're not respecting export maps (if we are, we might redirect around this location)
     if (
         rest !== "" && packageInfo && (
-            !(state.features & NodeResolutionFeatures.Exports) ||
-            !hasProperty((rootPackageInfo = getPackageJsonInfo(packageDirectory, !nodeModulesDirectoryExists, state))?.contents.packageJsonContent ?? emptyArray, "exports")
+            !(state.features & NodeResolutionFeatures.Exports)
+            || !hasProperty((rootPackageInfo = getPackageJsonInfo(packageDirectory, !nodeModulesDirectoryExists, state))?.contents.packageJsonContent ?? emptyArray, "exports")
         )
     ) {
         const fromFile = loadModuleFromFile(extensions, candidate, !nodeModulesDirectoryExists, state);
@@ -3041,8 +3041,8 @@ function loadModuleFromSpecificNodeModulesDirectory(extensions: Extensions, modu
     }
 
     const loader: ResolutionKindSpecificLoader = (extensions, candidate, onlyRecordFailures, state) => {
-        let pathAndExtension = (rest || !(state.features & NodeResolutionFeatures.EsmMode)) && loadModuleFromFile(extensions, candidate, onlyRecordFailures, state) ||
-            loadNodeModuleFromDirectoryWorker(
+        let pathAndExtension = (rest || !(state.features & NodeResolutionFeatures.EsmMode)) && loadModuleFromFile(extensions, candidate, onlyRecordFailures, state)
+            || loadNodeModuleFromDirectoryWorker(
                 extensions,
                 candidate,
                 onlyRecordFailures,
@@ -3157,9 +3157,9 @@ export function getPackageNameFromTypesPackageName(mangledName: string): string 
 
 /** @internal */
 export function unmangleScopedPackageName(typesPackageName: string): string {
-    return typesPackageName.includes(mangledScopedPackageSeparator) ?
-        "@" + typesPackageName.replace(mangledScopedPackageSeparator, directorySeparator) :
-        typesPackageName;
+    return typesPackageName.includes(mangledScopedPackageSeparator)
+        ? "@" + typesPackageName.replace(mangledScopedPackageSeparator, directorySeparator)
+        : typesPackageName;
 }
 
 function tryFindNonRelativeModuleNameInCache(cache: NonRelativeModuleNameResolutionCache | undefined, moduleName: string, mode: ResolutionMode, containingDirectory: string, redirectedReference: ResolvedProjectReference | undefined, state: ModuleResolutionState): SearchResult<Resolved> {
@@ -3203,8 +3203,8 @@ export function classicNameResolver(moduleName: string, containingFile: string, 
         resolvedPackageDirectory: false,
     };
 
-    const resolved = tryResolve(Extensions.TypeScript | Extensions.Declaration) ||
-        tryResolve(Extensions.JavaScript | (compilerOptions.resolveJsonModule ? Extensions.Json : 0));
+    const resolved = tryResolve(Extensions.TypeScript | Extensions.Declaration)
+        || tryResolve(Extensions.JavaScript | (compilerOptions.resolveJsonModule ? Extensions.Json : 0));
     // No originalPath because classic resolution doesn't resolve realPath
     return createResolvedModuleWithFailedLookupLocationsHandlingSymlink(
         moduleName,
@@ -3341,7 +3341,7 @@ function traceIfEnabled(state: ModuleResolutionState, diagnostic: DiagnosticMess
 }
 
 function useCaseSensitiveFileNames(state: ModuleResolutionState) {
-    return !state.host.useCaseSensitiveFileNames ? true :
-        typeof state.host.useCaseSensitiveFileNames === "boolean" ? state.host.useCaseSensitiveFileNames :
-        state.host.useCaseSensitiveFileNames();
+    return !state.host.useCaseSensitiveFileNames ? true
+        : typeof state.host.useCaseSensitiveFileNames === "boolean" ? state.host.useCaseSensitiveFileNames
+        : state.host.useCaseSensitiveFileNames();
 }

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -146,13 +146,13 @@ export function getModuleSpecifierPreferences(
 ): ModuleSpecifierPreferences {
     const filePreferredEnding = getPreferredEnding();
     return {
-        relativePreference: oldImportSpecifier !== undefined ? (isExternalModuleNameRelative(oldImportSpecifier) ?
-            RelativePreference.Relative :
-            RelativePreference.NonRelative) :
-            importModuleSpecifierPreference === "relative" ? RelativePreference.Relative :
-            importModuleSpecifierPreference === "non-relative" ? RelativePreference.NonRelative :
-            importModuleSpecifierPreference === "project-relative" ? RelativePreference.ExternalNonRelative :
-            RelativePreference.Shortest,
+        relativePreference: oldImportSpecifier !== undefined ? (isExternalModuleNameRelative(oldImportSpecifier)
+            ? RelativePreference.Relative
+            : RelativePreference.NonRelative)
+            : importModuleSpecifierPreference === "relative" ? RelativePreference.Relative
+            : importModuleSpecifierPreference === "non-relative" ? RelativePreference.NonRelative
+            : importModuleSpecifierPreference === "project-relative" ? RelativePreference.ExternalNonRelative
+            : RelativePreference.Shortest,
         getAllowedEndingsInPreferredOrder: syntaxImpliedNodeFormat => {
             const preferredEnding = syntaxImpliedNodeFormat !== importingSourceFile.impliedNodeFormat ? getPreferredEnding(syntaxImpliedNodeFormat) : filePreferredEnding;
             if ((syntaxImpliedNodeFormat ?? importingSourceFile.impliedNodeFormat) === ModuleKind.ESNext) {
@@ -265,8 +265,8 @@ function getModuleSpecifierWorker(
 ): string {
     const info = getInfo(importingSourceFileName, host);
     const modulePaths = getAllModulePaths(info, toFileName, host, userPreferences, options);
-    return firstDefined(modulePaths, modulePath => tryGetModuleNameAsNodeModule(modulePath, info, importingSourceFile, host, compilerOptions, userPreferences, /*packageNameOnly*/ undefined, options.overrideImportMode)) ||
-        getLocalModuleSpecifier(toFileName, info, compilerOptions, host, options.overrideImportMode || importingSourceFile.impliedNodeFormat, preferences);
+    return firstDefined(modulePaths, modulePath => tryGetModuleNameAsNodeModule(modulePath, info, importingSourceFile, host, compilerOptions, userPreferences, /*packageNameOnly*/ undefined, options.overrideImportMode))
+        || getLocalModuleSpecifier(toFileName, info, compilerOptions, host, options.overrideImportMode || importingSourceFile.impliedNodeFormat, preferences);
 }
 
 /** @internal */
@@ -391,9 +391,9 @@ function computeModuleSpecifiers(
                 if (importingSourceFile.impliedNodeFormat && importingSourceFile.impliedNodeFormat !== getModeForResolutionAtIndex(importingSourceFile, reason.index, compilerOptions)) return undefined;
                 const specifier = getModuleNameStringLiteralAt(importingSourceFile, reason.index).text;
                 // If the preference is for non relative and the module specifier is relative, ignore it
-                return preferences.relativePreference !== RelativePreference.NonRelative || !pathIsRelative(specifier) ?
-                    specifier :
-                    undefined;
+                return preferences.relativePreference !== RelativePreference.NonRelative || !pathIsRelative(specifier)
+                    ? specifier
+                    : undefined;
             },
         ));
     if (existingSpecifier) {
@@ -466,10 +466,10 @@ function computeModuleSpecifiers(
         }
     }
 
-    return pathsSpecifiers?.length ? pathsSpecifiers :
-        redirectPathsSpecifiers?.length ? redirectPathsSpecifiers :
-        nodeModulesSpecifiers?.length ? nodeModulesSpecifiers :
-        Debug.checkDefined(relativeSpecifiers);
+    return pathsSpecifiers?.length ? pathsSpecifiers
+        : redirectPathsSpecifiers?.length ? redirectPathsSpecifiers
+        : nodeModulesSpecifiers?.length ? nodeModulesSpecifiers
+        : Debug.checkDefined(relativeSpecifiers);
 }
 
 interface Info {
@@ -501,8 +501,8 @@ function getLocalModuleSpecifier(moduleFileName: string, info: Info, compilerOpt
 
     const { sourceDirectory, canonicalSourceDirectory, getCanonicalFileName } = info;
     const allowedEndings = getAllowedEndingsInPrefererredOrder(importMode);
-    const relativePath = rootDirs && tryGetModuleNameFromRootDirs(rootDirs, moduleFileName, sourceDirectory, getCanonicalFileName, allowedEndings, compilerOptions) ||
-        processEnding(ensurePathIsNonModuleName(getRelativePathFromDirectory(sourceDirectory, moduleFileName, getCanonicalFileName)), allowedEndings, compilerOptions);
+    const relativePath = rootDirs && tryGetModuleNameFromRootDirs(rootDirs, moduleFileName, sourceDirectory, getCanonicalFileName, allowedEndings, compilerOptions)
+        || processEnding(ensurePathIsNonModuleName(getRelativePathFromDirectory(sourceDirectory, moduleFileName, getCanonicalFileName)), allowedEndings, compilerOptions);
     if (!baseUrl && !paths && !getResolvePackageJsonImports(compilerOptions) || relativePreference === RelativePreference.Relative) {
         return pathsOnly ? undefined : relativePath;
     }
@@ -530,9 +530,9 @@ function getLocalModuleSpecifier(moduleFileName: string, info: Info, compilerOpt
     }
 
     if (relativePreference === RelativePreference.ExternalNonRelative && !pathIsRelative(maybeNonRelative)) {
-        const projectDirectory = compilerOptions.configFilePath ?
-            toPath(getDirectoryPath(compilerOptions.configFilePath), host.getCurrentDirectory(), info.getCanonicalFileName) :
-            info.getCanonicalFileName(host.getCurrentDirectory());
+        const projectDirectory = compilerOptions.configFilePath
+            ? toPath(getDirectoryPath(compilerOptions.configFilePath), host.getCurrentDirectory(), info.getCanonicalFileName)
+            : info.getCanonicalFileName(host.getCurrentDirectory());
         const modulePath = toPath(moduleFileName, projectDirectory, getCanonicalFileName);
         const sourceIsInternal = startsWith(canonicalSourceDirectory, projectDirectory);
         const targetIsInternal = startsWith(modulePath, projectDirectory);
@@ -824,10 +824,10 @@ function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<rea
                 const suffix = pattern.substring(indexOfStar + 1);
                 for (const { ending, value } of candidates) {
                     if (
-                        value.length >= prefix.length + suffix.length &&
-                        startsWith(value, prefix) &&
-                        endsWith(value, suffix) &&
-                        validateEnding({ ending, value })
+                        value.length >= prefix.length + suffix.length
+                        && startsWith(value, prefix)
+                        && endsWith(value, suffix)
+                        && validateEnding({ ending, value })
                     ) {
                         const matchedStar = value.substring(prefix.length, value.length - suffix.length);
                         if (!pathIsRelative(matchedStar)) {
@@ -837,8 +837,8 @@ function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<rea
                 }
             }
             else if (
-                some(candidates, c => c.ending !== ModuleSpecifierEnding.Minimal && pattern === c.value) ||
-                some(candidates, c => c.ending === ModuleSpecifierEnding.Minimal && pattern === c.value && validateEnding(c))
+                some(candidates, c => c.ending !== ModuleSpecifierEnding.Minimal && pattern === c.value)
+                || some(candidates, c => c.ending === ModuleSpecifierEnding.Minimal && pattern === c.value && validateEnding(c))
             ) {
                 return key;
             }
@@ -876,10 +876,10 @@ function tryGetModuleNameFromExportsOrImports(options: CompilerOptions, host: Mo
         switch (mode) {
             case MatchingMode.Exact:
                 if (
-                    extensionSwappedTarget && comparePaths(extensionSwappedTarget, pathOrPattern, ignoreCase) === Comparison.EqualTo ||
-                    comparePaths(targetFilePath, pathOrPattern, ignoreCase) === Comparison.EqualTo ||
-                    outputFile && comparePaths(outputFile, pathOrPattern, ignoreCase) === Comparison.EqualTo ||
-                    declarationFile && comparePaths(declarationFile, pathOrPattern, ignoreCase) === Comparison.EqualTo
+                    extensionSwappedTarget && comparePaths(extensionSwappedTarget, pathOrPattern, ignoreCase) === Comparison.EqualTo
+                    || comparePaths(targetFilePath, pathOrPattern, ignoreCase) === Comparison.EqualTo
+                    || outputFile && comparePaths(outputFile, pathOrPattern, ignoreCase) === Comparison.EqualTo
+                    || declarationFile && comparePaths(declarationFile, pathOrPattern, ignoreCase) === Comparison.EqualTo
                 ) {
                     return { moduleFileToTry: packageName };
                 }
@@ -1131,11 +1131,11 @@ function tryGetModuleNameAsNodeModule({ path, isRedirect }: ModulePath, { getCan
                     return { packageRootPath, moduleFileToTry };
                 }
                 else if (
-                    packageJsonContent?.type !== "module" &&
-                    !fileExtensionIsOneOf(canonicalModuleFileToTry, extensionsNotSupportingExtensionlessResolution) &&
-                    startsWith(canonicalModuleFileToTry, mainExportFile) &&
-                    getDirectoryPath(canonicalModuleFileToTry) === removeTrailingDirectorySeparator(mainExportFile) &&
-                    removeFileExtension(getBaseFileName(canonicalModuleFileToTry)) === "index"
+                    packageJsonContent?.type !== "module"
+                    && !fileExtensionIsOneOf(canonicalModuleFileToTry, extensionsNotSupportingExtensionlessResolution)
+                    && startsWith(canonicalModuleFileToTry, mainExportFile)
+                    && getDirectoryPath(canonicalModuleFileToTry) === removeTrailingDirectorySeparator(mainExportFile)
+                    && removeFileExtension(getBaseFileName(canonicalModuleFileToTry)) === "index"
                 ) {
                     // if mainExportFile is a directory, which contains moduleFileToTry, we just try index file
                     // example mainExportFile: `pkg/lib` and moduleFileToTry: `pkg/lib/index`, we can use packageRootPath

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -454,17 +454,17 @@ function visitNodes<T>(cbNode: (node: Node) => T, cbNodes: ((node: NodeArray<Nod
 
 /** @internal */
 export function isJSDocLikeText(text: string, start: number) {
-    return text.charCodeAt(start + 1) === CharacterCodes.asterisk &&
-        text.charCodeAt(start + 2) === CharacterCodes.asterisk &&
-        text.charCodeAt(start + 3) !== CharacterCodes.slash;
+    return text.charCodeAt(start + 1) === CharacterCodes.asterisk
+        && text.charCodeAt(start + 2) === CharacterCodes.asterisk
+        && text.charCodeAt(start + 3) !== CharacterCodes.slash;
 }
 
 /** @internal */
 export function isFileProbablyExternalModule(sourceFile: SourceFile) {
     // Try to use the first top-level import/export when available, then
     // fall back to looking for an 'import.meta' somewhere in the tree if necessary.
-    return forEach(sourceFile.statements, isAnExternalModuleIndicatorNode) ||
-        getImportMetaIfNecessary(sourceFile);
+    return forEach(sourceFile.statements, isAnExternalModuleIndicatorNode)
+        || getImportMetaIfNecessary(sourceFile);
 }
 
 function isAnExternalModuleIndicatorNode(node: Node) {
@@ -476,9 +476,9 @@ function isAnExternalModuleIndicatorNode(node: Node) {
 }
 
 function getImportMetaIfNecessary(sourceFile: SourceFile) {
-    return sourceFile.flags & NodeFlags.PossiblyContainsImportMeta ?
-        walkTreeForImportMeta(sourceFile) :
-        undefined;
+    return sourceFile.flags & NodeFlags.PossiblyContainsImportMeta
+        ? walkTreeForImportMeta(sourceFile)
+        : undefined;
 }
 
 function walkTreeForImportMeta(node: Node): Node | undefined {
@@ -498,174 +498,174 @@ type ForEachChildFunction<TNode> = <T>(node: TNode, cbNode: (node: Node) => T | 
 type ForEachChildTable = { [TNode in ForEachChildNodes as TNode["kind"]]: ForEachChildFunction<TNode>; };
 const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.QualifiedName]: function forEachChildInQualifiedName<T>(node: QualifiedName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.left) ||
-            visitNode(cbNode, node.right);
+        return visitNode(cbNode, node.left)
+            || visitNode(cbNode, node.right);
     },
     [SyntaxKind.TypeParameter]: function forEachChildInTypeParameter<T>(node: TypeParameterDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.constraint) ||
-            visitNode(cbNode, node.default) ||
-            visitNode(cbNode, node.expression);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.constraint)
+            || visitNode(cbNode, node.default)
+            || visitNode(cbNode, node.expression);
     },
     [SyntaxKind.ShorthandPropertyAssignment]: function forEachChildInShorthandPropertyAssignment<T>(node: ShorthandPropertyAssignment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.exclamationToken) ||
-            visitNode(cbNode, node.equalsToken) ||
-            visitNode(cbNode, node.objectAssignmentInitializer);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.exclamationToken)
+            || visitNode(cbNode, node.equalsToken)
+            || visitNode(cbNode, node.objectAssignmentInitializer);
     },
     [SyntaxKind.SpreadAssignment]: function forEachChildInSpreadAssignment<T>(node: SpreadAssignment, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
     },
     [SyntaxKind.Parameter]: function forEachChildInParameter<T>(node: ParameterDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.dotDotDotToken) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.initializer);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.dotDotDotToken)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.PropertyDeclaration]: function forEachChildInPropertyDeclaration<T>(node: PropertyDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.exclamationToken) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.initializer);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.exclamationToken)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.PropertySignature]: function forEachChildInPropertySignature<T>(node: PropertySignature, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.initializer);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.PropertyAssignment]: function forEachChildInPropertyAssignment<T>(node: PropertyAssignment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.exclamationToken) ||
-            visitNode(cbNode, node.initializer);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.exclamationToken)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.VariableDeclaration]: function forEachChildInVariableDeclaration<T>(node: VariableDeclaration, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.exclamationToken) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.initializer);
+        return visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.exclamationToken)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.BindingElement]: function forEachChildInBindingElement<T>(node: BindingElement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.dotDotDotToken) ||
-            visitNode(cbNode, node.propertyName) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.initializer);
+        return visitNode(cbNode, node.dotDotDotToken)
+            || visitNode(cbNode, node.propertyName)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.IndexSignature]: function forEachChildInIndexSignature<T>(node: IndexSignatureDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.ConstructorType]: function forEachChildInConstructorType<T>(node: ConstructorTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.FunctionType]: function forEachChildInFunctionType<T>(node: FunctionTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.CallSignature]: forEachChildInCallOrConstructSignature,
     [SyntaxKind.ConstructSignature]: forEachChildInCallOrConstructSignature,
     [SyntaxKind.MethodDeclaration]: function forEachChildInMethodDeclaration<T>(node: MethodDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.asteriskToken) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.exclamationToken) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.asteriskToken)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.exclamationToken)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.MethodSignature]: function forEachChildInMethodSignature<T>(node: MethodSignature, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.Constructor]: function forEachChildInConstructor<T>(node: ConstructorDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.GetAccessor]: function forEachChildInGetAccessor<T>(node: GetAccessorDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.SetAccessor]: function forEachChildInSetAccessor<T>(node: SetAccessorDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.FunctionDeclaration]: function forEachChildInFunctionDeclaration<T>(node: FunctionDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.asteriskToken) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.asteriskToken)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.FunctionExpression]: function forEachChildInFunctionExpression<T>(node: FunctionExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.asteriskToken) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.asteriskToken)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.ArrowFunction]: function forEachChildInArrowFunction<T>(node: ArrowFunction, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.equalsGreaterThanToken) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.equalsGreaterThanToken)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.ClassStaticBlockDeclaration]: function forEachChildInClassStaticBlockDeclaration<T>(node: ClassStaticBlockDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.TypeReference]: function forEachChildInTypeReference<T>(node: TypeReferenceNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.typeName) ||
-            visitNodes(cbNode, cbNodes, node.typeArguments);
+        return visitNode(cbNode, node.typeName)
+            || visitNodes(cbNode, cbNodes, node.typeArguments);
     },
     [SyntaxKind.TypePredicate]: function forEachChildInTypePredicate<T>(node: TypePredicateNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.assertsModifier) ||
-            visitNode(cbNode, node.parameterName) ||
-            visitNode(cbNode, node.type);
+        return visitNode(cbNode, node.assertsModifier)
+            || visitNode(cbNode, node.parameterName)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.TypeQuery]: function forEachChildInTypeQuery<T>(node: TypeQueryNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.exprName) ||
-            visitNodes(cbNode, cbNodes, node.typeArguments);
+        return visitNode(cbNode, node.exprName)
+            || visitNodes(cbNode, cbNodes, node.typeArguments);
     },
     [SyntaxKind.TypeLiteral]: function forEachChildInTypeLiteral<T>(node: TypeLiteralNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNodes(cbNode, cbNodes, node.members);
@@ -679,19 +679,19 @@ const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.UnionType]: forEachChildInUnionOrIntersectionType,
     [SyntaxKind.IntersectionType]: forEachChildInUnionOrIntersectionType,
     [SyntaxKind.ConditionalType]: function forEachChildInConditionalType<T>(node: ConditionalTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.checkType) ||
-            visitNode(cbNode, node.extendsType) ||
-            visitNode(cbNode, node.trueType) ||
-            visitNode(cbNode, node.falseType);
+        return visitNode(cbNode, node.checkType)
+            || visitNode(cbNode, node.extendsType)
+            || visitNode(cbNode, node.trueType)
+            || visitNode(cbNode, node.falseType);
     },
     [SyntaxKind.InferType]: function forEachChildInInferType<T>(node: InferTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.typeParameter);
     },
     [SyntaxKind.ImportType]: function forEachChildInImportType<T>(node: ImportTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.argument) ||
-            visitNode(cbNode, node.attributes) ||
-            visitNode(cbNode, node.qualifier) ||
-            visitNodes(cbNode, cbNodes, node.typeArguments);
+        return visitNode(cbNode, node.argument)
+            || visitNode(cbNode, node.attributes)
+            || visitNode(cbNode, node.qualifier)
+            || visitNodes(cbNode, cbNodes, node.typeArguments);
     },
     [SyntaxKind.ImportTypeAssertionContainer]: function forEachChildInImportTypeAssertionContainer<T>(node: ImportTypeAssertionContainer, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.assertClause);
@@ -699,25 +699,25 @@ const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.ParenthesizedType]: forEachChildInParenthesizedTypeOrTypeOperator,
     [SyntaxKind.TypeOperator]: forEachChildInParenthesizedTypeOrTypeOperator,
     [SyntaxKind.IndexedAccessType]: function forEachChildInIndexedAccessType<T>(node: IndexedAccessTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.objectType) ||
-            visitNode(cbNode, node.indexType);
+        return visitNode(cbNode, node.objectType)
+            || visitNode(cbNode, node.indexType);
     },
     [SyntaxKind.MappedType]: function forEachChildInMappedType<T>(node: MappedTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.readonlyToken) ||
-            visitNode(cbNode, node.typeParameter) ||
-            visitNode(cbNode, node.nameType) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.type) ||
-            visitNodes(cbNode, cbNodes, node.members);
+        return visitNode(cbNode, node.readonlyToken)
+            || visitNode(cbNode, node.typeParameter)
+            || visitNode(cbNode, node.nameType)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.type)
+            || visitNodes(cbNode, cbNodes, node.members);
     },
     [SyntaxKind.LiteralType]: function forEachChildInLiteralType<T>(node: LiteralTypeNode, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.literal);
     },
     [SyntaxKind.NamedTupleMember]: function forEachChildInNamedTupleMember<T>(node: NamedTupleMember, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.dotDotDotToken) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.type);
+        return visitNode(cbNode, node.dotDotDotToken)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.ObjectBindingPattern]: forEachChildInObjectOrArrayBindingPattern,
     [SyntaxKind.ArrayBindingPattern]: forEachChildInObjectOrArrayBindingPattern,
@@ -728,26 +728,26 @@ const forEachChildTable: ForEachChildTable = {
         return visitNodes(cbNode, cbNodes, node.properties);
     },
     [SyntaxKind.PropertyAccessExpression]: function forEachChildInPropertyAccessExpression<T>(node: PropertyAccessExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.questionDotToken) ||
-            visitNode(cbNode, node.name);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.questionDotToken)
+            || visitNode(cbNode, node.name);
     },
     [SyntaxKind.ElementAccessExpression]: function forEachChildInElementAccessExpression<T>(node: ElementAccessExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.questionDotToken) ||
-            visitNode(cbNode, node.argumentExpression);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.questionDotToken)
+            || visitNode(cbNode, node.argumentExpression);
     },
     [SyntaxKind.CallExpression]: forEachChildInCallOrNewExpression,
     [SyntaxKind.NewExpression]: forEachChildInCallOrNewExpression,
     [SyntaxKind.TaggedTemplateExpression]: function forEachChildInTaggedTemplateExpression<T>(node: TaggedTemplateExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tag) ||
-            visitNode(cbNode, node.questionDotToken) ||
-            visitNodes(cbNode, cbNodes, node.typeArguments) ||
-            visitNode(cbNode, node.template);
+        return visitNode(cbNode, node.tag)
+            || visitNode(cbNode, node.questionDotToken)
+            || visitNodes(cbNode, cbNodes, node.typeArguments)
+            || visitNode(cbNode, node.template);
     },
     [SyntaxKind.TypeAssertionExpression]: function forEachChildInTypeAssertionExpression<T>(node: TypeAssertion, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.expression);
+        return visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.expression);
     },
     [SyntaxKind.ParenthesizedExpression]: function forEachChildInParenthesizedExpression<T>(node: ParenthesizedExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
@@ -765,8 +765,8 @@ const forEachChildTable: ForEachChildTable = {
         return visitNode(cbNode, node.operand);
     },
     [SyntaxKind.YieldExpression]: function forEachChildInYieldExpression<T>(node: YieldExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.asteriskToken) ||
-            visitNode(cbNode, node.expression);
+        return visitNode(cbNode, node.asteriskToken)
+            || visitNode(cbNode, node.expression);
     },
     [SyntaxKind.AwaitExpression]: function forEachChildInAwaitExpression<T>(node: AwaitExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
@@ -775,13 +775,13 @@ const forEachChildTable: ForEachChildTable = {
         return visitNode(cbNode, node.operand);
     },
     [SyntaxKind.BinaryExpression]: function forEachChildInBinaryExpression<T>(node: BinaryExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.left) ||
-            visitNode(cbNode, node.operatorToken) ||
-            visitNode(cbNode, node.right);
+        return visitNode(cbNode, node.left)
+            || visitNode(cbNode, node.operatorToken)
+            || visitNode(cbNode, node.right);
     },
     [SyntaxKind.AsExpression]: function forEachChildInAsExpression<T>(node: AsExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.type);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.NonNullExpression]: function forEachChildInNonNullExpression<T>(node: NonNullExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
@@ -793,11 +793,11 @@ const forEachChildTable: ForEachChildTable = {
         return visitNode(cbNode, node.name);
     },
     [SyntaxKind.ConditionalExpression]: function forEachChildInConditionalExpression<T>(node: ConditionalExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.condition) ||
-            visitNode(cbNode, node.questionToken) ||
-            visitNode(cbNode, node.whenTrue) ||
-            visitNode(cbNode, node.colonToken) ||
-            visitNode(cbNode, node.whenFalse);
+        return visitNode(cbNode, node.condition)
+            || visitNode(cbNode, node.questionToken)
+            || visitNode(cbNode, node.whenTrue)
+            || visitNode(cbNode, node.colonToken)
+            || visitNode(cbNode, node.whenFalse);
     },
     [SyntaxKind.SpreadElement]: function forEachChildInSpreadElement<T>(node: SpreadElement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
@@ -805,12 +805,12 @@ const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.Block]: forEachChildInBlock,
     [SyntaxKind.ModuleBlock]: forEachChildInBlock,
     [SyntaxKind.SourceFile]: function forEachChildInSourceFile<T>(node: SourceFile, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.statements) ||
-            visitNode(cbNode, node.endOfFileToken);
+        return visitNodes(cbNode, cbNodes, node.statements)
+            || visitNode(cbNode, node.endOfFileToken);
     },
     [SyntaxKind.VariableStatement]: function forEachChildInVariableStatement<T>(node: VariableStatement, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.declarationList);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.declarationList);
     },
     [SyntaxKind.VariableDeclarationList]: function forEachChildInVariableDeclarationList<T>(node: VariableDeclarationList, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNodes(cbNode, cbNodes, node.declarations);
@@ -819,34 +819,34 @@ const forEachChildTable: ForEachChildTable = {
         return visitNode(cbNode, node.expression);
     },
     [SyntaxKind.IfStatement]: function forEachChildInIfStatement<T>(node: IfStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.thenStatement) ||
-            visitNode(cbNode, node.elseStatement);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.thenStatement)
+            || visitNode(cbNode, node.elseStatement);
     },
     [SyntaxKind.DoStatement]: function forEachChildInDoStatement<T>(node: DoStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.statement) ||
-            visitNode(cbNode, node.expression);
+        return visitNode(cbNode, node.statement)
+            || visitNode(cbNode, node.expression);
     },
     [SyntaxKind.WhileStatement]: function forEachChildInWhileStatement<T>(node: WhileStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.statement);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.statement);
     },
     [SyntaxKind.ForStatement]: function forEachChildInForStatement<T>(node: ForStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.initializer) ||
-            visitNode(cbNode, node.condition) ||
-            visitNode(cbNode, node.incrementor) ||
-            visitNode(cbNode, node.statement);
+        return visitNode(cbNode, node.initializer)
+            || visitNode(cbNode, node.condition)
+            || visitNode(cbNode, node.incrementor)
+            || visitNode(cbNode, node.statement);
     },
     [SyntaxKind.ForInStatement]: function forEachChildInForInStatement<T>(node: ForInStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.initializer) ||
-            visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.statement);
+        return visitNode(cbNode, node.initializer)
+            || visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.statement);
     },
     [SyntaxKind.ForOfStatement]: function forEachChildInForOfStatement<T>(node: ForOfStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.awaitModifier) ||
-            visitNode(cbNode, node.initializer) ||
-            visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.statement);
+        return visitNode(cbNode, node.awaitModifier)
+            || visitNode(cbNode, node.initializer)
+            || visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.statement);
     },
     [SyntaxKind.ContinueStatement]: forEachChildInContinueOrBreakStatement,
     [SyntaxKind.BreakStatement]: forEachChildInContinueOrBreakStatement,
@@ -854,38 +854,38 @@ const forEachChildTable: ForEachChildTable = {
         return visitNode(cbNode, node.expression);
     },
     [SyntaxKind.WithStatement]: function forEachChildInWithStatement<T>(node: WithStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.statement);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.statement);
     },
     [SyntaxKind.SwitchStatement]: function forEachChildInSwitchStatement<T>(node: SwitchStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.caseBlock);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.caseBlock);
     },
     [SyntaxKind.CaseBlock]: function forEachChildInCaseBlock<T>(node: CaseBlock, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNodes(cbNode, cbNodes, node.clauses);
     },
     [SyntaxKind.CaseClause]: function forEachChildInCaseClause<T>(node: CaseClause, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNodes(cbNode, cbNodes, node.statements);
+        return visitNode(cbNode, node.expression)
+            || visitNodes(cbNode, cbNodes, node.statements);
     },
     [SyntaxKind.DefaultClause]: function forEachChildInDefaultClause<T>(node: DefaultClause, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNodes(cbNode, cbNodes, node.statements);
     },
     [SyntaxKind.LabeledStatement]: function forEachChildInLabeledStatement<T>(node: LabeledStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.label) ||
-            visitNode(cbNode, node.statement);
+        return visitNode(cbNode, node.label)
+            || visitNode(cbNode, node.statement);
     },
     [SyntaxKind.ThrowStatement]: function forEachChildInThrowStatement<T>(node: ThrowStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
     },
     [SyntaxKind.TryStatement]: function forEachChildInTryStatement<T>(node: TryStatement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tryBlock) ||
-            visitNode(cbNode, node.catchClause) ||
-            visitNode(cbNode, node.finallyBlock);
+        return visitNode(cbNode, node.tryBlock)
+            || visitNode(cbNode, node.catchClause)
+            || visitNode(cbNode, node.finallyBlock);
     },
     [SyntaxKind.CatchClause]: function forEachChildInCatchClause<T>(node: CatchClause, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.variableDeclaration) ||
-            visitNode(cbNode, node.block);
+        return visitNode(cbNode, node.variableDeclaration)
+            || visitNode(cbNode, node.block);
     },
     [SyntaxKind.Decorator]: function forEachChildInDecorator<T>(node: Decorator, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
@@ -893,57 +893,57 @@ const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.ClassDeclaration]: forEachChildInClassDeclarationOrExpression,
     [SyntaxKind.ClassExpression]: forEachChildInClassDeclarationOrExpression,
     [SyntaxKind.InterfaceDeclaration]: function forEachChildInInterfaceDeclaration<T>(node: InterfaceDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNodes(cbNode, cbNodes, node.heritageClauses) ||
-            visitNodes(cbNode, cbNodes, node.members);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNodes(cbNode, cbNodes, node.heritageClauses)
+            || visitNodes(cbNode, cbNodes, node.members);
     },
     [SyntaxKind.TypeAliasDeclaration]: function forEachChildInTypeAliasDeclaration<T>(node: TypeAliasDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            visitNode(cbNode, node.type);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.EnumDeclaration]: function forEachChildInEnumDeclaration<T>(node: EnumDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNodes(cbNode, cbNodes, node.members);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNodes(cbNode, cbNodes, node.members);
     },
     [SyntaxKind.EnumMember]: function forEachChildInEnumMember<T>(node: EnumMember, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.initializer);
+        return visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.ModuleDeclaration]: function forEachChildInModuleDeclaration<T>(node: ModuleDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.body);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.body);
     },
     [SyntaxKind.ImportEqualsDeclaration]: function forEachChildInImportEqualsDeclaration<T>(node: ImportEqualsDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.moduleReference);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.moduleReference);
     },
     [SyntaxKind.ImportDeclaration]: function forEachChildInImportDeclaration<T>(node: ImportDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.importClause) ||
-            visitNode(cbNode, node.moduleSpecifier) ||
-            visitNode(cbNode, node.attributes);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.importClause)
+            || visitNode(cbNode, node.moduleSpecifier)
+            || visitNode(cbNode, node.attributes);
     },
     [SyntaxKind.ImportClause]: function forEachChildInImportClause<T>(node: ImportClause, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.namedBindings);
+        return visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.namedBindings);
     },
     [SyntaxKind.ImportAttributes]: function forEachChildInImportAttributes<T>(node: ImportAttributes, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNodes(cbNode, cbNodes, node.elements);
     },
     [SyntaxKind.ImportAttribute]: function forEachChildInImportAttribute<T>(node: ImportAttribute, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.value);
+        return visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.value);
     },
     [SyntaxKind.NamespaceExportDeclaration]: function forEachChildInNamespaceExportDeclaration<T>(node: NamespaceExportDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.name);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.name);
     },
     [SyntaxKind.NamespaceImport]: function forEachChildInNamespaceImport<T>(node: NamespaceImport, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.name);
@@ -954,32 +954,32 @@ const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.NamedImports]: forEachChildInNamedImportsOrExports,
     [SyntaxKind.NamedExports]: forEachChildInNamedImportsOrExports,
     [SyntaxKind.ExportDeclaration]: function forEachChildInExportDeclaration<T>(node: ExportDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.exportClause) ||
-            visitNode(cbNode, node.moduleSpecifier) ||
-            visitNode(cbNode, node.attributes);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.exportClause)
+            || visitNode(cbNode, node.moduleSpecifier)
+            || visitNode(cbNode, node.attributes);
     },
     [SyntaxKind.ImportSpecifier]: forEachChildInImportOrExportSpecifier,
     [SyntaxKind.ExportSpecifier]: forEachChildInImportOrExportSpecifier,
     [SyntaxKind.ExportAssignment]: function forEachChildInExportAssignment<T>(node: ExportAssignment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.modifiers) ||
-            visitNode(cbNode, node.expression);
+        return visitNodes(cbNode, cbNodes, node.modifiers)
+            || visitNode(cbNode, node.expression);
     },
     [SyntaxKind.TemplateExpression]: function forEachChildInTemplateExpression<T>(node: TemplateExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.head) ||
-            visitNodes(cbNode, cbNodes, node.templateSpans);
+        return visitNode(cbNode, node.head)
+            || visitNodes(cbNode, cbNodes, node.templateSpans);
     },
     [SyntaxKind.TemplateSpan]: function forEachChildInTemplateSpan<T>(node: TemplateSpan, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNode(cbNode, node.literal);
+        return visitNode(cbNode, node.expression)
+            || visitNode(cbNode, node.literal);
     },
     [SyntaxKind.TemplateLiteralType]: function forEachChildInTemplateLiteralType<T>(node: TemplateLiteralTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.head) ||
-            visitNodes(cbNode, cbNodes, node.templateSpans);
+        return visitNode(cbNode, node.head)
+            || visitNodes(cbNode, cbNodes, node.templateSpans);
     },
     [SyntaxKind.TemplateLiteralTypeSpan]: function forEachChildInTemplateLiteralTypeSpan<T>(node: TemplateLiteralTypeSpan, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.type) ||
-            visitNode(cbNode, node.literal);
+        return visitNode(cbNode, node.type)
+            || visitNode(cbNode, node.literal);
     },
     [SyntaxKind.ComputedPropertyName]: function forEachChildInComputedPropertyName<T>(node: ComputedPropertyName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
@@ -988,8 +988,8 @@ const forEachChildTable: ForEachChildTable = {
         return visitNodes(cbNode, cbNodes, node.types);
     },
     [SyntaxKind.ExpressionWithTypeArguments]: function forEachChildInExpressionWithTypeArguments<T>(node: ExpressionWithTypeArguments, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.expression) ||
-            visitNodes(cbNode, cbNodes, node.typeArguments);
+        return visitNode(cbNode, node.expression)
+            || visitNodes(cbNode, cbNodes, node.typeArguments);
     },
     [SyntaxKind.ExternalModuleReference]: function forEachChildInExternalModuleReference<T>(node: ExternalModuleReference, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
@@ -1001,14 +1001,14 @@ const forEachChildTable: ForEachChildTable = {
         return visitNodes(cbNode, cbNodes, node.elements);
     },
     [SyntaxKind.JsxElement]: function forEachChildInJsxElement<T>(node: JsxElement, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.openingElement) ||
-            visitNodes(cbNode, cbNodes, node.children) ||
-            visitNode(cbNode, node.closingElement);
+        return visitNode(cbNode, node.openingElement)
+            || visitNodes(cbNode, cbNodes, node.children)
+            || visitNode(cbNode, node.closingElement);
     },
     [SyntaxKind.JsxFragment]: function forEachChildInJsxFragment<T>(node: JsxFragment, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.openingFragment) ||
-            visitNodes(cbNode, cbNodes, node.children) ||
-            visitNode(cbNode, node.closingFragment);
+        return visitNode(cbNode, node.openingFragment)
+            || visitNodes(cbNode, cbNodes, node.children)
+            || visitNode(cbNode, node.closingFragment);
     },
     [SyntaxKind.JsxSelfClosingElement]: forEachChildInJsxOpeningOrSelfClosingElement,
     [SyntaxKind.JsxOpeningElement]: forEachChildInJsxOpeningOrSelfClosingElement,
@@ -1016,22 +1016,22 @@ const forEachChildTable: ForEachChildTable = {
         return visitNodes(cbNode, cbNodes, node.properties);
     },
     [SyntaxKind.JsxAttribute]: function forEachChildInJsxAttribute<T>(node: JsxAttribute, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.name) ||
-            visitNode(cbNode, node.initializer);
+        return visitNode(cbNode, node.name)
+            || visitNode(cbNode, node.initializer);
     },
     [SyntaxKind.JsxSpreadAttribute]: function forEachChildInJsxSpreadAttribute<T>(node: JsxSpreadAttribute, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.expression);
     },
     [SyntaxKind.JsxExpression]: function forEachChildInJsxExpression<T>(node: JsxExpression, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.dotDotDotToken) ||
-            visitNode(cbNode, node.expression);
+        return visitNode(cbNode, node.dotDotDotToken)
+            || visitNode(cbNode, node.expression);
     },
     [SyntaxKind.JsxClosingElement]: function forEachChildInJsxClosingElement<T>(node: JsxClosingElement, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.tagName);
     },
     [SyntaxKind.JsxNamespacedName]: function forEachChildInJsxNamespacedName<T>(node: JsxNamespacedName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.namespace) ||
-            visitNode(cbNode, node.name);
+        return visitNode(cbNode, node.namespace)
+            || visitNode(cbNode, node.name);
     },
     [SyntaxKind.OptionalType]: forEachChildInOptionalRestOrJSDocParameterModifier,
     [SyntaxKind.RestType]: forEachChildInOptionalRestOrJSDocParameterModifier,
@@ -1041,63 +1041,63 @@ const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.JSDocOptionalType]: forEachChildInOptionalRestOrJSDocParameterModifier,
     [SyntaxKind.JSDocVariadicType]: forEachChildInOptionalRestOrJSDocParameterModifier,
     [SyntaxKind.JSDocFunctionType]: function forEachChildInJSDocFunctionType<T>(node: JSDocFunctionType, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNodes(cbNode, cbNodes, node.parameters) ||
-            visitNode(cbNode, node.type);
+        return visitNodes(cbNode, cbNodes, node.parameters)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.JSDoc]: function forEachChildInJSDoc<T>(node: JSDoc, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment))
             || visitNodes(cbNode, cbNodes, node.tags);
     },
     [SyntaxKind.JSDocSeeTag]: function forEachChildInJSDocSeeTag<T>(node: JSDocSeeTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tagName) ||
-            visitNode(cbNode, node.name) ||
-            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+        return visitNode(cbNode, node.tagName)
+            || visitNode(cbNode, node.name)
+            || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
     },
     [SyntaxKind.JSDocNameReference]: function forEachChildInJSDocNameReference<T>(node: JSDocNameReference, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
         return visitNode(cbNode, node.name);
     },
     [SyntaxKind.JSDocMemberName]: function forEachChildInJSDocMemberName<T>(node: JSDocMemberName, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.left) ||
-            visitNode(cbNode, node.right);
+        return visitNode(cbNode, node.left)
+            || visitNode(cbNode, node.right);
     },
     [SyntaxKind.JSDocParameterTag]: forEachChildInJSDocParameterOrPropertyTag,
     [SyntaxKind.JSDocPropertyTag]: forEachChildInJSDocParameterOrPropertyTag,
     [SyntaxKind.JSDocAuthorTag]: function forEachChildInJSDocAuthorTag<T>(node: JSDocAuthorTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tagName) ||
-            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+        return visitNode(cbNode, node.tagName)
+            || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
     },
     [SyntaxKind.JSDocImplementsTag]: function forEachChildInJSDocImplementsTag<T>(node: JSDocImplementsTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tagName) ||
-            visitNode(cbNode, node.class) ||
-            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+        return visitNode(cbNode, node.tagName)
+            || visitNode(cbNode, node.class)
+            || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
     },
     [SyntaxKind.JSDocAugmentsTag]: function forEachChildInJSDocAugmentsTag<T>(node: JSDocAugmentsTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tagName) ||
-            visitNode(cbNode, node.class) ||
-            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+        return visitNode(cbNode, node.tagName)
+            || visitNode(cbNode, node.class)
+            || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
     },
     [SyntaxKind.JSDocTemplateTag]: function forEachChildInJSDocTemplateTag<T>(node: JSDocTemplateTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tagName) ||
-            visitNode(cbNode, node.constraint) ||
-            visitNodes(cbNode, cbNodes, node.typeParameters) ||
-            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+        return visitNode(cbNode, node.tagName)
+            || visitNode(cbNode, node.constraint)
+            || visitNodes(cbNode, cbNodes, node.typeParameters)
+            || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
     },
     [SyntaxKind.JSDocTypedefTag]: function forEachChildInJSDocTypedefTag<T>(node: JSDocTypedefTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tagName) ||
-            (node.typeExpression &&
-                    node.typeExpression.kind === SyntaxKind.JSDocTypeExpression
-                ? visitNode(cbNode, node.typeExpression) ||
-                    visitNode(cbNode, node.fullName) ||
-                    (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment))
-                : visitNode(cbNode, node.fullName) ||
-                    visitNode(cbNode, node.typeExpression) ||
-                    (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment)));
+        return visitNode(cbNode, node.tagName)
+            || (node.typeExpression
+                    && node.typeExpression.kind === SyntaxKind.JSDocTypeExpression
+                ? visitNode(cbNode, node.typeExpression)
+                    || visitNode(cbNode, node.fullName)
+                    || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment))
+                : visitNode(cbNode, node.fullName)
+                    || visitNode(cbNode, node.typeExpression)
+                    || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment)));
     },
     [SyntaxKind.JSDocCallbackTag]: function forEachChildInJSDocCallbackTag<T>(node: JSDocCallbackTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return visitNode(cbNode, node.tagName) ||
-            visitNode(cbNode, node.fullName) ||
-            visitNode(cbNode, node.typeExpression) ||
-            (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+        return visitNode(cbNode, node.tagName)
+            || visitNode(cbNode, node.fullName)
+            || visitNode(cbNode, node.typeExpression)
+            || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
     },
     [SyntaxKind.JSDocReturnTag]: forEachChildInJSDocTypeLikeTag,
     [SyntaxKind.JSDocTypeTag]: forEachChildInJSDocTypeLikeTag,
@@ -1107,9 +1107,9 @@ const forEachChildTable: ForEachChildTable = {
     [SyntaxKind.JSDocThrowsTag]: forEachChildInJSDocTypeLikeTag,
     [SyntaxKind.JSDocOverloadTag]: forEachChildInJSDocTypeLikeTag,
     [SyntaxKind.JSDocSignature]: function forEachChildInJSDocSignature<T>(node: JSDocSignature, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-        return forEach(node.typeParameters, cbNode) ||
-            forEach(node.parameters, cbNode) ||
-            visitNode(cbNode, node.type);
+        return forEach(node.typeParameters, cbNode)
+            || forEach(node.parameters, cbNode)
+            || visitNode(cbNode, node.type);
     },
     [SyntaxKind.JSDocLink]: forEachChildInJSDocLinkCodeOrPlain,
     [SyntaxKind.JSDocLinkCode]: forEachChildInJSDocLinkCodeOrPlain,
@@ -1131,9 +1131,9 @@ const forEachChildTable: ForEachChildTable = {
 // shared
 
 function forEachChildInCallOrConstructSignature<T>(node: CallSignatureDeclaration | ConstructSignatureDeclaration, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    return visitNodes(cbNode, cbNodes, node.typeParameters) ||
-        visitNodes(cbNode, cbNodes, node.parameters) ||
-        visitNode(cbNode, node.type);
+    return visitNodes(cbNode, cbNodes, node.typeParameters)
+        || visitNodes(cbNode, cbNodes, node.parameters)
+        || visitNode(cbNode, node.type);
 }
 
 function forEachChildInUnionOrIntersectionType<T>(node: UnionTypeNode | IntersectionTypeNode, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
@@ -1149,11 +1149,11 @@ function forEachChildInObjectOrArrayBindingPattern<T>(node: BindingPattern, cbNo
 }
 
 function forEachChildInCallOrNewExpression<T>(node: CallExpression | NewExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    return visitNode(cbNode, node.expression) ||
+    return visitNode(cbNode, node.expression)
         // TODO: should we separate these branches out?
-        visitNode(cbNode, (node as CallExpression).questionDotToken) ||
-        visitNodes(cbNode, cbNodes, node.typeArguments) ||
-        visitNodes(cbNode, cbNodes, node.arguments);
+        || visitNode(cbNode, (node as CallExpression).questionDotToken)
+        || visitNodes(cbNode, cbNodes, node.typeArguments)
+        || visitNodes(cbNode, cbNodes, node.arguments);
 }
 
 function forEachChildInBlock<T>(node: Block | ModuleBlock, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
@@ -1165,11 +1165,11 @@ function forEachChildInContinueOrBreakStatement<T>(node: ContinueStatement | Bre
 }
 
 function forEachChildInClassDeclarationOrExpression<T>(node: ClassDeclaration | ClassExpression, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    return visitNodes(cbNode, cbNodes, node.modifiers) ||
-        visitNode(cbNode, node.name) ||
-        visitNodes(cbNode, cbNodes, node.typeParameters) ||
-        visitNodes(cbNode, cbNodes, node.heritageClauses) ||
-        visitNodes(cbNode, cbNodes, node.members);
+    return visitNodes(cbNode, cbNodes, node.modifiers)
+        || visitNode(cbNode, node.name)
+        || visitNodes(cbNode, cbNodes, node.typeParameters)
+        || visitNodes(cbNode, cbNodes, node.heritageClauses)
+        || visitNodes(cbNode, cbNodes, node.members);
 }
 
 function forEachChildInNamedImportsOrExports<T>(node: NamedImports | NamedExports, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
@@ -1177,14 +1177,14 @@ function forEachChildInNamedImportsOrExports<T>(node: NamedImports | NamedExport
 }
 
 function forEachChildInImportOrExportSpecifier<T>(node: ImportSpecifier | ExportSpecifier, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    return visitNode(cbNode, node.propertyName) ||
-        visitNode(cbNode, node.name);
+    return visitNode(cbNode, node.propertyName)
+        || visitNode(cbNode, node.name);
 }
 
 function forEachChildInJsxOpeningOrSelfClosingElement<T>(node: JsxOpeningLikeElement, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    return visitNode(cbNode, node.tagName) ||
-        visitNodes(cbNode, cbNodes, node.typeArguments) ||
-        visitNode(cbNode, node.attributes);
+    return visitNode(cbNode, node.tagName)
+        || visitNodes(cbNode, cbNodes, node.typeArguments)
+        || visitNode(cbNode, node.attributes);
 }
 
 function forEachChildInOptionalRestOrJSDocParameterModifier<T>(node: OptionalTypeNode | RestTypeNode | JSDocTypeExpression | JSDocNullableType | JSDocNonNullableType | JSDocOptionalType | JSDocVariadicType, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
@@ -1192,17 +1192,17 @@ function forEachChildInOptionalRestOrJSDocParameterModifier<T>(node: OptionalTyp
 }
 
 function forEachChildInJSDocParameterOrPropertyTag<T>(node: JSDocParameterTag | JSDocPropertyTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    return visitNode(cbNode, node.tagName) ||
-        (node.isNameFirst
+    return visitNode(cbNode, node.tagName)
+        || (node.isNameFirst
             ? visitNode(cbNode, node.name) || visitNode(cbNode, node.typeExpression)
-            : visitNode(cbNode, node.typeExpression) || visitNode(cbNode, node.name)) ||
-        (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+            : visitNode(cbNode, node.typeExpression) || visitNode(cbNode, node.name))
+        || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
 }
 
 function forEachChildInJSDocTypeLikeTag<T>(node: JSDocReturnTag | JSDocTypeTag | JSDocThisTag | JSDocEnumTag | JSDocThrowsTag | JSDocOverloadTag | JSDocSatisfiesTag, cbNode: (node: Node) => T | undefined, cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
-    return visitNode(cbNode, node.tagName) ||
-        visitNode(cbNode, node.typeExpression) ||
-        (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
+    return visitNode(cbNode, node.tagName)
+        || visitNode(cbNode, node.typeExpression)
+        || (typeof node.comment === "string" ? undefined : visitNodes(cbNode, cbNodes, node.comment));
 }
 
 function forEachChildInJSDocLinkCodeOrPlain<T>(node: JSDocLink | JSDocLinkCode | JSDocLinkPlain, cbNode: (node: Node) => T | undefined, _cbNodes?: (nodes: NodeArray<Node>) => T | undefined): T | undefined {
@@ -2516,8 +2516,8 @@ namespace Parser {
 
     function parseExpectedToken<TKind extends SyntaxKind>(t: TKind, diagnosticMessage?: DiagnosticMessage, arg0?: string): Token<TKind>;
     function parseExpectedToken(t: SyntaxKind, diagnosticMessage?: DiagnosticMessage, arg0?: string): Node {
-        return parseOptionalToken(t) ||
-            createMissingNode(t, /*reportAtCurrentPosition*/ false, diagnosticMessage || Diagnostics._0_expected, arg0 || tokenToString(t)!);
+        return parseOptionalToken(t)
+            || createMissingNode(t, /*reportAtCurrentPosition*/ false, diagnosticMessage || Diagnostics._0_expected, arg0 || tokenToString(t)!);
     }
 
     function parseExpectedTokenJSDoc<TKind extends JSDocSyntaxKind>(t: TKind): Token<TKind>;
@@ -2603,12 +2603,12 @@ namespace Parser {
         }
 
         const pos = getNodePos();
-        const result = kind === SyntaxKind.Identifier ? factoryCreateIdentifier("", /*originalKeywordKind*/ undefined) :
-            isTemplateLiteralKind(kind) ? factory.createTemplateLiteralLikeNode(kind, "", "", /*templateFlags*/ undefined) :
-            kind === SyntaxKind.NumericLiteral ? factoryCreateNumericLiteral("", /*numericLiteralFlags*/ undefined) :
-            kind === SyntaxKind.StringLiteral ? factoryCreateStringLiteral("", /*isSingleQuote*/ undefined) :
-            kind === SyntaxKind.MissingDeclaration ? factory.createMissingDeclaration() :
-            factoryCreateToken(kind);
+        const result = kind === SyntaxKind.Identifier ? factoryCreateIdentifier("", /*originalKeywordKind*/ undefined)
+            : isTemplateLiteralKind(kind) ? factory.createTemplateLiteralLikeNode(kind, "", "", /*templateFlags*/ undefined)
+            : kind === SyntaxKind.NumericLiteral ? factoryCreateNumericLiteral("", /*numericLiteralFlags*/ undefined)
+            : kind === SyntaxKind.StringLiteral ? factoryCreateStringLiteral("", /*isSingleQuote*/ undefined)
+            : kind === SyntaxKind.MissingDeclaration ? factory.createMissingDeclaration()
+            : factoryCreateToken(kind);
         return finishNode(result, pos) as T;
     }
 
@@ -2652,9 +2652,9 @@ namespace Parser {
         const isReservedWord = scanner.isReservedWord();
         const msgArg = scanner.getTokenText();
 
-        const defaultMessage = isReservedWord ?
-            Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here :
-            Diagnostics.Identifier_expected;
+        const defaultMessage = isReservedWord
+            ? Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here
+            : Diagnostics.Identifier_expected;
 
         return createMissingNode<Identifier>(SyntaxKind.Identifier, reportAtCurrentPosition, diagnosticMessage || defaultMessage, msgArg);
     }
@@ -2679,9 +2679,9 @@ namespace Parser {
     }
 
     function isLiteralPropertyName(): boolean {
-        return tokenIsIdentifierOrKeyword(token()) ||
-            token() === SyntaxKind.StringLiteral ||
-            token() === SyntaxKind.NumericLiteral;
+        return tokenIsIdentifierOrKeyword(token())
+            || token() === SyntaxKind.StringLiteral
+            || token() === SyntaxKind.NumericLiteral;
     }
 
     function isImportAttributeName(): boolean {
@@ -2944,8 +2944,8 @@ namespace Parser {
 
     function isHeritageClauseExtendsOrImplementsKeyword(): boolean {
         if (
-            token() === SyntaxKind.ImplementsKeyword ||
-            token() === SyntaxKind.ExtendsKeyword
+            token() === SyntaxKind.ImplementsKeyword
+            || token() === SyntaxKind.ExtendsKeyword
         ) {
             return lookAhead(nextTokenIsStartOfExpression);
         }
@@ -3260,8 +3260,8 @@ namespace Parser {
                     // may have a method calls "constructor(...)" and we must reparse that
                     // into an actual .ConstructorDeclaration.
                     const methodDeclaration = node as MethodDeclaration;
-                    const nameIsConstructor = methodDeclaration.name.kind === SyntaxKind.Identifier &&
-                        methodDeclaration.name.escapedText === "constructor";
+                    const nameIsConstructor = methodDeclaration.name.kind === SyntaxKind.Identifier
+                        && methodDeclaration.name.escapedText === "constructor";
 
                     return !nameIsConstructor;
             }
@@ -3726,16 +3726,16 @@ namespace Parser {
 
     function parseLiteralLikeNode(kind: SyntaxKind): LiteralLikeNode {
         const pos = getNodePos();
-        const node = isTemplateLiteralKind(kind) ? factory.createTemplateLiteralLikeNode(kind, scanner.getTokenValue(), getTemplateLiteralRawText(kind), scanner.getTokenFlags() & TokenFlags.TemplateLiteralLikeFlags) :
+        const node = isTemplateLiteralKind(kind) ? factory.createTemplateLiteralLikeNode(kind, scanner.getTokenValue(), getTemplateLiteralRawText(kind), scanner.getTokenFlags() & TokenFlags.TemplateLiteralLikeFlags)
             // Note that theoretically the following condition would hold true literals like 009,
             // which is not octal. But because of how the scanner separates the tokens, we would
             // never get a token like this. Instead, we would get 00 and 9 as two separate tokens.
             // We also do not need to check for negatives because any prefix operator would be part of a
             // parent unary expression.
-            kind === SyntaxKind.NumericLiteral ? factoryCreateNumericLiteral(scanner.getTokenValue(), scanner.getNumericLiteralFlags()) :
-            kind === SyntaxKind.StringLiteral ? factoryCreateStringLiteral(scanner.getTokenValue(), /*isSingleQuote*/ undefined, scanner.hasExtendedUnicodeEscape()) :
-            isLiteralKind(kind) ? factoryCreateLiteralLikeNode(kind, scanner.getTokenValue()) :
-            Debug.fail();
+            : kind === SyntaxKind.NumericLiteral ? factoryCreateNumericLiteral(scanner.getTokenValue(), scanner.getNumericLiteralFlags())
+            : kind === SyntaxKind.StringLiteral ? factoryCreateStringLiteral(scanner.getTokenValue(), /*isSingleQuote*/ undefined, scanner.hasExtendedUnicodeEscape())
+            : isLiteralKind(kind) ? factoryCreateLiteralLikeNode(kind, scanner.getTokenValue())
+            : Debug.fail();
 
         if (scanner.hasExtendedUnicodeEscape()) {
             node.hasExtendedUnicodeEscape = true;
@@ -3828,12 +3828,12 @@ namespace Parser {
         //      Foo(?=
         //      (?|
         if (
-            token() === SyntaxKind.CommaToken ||
-            token() === SyntaxKind.CloseBraceToken ||
-            token() === SyntaxKind.CloseParenToken ||
-            token() === SyntaxKind.GreaterThanToken ||
-            token() === SyntaxKind.EqualsToken ||
-            token() === SyntaxKind.BarToken
+            token() === SyntaxKind.CommaToken
+            || token() === SyntaxKind.CloseBraceToken
+            || token() === SyntaxKind.CloseParenToken
+            || token() === SyntaxKind.GreaterThanToken
+            || token() === SyntaxKind.EqualsToken
+            || token() === SyntaxKind.BarToken
         ) {
             return finishNode(factory.createJSDocUnknownType(), pos);
         }
@@ -3958,11 +3958,11 @@ namespace Parser {
     }
 
     function isStartOfParameter(isJSDocParameter: boolean): boolean {
-        return token() === SyntaxKind.DotDotDotToken ||
-            isBindingIdentifierOrPrivateIdentifierOrPattern() ||
-            isModifierKind(token()) ||
-            token() === SyntaxKind.AtToken ||
-            isStartOfType(/*inStartOfParameter*/ !isJSDocParameter);
+        return token() === SyntaxKind.DotDotDotToken
+            || isBindingIdentifierOrPrivateIdentifierOrPattern()
+            || isModifierKind(token())
+            || token() === SyntaxKind.AtToken
+            || isStartOfType(/*inStartOfParameter*/ !isJSDocParameter);
     }
 
     function parseNameOfParameter(modifiers: NodeArray<ModifierLike> | undefined) {
@@ -4008,9 +4008,9 @@ namespace Parser {
         //      BindingElement[?Yield,?Await]
 
         // Decorators are parsed in the outer [Await] context, the rest of the parameter is parsed in the function's [Await] context.
-        const modifiers = inOuterAwaitContext ?
-            doInAwaitContext(() => parseModifiers(/*allowDecorators*/ true)) :
-            doOutsideOfAwaitContext(() => parseModifiers(/*allowDecorators*/ true));
+        const modifiers = inOuterAwaitContext
+            ? doInAwaitContext(() => parseModifiers(/*allowDecorators*/ true))
+            : doOutsideOfAwaitContext(() => parseModifiers(/*allowDecorators*/ true));
 
         if (token() === SyntaxKind.ThisKeyword) {
             const node = factory.createParameterDeclaration(
@@ -4104,9 +4104,9 @@ namespace Parser {
         setYieldContext(!!(flags & SignatureFlags.Yield));
         setAwaitContext(!!(flags & SignatureFlags.Await));
 
-        const parameters = flags & SignatureFlags.JSDoc ?
-            parseDelimitedList(ParsingContext.JSDocParameters, parseJSDocParameter) :
-            parseDelimitedList(ParsingContext.Parameters, () => allowAmbiguity ? parseParameter(savedAwaitContext) : parseParameterForSpeculation(savedAwaitContext));
+        const parameters = flags & SignatureFlags.JSDoc
+            ? parseDelimitedList(ParsingContext.JSDocParameters, parseJSDocParameter)
+            : parseDelimitedList(ParsingContext.Parameters, () => allowAmbiguity ? parseParameter(savedAwaitContext) : parseParameterForSpeculation(savedAwaitContext));
 
         setYieldContext(savedYieldContext);
         setAwaitContext(savedAwaitContext);
@@ -4259,10 +4259,10 @@ namespace Parser {
     function isTypeMemberStart(): boolean {
         // Return true if we have the start of a signature member
         if (
-            token() === SyntaxKind.OpenParenToken ||
-            token() === SyntaxKind.LessThanToken ||
-            token() === SyntaxKind.GetKeyword ||
-            token() === SyntaxKind.SetKeyword
+            token() === SyntaxKind.OpenParenToken
+            || token() === SyntaxKind.LessThanToken
+            || token() === SyntaxKind.GetKeyword
+            || token() === SyntaxKind.SetKeyword
         ) {
             return true;
         }
@@ -4284,12 +4284,12 @@ namespace Parser {
         // If we were able to get any potential identifier, check that it is
         // the start of a member declaration
         if (idToken) {
-            return token() === SyntaxKind.OpenParenToken ||
-                token() === SyntaxKind.LessThanToken ||
-                token() === SyntaxKind.QuestionToken ||
-                token() === SyntaxKind.ColonToken ||
-                token() === SyntaxKind.CommaToken ||
-                canParseSemicolon();
+            return token() === SyntaxKind.OpenParenToken
+                || token() === SyntaxKind.LessThanToken
+                || token() === SyntaxKind.QuestionToken
+                || token() === SyntaxKind.ColonToken
+                || token() === SyntaxKind.CommaToken
+                || canParseSemicolon();
         }
         return false;
     }
@@ -4497,9 +4497,9 @@ namespace Parser {
         if (negative) {
             nextToken();
         }
-        let expression: BooleanLiteral | NullLiteral | LiteralExpression | PrefixUnaryExpression = token() === SyntaxKind.TrueKeyword || token() === SyntaxKind.FalseKeyword || token() === SyntaxKind.NullKeyword ?
-            parseTokenNode<BooleanLiteral | NullLiteral>() :
-            parseLiteralLikeNode(token()) as LiteralExpression;
+        let expression: BooleanLiteral | NullLiteral | LiteralExpression | PrefixUnaryExpression = token() === SyntaxKind.TrueKeyword || token() === SyntaxKind.FalseKeyword || token() === SyntaxKind.NullKeyword
+            ? parseTokenNode<BooleanLiteral | NullLiteral>()
+            : parseLiteralLikeNode(token()) as LiteralExpression;
         if (negative) {
             expression = finishNode(factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, expression), pos);
         }
@@ -4822,8 +4822,8 @@ namespace Parser {
         if (token() === SyntaxKind.OpenParenToken && lookAhead(isUnambiguouslyStartOfFunctionType)) {
             return true;
         }
-        return token() === SyntaxKind.NewKeyword ||
-            token() === SyntaxKind.AbstractKeyword && lookAhead(nextTokenIsNewKeyword);
+        return token() === SyntaxKind.NewKeyword
+            || token() === SyntaxKind.AbstractKeyword && lookAhead(nextTokenIsNewKeyword);
     }
 
     function skipParameterStart(): boolean {
@@ -4855,8 +4855,8 @@ namespace Parser {
             // We successfully skipped modifiers (if any) and an identifier or binding pattern,
             // now see if we have something that indicates a parameter declaration
             if (
-                token() === SyntaxKind.ColonToken || token() === SyntaxKind.CommaToken ||
-                token() === SyntaxKind.QuestionToken || token() === SyntaxKind.EqualsToken
+                token() === SyntaxKind.ColonToken || token() === SyntaxKind.CommaToken
+                || token() === SyntaxKind.QuestionToken || token() === SyntaxKind.EqualsToken
             ) {
                 // ( xxx :
                 // ( xxx ,
@@ -4997,11 +4997,11 @@ namespace Parser {
 
     function isStartOfExpressionStatement(): boolean {
         // As per the grammar, none of '{' or 'function' or 'class' can start an expression statement.
-        return token() !== SyntaxKind.OpenBraceToken &&
-            token() !== SyntaxKind.FunctionKeyword &&
-            token() !== SyntaxKind.ClassKeyword &&
-            token() !== SyntaxKind.AtToken &&
-            isStartOfExpression();
+        return token() !== SyntaxKind.OpenBraceToken
+            && token() !== SyntaxKind.FunctionKeyword
+            && token() !== SyntaxKind.ClassKeyword
+            && token() !== SyntaxKind.AtToken
+            && isStartOfExpression();
     }
 
     function parseExpression(): Expression {
@@ -5142,8 +5142,8 @@ namespace Parser {
         nextToken();
 
         if (
-            !scanner.hasPrecedingLineBreak() &&
-            (token() === SyntaxKind.AsteriskToken || isStartOfExpression())
+            !scanner.hasPrecedingLineBreak()
+            && (token() === SyntaxKind.AsteriskToken || isStartOfExpression())
         ) {
             return finishNode(
                 factory.createYieldExpression(
@@ -5190,9 +5190,9 @@ namespace Parser {
         // following => or { token. Otherwise, we *might* have an arrow function.  Try to parse
         // it out, but don't allow any ambiguity, and return 'undefined' if this could be an
         // expression instead.
-        return triState === Tristate.True ?
-            parseParenthesizedArrowFunctionExpression(/*allowAmbiguity*/ true, /*allowReturnTypeInArrowFunction*/ true) :
-            tryParse(() => parsePossibleParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction));
+        return triState === Tristate.True
+            ? parseParenthesizedArrowFunctionExpression(/*allowAmbiguity*/ true, /*allowReturnTypeInArrowFunction*/ true)
+            : tryParse(() => parsePossibleParenthesizedArrowFunctionExpression(allowReturnTypeInArrowFunction));
     }
 
     //  True        -> We definitely expect a parenthesized arrow function here.
@@ -5502,11 +5502,11 @@ namespace Parser {
         }
 
         if (
-            token() !== SyntaxKind.SemicolonToken &&
-            token() !== SyntaxKind.FunctionKeyword &&
-            token() !== SyntaxKind.ClassKeyword &&
-            isStartOfStatement() &&
-            !isStartOfExpressionStatement()
+            token() !== SyntaxKind.SemicolonToken
+            && token() !== SyntaxKind.FunctionKeyword
+            && token() !== SyntaxKind.ClassKeyword
+            && isStartOfStatement()
+            && !isStartOfExpressionStatement()
         ) {
             // Check if we got a plain statement (i.e. no expression-statements, no function/class expressions/declarations)
             //
@@ -5597,9 +5597,9 @@ namespace Parser {
             //            ^^token; leftOperand = b. Return b ** c to the caller as a rightOperand
             //      a ** b - c
             //             ^token; leftOperand = b. Return b to the caller as a rightOperand
-            const consumeCurrentOperator = token() === SyntaxKind.AsteriskAsteriskToken ?
-                newPrecedence >= precedence :
-                newPrecedence > precedence;
+            const consumeCurrentOperator = token() === SyntaxKind.AsteriskAsteriskToken
+                ? newPrecedence >= precedence
+                : newPrecedence > precedence;
 
             if (!consumeCurrentOperator) {
                 break;
@@ -5621,8 +5621,8 @@ namespace Parser {
                 else {
                     const keywordKind = token();
                     nextToken();
-                    leftOperand = keywordKind === SyntaxKind.SatisfiesKeyword ? makeSatisfiesExpression(leftOperand, parseType()) :
-                        makeAsExpression(leftOperand, parseType());
+                    leftOperand = keywordKind === SyntaxKind.SatisfiesKeyword ? makeSatisfiesExpression(leftOperand, parseType())
+                        : makeAsExpression(leftOperand, parseType());
                 }
             }
             else {
@@ -5710,9 +5710,9 @@ namespace Parser {
         if (isUpdateExpression()) {
             const pos = getNodePos();
             const updateExpression = parseUpdateExpression();
-            return token() === SyntaxKind.AsteriskAsteriskToken ?
-                parseBinaryExpressionRest(getBinaryOperatorPrecedence(token()), updateExpression, pos) as BinaryExpression :
-                updateExpression;
+            return token() === SyntaxKind.AsteriskAsteriskToken
+                ? parseBinaryExpressionRest(getBinaryOperatorPrecedence(token()), updateExpression, pos) as BinaryExpression
+                : updateExpression;
         }
 
         /**
@@ -6370,9 +6370,9 @@ namespace Parser {
     function parsePropertyAccessExpressionRest(pos: number, expression: LeftHandSideExpression, questionDotToken: QuestionDotToken | undefined) {
         const name = parseRightSideOfDot(/*allowIdentifierNames*/ true, /*allowPrivateIdentifiers*/ true, /*allowUnicodeEscapeSequenceInIdentifierName*/ true);
         const isOptionalChain = questionDotToken || tryReparseOptionalChain(expression);
-        const propertyAccess = isOptionalChain ?
-            factoryCreatePropertyAccessChain(expression, questionDotToken, name) :
-            factoryCreatePropertyAccessExpression(expression, name);
+        const propertyAccess = isOptionalChain
+            ? factoryCreatePropertyAccessChain(expression, questionDotToken, name)
+            : factoryCreatePropertyAccessExpression(expression, name);
         if (isOptionalChain && isPrivateIdentifier(propertyAccess.name)) {
             parseErrorAtRange(propertyAccess.name, Diagnostics.An_optional_chain_cannot_contain_private_identifiers);
         }
@@ -6399,9 +6399,9 @@ namespace Parser {
 
         parseExpected(SyntaxKind.CloseBracketToken);
 
-        const indexedAccess = questionDotToken || tryReparseOptionalChain(expression) ?
-            factoryCreateElementAccessChain(expression, questionDotToken, argumentExpression) :
-            factoryCreateElementAccessExpression(expression, argumentExpression);
+        const indexedAccess = questionDotToken || tryReparseOptionalChain(expression)
+            ? factoryCreateElementAccessChain(expression, questionDotToken, argumentExpression)
+            : factoryCreateElementAccessExpression(expression, argumentExpression);
         return finishNode(indexedAccess, pos);
     }
 
@@ -6430,9 +6430,9 @@ namespace Parser {
 
             if (isTemplateStartOfTaggedTemplate()) {
                 // Absorb type arguments into TemplateExpression when preceding expression is ExpressionWithTypeArguments
-                expression = !questionDotToken && expression.kind === SyntaxKind.ExpressionWithTypeArguments ?
-                    parseTaggedTemplateRest(pos, (expression as ExpressionWithTypeArguments).expression, questionDotToken, (expression as ExpressionWithTypeArguments).typeArguments) :
-                    parseTaggedTemplateRest(pos, expression, questionDotToken, /*typeArguments*/ undefined);
+                expression = !questionDotToken && expression.kind === SyntaxKind.ExpressionWithTypeArguments
+                    ? parseTaggedTemplateRest(pos, (expression as ExpressionWithTypeArguments).expression, questionDotToken, (expression as ExpressionWithTypeArguments).typeArguments)
+                    : parseTaggedTemplateRest(pos, expression, questionDotToken, /*typeArguments*/ undefined);
                 continue;
             }
 
@@ -6461,9 +6461,9 @@ namespace Parser {
         const tagExpression = factory.createTaggedTemplateExpression(
             tag,
             typeArguments,
-            token() === SyntaxKind.NoSubstitutionTemplateLiteral ?
-                (reScanTemplateToken(/*isTaggedTemplate*/ true), parseLiteralNode() as NoSubstitutionTemplateLiteral) :
-                parseTemplateExpression(/*isTaggedTemplate*/ true),
+            token() === SyntaxKind.NoSubstitutionTemplateLiteral
+                ? (reScanTemplateToken(/*isTaggedTemplate*/ true), parseLiteralNode() as NoSubstitutionTemplateLiteral)
+                : parseTemplateExpression(/*isTaggedTemplate*/ true),
         );
         if (questionDotToken || tag.flags & NodeFlags.OptionalChain) {
             (tagExpression as Mutable<Node>).flags |= NodeFlags.OptionalChain;
@@ -6491,9 +6491,9 @@ namespace Parser {
                     expression = (expression as ExpressionWithTypeArguments).expression;
                 }
                 const argumentList = parseArgumentList();
-                const callExpr = questionDotToken || tryReparseOptionalChain(expression) ?
-                    factoryCreateCallChain(expression, questionDotToken, typeArguments, argumentList) :
-                    factoryCreateCallExpression(expression, typeArguments, argumentList);
+                const callExpr = questionDotToken || tryReparseOptionalChain(expression)
+                    ? factoryCreateCallChain(expression, questionDotToken, typeArguments, argumentList)
+                    : factoryCreateCallExpression(expression, typeArguments, argumentList);
                 expression = finishNode(callExpr, pos);
                 continue;
             }
@@ -6632,9 +6632,9 @@ namespace Parser {
     }
 
     function parseArgumentOrArrayLiteralElement(): Expression {
-        return token() === SyntaxKind.DotDotDotToken ? parseSpreadElement() :
-            token() === SyntaxKind.CommaToken ? finishNode(factory.createOmittedExpression(), getNodePos()) :
-            parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
+        return token() === SyntaxKind.DotDotDotToken ? parseSpreadElement()
+            : token() === SyntaxKind.CommaToken ? finishNode(factory.createOmittedExpression(), getNodePos())
+            : parseAssignmentExpressionOrHigher(/*allowReturnTypeInArrowFunction*/ true);
     }
 
     function parseArgumentExpression(): Expression {
@@ -6733,10 +6733,10 @@ namespace Parser {
         const asteriskToken = parseOptionalToken(SyntaxKind.AsteriskToken);
         const isGenerator = asteriskToken ? SignatureFlags.Yield : SignatureFlags.None;
         const isAsync = some(modifiers, isAsyncModifier) ? SignatureFlags.Await : SignatureFlags.None;
-        const name = isGenerator && isAsync ? doInYieldAndAwaitContext(parseOptionalBindingIdentifier) :
-            isGenerator ? doInYieldContext(parseOptionalBindingIdentifier) :
-            isAsync ? doInAwaitContext(parseOptionalBindingIdentifier) :
-            parseOptionalBindingIdentifier();
+        const name = isGenerator && isAsync ? doInYieldAndAwaitContext(parseOptionalBindingIdentifier)
+            : isGenerator ? doInYieldContext(parseOptionalBindingIdentifier)
+            : isAsync ? doInAwaitContext(parseOptionalBindingIdentifier)
+            : parseOptionalBindingIdentifier();
 
         const typeParameters = parseTypeParameters();
         const parameters = parseParameters(isGenerator | isAsync);
@@ -6890,10 +6890,10 @@ namespace Parser {
         let initializer!: VariableDeclarationList | Expression;
         if (token() !== SyntaxKind.SemicolonToken) {
             if (
-                token() === SyntaxKind.VarKeyword || token() === SyntaxKind.LetKeyword || token() === SyntaxKind.ConstKeyword ||
-                token() === SyntaxKind.UsingKeyword && lookAhead(nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLineDisallowOf) ||
+                token() === SyntaxKind.VarKeyword || token() === SyntaxKind.LetKeyword || token() === SyntaxKind.ConstKeyword
+                || token() === SyntaxKind.UsingKeyword && lookAhead(nextTokenIsBindingIdentifierOrStartOfDestructuringOnSameLineDisallowOf)
                 // this one is meant to allow of
-                token() === SyntaxKind.AwaitKeyword && lookAhead(nextTokenIsUsingKeywordThenBindingIdentifierOrStartOfObjectDestructuringOnSameLine)
+                || token() === SyntaxKind.AwaitKeyword && lookAhead(nextTokenIsUsingKeywordThenBindingIdentifierOrStartOfObjectDestructuringOnSameLine)
             ) {
                 initializer = parseVariableDeclarationList(/*inForStatementInitializer*/ true);
             }
@@ -7189,17 +7189,17 @@ namespace Parser {
 
                 case SyntaxKind.ImportKeyword:
                     nextToken();
-                    return token() === SyntaxKind.StringLiteral || token() === SyntaxKind.AsteriskToken ||
-                        token() === SyntaxKind.OpenBraceToken || tokenIsIdentifierOrKeyword(token());
+                    return token() === SyntaxKind.StringLiteral || token() === SyntaxKind.AsteriskToken
+                        || token() === SyntaxKind.OpenBraceToken || tokenIsIdentifierOrKeyword(token());
                 case SyntaxKind.ExportKeyword:
                     let currentToken = nextToken();
                     if (currentToken === SyntaxKind.TypeKeyword) {
                         currentToken = lookAhead(nextToken);
                     }
                     if (
-                        currentToken === SyntaxKind.EqualsToken || currentToken === SyntaxKind.AsteriskToken ||
-                        currentToken === SyntaxKind.OpenBraceToken || currentToken === SyntaxKind.DefaultKeyword ||
-                        currentToken === SyntaxKind.AsKeyword || currentToken === SyntaxKind.AtToken
+                        currentToken === SyntaxKind.EqualsToken || currentToken === SyntaxKind.AsteriskToken
+                        || currentToken === SyntaxKind.OpenBraceToken || currentToken === SyntaxKind.DefaultKeyword
+                        || currentToken === SyntaxKind.AsKeyword || currentToken === SyntaxKind.AtToken
                     ) {
                         return true;
                     }
@@ -7595,8 +7595,8 @@ namespace Parser {
         const name = parseIdentifierOrPattern(Diagnostics.Private_identifiers_are_not_allowed_in_variable_declarations);
         let exclamationToken: ExclamationToken | undefined;
         if (
-            allowExclamation && name.kind === SyntaxKind.Identifier &&
-            token() === SyntaxKind.ExclamationToken && !scanner.hasPrecedingLineBreak()
+            allowExclamation && name.kind === SyntaxKind.Identifier
+            && token() === SyntaxKind.ExclamationToken && !scanner.hasPrecedingLineBreak()
         ) {
             exclamationToken = parseTokenNode<Token<SyntaxKind.ExclamationToken>>();
         }
@@ -8041,11 +8041,11 @@ namespace Parser {
         // It is very important that we check this *after* checking indexers because
         // the [ token can start an index signature or a computed property name
         if (
-            tokenIsIdentifierOrKeyword(token()) ||
-            token() === SyntaxKind.StringLiteral ||
-            token() === SyntaxKind.NumericLiteral ||
-            token() === SyntaxKind.AsteriskToken ||
-            token() === SyntaxKind.OpenBracketToken
+            tokenIsIdentifierOrKeyword(token())
+            || token() === SyntaxKind.StringLiteral
+            || token() === SyntaxKind.NumericLiteral
+            || token() === SyntaxKind.AsteriskToken
+            || token() === SyntaxKind.OpenBracketToken
         ) {
             const isAmbient = some(modifiers, isDeclareModifier);
             if (isAmbient) {
@@ -8164,8 +8164,8 @@ namespace Parser {
     }
 
     function tryParseTypeArguments(): NodeArray<TypeNode> | undefined {
-        return token() === SyntaxKind.LessThanToken ?
-            parseBracketedList(ParsingContext.TypeArguments, parseType, SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken) : undefined;
+        return token() === SyntaxKind.LessThanToken
+            ? parseBracketedList(ParsingContext.TypeArguments, parseType, SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken) : undefined;
     }
 
     function isHeritageClause(): boolean {
@@ -8294,8 +8294,8 @@ namespace Parser {
     }
 
     function isExternalModuleReference() {
-        return token() === SyntaxKind.RequireKeyword &&
-            lookAhead(nextTokenIsOpenParen);
+        return token() === SyntaxKind.RequireKeyword
+            && lookAhead(nextTokenIsOpenParen);
     }
 
     function nextTokenIsOpenParen() {
@@ -8334,9 +8334,9 @@ namespace Parser {
 
         let isTypeOnly = false;
         if (
-            identifier?.escapedText === "type" &&
-            (token() !== SyntaxKind.FromKeyword || isIdentifier() && lookAhead(nextTokenIsFromKeywordOrEqualsToken)) &&
-            (isIdentifier() || tokenAfterImportDefinitelyProducesImportDeclaration())
+            identifier?.escapedText === "type"
+            && (token() !== SyntaxKind.FromKeyword || isIdentifier() && lookAhead(nextTokenIsFromKeywordOrEqualsToken))
+            && (isIdentifier() || tokenAfterImportDefinitelyProducesImportDeclaration())
         ) {
             isTypeOnly = true;
             identifier = isIdentifier() ? parseIdentifier() : undefined;
@@ -8351,9 +8351,9 @@ namespace Parser {
         //  import ModuleSpecifier;
         let importClause: ImportClause | undefined;
         if (
-            identifier || // import id
-            token() === SyntaxKind.AsteriskToken || // import *
-            token() === SyntaxKind.OpenBraceToken // import {
+            identifier // import id
+            || token() === SyntaxKind.AsteriskToken // import *
+            || token() === SyntaxKind.OpenBraceToken // import {
         ) {
             importClause = parseImportClause(identifier, afterImportPos, isTypeOnly);
             parseExpected(SyntaxKind.FromKeyword);
@@ -8434,8 +8434,8 @@ namespace Parser {
         // parse namespace or named imports
         let namedBindings: NamespaceImport | NamedImports | undefined;
         if (
-            !identifier ||
-            parseOptional(SyntaxKind.CommaToken)
+            !identifier
+            || parseOptional(SyntaxKind.CommaToken)
         ) {
             namedBindings = token() === SyntaxKind.AsteriskToken ? parseNamespaceImport() : parseNamedImportsOrExports(SyntaxKind.NamedImports);
         }
@@ -9524,17 +9524,17 @@ namespace Parser {
                     if (hasChildren) {
                         const isArrayType = typeExpression && typeExpression.type.kind === SyntaxKind.ArrayType;
                         const jsdocTypeLiteral = factory.createJSDocTypeLiteral(jsDocPropertyTags, isArrayType);
-                        typeExpression = childTypeTag && childTypeTag.typeExpression && !isObjectOrObjectArrayTypeReference(childTypeTag.typeExpression.type) ?
-                            childTypeTag.typeExpression :
-                            finishNode(jsdocTypeLiteral, start);
+                        typeExpression = childTypeTag && childTypeTag.typeExpression && !isObjectOrObjectArrayTypeReference(childTypeTag.typeExpression.type)
+                            ? childTypeTag.typeExpression
+                            : finishNode(jsdocTypeLiteral, start);
                         end = typeExpression.end;
                     }
                 }
 
                 // Only include the characters between the name end and the next token if a comment was actually parsed out - otherwise it's just whitespace
-                end = end || comment !== undefined ?
-                    getNodePos() :
-                    (fullName ?? typeExpression ?? tagName).end;
+                end = end || comment !== undefined
+                    ? getNodePos()
+                    : (fullName ?? typeExpression ?? tagName).end;
 
                 if (!comment) {
                     comment = parseTrailingTagComments(start, end, indent, indentText);
@@ -9643,8 +9643,8 @@ namespace Parser {
                             if (canParseTag) {
                                 const child = tryParseChildTag(target, indent);
                                 if (
-                                    child && (child.kind === SyntaxKind.JSDocParameterTag || child.kind === SyntaxKind.JSDocPropertyTag) &&
-                                    name && (isIdentifierNode(child.name) || !escapedTextsEqual(name, child.name.left))
+                                    child && (child.kind === SyntaxKind.JSDocParameterTag || child.kind === SyntaxKind.JSDocPropertyTag)
+                                    && name && (isIdentifierNode(child.name) || !escapedTextsEqual(name, child.name.left))
                                 ) {
                                     return false;
                                 }
@@ -10060,12 +10060,12 @@ namespace IncrementalParser {
         // However any element that ended after that will have their pos adjusted to be
         // at the end of the new range.  i.e. any node that ended in the 'Y' range will
         // be adjusted to have their end at the end of the 'Z' range.
-        const end = element.end >= changeRangeOldEnd ?
+        const end = element.end >= changeRangeOldEnd
             // Element ends after the change range.  Always adjust the end pos.
-            element.end + delta :
+            ? element.end + delta
             // Element ends in the change range.  The element will keep its position if
             // possible. Or Move backward to the new-end if it's in the 'Y' range.
-            Math.min(element.end, changeRangeNewEnd);
+            : Math.min(element.end, changeRangeNewEnd);
 
         Debug.assert(pos <= end);
         if (element.parent) {
@@ -10689,13 +10689,13 @@ export function tagNamesAreEquivalent(lhs: JsxTagNameExpression, rhs: JsxTagName
     }
 
     if (lhs.kind === SyntaxKind.JsxNamespacedName) {
-        return lhs.namespace.escapedText === (rhs as JsxNamespacedName).namespace.escapedText &&
-            lhs.name.escapedText === (rhs as JsxNamespacedName).name.escapedText;
+        return lhs.namespace.escapedText === (rhs as JsxNamespacedName).namespace.escapedText
+            && lhs.name.escapedText === (rhs as JsxNamespacedName).name.escapedText;
     }
 
     // If we are at this statement then we must have PropertyAccessExpression and because tag name in Jsx element can only
     // take forms of JsxTagNameExpression which includes an identifier, "this" expression, or another propertyAccessExpression
     // it is safe to case the expression property as such. See parseJsxElementName for how we parse tag name in Jsx element
-    return (lhs as PropertyAccessExpression).name.escapedText === (rhs as PropertyAccessExpression).name.escapedText &&
-        tagNamesAreEquivalent((lhs as PropertyAccessExpression).expression as JsxTagNameExpression, (rhs as PropertyAccessExpression).expression as JsxTagNameExpression);
+    return (lhs as PropertyAccessExpression).name.escapedText === (rhs as PropertyAccessExpression).name.escapedText
+        && tagNamesAreEquivalent((lhs as PropertyAccessExpression).expression as JsxTagNameExpression, (rhs as PropertyAccessExpression).expression as JsxTagNameExpression);
 }

--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -144,8 +144,8 @@ export function hasTrailingDirectorySeparator(path: string) {
 //// Path Parsing
 
 function isVolumeCharacter(charCode: number) {
-    return (charCode >= CharacterCodes.a && charCode <= CharacterCodes.z) ||
-        (charCode >= CharacterCodes.A && charCode <= CharacterCodes.Z);
+    return (charCode >= CharacterCodes.a && charCode <= CharacterCodes.z)
+        || (charCode >= CharacterCodes.A && charCode <= CharacterCodes.Z);
 }
 
 function getFileUrlVolumeSeparatorEnd(url: string, start: number) {
@@ -195,8 +195,8 @@ function getEncodedRootLength(path: string): number {
             const scheme = path.slice(0, schemeEnd);
             const authority = path.slice(authorityStart, authorityEnd);
             if (
-                scheme === "file" && (authority === "" || authority === "localhost") &&
-                isVolumeCharacter(path.charCodeAt(authorityEnd + 1))
+                scheme === "file" && (authority === "" || authority === "localhost")
+                && isVolumeCharacter(path.charCodeAt(authorityEnd + 1))
             ) {
                 const volumeSeparatorEnd = getFileUrlVolumeSeparatorEnd(path, authorityEnd + 2);
                 if (volumeSeparatorEnd !== -1) {
@@ -770,8 +770,8 @@ export function changeAnyExtension(path: string, ext: string, extensions?: strin
 export function changeFullExtension(path: string, newExtension: string) {
     const declarationExtension = getDeclarationFileExtension(path);
     if (declarationExtension) {
-        return path.slice(0, path.length - declarationExtension.length) +
-            (startsWith(newExtension, ".") ? newExtension : ("." + newExtension));
+        return path.slice(0, path.length - declarationExtension.length)
+            + (startsWith(newExtension, ".") ? newExtension : ("." + newExtension));
     }
     return changeAnyExtension(path, newExtension);
 }

--- a/src/compiler/performanceCore.ts
+++ b/src/compiler/performanceCore.ts
@@ -55,21 +55,21 @@ declare const PerformanceObserver: PerformanceObserverConstructor | undefined;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function hasRequiredAPI(performance: Performance | undefined, PerformanceObserver: PerformanceObserverConstructor | undefined) {
-    return typeof performance === "object" &&
-        typeof performance.timeOrigin === "number" &&
-        typeof performance.mark === "function" &&
-        typeof performance.measure === "function" &&
-        typeof performance.now === "function" &&
-        typeof performance.clearMarks === "function" &&
-        typeof performance.clearMeasures === "function" &&
-        typeof PerformanceObserver === "function";
+    return typeof performance === "object"
+        && typeof performance.timeOrigin === "number"
+        && typeof performance.mark === "function"
+        && typeof performance.measure === "function"
+        && typeof performance.now === "function"
+        && typeof performance.clearMarks === "function"
+        && typeof performance.clearMeasures === "function"
+        && typeof PerformanceObserver === "function";
 }
 
 function tryGetWebPerformanceHooks(): PerformanceHooks | undefined {
     if (
-        typeof performance === "object" &&
-        typeof PerformanceObserver === "function" &&
-        hasRequiredAPI(performance, PerformanceObserver)
+        typeof performance === "object"
+        && typeof PerformanceObserver === "function"
+        && hasRequiredAPI(performance, PerformanceObserver)
     ) {
         return {
             // For now we always write native performance events when running in the browser. We may
@@ -116,6 +116,6 @@ export function tryGetNativePerformanceHooks() {
  *
  * @internal
  */
-export const timestamp = nativePerformance ? () => nativePerformance.now() :
-    Date.now ? Date.now :
-    () => +(new Date());
+export const timestamp = nativePerformance ? () => nativePerformance.now()
+    : Date.now ? Date.now
+    : () => +(new Date());

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1265,8 +1265,8 @@ export function isProgramUptoDate(
     return true;
 
     function sourceFileNotUptoDate(sourceFile: SourceFile) {
-        return !sourceFileVersionUptoDate(sourceFile) ||
-            hasInvalidatedResolutions(sourceFile.path);
+        return !sourceFileVersionUptoDate(sourceFile)
+            || hasInvalidatedResolutions(sourceFile.path);
     }
 
     function sourceFileVersionUptoDate(sourceFile: SourceFile) {
@@ -1274,8 +1274,8 @@ export function isProgramUptoDate(
     }
 
     function projectReferenceUptoDate(oldRef: ProjectReference, newRef: ProjectReference, index: number) {
-        return projectReferenceIsEqualTo(oldRef, newRef) &&
-            resolvedProjectReferenceUptoDate(program!.getResolvedProjectReferences()![index], oldRef);
+        return projectReferenceIsEqualTo(oldRef, newRef)
+            && resolvedProjectReferenceUptoDate(program!.getResolvedProjectReferences()![index], oldRef);
     }
 
     function resolvedProjectReferenceUptoDate(oldResolvedRef: ResolvedProjectReference | undefined, oldRef: ProjectReference): boolean {
@@ -1310,9 +1310,9 @@ export function isProgramUptoDate(
 }
 
 export function getConfigFileParsingDiagnostics(configFileParseResult: ParsedCommandLine): readonly Diagnostic[] {
-    return configFileParseResult.options.configFile ?
-        [...configFileParseResult.options.configFile.parseDiagnostics, ...configFileParseResult.errors] :
-        configFileParseResult.errors;
+    return configFileParseResult.options.configFile
+        ? [...configFileParseResult.options.configFile.parseDiagnostics, ...configFileParseResult.errors]
+        : configFileParseResult.errors;
 }
 
 /**
@@ -1340,10 +1340,10 @@ export function getImpliedNodeFormatForFileWorker(
     switch (getEmitModuleResolutionKind(options)) {
         case ModuleResolutionKind.Node16:
         case ModuleResolutionKind.NodeNext:
-            return fileExtensionIsOneOf(fileName, [Extension.Dmts, Extension.Mts, Extension.Mjs]) ? ModuleKind.ESNext :
-                fileExtensionIsOneOf(fileName, [Extension.Dcts, Extension.Cts, Extension.Cjs]) ? ModuleKind.CommonJS :
-                fileExtensionIsOneOf(fileName, [Extension.Dts, Extension.Ts, Extension.Tsx, Extension.Js, Extension.Jsx]) ? lookupFromPackageJson() :
-                undefined; // other extensions, like `json` or `tsbuildinfo`, are set as `undefined` here but they should never be fed through the transformer pipeline
+            return fileExtensionIsOneOf(fileName, [Extension.Dmts, Extension.Mts, Extension.Mjs]) ? ModuleKind.ESNext
+                : fileExtensionIsOneOf(fileName, [Extension.Dcts, Extension.Cts, Extension.Cjs]) ? ModuleKind.CommonJS
+                : fileExtensionIsOneOf(fileName, [Extension.Dts, Extension.Ts, Extension.Tsx, Extension.Js, Extension.Jsx]) ? lookupFromPackageJson()
+                : undefined; // other extensions, like `json` or `tsbuildinfo`, are set as `undefined` here but they should never be fed through the transformer pipeline
         default:
             return undefined;
     }
@@ -1602,12 +1602,12 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 options,
                 containingSourceFile,
             ).map(resolved =>
-                resolved ?
-                    ((resolved as ResolvedModuleFull).extension !== undefined) ?
-                        { resolvedModule: resolved as ResolvedModuleFull } :
+                resolved
+                    ? ((resolved as ResolvedModuleFull).extension !== undefined)
+                        ? { resolvedModule: resolved as ResolvedModuleFull }
                         // An older host may have omitted extension, in which case we should infer it from the file extension of resolvedFileName.
-                        { resolvedModule: { ...resolved, extension: extensionFromPath(resolved.resolvedFileName) } } :
-                    emptyResolution
+                        : { resolvedModule: { ...resolved, extension: extensionFromPath(resolved.resolvedFileName) } }
+                    : emptyResolution
             );
         moduleResolutionCache = host.getModuleResolutionCache?.();
     }
@@ -1706,8 +1706,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     let mapFromFileToProjectReferenceRedirects: Map<Path, Path> | undefined;
     let mapFromToProjectReferenceRedirectSource: Map<Path, SourceOfProjectReferenceRedirect> | undefined;
 
-    const useSourceOfProjectReferenceRedirect = !!host.useSourceOfProjectReferenceRedirect?.() &&
-        !options.disableSourceOfProjectReferenceRedirect;
+    const useSourceOfProjectReferenceRedirect = !!host.useSourceOfProjectReferenceRedirect?.()
+        && !options.disableSourceOfProjectReferenceRedirect;
     const { onProgramCreateComplete, fileExists, directoryExists } = updateHostForUseSourceOfProjectReferenceRedirect({
         compilerHost: host,
         getSymlinkCache,
@@ -1824,9 +1824,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         for (const oldSourceFile of oldSourceFiles) {
             const newFile = getSourceFileByPath(oldSourceFile.resolvedPath);
             if (
-                shouldCreateNewSourceFile || !newFile || newFile.impliedNodeFormat !== oldSourceFile.impliedNodeFormat ||
+                shouldCreateNewSourceFile || !newFile || newFile.impliedNodeFormat !== oldSourceFile.impliedNodeFormat
                 // old file wasn't redirect but new file is
-                (oldSourceFile.resolvedPath === oldSourceFile.path && newFile.resolvedPath !== oldSourceFile.path)
+                || (oldSourceFile.resolvedPath === oldSourceFile.path && newFile.resolvedPath !== oldSourceFile.path)
             ) {
                 host.onReleaseOldSourceFile(oldSourceFile, oldProgram.getCompilerOptions(), !!getSourceFileByPath(oldSourceFile.path));
             }
@@ -2183,9 +2183,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                     if (isTraceEnabled(options, host)) {
                         trace(
                             host,
-                            oldResolution.resolvedModule.packageId ?
-                                Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 :
-                                Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2,
+                            oldResolution.resolvedModule.packageId
+                                ? Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3
+                                : Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2,
                             moduleName.text,
                             getNormalizedAbsolutePath(file.originalFileName, currentDirectory),
                             oldResolution.resolvedModule.resolvedFileName,
@@ -2285,24 +2285,24 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         let reusedNames: T[] | undefined;
         const containingSourceFile = !isString(containingFile) ? containingFile : undefined;
         const oldSourceFile = !isString(containingFile) ? oldProgram && oldProgram.getSourceFile(containingFile.fileName) : undefined;
-        const canReuseResolutions = !isString(containingFile) ?
-            containingFile === oldSourceFile && !hasInvalidatedResolutions(containingFile.path) :
-            !hasInvalidatedResolutions(toPath(containingFile));
+        const canReuseResolutions = !isString(containingFile)
+            ? containingFile === oldSourceFile && !hasInvalidatedResolutions(containingFile.path)
+            : !hasInvalidatedResolutions(toPath(containingFile));
         for (let i = 0; i < typeDirectiveNames.length; i++) {
             const entry = typeDirectiveNames[i];
             if (canReuseResolutions) {
                 const typeDirectiveName = getTypeReferenceResolutionName(entry);
                 const mode = getModeForFileReference(entry, containingSourceFile?.impliedNodeFormat);
-                const oldResolution = !isString(containingFile) ?
-                    oldProgram?.getResolvedTypeReferenceDirective(containingFile, typeDirectiveName, mode) :
-                    oldProgram?.getAutomaticTypeDirectiveResolutions()?.get(typeDirectiveName, mode);
+                const oldResolution = !isString(containingFile)
+                    ? oldProgram?.getResolvedTypeReferenceDirective(containingFile, typeDirectiveName, mode)
+                    : oldProgram?.getAutomaticTypeDirectiveResolutions()?.get(typeDirectiveName, mode);
                 if (oldResolution?.resolvedTypeReferenceDirective) {
                     if (isTraceEnabled(options, host)) {
                         trace(
                             host,
-                            oldResolution.resolvedTypeReferenceDirective.packageId ?
-                                Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 :
-                                Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2,
+                            oldResolution.resolvedTypeReferenceDirective.packageId
+                                ? Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3
+                                : Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2,
                             typeDirectiveName,
                             !isString(containingFile) ? getNormalizedAbsolutePath(containingFile.originalFileName, currentDirectory) : containingFile,
                             oldResolution.resolvedTypeReferenceDirective.resolvedFileName,
@@ -2352,9 +2352,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 const newResolvedRef = parseProjectReferenceConfigFile(newRef);
                 if (oldResolvedRef) {
                     // Resolved project reference has gone missing or changed
-                    return !newResolvedRef ||
-                        newResolvedRef.sourceFile !== oldResolvedRef.sourceFile ||
-                        !arrayIsEqualTo(oldResolvedRef.commandLine.fileNames, newResolvedRef.commandLine.fileNames);
+                    return !newResolvedRef
+                        || newResolvedRef.sourceFile !== oldResolvedRef.sourceFile
+                        || !arrayIsEqualTo(oldResolvedRef.commandLine.fileNames, newResolvedRef.commandLine.fileNames);
                 }
                 else {
                     // A previously-unresolved reference may be resolved now
@@ -2567,8 +2567,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         }
 
         if (
-            oldProgram.resolvedLibReferences &&
-            forEachEntry(oldProgram.resolvedLibReferences, (resolution, libFileName) => pathForLibFileWorker(libFileName).actual !== resolution.actual)
+            oldProgram.resolvedLibReferences
+            && forEachEntry(oldProgram.resolvedLibReferences, (resolution, libFileName) => pathForLibFileWorker(libFileName).actual !== resolution.actual)
         ) {
             return StructureIsReused.SafeModules;
         }
@@ -3561,9 +3561,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         const result = getImpliedNodeFormatForFileWorker(getNormalizedAbsolutePath(fileName, currentDirectory), moduleResolutionCache?.getPackageJsonInfoCache(), host, options);
         const languageVersion = getEmitScriptTarget(options);
         const setExternalModuleIndicator = getSetExternalModuleIndicator(options);
-        return typeof result === "object" ?
-            { ...result, languageVersion, setExternalModuleIndicator, jsDocParsingMode: host.jsDocParsingMode } :
-            { languageVersion, impliedNodeFormat: result, setExternalModuleIndicator, jsDocParsingMode: host.jsDocParsingMode };
+        return typeof result === "object"
+            ? { ...result, languageVersion, setExternalModuleIndicator, jsDocParsingMode: host.jsDocParsingMode }
+            : { languageVersion, impliedNodeFormat: result, setExternalModuleIndicator, jsDocParsingMode: host.jsDocParsingMode };
     }
 
     function findSourceFileWorker(fileName: string, isDefaultLib: boolean, ignoreNoDefaultLib: boolean, reason: FileIncludeReason, packageId: PackageId | undefined): SourceFile | undefined {
@@ -3575,19 +3575,19 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             // Note:: Currently we try the real path only if the
             // file is from node_modules to avoid having to run real path on all file paths
             if (
-                !source &&
-                host.realpath &&
-                options.preserveSymlinks &&
-                isDeclarationFileName(fileName) &&
-                fileName.includes(nodeModulesPathPart)
+                !source
+                && host.realpath
+                && options.preserveSymlinks
+                && isDeclarationFileName(fileName)
+                && fileName.includes(nodeModulesPathPart)
             ) {
                 const realPath = toPath(host.realpath(fileName));
                 if (realPath !== path) source = getSourceOfProjectReferenceRedirect(realPath);
             }
             if (source) {
-                const file = isString(source) ?
-                    findSourceFile(source, isDefaultLib, ignoreNoDefaultLib, reason, packageId) :
-                    undefined;
+                const file = isString(source)
+                    ? findSourceFile(source, isDefaultLib, ignoreNoDefaultLib, reason, packageId)
+                    : undefined;
                 if (file) addFileToFilesByName(file, path, fileName, /*redirectedPath*/ undefined);
                 return file;
             }
@@ -3770,9 +3770,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
     function getProjectReferenceOutputName(referencedProject: ResolvedProjectReference, fileName: string) {
         const out = referencedProject.commandLine.options.outFile;
-        return out ?
-            changeExtension(out, Extension.Dts) :
-            getOutputDeclarationFileName(fileName, referencedProject.commandLine, !host.useCaseSensitiveFileNames());
+        return out
+            ? changeExtension(out, Extension.Dts)
+            : getOutputDeclarationFileName(fileName, referencedProject.commandLine, !host.useCaseSensitiveFileNames());
     }
 
     /**
@@ -3852,8 +3852,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         const typeDirectives = file.typeReferenceDirectives;
         if (!typeDirectives.length) return;
 
-        const resolutions = resolvedTypeReferenceDirectiveNamesProcessing?.get(file.path) ||
-            resolveTypeReferenceDirectiveNamesReusingOldState(typeDirectives, file);
+        const resolutions = resolvedTypeReferenceDirectiveNamesProcessing?.get(file.path)
+            || resolveTypeReferenceDirectiveNamesReusingOldState(typeDirectives, file);
         const resolutionsInFile = createModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>();
         (resolvedTypeReferenceDirectiveNames ??= new Map()).set(file.path, resolutionsInFile);
         for (let index = 0; index < typeDirectives.length; index++) {
@@ -3956,11 +3956,11 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                     const resolveFrom = getInferredLibraryNameResolveFrom(options, currentDirectory, libFileName);
                     trace(
                         host,
-                        oldResolution.resolution.resolvedModule ?
-                            oldResolution.resolution.resolvedModule.packageId ?
-                                Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 :
-                                Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2 :
-                            Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved,
+                        oldResolution.resolution.resolvedModule
+                            ? oldResolution.resolution.resolvedModule.packageId
+                                ? Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3
+                                : Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2
+                            : Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved,
                         libraryName,
                         getNormalizedAbsolutePath(resolveFrom, currentDirectory),
                         oldResolution.resolution.resolvedModule?.resolvedFileName,
@@ -3982,9 +3982,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         tracing?.pop();
         const result: LibResolution = {
             resolution,
-            actual: resolution.resolvedModule ?
-                resolution.resolvedModule.resolvedFileName :
-                combinePaths(defaultLibraryPath, libFileName),
+            actual: resolution.resolvedModule
+                ? resolution.resolvedModule.resolvedFileName
+                : combinePaths(defaultLibraryPath, libFileName),
         };
         (resolvedLibProcessing ??= new Map()).set(libFileName, result);
         return result;
@@ -4021,8 +4021,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         if (file.imports.length || file.moduleAugmentations.length) {
             // Because global augmentation doesn't have string literal name, we can check for global augmentation as such.
             const moduleNames = getModuleNames(file);
-            const resolutions = resolvedModulesProcessing?.get(file.path) ||
-                resolveModuleNamesReusingOldState(moduleNames, file);
+            const resolutions = resolvedModulesProcessing?.get(file.path)
+                || resolveModuleNamesReusingOldState(moduleNames, file);
             Debug.assert(resolutions.length === moduleNames.length);
             const optionsForFile = getRedirectReferenceForResolution(file)?.commandLine.options || options;
             const resolutionsInFile = createModeAwareCache<ResolutionWithFailedLookupLocations>();
@@ -4320,10 +4320,10 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         // there has to be common source directory if user specified --outdir || --rootDir || --sourceRoot
         // if user specified --mapRoot, there needs to be common source directory if there would be multiple files being emitted
         if (
-            options.outDir || // there is --outDir specified
-            options.rootDir || // there is --rootDir specified
-            options.sourceRoot || // there is --sourceRoot specified
-            options.mapRoot // there is --mapRoot specified
+            options.outDir // there is --outDir specified
+            || options.rootDir // there is --rootDir specified
+            || options.sourceRoot // there is --sourceRoot specified
+            || options.mapRoot // there is --mapRoot specified
         ) {
             // Precalculate and cache the common source directory
             const dir = getCommonSourceDirectory();
@@ -4349,8 +4349,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         }
 
         if (
-            options.emitDecoratorMetadata &&
-            !options.experimentalDecorators
+            options.emitDecoratorMetadata
+            && !options.experimentalDecorators
         ) {
             createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "emitDecoratorMetadata", "experimentalDecorators");
         }
@@ -4421,17 +4421,17 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         }
 
         if (
-            ModuleKind[moduleKind] &&
-            (ModuleKind.Node16 <= moduleKind && moduleKind <= ModuleKind.NodeNext) &&
-            !(ModuleResolutionKind.Node16 <= moduleResolution && moduleResolution <= ModuleResolutionKind.NodeNext)
+            ModuleKind[moduleKind]
+            && (ModuleKind.Node16 <= moduleKind && moduleKind <= ModuleKind.NodeNext)
+            && !(ModuleResolutionKind.Node16 <= moduleResolution && moduleResolution <= ModuleResolutionKind.NodeNext)
         ) {
             const moduleKindName = ModuleKind[moduleKind];
             createOptionValueDiagnostic("moduleResolution", Diagnostics.Option_moduleResolution_must_be_set_to_0_or_left_unspecified_when_option_module_is_set_to_1, moduleKindName, moduleKindName);
         }
         else if (
-            ModuleResolutionKind[moduleResolution] &&
-            (ModuleResolutionKind.Node16 <= moduleResolution && moduleResolution <= ModuleResolutionKind.NodeNext) &&
-            !(ModuleKind.Node16 <= moduleKind && moduleKind <= ModuleKind.NodeNext)
+            ModuleResolutionKind[moduleResolution]
+            && (ModuleResolutionKind.Node16 <= moduleResolution && moduleResolution <= ModuleResolutionKind.NodeNext)
+            && !(ModuleKind.Node16 <= moduleKind && moduleKind <= ModuleKind.NodeNext)
         ) {
             const moduleResolutionName = ModuleResolutionKind[moduleResolution];
             createOptionValueDiagnostic("module", Diagnostics.Option_module_must_be_set_to_0_when_option_moduleResolution_is_set_to_1, moduleResolutionName, moduleResolutionName);
@@ -4597,9 +4597,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         const fileIncludeReasonDetails = fileIncludeReasons && chainDiagnosticMessages(fileIncludeReasons, Diagnostics.The_file_is_in_the_program_because_Colon);
         const redirectInfo = file && explainIfFileIsRedirectAndImpliedFormat(file);
         const chain = chainDiagnosticMessages(redirectInfo ? fileIncludeReasonDetails ? [fileIncludeReasonDetails, ...redirectInfo] : redirectInfo : fileIncludeReasonDetails, diagnostic, ...args || emptyArray);
-        return location && isReferenceFileLocation(location) ?
-            createFileDiagnosticFromMessageChain(location.file, location.pos, location.end - location.pos, chain, relatedInfo) :
-            createCompilerDiagnosticFromMessageChain(chain, relatedInfo);
+        return location && isReferenceFileLocation(location)
+            ? createFileDiagnosticFromMessageChain(location.file, location.pos, location.end - location.pos, chain, relatedInfo)
+            : createCompilerDiagnosticFromMessageChain(chain, relatedInfo);
 
         function processReason(reason: FileIncludeReason) {
             (fileIncludeReasons ||= []).push(fileIncludeReasonToDiagnostics(program, reason));
@@ -4683,15 +4683,15 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 if (!referenceInfo) return undefined;
                 const { sourceFile, index } = referenceInfo;
                 const referencesSyntax = forEachTsConfigPropArray(sourceFile as TsConfigSourceFile, "references", property => isArrayLiteralExpression(property.initializer) ? property.initializer : undefined);
-                return referencesSyntax && referencesSyntax.elements.length > index ?
-                    createDiagnosticForNodeInSourceFile(
+                return referencesSyntax && referencesSyntax.elements.length > index
+                    ? createDiagnosticForNodeInSourceFile(
                         sourceFile,
                         referencesSyntax.elements[index],
-                        reason.kind === FileIncludeKind.OutputFromProjectReference ?
-                            Diagnostics.File_is_output_from_referenced_project_specified_here :
-                            Diagnostics.File_is_source_from_referenced_project_specified_here,
-                    ) :
-                    undefined;
+                        reason.kind === FileIncludeKind.OutputFromProjectReference
+                            ? Diagnostics.File_is_output_from_referenced_project_specified_here
+                            : Diagnostics.File_is_source_from_referenced_project_specified_here,
+                    )
+                    : undefined;
             case FileIncludeKind.AutomaticTypeDirectiveFile:
                 if (!options.types) return undefined;
                 configFileNode = getOptionsSyntaxByArrayElementValue("types", reason.typeReference);
@@ -4765,8 +4765,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         let needCompilerDiagnostic = true;
         forEachOptionPathsSyntax(pathProp => {
             if (
-                isObjectLiteralExpression(pathProp.initializer) &&
-                createOptionDiagnosticInObjectLiteralSyntax(
+                isObjectLiteralExpression(pathProp.initializer)
+                && createOptionDiagnosticInObjectLiteralSyntax(
                     pathProp.initializer,
                     onKey,
                     key,
@@ -4823,8 +4823,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     function createDiagnosticForOption(onKey: boolean, option1: string, option2: string | undefined, message: DiagnosticMessage, ...args: DiagnosticArguments): void;
     function createDiagnosticForOption(onKey: boolean, option1: string, option2: string | undefined, message: DiagnosticMessage | DiagnosticMessageChain, ...args: DiagnosticArguments): void {
         const compilerOptionsObjectLiteralSyntax = getCompilerOptionsObjectLiteralSyntax();
-        const needCompilerDiagnostic = !compilerOptionsObjectLiteralSyntax ||
-            !createOptionDiagnosticInObjectLiteralSyntax(compilerOptionsObjectLiteralSyntax, onKey, option1, option2, message, ...args);
+        const needCompilerDiagnostic = !compilerOptionsObjectLiteralSyntax
+            || !createOptionDiagnosticInObjectLiteralSyntax(compilerOptionsObjectLiteralSyntax, onKey, option1, option2, message, ...args);
 
         if (needCompilerDiagnostic) {
             // eslint-disable-next-line local/no-in-operator
@@ -4901,8 +4901,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         if (fileExtensionIsOneOf(filePath, supportedJSExtensionsFlat) || isDeclarationFileName(filePath)) {
             // Otherwise just check if sourceFile with the name exists
             const filePathWithoutExtension = removeFileExtension(filePath);
-            return !!getSourceFileByPath((filePathWithoutExtension + Extension.Ts) as Path) ||
-                !!getSourceFileByPath((filePathWithoutExtension + Extension.Tsx) as Path);
+            return !!getSourceFileByPath((filePathWithoutExtension + Extension.Ts) as Path)
+                || !!getSourceFileByPath((filePathWithoutExtension + Extension.Tsx) as Path);
         }
         return false;
     }
@@ -4993,16 +4993,16 @@ function updateHostForUseSourceOfProjectReferenceRedirect(host: HostForUseSource
         // Call getDirectories only if directory actually present on the host
         // This is needed to ensure that we arent getting directories that we fake about presence for
         host.compilerHost.getDirectories = path =>
-            !host.getResolvedProjectReferences() || (originalDirectoryExists && originalDirectoryExists.call(host.compilerHost, path)) ?
-                originalGetDirectories.call(host.compilerHost, path) :
-                [];
+            !host.getResolvedProjectReferences() || (originalDirectoryExists && originalDirectoryExists.call(host.compilerHost, path))
+                ? originalGetDirectories.call(host.compilerHost, path)
+                : [];
     }
 
     // This is something we keep for life time of the host
     if (originalRealpath) {
         host.compilerHost.realpath = s =>
-            host.getSymlinkCache().getSymlinkedFiles()?.get(host.toPath(s)) ||
-            originalRealpath.call(host.compilerHost, s);
+            host.getSymlinkCache().getSymlinkedFiles()?.get(host.toPath(s))
+            || originalRealpath.call(host.compilerHost, s);
     }
 
     return { onProgramCreateComplete, fileExists, directoryExists };
@@ -5028,9 +5028,9 @@ function updateHostForUseSourceOfProjectReferenceRedirect(host: HostForUseSource
 
     function fileExistsIfProjectReferenceDts(file: string) {
         const source = host.getSourceOfProjectReferenceRedirect(host.toPath(file));
-        return source !== undefined ?
-            isString(source) ? originalFileExists.call(host.compilerHost, source) as boolean : true :
-            undefined;
+        return source !== undefined
+            ? isString(source) ? originalFileExists.call(host.compilerHost, source) as boolean : true
+            : undefined;
     }
 
     function directoryExistsIfProjectReferenceDeclDir(dir: string) {
@@ -5039,11 +5039,11 @@ function updateHostForUseSourceOfProjectReferenceRedirect(host: HostForUseSource
         return forEachKey(
             setOfDeclarationDirectories!,
             declDirPath =>
-                dirPath === declDirPath ||
+                dirPath === declDirPath
                 // Any parent directory of declaration dir
-                startsWith(declDirPath, dirPathWithTrailingDirectorySeparator) ||
+                || startsWith(declDirPath, dirPathWithTrailingDirectorySeparator)
                 // Any directory inside declaration dir
-                startsWith(dirPath, `${declDirPath}/`),
+                || startsWith(dirPath, `${declDirPath}/`),
         );
     }
 
@@ -5059,8 +5059,8 @@ function updateHostForUseSourceOfProjectReferenceRedirect(host: HostForUseSource
         const real = normalizePath(originalRealpath.call(host.compilerHost, directory));
         let realPath: Path;
         if (
-            real === directory ||
-            (realPath = ensureTrailingDirectorySeparator(host.toPath(real))) === directoryPath
+            real === directory
+            || (realPath = ensureTrailingDirectorySeparator(host.toPath(real))) === directoryPath
         ) {
             // not symlinked
             symlinkCache.setSymlinkedDirectory(directoryPath, false);
@@ -5074,9 +5074,9 @@ function updateHostForUseSourceOfProjectReferenceRedirect(host: HostForUseSource
     }
 
     function fileOrDirectoryExistsUsingSource(fileOrDirectory: string, isFile: boolean): boolean {
-        const fileOrDirectoryExistsUsingSource = isFile ?
-            (file: string) => fileExistsIfProjectReferenceDts(file) :
-            (dir: string) => directoryExistsIfProjectReferenceDeclDir(dir);
+        const fileOrDirectoryExistsUsingSource = isFile
+            ? (file: string) => fileExistsIfProjectReferenceDts(file)
+            : (dir: string) => directoryExistsIfProjectReferenceDeclDir(dir);
         // Check current directory or file
         const result = fileOrDirectoryExistsUsingSource(fileOrDirectory);
         if (result !== undefined) return result;
@@ -5122,9 +5122,9 @@ export function handleNoEmitOptions<T extends BuilderProgram>(
     if (options.noEmit) {
         // Cache the semantic diagnostics
         program.getSemanticDiagnostics(sourceFile, cancellationToken);
-        return sourceFile || options.outFile ?
-            emitSkippedWithNoDiagnostics :
-            program.emitBuildInfo(writeFile, cancellationToken);
+        return sourceFile || options.outFile
+            ? emitSkippedWithNoDiagnostics
+            : program.emitBuildInfo(writeFile, cancellationToken);
     }
 
     // If the noEmitOnError flag is set, then check if we have any errors so far.  If so,

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -251,9 +251,9 @@ export function removeIgnoredPath(path: Path): Path | undefined {
         return removeSuffix(path, "/.staging") as Path;
     }
 
-    return some(ignoredPaths, searchPath => path.includes(searchPath)) ?
-        undefined :
-        path;
+    return some(ignoredPaths, searchPath => path.includes(searchPath))
+        ? undefined
+        : path;
 }
 
 function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPathComponents>, length: number) {
@@ -262,9 +262,9 @@ function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPathCompo
     let indexAfterOsRoot = 1;
     let isDosStyle = pathComponents[0].search(/[a-zA-Z]:/) === 0;
     if (
-        pathComponents[0] !== directorySeparator &&
-        !isDosStyle && // Non dos style paths
-        pathComponents[1].search(/[a-zA-Z]\$$/) === 0 // Dos style nextPart
+        pathComponents[0] !== directorySeparator
+        && !isDosStyle // Non dos style paths
+        && pathComponents[1].search(/[a-zA-Z]\$$/) === 0 // Dos style nextPart
     ) {
         // ignore "//vda1cs4850/c$/folderAtRoot"
         if (length === 2) return 2;
@@ -273,8 +273,8 @@ function perceivedOsRootLengthForWatching(pathComponents: Readonly<PathPathCompo
     }
 
     if (
-        isDosStyle &&
-        !pathComponents[indexAfterOsRoot].match(/^users$/i)
+        isDosStyle
+        && !pathComponents[indexAfterOsRoot].match(/^users$/i)
     ) {
         // Paths like c:/notUsers
         return indexAfterOsRoot;
@@ -440,9 +440,9 @@ export function getDirectoryToWatchFailedLookupLocationFromTypeRoot(
 /** @internal */
 export function getRootDirectoryOfResolutionCache(rootDirForResolution: string, getCurrentDirectory: () => string | undefined) {
     const normalized = getNormalizedAbsolutePath(rootDirForResolution, getCurrentDirectory());
-    return !isDiskPathRoot(normalized) ?
-        removeTrailingDirectorySeparator(normalized) :
-        normalized;
+    return !isDiskPathRoot(normalized)
+        ? removeTrailingDirectorySeparator(normalized)
+        : normalized;
 }
 
 /** @internal */
@@ -690,13 +690,13 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
         filesWithInvalidatedResolutions = undefined;
         return {
             hasInvalidatedResolutions: path =>
-                customHasInvalidatedResolutions(path) ||
-                allModuleAndTypeResolutionsAreInvalidated ||
-                !!collected?.has(path) ||
-                isFileWithInvalidatedNonRelativeUnresolvedImports(path),
+                customHasInvalidatedResolutions(path)
+                || allModuleAndTypeResolutionsAreInvalidated
+                || !!collected?.has(path)
+                || isFileWithInvalidatedNonRelativeUnresolvedImports(path),
             hasInvalidatedLibResolutions: libFileName =>
-                customHasInvalidatedLibResolutions(libFileName) ||
-                !!resolvedLibraries?.get(libFileName)?.isInvalidated,
+                customHasInvalidatedLibResolutions(libFileName)
+                || !!resolvedLibraries?.get(libFileName)?.isInvalidated,
         };
     }
 
@@ -815,9 +815,9 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
         // All the resolutions in this file are invalidated if this file wasn't resolved using same redirect
         const program = resolutionHost.getCurrentProgram();
         const oldRedirect = program && program.getResolvedProjectReferenceToRedirect(containingFile);
-        const unmatchedRedirects = oldRedirect ?
-            !redirectedReference || redirectedReference.sourceFile.path !== oldRedirect.sourceFile.path :
-            !!redirectedReference;
+        const unmatchedRedirects = oldRedirect
+            ? !redirectedReference || redirectedReference.sourceFile.path !== oldRedirect.sourceFile.path
+            : !!redirectedReference;
 
         const seenNamesInFile = createModeAwareCache<true>();
         for (const entry of entries) {
@@ -826,10 +826,10 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
             let resolution = resolutionsInFile.get(name, mode);
             // Resolution is valid if it is present and not invalidated
             if (
-                !seenNamesInFile.has(name, mode) &&
-                (allModuleAndTypeResolutionsAreInvalidated || unmatchedRedirects || !resolution || resolution.isInvalidated ||
+                !seenNamesInFile.has(name, mode)
+                && (allModuleAndTypeResolutionsAreInvalidated || unmatchedRedirects || !resolution || resolution.isInvalidated
                     // If the name is unresolved import that was invalidated, recalculate
-                    (hasInvalidatedNonRelativeUnresolvedImport && !isExternalModuleNameRelative(name) && shouldRetryResolution(resolution)))
+                    || (hasInvalidatedNonRelativeUnresolvedImport && !isExternalModuleNameRelative(name) && shouldRetryResolution(resolution)))
             ) {
                 const existingResolution = resolution;
                 resolution = loader.resolve(name, mode);
@@ -856,17 +856,17 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
                     const resolved = getResolutionWithResolvedFileName(resolution!);
                     trace(
                         host,
-                        perFileCache === resolvedModuleNames as unknown ?
-                            resolved?.resolvedFileName ?
-                                resolved.packageId ?
-                                    Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 :
-                                    Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2 :
-                                Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved :
-                            resolved?.resolvedFileName ?
-                            resolved.packageId ?
-                                Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 :
-                                Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2 :
-                            Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_not_resolved,
+                        perFileCache === resolvedModuleNames as unknown
+                            ? resolved?.resolvedFileName
+                                ? resolved.packageId
+                                    ? Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3
+                                    : Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2
+                                : Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved
+                            : resolved?.resolvedFileName
+                            ? resolved.packageId
+                                ? Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3
+                                : Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_successfully_resolved_to_2
+                            : Diagnostics.Reusing_resolution_of_type_reference_directive_0_from_1_of_old_program_it_was_not_resolved,
                         name,
                         containingFile,
                         resolved?.resolvedFileName,
@@ -997,11 +997,11 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
                 const resolved = getResolvedModule(resolution);
                 trace(
                     host,
-                    resolved?.resolvedFileName ?
-                        resolved.packageId ?
-                            Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3 :
-                            Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2 :
-                        Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved,
+                    resolved?.resolvedFileName
+                        ? resolved.packageId
+                            ? Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2_with_Package_ID_3
+                            : Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_successfully_resolved_to_2
+                        : Diagnostics.Reusing_resolution_of_module_0_from_1_of_old_program_it_was_not_resolved,
                     libraryName,
                     resolveFrom,
                     resolved?.resolvedFileName,
@@ -1143,8 +1143,8 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
         const files = forResolution ? 0 : 1;
         if (!isSymlink || !symlinkWatcher) {
             const watcher: FileWatcherOfAffectingLocation = {
-                watcher: canWatchAffectingLocation(resolutionHost.toPath(locationToWatch)) ?
-                    resolutionHost.watchAffectingFileLocation(locationToWatch, (fileName, eventKind) => {
+                watcher: canWatchAffectingLocation(resolutionHost.toPath(locationToWatch))
+                    ? resolutionHost.watchAffectingFileLocation(locationToWatch, (fileName, eventKind) => {
                         cachedDirectoryStructureHost?.addOrDeleteFile(fileName, resolutionHost.toPath(locationToWatch), eventKind);
                         invalidateAffectingFileWatcher(locationToWatch, moduleResolutionCache.getPackageJsonInfoCache().getInternalMap());
                         resolutionHost.scheduleInvalidateResolutionsOfFailedLookupLocations();
@@ -1350,9 +1350,9 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
         // Resolution is invalidated if the resulting file name is same as the deleted file path
         const prevHasChangedAutomaticTypeDirectiveNames = hasChangedAutomaticTypeDirectiveNames;
         if (
-            invalidateResolutions(resolvedFileToResolution.get(filePath), returnTrue) &&
-            hasChangedAutomaticTypeDirectiveNames &&
-            !prevHasChangedAutomaticTypeDirectiveNames
+            invalidateResolutions(resolvedFileToResolution.get(filePath), returnTrue)
+            && hasChangedAutomaticTypeDirectiveNames
+            && !prevHasChangedAutomaticTypeDirectiveNames
         ) {
             resolutionHost.onChangedAutomaticTypeDirectiveNames();
         }
@@ -1384,8 +1384,8 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
             // Return early if it does not have any of the watching extension or not the custom failed lookup path
             const dirOfFileOrDirectory = getDirectoryPath(fileOrDirectoryPath);
             if (
-                isNodeModulesAtTypesDirectory(fileOrDirectoryPath) || isNodeModulesDirectory(fileOrDirectoryPath) ||
-                isNodeModulesAtTypesDirectory(dirOfFileOrDirectory) || isNodeModulesDirectory(dirOfFileOrDirectory)
+                isNodeModulesAtTypesDirectory(fileOrDirectoryPath) || isNodeModulesDirectory(fileOrDirectoryPath)
+                || isNodeModulesAtTypesDirectory(dirOfFileOrDirectory) || isNodeModulesDirectory(dirOfFileOrDirectory)
             ) {
                 // Invalidate any resolution from this directory
                 (failedLookupChecks ||= new Set()).add(fileOrDirectoryPath);
@@ -1461,16 +1461,16 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
     function canInvalidateFailedLookupResolution(resolution: ResolutionWithFailedLookupLocations) {
         if (canInvalidatedFailedLookupResolutionWithAffectingLocation(resolution)) return true;
         if (!failedLookupChecks && !startsWithPathChecks && !isInDirectoryChecks) return false;
-        return resolution.failedLookupLocations?.some(location => isInvalidatedFailedLookup(resolutionHost.toPath(location))) ||
-            (!!resolution.alternateResult && isInvalidatedFailedLookup(resolutionHost.toPath(resolution.alternateResult)));
+        return resolution.failedLookupLocations?.some(location => isInvalidatedFailedLookup(resolutionHost.toPath(location)))
+            || (!!resolution.alternateResult && isInvalidatedFailedLookup(resolutionHost.toPath(resolution.alternateResult)));
     }
 
     function isInvalidatedFailedLookup(locationPath: Path) {
-        return failedLookupChecks?.has(locationPath) ||
-            firstDefinedIterator(startsWithPathChecks?.keys() || [], fileOrDirectoryPath => startsWith(locationPath, fileOrDirectoryPath) ? true : undefined) ||
-            firstDefinedIterator(isInDirectoryChecks?.keys() || [], dirPath =>
-                locationPath.length > dirPath.length &&
-                    startsWith(locationPath, dirPath) && (isDiskPathRoot(dirPath) || locationPath[dirPath.length] === directorySeparator) ? true : undefined);
+        return failedLookupChecks?.has(locationPath)
+            || firstDefinedIterator(startsWithPathChecks?.keys() || [], fileOrDirectoryPath => startsWith(locationPath, fileOrDirectoryPath) ? true : undefined)
+            || firstDefinedIterator(isInDirectoryChecks?.keys() || [], dirPath =>
+                locationPath.length > dirPath.length
+                    && startsWith(locationPath, dirPath) && (isDiskPathRoot(dirPath) || locationPath[dirPath.length] === directorySeparator) ? true : undefined);
     }
 
     function canInvalidatedFailedLookupResolutionWithAffectingLocation(resolution: ResolutionWithFailedLookupLocations) {
@@ -1483,8 +1483,8 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
 
     function createTypeRootsWatch(typeRoot: string): FileWatcher {
         // Create new watch and recursive info
-        return canWatchTypeRootPath(typeRoot) ?
-            resolutionHost.watchTypeRootsDirectory(typeRoot, fileOrDirectory => {
+        return canWatchTypeRootPath(typeRoot)
+            ? resolutionHost.watchTypeRootsDirectory(typeRoot, fileOrDirectory => {
                 const fileOrDirectoryPath = resolutionHost.toPath(fileOrDirectory);
                 if (cachedDirectoryStructureHost) {
                     // Since the file existence changed, update the sourceFiles cache
@@ -1510,8 +1510,8 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
                 if (dirPath) {
                     scheduleInvalidateResolutionOfFailedLookupLocation(fileOrDirectoryPath, dirPath === fileOrDirectoryPath);
                 }
-            }, WatchDirectoryFlags.Recursive) :
-            noopFileWatcher;
+            }, WatchDirectoryFlags.Recursive)
+            : noopFileWatcher;
     }
 
     /**
@@ -1556,7 +1556,7 @@ export function createResolutionCache(resolutionHost: ResolutionCacheHost, rootD
 
 function resolutionIsSymlink(resolution: ResolutionWithFailedLookupLocations) {
     return !!(
-        (resolution as ResolvedModuleWithFailedLookupLocations).resolvedModule?.originalPath ||
-        (resolution as ResolvedTypeReferenceDirectiveWithFailedLookupLocations).resolvedTypeReferenceDirective?.originalPath
+        (resolution as ResolvedModuleWithFailedLookupLocations).resolvedModule?.originalPath
+        || (resolution as ResolvedTypeReferenceDirectiveWithFailedLookupLocations).resolvedTypeReferenceDirective?.originalPath
     );
 }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -355,15 +355,15 @@ function lookupInUnicodeMap(code: number, map: readonly number[]): boolean {
 }
 
 /** @internal */ export function isUnicodeIdentifierStart(code: number, languageVersion: ScriptTarget | undefined) {
-    return languageVersion! >= ScriptTarget.ES2015 ?
-        lookupInUnicodeMap(code, unicodeESNextIdentifierStart) :
-        lookupInUnicodeMap(code, unicodeES5IdentifierStart);
+    return languageVersion! >= ScriptTarget.ES2015
+        ? lookupInUnicodeMap(code, unicodeESNextIdentifierStart)
+        : lookupInUnicodeMap(code, unicodeES5IdentifierStart);
 }
 
 function isUnicodeIdentifierPart(code: number, languageVersion: ScriptTarget | undefined) {
-    return languageVersion! >= ScriptTarget.ES2015 ?
-        lookupInUnicodeMap(code, unicodeESNextIdentifierPart) :
-        lookupInUnicodeMap(code, unicodeES5IdentifierPart);
+    return languageVersion! >= ScriptTarget.ES2015
+        ? lookupInUnicodeMap(code, unicodeESNextIdentifierPart)
+        : lookupInUnicodeMap(code, unicodeES5IdentifierPart);
 }
 
 function makeReverseMap(source: Map<string, number>): string[] {
@@ -422,9 +422,9 @@ export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: 
 /** @internal */
 export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number, allowEdits?: true): number; // eslint-disable-line @typescript-eslint/unified-signatures
 export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number, allowEdits?: true): number {
-    return sourceFile.getPositionOfLineAndCharacter ?
-        sourceFile.getPositionOfLineAndCharacter(line, character, allowEdits) :
-        computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text, allowEdits);
+    return sourceFile.getPositionOfLineAndCharacter
+        ? sourceFile.getPositionOfLineAndCharacter(line, character, allowEdits)
+        : computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text, allowEdits);
 }
 
 /** @internal */
@@ -513,18 +513,18 @@ export function isWhiteSpaceLike(ch: number): boolean {
 export function isWhiteSpaceSingleLine(ch: number): boolean {
     // Note: nextLine is in the Zs space, and should be considered to be a whitespace.
     // It is explicitly not a line-break as it isn't in the exact set specified by EcmaScript.
-    return ch === CharacterCodes.space ||
-        ch === CharacterCodes.tab ||
-        ch === CharacterCodes.verticalTab ||
-        ch === CharacterCodes.formFeed ||
-        ch === CharacterCodes.nonBreakingSpace ||
-        ch === CharacterCodes.nextLine ||
-        ch === CharacterCodes.ogham ||
-        ch >= CharacterCodes.enQuad && ch <= CharacterCodes.zeroWidthSpace ||
-        ch === CharacterCodes.narrowNoBreakSpace ||
-        ch === CharacterCodes.mathematicalSpace ||
-        ch === CharacterCodes.ideographicSpace ||
-        ch === CharacterCodes.byteOrderMark;
+    return ch === CharacterCodes.space
+        || ch === CharacterCodes.tab
+        || ch === CharacterCodes.verticalTab
+        || ch === CharacterCodes.formFeed
+        || ch === CharacterCodes.nonBreakingSpace
+        || ch === CharacterCodes.nextLine
+        || ch === CharacterCodes.ogham
+        || ch >= CharacterCodes.enQuad && ch <= CharacterCodes.zeroWidthSpace
+        || ch === CharacterCodes.narrowNoBreakSpace
+        || ch === CharacterCodes.mathematicalSpace
+        || ch === CharacterCodes.ideographicSpace
+        || ch === CharacterCodes.byteOrderMark;
 }
 
 export function isLineBreak(ch: number): boolean {
@@ -539,10 +539,10 @@ export function isLineBreak(ch: number): boolean {
     // Only the characters in Table 3 are treated as line terminators. Other new line or line
     // breaking characters are treated as white space but not as line terminators.
 
-    return ch === CharacterCodes.lineFeed ||
-        ch === CharacterCodes.carriageReturn ||
-        ch === CharacterCodes.lineSeparator ||
-        ch === CharacterCodes.paragraphSeparator;
+    return ch === CharacterCodes.lineFeed
+        || ch === CharacterCodes.carriageReturn
+        || ch === CharacterCodes.lineSeparator
+        || ch === CharacterCodes.paragraphSeparator;
 }
 
 function isDigit(ch: number): boolean {
@@ -703,8 +703,8 @@ function isConflictMarkerTrivia(text: string, pos: number) {
                 }
             }
 
-            return ch === CharacterCodes.equals ||
-                text.charCodeAt(pos + mergeConflictMarkerLength) === CharacterCodes.space;
+            return ch === CharacterCodes.equals
+                || text.charCodeAt(pos + mergeConflictMarkerLength) === CharacterCodes.space;
         }
     }
 
@@ -925,17 +925,17 @@ export function getShebang(text: string): string | undefined {
 }
 
 export function isIdentifierStart(ch: number, languageVersion: ScriptTarget | undefined): boolean {
-    return ch >= CharacterCodes.A && ch <= CharacterCodes.Z || ch >= CharacterCodes.a && ch <= CharacterCodes.z ||
-        ch === CharacterCodes.$ || ch === CharacterCodes._ ||
-        ch > CharacterCodes.maxAsciiCharacter && isUnicodeIdentifierStart(ch, languageVersion);
+    return ch >= CharacterCodes.A && ch <= CharacterCodes.Z || ch >= CharacterCodes.a && ch <= CharacterCodes.z
+        || ch === CharacterCodes.$ || ch === CharacterCodes._
+        || ch > CharacterCodes.maxAsciiCharacter && isUnicodeIdentifierStart(ch, languageVersion);
 }
 
 export function isIdentifierPart(ch: number, languageVersion: ScriptTarget | undefined, identifierVariant?: LanguageVariant): boolean {
-    return ch >= CharacterCodes.A && ch <= CharacterCodes.Z || ch >= CharacterCodes.a && ch <= CharacterCodes.z ||
-        ch >= CharacterCodes._0 && ch <= CharacterCodes._9 || ch === CharacterCodes.$ || ch === CharacterCodes._ ||
+    return ch >= CharacterCodes.A && ch <= CharacterCodes.Z || ch >= CharacterCodes.a && ch <= CharacterCodes.z
+        || ch >= CharacterCodes._0 && ch <= CharacterCodes._9 || ch === CharacterCodes.$ || ch === CharacterCodes._
         // "-" and ":" are valid in JSX Identifiers
-        (identifierVariant === LanguageVariant.JSX ? (ch === CharacterCodes.minus || ch === CharacterCodes.colon) : false) ||
-        ch > CharacterCodes.maxAsciiCharacter && isUnicodeIdentifierPart(ch, languageVersion);
+        || (identifierVariant === LanguageVariant.JSX ? (ch === CharacterCodes.minus || ch === CharacterCodes.colon) : false)
+        || ch > CharacterCodes.maxAsciiCharacter && isUnicodeIdentifierPart(ch, languageVersion);
 }
 
 /** @internal */
@@ -1294,8 +1294,8 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                 ch += CharacterCodes.a - CharacterCodes.A; // standardize hex literals to lowercase
             }
             else if (
-                !((ch >= CharacterCodes._0 && ch <= CharacterCodes._9) ||
-                    (ch >= CharacterCodes.a && ch <= CharacterCodes.f))
+                !((ch >= CharacterCodes._0 && ch <= CharacterCodes._9)
+                    || (ch >= CharacterCodes.a && ch <= CharacterCodes.f))
             ) {
                 break;
             }
@@ -2079,9 +2079,9 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
                         return pos += 2, token = SyntaxKind.LessThanEqualsToken;
                     }
                     if (
-                        languageVariant === LanguageVariant.JSX &&
-                        text.charCodeAt(pos + 1) === CharacterCodes.slash &&
-                        text.charCodeAt(pos + 2) !== CharacterCodes.asterisk
+                        languageVariant === LanguageVariant.JSX
+                        && text.charCodeAt(pos + 1) === CharacterCodes.slash
+                        && text.charCodeAt(pos + 2) !== CharacterCodes.asterisk
                     ) {
                         return pos += 2, token = SyntaxKind.LessThanSlashToken;
                     }

--- a/src/compiler/semver.ts
+++ b/src/compiler/semver.ts
@@ -322,9 +322,9 @@ function parseHyphen(left: string, right: string, comparators: Comparator[]) {
 
     if (!isWildcard(rightResult.major)) {
         comparators.push(
-            isWildcard(rightResult.minor) ? createComparator("<", rightResult.version.increment("major")) :
-                isWildcard(rightResult.patch) ? createComparator("<", rightResult.version.increment("minor")) :
-                createComparator("<=", rightResult.version),
+            isWildcard(rightResult.minor) ? createComparator("<", rightResult.version.increment("major"))
+                : isWildcard(rightResult.patch) ? createComparator("<", rightResult.version.increment("minor"))
+                : createComparator("<=", rightResult.version),
         );
     }
 
@@ -343,8 +343,8 @@ function parseComparator(operator: string, text: string, comparators: Comparator
                 comparators.push(createComparator(
                     "<",
                     version.increment(
-                        isWildcard(minor) ? "major" :
-                            "minor",
+                        isWildcard(minor) ? "major"
+                            : "minor",
                     ),
                 ));
                 break;
@@ -353,25 +353,25 @@ function parseComparator(operator: string, text: string, comparators: Comparator
                 comparators.push(createComparator(
                     "<",
                     version.increment(
-                        version.major > 0 || isWildcard(minor) ? "major" :
-                            version.minor > 0 || isWildcard(patch) ? "minor" :
-                            "patch",
+                        version.major > 0 || isWildcard(minor) ? "major"
+                            : version.minor > 0 || isWildcard(patch) ? "minor"
+                            : "patch",
                     ),
                 ));
                 break;
             case "<":
             case ">=":
                 comparators.push(
-                    isWildcard(minor) || isWildcard(patch) ? createComparator(operator, version.with({ prerelease: "0" })) :
-                        createComparator(operator, version),
+                    isWildcard(minor) || isWildcard(patch) ? createComparator(operator, version.with({ prerelease: "0" }))
+                        : createComparator(operator, version),
                 );
                 break;
             case "<=":
             case ">":
                 comparators.push(
-                    isWildcard(minor) ? createComparator(operator === "<=" ? "<" : ">=", version.increment("major").with({ prerelease: "0" })) :
-                        isWildcard(patch) ? createComparator(operator === "<=" ? "<" : ">=", version.increment("minor").with({ prerelease: "0" })) :
-                        createComparator(operator, version),
+                    isWildcard(minor) ? createComparator(operator === "<=" ? "<" : ">=", version.increment("major").with({ prerelease: "0" }))
+                        : isWildcard(patch) ? createComparator(operator === "<=" ? "<" : ">=", version.increment("minor").with({ prerelease: "0" }))
+                        : createComparator(operator, version),
                 );
                 break;
             case "=":

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -149,8 +149,8 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
         enter();
         // If this location wasn't recorded or the location in source is going backwards, record the mapping
         if (
-            isNewGeneratedPosition(generatedLine, generatedCharacter) ||
-            isBacktrackingSourcePosition(sourceIndex, sourceLine, sourceCharacter)
+            isNewGeneratedPosition(generatedLine, generatedCharacter)
+            || isBacktrackingSourcePosition(sourceIndex, sourceLine, sourceCharacter)
         ) {
             commitPendingMapping();
             pendingGeneratedLine = generatedLine;
@@ -184,8 +184,8 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
         for (const raw of mappingIterator) {
             if (
                 end && (
-                    raw.generatedLine > end.line ||
-                    (raw.generatedLine === end.line && raw.generatedCharacter > end.character)
+                    raw.generatedLine > end.line
+                    || (raw.generatedLine === end.line && raw.generatedCharacter > end.character)
                 )
             ) {
                 break;
@@ -193,8 +193,8 @@ export function createSourceMapGenerator(host: EmitHost, file: string, sourceRoo
 
             if (
                 start && (
-                    raw.generatedLine < start.line ||
-                    (start.line === raw.generatedLine && raw.generatedCharacter < start.character)
+                    raw.generatedLine < start.line
+                    || (start.line === raw.generatedLine && raw.generatedCharacter < start.character)
                 )
             ) {
                 continue;
@@ -576,9 +576,9 @@ export function decodeMappings(mappings: string): MappingsDecoder {
     }
 
     function isSourceMappingSegmentEnd() {
-        return (pos === mappings.length ||
-            mappings.charCodeAt(pos) === CharacterCodes.comma ||
-            mappings.charCodeAt(pos) === CharacterCodes.semicolon);
+        return (pos === mappings.length
+            || mappings.charCodeAt(pos) === CharacterCodes.comma
+            || mappings.charCodeAt(pos) === CharacterCodes.semicolon);
     }
 
     function base64VLQFormatDecode(): number {
@@ -635,21 +635,21 @@ export function isSourceMapping(mapping: Mapping): mapping is SourceMapping {
 }
 
 function base64FormatEncode(value: number) {
-    return value >= 0 && value < 26 ? CharacterCodes.A + value :
-        value >= 26 && value < 52 ? CharacterCodes.a + value - 26 :
-        value >= 52 && value < 62 ? CharacterCodes._0 + value - 52 :
-        value === 62 ? CharacterCodes.plus :
-        value === 63 ? CharacterCodes.slash :
-        Debug.fail(`${value}: not a base64 value`);
+    return value >= 0 && value < 26 ? CharacterCodes.A + value
+        : value >= 26 && value < 52 ? CharacterCodes.a + value - 26
+        : value >= 52 && value < 62 ? CharacterCodes._0 + value - 52
+        : value === 62 ? CharacterCodes.plus
+        : value === 63 ? CharacterCodes.slash
+        : Debug.fail(`${value}: not a base64 value`);
 }
 
 function base64FormatDecode(ch: number) {
-    return ch >= CharacterCodes.A && ch <= CharacterCodes.Z ? ch - CharacterCodes.A :
-        ch >= CharacterCodes.a && ch <= CharacterCodes.z ? ch - CharacterCodes.a + 26 :
-        ch >= CharacterCodes._0 && ch <= CharacterCodes._9 ? ch - CharacterCodes._0 + 52 :
-        ch === CharacterCodes.plus ? 62 :
-        ch === CharacterCodes.slash ? 63 :
-        -1;
+    return ch >= CharacterCodes.A && ch <= CharacterCodes.Z ? ch - CharacterCodes.A
+        : ch >= CharacterCodes.a && ch <= CharacterCodes.z ? ch - CharacterCodes.a + 26
+        : ch >= CharacterCodes._0 && ch <= CharacterCodes._9 ? ch - CharacterCodes._0 + 52
+        : ch === CharacterCodes.plus ? 62
+        : ch === CharacterCodes.slash ? 63
+        : -1;
 }
 
 interface MappedPosition {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -174,8 +174,8 @@ function setCustomPollingValues(system: System) {
 
     function getCustomPollingBasedLevels(baseVariable: string, defaultLevels: Levels) {
         const customLevels = getCustomLevels(baseVariable);
-        return (pollingIntervalChanged || customLevels) &&
-            createPollingIntervalBasedLevels(customLevels ? { ...defaultLevels, ...customLevels } : defaultLevels);
+        return (pollingIntervalChanged || customLevels)
+            && createPollingIntervalBasedLevels(customLevels ? { ...defaultLevels, ...customLevels } : defaultLevels);
     }
 }
 
@@ -389,8 +389,8 @@ function createUseFsEventsOnParentDirectoryWatchFile(fsWatch: FsWatch, useCaseSe
         const filePath = toCanonicalName(fileName);
         fileWatcherCallbacks.add(filePath, callback);
         const dirPath = getDirectoryPath(filePath) || ".";
-        const watcher = dirWatchers.get(dirPath) ||
-            createDirectoryWatcher(getDirectoryPath(fileName) || ".", dirPath, fallbackOptions);
+        const watcher = dirWatchers.get(dirPath)
+            || createDirectoryWatcher(getDirectoryPath(fileName) || ".", dirPath, fallbackOptions);
         watcher.referenceCount++;
         return {
             close: () => {
@@ -596,9 +596,9 @@ function createDirectoryWatcherSupportingRecursive({
     const toCanonicalFilePath = createGetCanonicalFileName(useCaseSensitiveFileNames);
 
     return (dirName, callback, recursive, options) =>
-        recursive ?
-            createDirectoryWatcher(dirName, options, callback) :
-            watchDirectory(dirName, callback, recursive, options);
+        recursive
+            ? createDirectoryWatcher(dirName, options, callback)
+            : watchDirectory(dirName, callback, recursive, options);
 
     /**
      * Create the directory watcher for the dirPath.
@@ -808,8 +808,8 @@ function createDirectoryWatcherSupportingRecursive({
     }
 
     function isIgnoredPath(path: string, options: WatchOptions | undefined) {
-        return some(ignoredPaths, searchPath => isInPath(path, searchPath)) ||
-            isIgnoredByWatchOptions(path, options, useCaseSensitiveFileNames, getCurrentDirectory);
+        return some(ignoredPaths, searchPath => isInPath(path, searchPath))
+            || isIgnoredByWatchOptions(path, options, useCaseSensitiveFileNames, getCurrentDirectory);
     }
 
     function isInPath(path: string, searchPath: string) {
@@ -864,8 +864,8 @@ function isIgnoredByWatchOptions(
     getCurrentDirectory: System["getCurrentDirectory"],
 ) {
     return (options?.excludeDirectories || options?.excludeFiles) && (
-        matchesExclude(pathToCheck, options?.excludeFiles, useCaseSensitiveFileNames, getCurrentDirectory()) ||
-        matchesExclude(pathToCheck, options?.excludeDirectories, useCaseSensitiveFileNames, getCurrentDirectory())
+        matchesExclude(pathToCheck, options?.excludeFiles, useCaseSensitiveFileNames, getCurrentDirectory())
+        || matchesExclude(pathToCheck, options?.excludeDirectories, useCaseSensitiveFileNames, getCurrentDirectory())
     );
 }
 
@@ -1009,11 +1009,11 @@ export function createSystemWatchFunctions({
                 useNonPollingWatchers = true;
             // fall through
             default:
-                return useNonPollingWatchers ?
+                return useNonPollingWatchers
                     // Use notifications from FS to watch with falling back to fs.watchFile
-                    generateWatchFileOptions(WatchFileKind.UseFsEventsOnParentDirectory, PollingWatchKind.PriorityInterval, options) :
+                    ? generateWatchFileOptions(WatchFileKind.UseFsEventsOnParentDirectory, PollingWatchKind.PriorityInterval, options)
                     // Default to using fs events
-                    { watchFile: WatchFileKind.UseFsEvents };
+                    : { watchFile: WatchFileKind.UseFsEvents };
         }
     }
 
@@ -1025,9 +1025,9 @@ export function createSystemWatchFunctions({
         const defaultFallbackPolling = options?.fallbackPolling;
         return {
             watchFile,
-            fallbackPolling: defaultFallbackPolling === undefined ?
-                fallbackPolling :
-                defaultFallbackPolling,
+            fallbackPolling: defaultFallbackPolling === undefined
+                ? fallbackPolling
+                : defaultFallbackPolling,
         };
     }
 
@@ -1111,9 +1111,9 @@ export function createSystemWatchFunctions({
                 const defaultFallbackPolling = options?.fallbackPolling;
                 return {
                     watchDirectory: WatchDirectoryKind.UseFsEvents,
-                    fallbackPolling: defaultFallbackPolling !== undefined ?
-                        defaultFallbackPolling :
-                        undefined,
+                    fallbackPolling: defaultFallbackPolling !== undefined
+                        ? defaultFallbackPolling
+                        : undefined,
                 };
         }
     }
@@ -1159,9 +1159,9 @@ export function createSystemWatchFunctions({
             lastDirectoryPart = lastDirectoryPartWithDirectorySeparator.slice(directorySeparator.length);
         }
         /** Watcher for the file system entry depending on whether it is missing or present */
-        let watcher: FileWatcher | undefined = !fileSystemEntryExists(fileOrDirectory, entryKind) ?
-            watchMissingFileSystemEntry() :
-            watchPresentFileSystemEntry();
+        let watcher: FileWatcher | undefined = !fileSystemEntryExists(fileOrDirectory, entryKind)
+            ? watchMissingFileSystemEntry()
+            : watchPresentFileSystemEntry();
         return {
             close: () => {
                 // Close the watcher (either existing file system entry watcher or missing file system entry watcher)
@@ -1194,9 +1194,9 @@ export function createSystemWatchFunctions({
                 const presentWatcher = (!fsWatchWithTimestamp ? fsWatchWorker : fsWatchWorkerHandlingTimestamp)(
                     fileOrDirectory,
                     recursive,
-                    inodeWatching ?
-                        callbackChangingToMissingFileSystemEntry :
-                        callback,
+                    inodeWatching
+                        ? callbackChangingToMissingFileSystemEntry
+                        : callback,
                 );
                 // Watch the missing file or directory or error
                 presentWatcher.on("error", () => {
@@ -1229,10 +1229,10 @@ export function createSystemWatchFunctions({
             // because relativeName is not guaranteed to be correct we need to check on each rename with few combinations
             // Eg on ubuntu while watching app/node_modules the relativeName is "node_modules" which is neither relative nor full path
             if (
-                event === "rename" &&
-                (!relativeName ||
-                    relativeName === lastDirectoryPart ||
-                    endsWith(relativeName, lastDirectoryPartWithDirectorySeparator!))
+                event === "rename"
+                && (!relativeName
+                    || relativeName === lastDirectoryPart
+                    || endsWith(relativeName, lastDirectoryPartWithDirectorySeparator!))
             ) {
                 const modifiedTime = getModifiedTime(fileOrDirectory) || missingFileModifiedTime;
                 if (originalRelativeName) callback(event, originalRelativeName, modifiedTime);
@@ -1804,8 +1804,8 @@ export let sys: System = (() => {
             // (ref: https://github.com/nodejs/node/pull/2649 and https://github.com/Microsoft/TypeScript/issues/4643)
             return _fs.watch(
                 fileOrDirectory,
-                fsSupportsRecursiveFsWatch ?
-                    { persistent: true, recursive: !!recursive } : { persistent: true },
+                fsSupportsRecursiveFsWatch
+                    ? { persistent: true, recursive: !!recursive } : { persistent: true },
                 callback,
             );
         }

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -516,9 +516,9 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
 
         let statements: Statement[] | undefined;
         if (
-            lexicalEnvironmentVariableDeclarations ||
-            lexicalEnvironmentFunctionDeclarations ||
-            lexicalEnvironmentStatements
+            lexicalEnvironmentVariableDeclarations
+            || lexicalEnvironmentFunctionDeclarations
+            || lexicalEnvironmentStatements
         ) {
             if (lexicalEnvironmentFunctionDeclarations) {
                 statements = [...lexicalEnvironmentFunctionDeclarations];
@@ -566,9 +566,9 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
     }
 
     function setLexicalEnvironmentFlags(flags: LexicalEnvironmentFlags, value: boolean): void {
-        lexicalEnvironmentFlags = value ?
-            lexicalEnvironmentFlags | flags :
-            lexicalEnvironmentFlags & ~flags;
+        lexicalEnvironmentFlags = value
+            ? lexicalEnvironmentFlags | flags
+            : lexicalEnvironmentFlags & ~flags;
     }
 
     function getLexicalEnvironmentFlags(): LexicalEnvironmentFlags {
@@ -592,8 +592,8 @@ export function transformNodes<T extends Node>(resolver: EmitResolver | undefine
     function endBlockScope() {
         Debug.assert(state > TransformationState.Uninitialized, "Cannot end a block scope during initialization.");
         Debug.assert(state < TransformationState.Completed, "Cannot end a block scope after transformation has completed.");
-        const statements: Statement[] | undefined = some(blockScopedVariableDeclarations) ?
-            [
+        const statements: Statement[] | undefined = some(blockScopedVariableDeclarations)
+            ? [
                 factory.createVariableStatement(
                     /*modifiers*/ undefined,
                     factory.createVariableDeclarationList(

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -378,9 +378,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     // We need to transform `accessor` fields when target < ESNext.
     // We may need to transform `accessor` fields when `useDefineForClassFields: false`
-    const shouldTransformAutoAccessors = languageVersion < ScriptTarget.ESNext ? Ternary.True :
-        !useDefineForClassFields ? Ternary.Maybe :
-        Ternary.False;
+    const shouldTransformAutoAccessors = languageVersion < ScriptTarget.ESNext ? Ternary.True
+        : !useDefineForClassFields ? Ternary.Maybe
+        : Ternary.False;
 
     // We need to transform `this` in a static initializer into a reference to the class
     // when target < ES2022 since the assignment will be moved outside of the class body.
@@ -390,9 +390,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
     // the es2015 transformation handles those.
     const shouldTransformSuperInStaticInitializers = shouldTransformThisInStaticInitializers && languageVersion >= ScriptTarget.ES2015;
 
-    const shouldTransformAnything = shouldTransformInitializers ||
-        shouldTransformPrivateElementsOrClassStaticBlocks ||
-        shouldTransformAutoAccessors === Ternary.True;
+    const shouldTransformAnything = shouldTransformInitializers
+        || shouldTransformPrivateElementsOrClassStaticBlocks
+        || shouldTransformAutoAccessors === Ternary.True;
 
     const previousOnSubstituteNode = context.onSubstituteNode;
     context.onSubstituteNode = onSubstituteNode;
@@ -457,8 +457,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function visitor(node: Node): VisitResult<Node> {
         if (
-            !(node.transformFlags & TransformFlags.ContainsClassFields) &&
-            !(node.transformFlags & TransformFlags.ContainsLexicalThisOrSuper)
+            !(node.transformFlags & TransformFlags.ContainsClassFields)
+            && !(node.transformFlags & TransformFlags.ContainsLexicalThisOrSuper)
         ) {
             return node;
         }
@@ -703,9 +703,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
         pendingStatements = [];
 
         const visitedNode = visitEachChild(node, visitor, context);
-        const statement = some(pendingStatements) ?
-            [visitedNode, ...pendingStatements] :
-            visitedNode;
+        const statement = some(pendingStatements)
+            ? [visitedNode, ...pendingStatements]
+            : visitedNode;
 
         pendingStatements = savedPendingStatements;
         return statement;
@@ -1063,23 +1063,23 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function transformFieldInitializer(node: PropertyDeclaration) {
         Debug.assert(!hasDecorators(node), "Decorators should already have been transformed and elided.");
-        return isPrivateIdentifierClassElementDeclaration(node) ?
-            transformPrivateFieldInitializer(node) :
-            transformPublicFieldInitializer(node);
+        return isPrivateIdentifierClassElementDeclaration(node)
+            ? transformPrivateFieldInitializer(node)
+            : transformPublicFieldInitializer(node);
     }
 
     function shouldTransformAutoAccessorsInCurrentClass() {
-        return shouldTransformAutoAccessors === Ternary.True ||
-            shouldTransformAutoAccessors === Ternary.Maybe &&
-                !!lexicalEnvironment?.data && !!(lexicalEnvironment.data.facts & ClassFacts.WillHoistInitializersToConstructor);
+        return shouldTransformAutoAccessors === Ternary.True
+            || shouldTransformAutoAccessors === Ternary.Maybe
+                && !!lexicalEnvironment?.data && !!(lexicalEnvironment.data.facts & ClassFacts.WillHoistInitializersToConstructor);
     }
 
     function visitPropertyDeclaration(node: PropertyDeclaration) {
         // If this is an auto-accessor, we defer to `transformAutoAccessor`. That function
         // will in turn call `transformFieldInitializer` as needed.
         if (
-            isAutoAccessorPropertyDeclaration(node) && (shouldTransformAutoAccessorsInCurrentClass() ||
-                hasStaticModifier(node) && getInternalEmitFlags(node) & InternalEmitFlags.TransformPrivateStaticElements)
+            isAutoAccessorPropertyDeclaration(node) && (shouldTransformAutoAccessorsInCurrentClass()
+                || hasStaticModifier(node) && getInternalEmitFlags(node) & InternalEmitFlags.TransformPrivateStaticElements)
         ) {
             return transformAutoAccessor(node);
         }
@@ -1088,10 +1088,10 @@ export function transformClassFields(context: TransformationContext): (x: Source
     }
 
     function shouldForceDynamicThis() {
-        return !!currentClassElement &&
-            hasStaticModifier(currentClassElement) &&
-            isAccessor(currentClassElement) &&
-            isAutoAccessorPropertyDeclaration(getOriginalNode(currentClassElement));
+        return !!currentClassElement
+            && hasStaticModifier(currentClassElement)
+            && isAccessor(currentClassElement)
+            && isAutoAccessorPropertyDeclaration(getOriginalNode(currentClassElement));
     }
 
     /**
@@ -1161,12 +1161,12 @@ export function transformClassFields(context: TransformationContext): (x: Source
             }
         }
         if (
-            shouldTransformSuperInStaticInitializers &&
-            currentClassElement &&
-            isSuperProperty(node) &&
-            isIdentifier(node.name) &&
-            isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement) &&
-            lexicalEnvironment?.data
+            shouldTransformSuperInStaticInitializers
+            && currentClassElement
+            && isSuperProperty(node)
+            && isIdentifier(node.name)
+            && isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement)
+            && lexicalEnvironment?.data
         ) {
             const { classConstructor, superClassReference, facts } = lexicalEnvironment.data;
             if (facts & ClassFacts.ClassWasDecorated) {
@@ -1189,11 +1189,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function visitElementAccessExpression(node: ElementAccessExpression) {
         if (
-            shouldTransformSuperInStaticInitializers &&
-            currentClassElement &&
-            isSuperProperty(node) &&
-            isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement) &&
-            lexicalEnvironment?.data
+            shouldTransformSuperInStaticInitializers
+            && currentClassElement
+            && isSuperProperty(node)
+            && isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement)
+            && lexicalEnvironment?.data
         ) {
             const { classConstructor, superClassReference, facts } = lexicalEnvironment.data;
             if (facts & ClassFacts.ClassWasDecorated) {
@@ -1217,8 +1217,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function visitPreOrPostfixUnaryExpression(node: PrefixUnaryExpression | PostfixUnaryExpression, discarded: boolean) {
         if (
-            node.operator === SyntaxKind.PlusPlusToken ||
-            node.operator === SyntaxKind.MinusMinusToken
+            node.operator === SyntaxKind.PlusPlusToken
+            || node.operator === SyntaxKind.MinusMinusToken
         ) {
             const operand = skipParentheses(node.operand);
 
@@ -1248,11 +1248,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 }
             }
             else if (
-                shouldTransformSuperInStaticInitializers &&
-                currentClassElement &&
-                isSuperProperty(operand) &&
-                isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement) &&
-                lexicalEnvironment?.data
+                shouldTransformSuperInStaticInitializers
+                && currentClassElement
+                && isSuperProperty(operand)
+                && isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement)
+                && lexicalEnvironment?.data
             ) {
                 // converts `++super.a` into `(Reflect.set(_baseTemp, "a", (_a = Reflect.get(_baseTemp, "a", _classTemp), _b = ++_a), _classTemp), _b)`
                 // converts `++super[f()]` into `(Reflect.set(_baseTemp, _a = f(), (_b = Reflect.get(_baseTemp, _a, _classTemp), _c = ++_b), _classTemp), _c)`
@@ -1265,9 +1265,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 const { classConstructor, superClassReference, facts } = lexicalEnvironment.data;
                 if (facts & ClassFacts.ClassWasDecorated) {
                     const expression = visitInvalidSuperProperty(operand);
-                    return isPrefixUnaryExpression(node) ?
-                        factory.updatePrefixUnaryExpression(node, expression) :
-                        factory.updatePostfixUnaryExpression(node, expression);
+                    return isPrefixUnaryExpression(node)
+                        ? factory.updatePrefixUnaryExpression(node, expression)
+                        : factory.updatePostfixUnaryExpression(node, expression);
                 }
                 if (classConstructor && superClassReference) {
                     let setterName: Expression | undefined;
@@ -1339,8 +1339,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function visitCallExpression(node: CallExpression) {
         if (
-            isPrivateIdentifierPropertyAccessExpression(node.expression) &&
-            accessPrivateIdentifier(node.expression.name)
+            isPrivateIdentifierPropertyAccessExpression(node.expression)
+            && accessPrivateIdentifier(node.expression.name)
         ) {
             // obj.#x()
 
@@ -1364,11 +1364,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
         }
 
         if (
-            shouldTransformSuperInStaticInitializers &&
-            currentClassElement &&
-            isSuperProperty(node.expression) &&
-            isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement) &&
-            lexicalEnvironment?.data?.classConstructor
+            shouldTransformSuperInStaticInitializers
+            && currentClassElement
+            && isSuperProperty(node.expression)
+            && isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement)
+            && lexicalEnvironment?.data?.classConstructor
         ) {
             // super.x()
             // super[x]()
@@ -1389,8 +1389,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function visitTaggedTemplateExpression(node: TaggedTemplateExpression) {
         if (
-            isPrivateIdentifierPropertyAccessExpression(node.tag) &&
-            accessPrivateIdentifier(node.tag.name)
+            isPrivateIdentifierPropertyAccessExpression(node.tag)
+            && accessPrivateIdentifier(node.tag.name)
         ) {
             // Bind the `this` correctly for tagged template literals when the tag is a private identifier property access.
             const { thisArg, target } = factory.createCallBinding(node.tag, hoistVariableDeclaration, languageVersion);
@@ -1406,11 +1406,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
             );
         }
         if (
-            shouldTransformSuperInStaticInitializers &&
-            currentClassElement &&
-            isSuperProperty(node.tag) &&
-            isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement) &&
-            lexicalEnvironment?.data?.classConstructor
+            shouldTransformSuperInStaticInitializers
+            && currentClassElement
+            && isSuperProperty(node.tag)
+            && isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement)
+            && lexicalEnvironment?.data?.classConstructor
         ) {
             // converts `` super.f`x` `` into `` Reflect.get(_baseTemp, "f", _classTemp).bind(_classTemp)`x` ``
             const invocation = factory.createFunctionBindCall(
@@ -1441,8 +1441,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 // If the generated `_classThis` assignment is a noop (i.e., `_classThis = _classThis`), we can
                 // eliminate the expression
                 if (
-                    isAssignmentExpression(result, /*excludeCompoundAssignment*/ true) &&
-                    result.left === result.right
+                    isAssignmentExpression(result, /*excludeCompoundAssignment*/ true)
+                    && result.left === result.right
                 ) {
                     return undefined;
                 }
@@ -1477,12 +1477,12 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 return false;
             }
 
-            const hasTransformableStatics = (shouldTransformPrivateElementsOrClassStaticBlocks ||
-                !!(getInternalEmitFlags(node) && InternalEmitFlags.TransformPrivateStaticElements)) &&
-                some(staticPropertiesOrClassStaticBlocks, node =>
-                    isClassStaticBlockDeclaration(node) ||
-                    isPrivateIdentifierClassElementDeclaration(node) ||
-                    shouldTransformInitializers && isInitializedProperty(node));
+            const hasTransformableStatics = (shouldTransformPrivateElementsOrClassStaticBlocks
+                || !!(getInternalEmitFlags(node) && InternalEmitFlags.TransformPrivateStaticElements))
+                && some(staticPropertiesOrClassStaticBlocks, node =>
+                    isClassStaticBlockDeclaration(node)
+                    || isPrivateIdentifierClassElementDeclaration(node)
+                    || shouldTransformInitializers && isInitializedProperty(node));
             return hasTransformableStatics;
         }
         return false;
@@ -1501,9 +1501,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 node.operatorToken,
                 visitNode(node.right, visitor, isExpression),
             );
-            const expr = some(pendingExpressions) ?
-                factory.inlineExpressions(compact([...pendingExpressions, node])) :
-                node;
+            const expr = some(pendingExpressions)
+                ? factory.inlineExpressions(compact([...pendingExpressions, node]))
+                : node;
             pendingExpressions = savedPendingExpressions;
             return expr;
         }
@@ -1554,11 +1554,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
                 }
             }
             else if (
-                shouldTransformSuperInStaticInitializers &&
-                currentClassElement &&
-                isSuperProperty(node.left) &&
-                isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement) &&
-                lexicalEnvironment?.data
+                shouldTransformSuperInStaticInitializers
+                && currentClassElement
+                && isSuperProperty(node.left)
+                && isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement)
+                && lexicalEnvironment?.data
             ) {
                 // super.x = ...
                 // super[x] = ...
@@ -1574,9 +1574,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
                     );
                 }
                 if (classConstructor && superClassReference) {
-                    let setterName = isElementAccessExpression(node.left) ? visitNode(node.left.argumentExpression, visitor, isExpression) :
-                        isIdentifier(node.left.name) ? factory.createStringLiteralFromNode(node.left.name) :
-                        undefined;
+                    let setterName = isElementAccessExpression(node.left) ? visitNode(node.left.argumentExpression, visitor, isExpression)
+                        : isIdentifier(node.left.name) ? factory.createStringLiteralFromNode(node.left.name)
+                        : undefined;
                     if (setterName) {
                         // converts `super.x = 1` into `(Reflect.set(_baseTemp, "x", _a = 1, _classTemp), _a)`
                         // converts `super[f()] = 1` into `(Reflect.set(_baseTemp, f(), _a = 1, _classTemp), _a)`
@@ -1638,9 +1638,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
     }
 
     function visitCommaListExpression(node: CommaListExpression, discarded: boolean) {
-        const elements = discarded ?
-            visitCommaListElements(node.elements, discardedValueVisitor) :
-            visitCommaListElements(node.elements, visitor, discardedValueVisitor);
+        const elements = discarded
+            ? visitCommaListElements(node.elements, discardedValueVisitor)
+            : visitCommaListElements(node.elements, visitor, discardedValueVisitor);
         return factory.updateCommaListExpression(node, elements);
     }
 
@@ -1650,8 +1650,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
         //     ...
         //     2. Return ? NamedEvaluation of |Expression| with argument _name_.
 
-        const visitorFunc: Visitor<Node, Node> = discarded ? discardedValueVisitor :
-            visitor;
+        const visitorFunc: Visitor<Node, Node> = discarded ? discardedValueVisitor
+            : visitor;
         const expression = visitNode(node.expression, visitorFunc, isExpression);
         return factory.updateParenthesizedExpression(node, expression);
     }
@@ -1726,8 +1726,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
         for (const member of node.members) {
             if (isStatic(member)) {
                 if (
-                    member.name && (isPrivateIdentifier(member.name) || isAutoAccessorPropertyDeclaration(member)) &&
-                    shouldTransformPrivateElementsOrClassStaticBlocks
+                    member.name && (isPrivateIdentifier(member.name) || isAutoAccessorPropertyDeclaration(member))
+                    && shouldTransformPrivateElementsOrClassStaticBlocks
                 ) {
                     facts |= ClassFacts.NeedsClassConstructorReference;
                 }
@@ -1766,10 +1766,10 @@ export function transformClassFields(context: TransformationContext): (x: Source
             }
         }
 
-        const willHoistInitializersToConstructor = shouldTransformInitializersUsingDefine && containsPublicInstanceFields ||
-            shouldTransformInitializersUsingSet && containsInitializedPublicInstanceFields ||
-            shouldTransformPrivateElementsOrClassStaticBlocks && containsInstancePrivateElements ||
-            shouldTransformPrivateElementsOrClassStaticBlocks && containsInstanceAutoAccessors && shouldTransformAutoAccessors === Ternary.True;
+        const willHoistInitializersToConstructor = shouldTransformInitializersUsingDefine && containsPublicInstanceFields
+            || shouldTransformInitializersUsingSet && containsInitializedPublicInstanceFields
+            || shouldTransformPrivateElementsOrClassStaticBlocks && containsInstancePrivateElements
+            || shouldTransformPrivateElementsOrClassStaticBlocks && containsInstanceAutoAccessors && shouldTransformAutoAccessors === Ternary.True;
 
         if (willHoistInitializersToConstructor) {
             facts |= ClassFacts.WillHoistInitializersToConstructor;
@@ -1814,8 +1814,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
                     // If the class name was assigned from a string literal based on an Identifier, use the Identifier
                     // as the prefix.
                     if (
-                        node.emitNode.assignedName.textSourceNode &&
-                        isIdentifier(node.emitNode.assignedName.textSourceNode)
+                        node.emitNode.assignedName.textSourceNode
+                        && isIdentifier(node.emitNode.assignedName.textSourceNode)
                     ) {
                         getPrivateIdentifierEnvironment().data.className = node.emitNode.assignedName.textSourceNode;
                     }
@@ -2016,11 +2016,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
         // Static initializers are transformed to `static {}` blocks when `useDefineForClassFields: false`
         // and not also transforming static blocks.
-        const hasTransformableStatics = (shouldTransformPrivateElementsOrClassStaticBlocks || getInternalEmitFlags(node) & InternalEmitFlags.TransformPrivateStaticElements) &&
-            some(staticPropertiesOrClassStaticBlocks, node =>
-                isClassStaticBlockDeclaration(node) ||
-                isPrivateIdentifierClassElementDeclaration(node) ||
-                shouldTransformInitializers && isInitializedProperty(node));
+        const hasTransformableStatics = (shouldTransformPrivateElementsOrClassStaticBlocks || getInternalEmitFlags(node) & InternalEmitFlags.TransformPrivateStaticElements)
+            && some(staticPropertiesOrClassStaticBlocks, node =>
+                isClassStaticBlockDeclaration(node)
+                || isPrivateIdentifierClassElementDeclaration(node)
+                || shouldTransformInitializers && isInitializedProperty(node));
 
         if (hasTransformableStatics || some(pendingExpressions)) {
             if (isDecoratedClassDeclaration) {
@@ -2087,9 +2087,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function visitThisExpression(node: ThisExpression) {
         if (
-            shouldTransformThisInStaticInitializers && currentClassElement &&
-            isClassStaticBlockDeclaration(currentClassElement) &&
-            lexicalEnvironment?.data
+            shouldTransformThisInStaticInitializers && currentClassElement
+            && isClassStaticBlockDeclaration(currentClassElement)
+            && lexicalEnvironment?.data
         ) {
             const { classThis, classConstructor } = lexicalEnvironment.data;
             return classThis ?? classConstructor ?? node;
@@ -2126,8 +2126,8 @@ export function transformClassFields(context: TransformationContext): (x: Source
                     if (isAutoAccessorPropertyDeclaration(member)) {
                         const storageName = factory.getGeneratedPrivateNameForNode(member.name, /*prefix*/ undefined, "_accessor_storage");
                         if (
-                            shouldTransformPrivateElementsOrClassStaticBlocks ||
-                            shouldTransformPrivateStaticElementsInClass && hasStaticModifier(member)
+                            shouldTransformPrivateElementsOrClassStaticBlocks
+                            || shouldTransformPrivateStaticElementsInClass && hasStaticModifier(member)
                         ) {
                             addPrivateIdentifierToEnvironment(member, storageName, addPrivateIdentifierPropertyDeclarationToEnvironment);
                         }
@@ -2189,9 +2189,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
             membersArray = append(membersArray, classNamedEvaluationHelperBlock);
             membersArray = append(membersArray, syntheticConstructor);
             membersArray = append(membersArray, syntheticStaticBlock);
-            const remainingMembers = classThisAssignmentBlock || classNamedEvaluationHelperBlock ?
-                filter(members, member => member !== classThisAssignmentBlock && member !== classNamedEvaluationHelperBlock) :
-                members;
+            const remainingMembers = classThisAssignmentBlock || classNamedEvaluationHelperBlock
+                ? filter(members, member => member !== classThisAssignmentBlock && member !== classNamedEvaluationHelperBlock)
+                : members;
             membersArray = addRange(membersArray, remainingMembers);
             members = setTextRange(factory.createNodeArray(membersArray), /*location*/ node.members);
         }
@@ -2412,9 +2412,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
             return undefined;
         }
 
-        const multiLine = constructor?.body && constructor.body.statements.length >= statements.length ?
-            constructor.body.multiLine ?? statements.length > 0 :
-            statements.length > 0;
+        const multiLine = constructor?.body && constructor.body.statements.length >= statements.length
+            ? constructor.body.multiLine ?? statements.length > 0
+            : statements.length > 0;
 
         return setTextRange(
             factory.createBlock(
@@ -2450,9 +2450,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
     }
 
     function transformPropertyOrClassStaticBlock(property: PropertyDeclaration | ClassStaticBlockDeclaration, receiver: LeftHandSideExpression) {
-        const expression = isClassStaticBlockDeclaration(property) ?
-            setCurrentClassElementAnd(property, transformClassStaticBlockDeclaration, property) :
-            transformProperty(property, receiver);
+        const expression = isClassStaticBlockDeclaration(property)
+            ? setCurrentClassElementAnd(property, transformClassStaticBlockDeclaration, property)
+            : transformProperty(property, receiver);
         if (!expression) {
             return undefined;
         }
@@ -2496,9 +2496,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function generateInitializedPropertyExpressionsOrClassStaticBlock(propertiesOrClassStaticBlocks: readonly (PropertyDeclaration | ClassStaticBlockDeclaration)[], receiver: LeftHandSideExpression) {
         const expressions: Expression[] = [];
         for (const property of propertiesOrClassStaticBlocks) {
-            const expression = isClassStaticBlockDeclaration(property) ?
-                setCurrentClassElementAnd(property, transformClassStaticBlockDeclaration, property) :
-                setCurrentClassElementAnd(property, () => transformProperty(property, receiver), /*arg*/ undefined);
+            const expression = isClassStaticBlockDeclaration(property)
+                ? setCurrentClassElementAnd(property, transformClassStaticBlockDeclaration, property)
+                : setCurrentClassElementAnd(property, () => transformProperty(property, receiver), /*arg*/ undefined);
             if (!expression) {
                 continue;
             }
@@ -2541,11 +2541,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
             property = transformNamedEvaluation(context, property);
         }
 
-        const propertyName = hasAccessorModifier(property) ?
-            factory.getGeneratedPrivateNameForNode(property.name) :
-            isComputedPropertyName(property.name) && !isSimpleInlineableExpression(property.name.expression) ?
-            factory.updateComputedPropertyName(property.name, factory.getGeneratedNameForNode(property.name)) :
-            property.name;
+        const propertyName = hasAccessorModifier(property)
+            ? factory.getGeneratedPrivateNameForNode(property.name)
+            : isComputedPropertyName(property.name) && !isSimpleInlineableExpression(property.name.expression)
+            ? factory.updateComputedPropertyName(property.name, factory.getGeneratedNameForNode(property.name))
+            : property.name;
 
         if (hasStaticModifier(property)) {
             currentClassElement = property;
@@ -2597,11 +2597,11 @@ export function transformClassFields(context: TransformationContext): (x: Source
             if (initializer) {
                 // unwrap `(__runInitializers(this, _instanceExtraInitializers), void 0)`
                 if (
-                    isParenthesizedExpression(initializer) &&
-                    isCommaExpression(initializer.expression) &&
-                    isCallToHelper(initializer.expression.left, "___runInitializers" as __String) &&
-                    isVoidExpression(initializer.expression.right) &&
-                    isNumericLiteral(initializer.expression.right.expression)
+                    isParenthesizedExpression(initializer)
+                    && isCommaExpression(initializer.expression)
+                    && isCallToHelper(initializer.expression.left, "___runInitializers" as __String)
+                    && isVoidExpression(initializer.expression.right)
+                    && isNumericLiteral(initializer.expression.right.expression)
                 ) {
                     initializer = initializer.expression.left;
                 }
@@ -2685,13 +2685,13 @@ export function transformClassFields(context: TransformationContext): (x: Source
     }
 
     function visitInvalidSuperProperty(node: SuperProperty) {
-        return isPropertyAccessExpression(node) ?
-            factory.updatePropertyAccessExpression(
+        return isPropertyAccessExpression(node)
+            ? factory.updatePropertyAccessExpression(
                 node,
                 factory.createVoidZero(),
                 node.name,
-            ) :
-            factory.updateElementAccessExpression(
+            )
+            : factory.updateElementAccessExpression(
                 node,
                 factory.createVoidZero(),
                 visitNode(node.argumentExpression, visitor, isExpression),
@@ -2833,9 +2833,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
         _previousInfo: PrivateIdentifierInfo | undefined,
     ) {
         const methodName = createHoistedVariableForPrivateName(name);
-        const brandCheckIdentifier = isStatic ?
-            Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment") :
-            Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
+        const brandCheckIdentifier = isStatic
+            ? Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment")
+            : Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
 
         setPrivateIdentifier(privateEnv, name, {
             kind: PrivateIdentifierKind.Method,
@@ -2856,9 +2856,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
         previousInfo: PrivateIdentifierInfo | undefined,
     ) {
         const getterName = createHoistedVariableForPrivateName(name, "_get");
-        const brandCheckIdentifier = isStatic ?
-            Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment") :
-            Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
+        const brandCheckIdentifier = isStatic
+            ? Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment")
+            : Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
 
         if (previousInfo?.kind === PrivateIdentifierKind.Accessor && previousInfo.isStatic === isStatic && !previousInfo.getterName) {
             previousInfo.getterName = getterName;
@@ -2885,13 +2885,13 @@ export function transformClassFields(context: TransformationContext): (x: Source
         previousInfo: PrivateIdentifierInfo | undefined,
     ) {
         const setterName = createHoistedVariableForPrivateName(name, "_set");
-        const brandCheckIdentifier = isStatic ?
-            Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment") :
-            Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
+        const brandCheckIdentifier = isStatic
+            ? Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment")
+            : Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
 
         if (
-            previousInfo?.kind === PrivateIdentifierKind.Accessor &&
-            previousInfo.isStatic === isStatic && !previousInfo.setterName
+            previousInfo?.kind === PrivateIdentifierKind.Accessor
+            && previousInfo.isStatic === isStatic && !previousInfo.setterName
         ) {
             previousInfo.setterName = setterName;
         }
@@ -2918,9 +2918,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
     ) {
         const getterName = createHoistedVariableForPrivateName(name, "_get");
         const setterName = createHoistedVariableForPrivateName(name, "_set");
-        const brandCheckIdentifier = isStatic ?
-            Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment") :
-            Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
+        const brandCheckIdentifier = isStatic
+            ? Debug.checkDefined(lex.classThis ?? lex.classConstructor, "classConstructor should be set in private identifier environment")
+            : Debug.checkDefined(privateEnv.data.weakSetName, "weakSetName should be set in private identifier environment");
 
         setPrivateIdentifier(privateEnv, name, {
             kind: PrivateIdentifierKind.Accessor,
@@ -2956,9 +2956,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
     function createHoistedVariableForClass(name: string | PrivateIdentifier | undefined, node: PrivateIdentifier | ClassStaticBlockDeclaration, suffix?: string): Identifier {
         const { className } = getPrivateIdentifierEnvironment().data;
         const prefix: GeneratedNamePart | string = className ? { prefix: "_", node: className, suffix: "_" } : "_";
-        const identifier = typeof name === "object" ? factory.getGeneratedNameForNode(name, GeneratedIdentifierFlags.Optimistic | GeneratedIdentifierFlags.ReservedInNestedScopes, prefix, suffix) :
-            typeof name === "string" ? factory.createUniqueName(name, GeneratedIdentifierFlags.Optimistic, prefix, suffix) :
-            factory.createTempVariable(/*recordTempVariable*/ undefined, /*reservedInNestedScopes*/ true, prefix, suffix);
+        const identifier = typeof name === "object" ? factory.getGeneratedNameForNode(name, GeneratedIdentifierFlags.Optimistic | GeneratedIdentifierFlags.ReservedInNestedScopes, prefix, suffix)
+            : typeof name === "string" ? factory.createUniqueName(name, GeneratedIdentifierFlags.Optimistic, prefix, suffix)
+            : factory.createTempVariable(/*recordTempVariable*/ undefined, /*reservedInNestedScopes*/ true, prefix, suffix);
 
         if (resolver.getNodeCheckFlags(node) & NodeCheckFlags.BlockScopedBindingInLoop) {
             addBlockScopedVariable(identifier);
@@ -3018,20 +3018,20 @@ export function transformClassFields(context: TransformationContext): (x: Source
             return wrapPrivateIdentifierForDestructuringTarget(node);
         }
         else if (
-            shouldTransformSuperInStaticInitializers &&
-            currentClassElement &&
-            isSuperProperty(node) &&
-            isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement) &&
-            lexicalEnvironment?.data
+            shouldTransformSuperInStaticInitializers
+            && currentClassElement
+            && isSuperProperty(node)
+            && isStaticPropertyDeclarationOrClassStaticBlock(currentClassElement)
+            && lexicalEnvironment?.data
         ) {
             const { classConstructor, superClassReference, facts } = lexicalEnvironment.data;
             if (facts & ClassFacts.ClassWasDecorated) {
                 return visitInvalidSuperProperty(node);
             }
             else if (classConstructor && superClassReference) {
-                const name = isElementAccessExpression(node) ? visitNode(node.argumentExpression, visitor, isExpression) :
-                    isIdentifier(node.name) ? factory.createStringLiteralFromNode(node.name) :
-                    undefined;
+                const name = isElementAccessExpression(node) ? visitNode(node.argumentExpression, visitor, isExpression)
+                    : isIdentifier(node.name) ? factory.createStringLiteralFromNode(node.name)
+                    : undefined;
                 if (name) {
                     const temp = factory.createTempVariable(/*recordTempVariable*/ undefined);
                     return factory.createAssignmentTargetWrapper(
@@ -3267,9 +3267,9 @@ export function transformClassFields(context: TransformationContext): (x: Source
 
     function substituteThisExpression(node: ThisExpression) {
         if (
-            enabledSubstitutions & ClassPropertySubstitutionFlags.ClassStaticThisOrSuperReference &&
-            lexicalEnvironment?.data &&
-            !noSubstitution.has(node)
+            enabledSubstitutions & ClassPropertySubstitutionFlags.ClassStaticThisOrSuperReference
+            && lexicalEnvironment?.data
+            && !noSubstitution.has(node)
         ) {
             const { facts, classConstructor, classThis } = lexicalEnvironment.data;
             const substituteThis = shouldSubstituteThisWithClassThis ? classThis ?? classConstructor : classConstructor;

--- a/src/compiler/transformers/classThis.ts
+++ b/src/compiler/transformers/classThis.ts
@@ -76,11 +76,11 @@ export function isClassThisAssignmentBlock(node: Node): node is ClassThisAssignm
     }
 
     const statement = node.body.statements[0];
-    return isExpressionStatement(statement) &&
-        isAssignmentExpression(statement.expression, /*excludeCompoundAssignment*/ true) &&
-        isIdentifier(statement.expression.left) &&
-        node.emitNode?.classThis === statement.expression.left &&
-        statement.expression.right.kind === SyntaxKind.ThisKeyword;
+    return isExpressionStatement(statement)
+        && isAssignmentExpression(statement.expression, /*excludeCompoundAssignment*/ true)
+        && isIdentifier(statement.expression.left)
+        && node.emitNode?.classThis === statement.expression.left
+        && statement.expression.right.kind === SyntaxKind.ThisKeyword;
 }
 
 /**
@@ -126,16 +126,16 @@ export function injectClassThisAssignmentIfMissing<T extends ClassLikeDeclaratio
     const members = factory.createNodeArray([staticBlock, ...node.members]);
     setTextRange(members, node.members);
 
-    const updatedNode = isClassDeclaration(node) ?
-        factory.updateClassDeclaration(
+    const updatedNode = isClassDeclaration(node)
+        ? factory.updateClassDeclaration(
             node,
             node.modifiers,
             node.name,
             node.typeParameters,
             node.heritageClauses,
             members,
-        ) :
-        factory.updateClassExpression(
+        )
+        : factory.updateClassExpression(
             node,
             node.modifiers,
             node.name,

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -225,13 +225,13 @@ export function getDeclarationDiagnostics(host: EmitHost, resolver: EmitResolver
     return result.diagnostics;
 }
 
-const declarationEmitNodeBuilderFlags = NodeBuilderFlags.MultilineObjectLiterals |
-    NodeBuilderFlags.WriteClassExpressionAsTypeLiteral |
-    NodeBuilderFlags.UseTypeOfFunction |
-    NodeBuilderFlags.UseStructuralFallback |
-    NodeBuilderFlags.AllowEmptyTuple |
-    NodeBuilderFlags.GenerateNamesForShadowedTypeParams |
-    NodeBuilderFlags.NoTruncation;
+const declarationEmitNodeBuilderFlags = NodeBuilderFlags.MultilineObjectLiterals
+    | NodeBuilderFlags.WriteClassExpressionAsTypeLiteral
+    | NodeBuilderFlags.UseTypeOfFunction
+    | NodeBuilderFlags.UseStructuralFallback
+    | NodeBuilderFlags.AllowEmptyTuple
+    | NodeBuilderFlags.GenerateNamesForShadowedTypeParams
+    | NodeBuilderFlags.NoTruncation;
 
 /**
  * Transforms a ts file into a .d.ts file
@@ -370,10 +370,10 @@ export function transformDeclarations(context: TransformationContext) {
     }
 
     function errorDeclarationNameWithFallback() {
-        return errorNameNode ? declarationNameToString(errorNameNode) :
-            errorFallbackNode && getNameOfDeclaration(errorFallbackNode) ? declarationNameToString(getNameOfDeclaration(errorFallbackNode)) :
-            errorFallbackNode && isExportAssignment(errorFallbackNode) ? errorFallbackNode.isExportEquals ? "export=" : "default" :
-            "(Missing)"; // same fallback declarationNameToString uses when node is zero-width (ie, nameless)
+        return errorNameNode ? declarationNameToString(errorNameNode)
+            : errorFallbackNode && getNameOfDeclaration(errorFallbackNode) ? declarationNameToString(getNameOfDeclaration(errorFallbackNode))
+            : errorFallbackNode && isExportAssignment(errorFallbackNode) ? errorFallbackNode.isExportEquals ? "export=" : "default"
+            : "(Missing)"; // same fallback declarationNameToString uses when node is zero-width (ie, nameless)
     }
 
     function reportInaccessibleUniqueSymbolError() {

--- a/src/compiler/transformers/declarations/diagnostics.ts
+++ b/src/compiler/transformers/declarations/diagnostics.ts
@@ -104,28 +104,28 @@ export type DeclarationDiagnosticProducing =
 
 /** @internal */
 export function canProduceDiagnostics(node: Node): node is DeclarationDiagnosticProducing {
-    return isVariableDeclaration(node) ||
-        isPropertyDeclaration(node) ||
-        isPropertySignature(node) ||
-        isBindingElement(node) ||
-        isSetAccessor(node) ||
-        isGetAccessor(node) ||
-        isConstructSignatureDeclaration(node) ||
-        isCallSignatureDeclaration(node) ||
-        isMethodDeclaration(node) ||
-        isMethodSignature(node) ||
-        isFunctionDeclaration(node) ||
-        isParameter(node) ||
-        isTypeParameterDeclaration(node) ||
-        isExpressionWithTypeArguments(node) ||
-        isImportEqualsDeclaration(node) ||
-        isTypeAliasDeclaration(node) ||
-        isConstructorDeclaration(node) ||
-        isIndexSignatureDeclaration(node) ||
-        isPropertyAccessExpression(node) ||
-        isElementAccessExpression(node) ||
-        isBinaryExpression(node) ||
-        isJSDocTypeAlias(node);
+    return isVariableDeclaration(node)
+        || isPropertyDeclaration(node)
+        || isPropertySignature(node)
+        || isBindingElement(node)
+        || isSetAccessor(node)
+        || isGetAccessor(node)
+        || isConstructSignatureDeclaration(node)
+        || isCallSignatureDeclaration(node)
+        || isMethodDeclaration(node)
+        || isMethodSignature(node)
+        || isFunctionDeclaration(node)
+        || isParameter(node)
+        || isTypeParameterDeclaration(node)
+        || isExpressionWithTypeArguments(node)
+        || isImportEqualsDeclaration(node)
+        || isTypeAliasDeclaration(node)
+        || isConstructorDeclaration(node)
+        || isIndexSignatureDeclaration(node)
+        || isPropertyAccessExpression(node)
+        || isElementAccessExpression(node)
+        || isBinaryExpression(node)
+        || isJSDocTypeAlias(node);
 }
 
 /** @internal */
@@ -150,23 +150,23 @@ export function createGetSymbolAccessibilityDiagnosticForNodeName(node: Declarat
 
     function getAccessorNameVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
         if (isStatic(node)) {
-            return symbolAccessibilityResult.errorModuleName ?
-                symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                    Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                    Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_private_name_1;
+            return symbolAccessibilityResult.errorModuleName
+                ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                    ? Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                    : Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2
+                : Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_private_name_1;
         }
         else if (node.parent.kind === SyntaxKind.ClassDeclaration) {
-            return symbolAccessibilityResult.errorModuleName ?
-                symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                    Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                    Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                Diagnostics.Public_property_0_of_exported_class_has_or_is_using_private_name_1;
+            return symbolAccessibilityResult.errorModuleName
+                ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                    ? Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                    : Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2
+                : Diagnostics.Public_property_0_of_exported_class_has_or_is_using_private_name_1;
         }
         else {
-            return symbolAccessibilityResult.errorModuleName ?
-                Diagnostics.Property_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2 :
-                Diagnostics.Property_0_of_exported_interface_has_or_is_using_private_name_1;
+            return symbolAccessibilityResult.errorModuleName
+                ? Diagnostics.Property_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2
+                : Diagnostics.Property_0_of_exported_interface_has_or_is_using_private_name_1;
         }
     }
 
@@ -181,23 +181,23 @@ export function createGetSymbolAccessibilityDiagnosticForNodeName(node: Declarat
 
     function getMethodNameVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
         if (isStatic(node)) {
-            return symbolAccessibilityResult.errorModuleName ?
-                symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                    Diagnostics.Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                    Diagnostics.Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                Diagnostics.Public_static_method_0_of_exported_class_has_or_is_using_private_name_1;
+            return symbolAccessibilityResult.errorModuleName
+                ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                    ? Diagnostics.Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                    : Diagnostics.Public_static_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2
+                : Diagnostics.Public_static_method_0_of_exported_class_has_or_is_using_private_name_1;
         }
         else if (node.parent.kind === SyntaxKind.ClassDeclaration) {
-            return symbolAccessibilityResult.errorModuleName ?
-                symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                    Diagnostics.Public_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                    Diagnostics.Public_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                Diagnostics.Public_method_0_of_exported_class_has_or_is_using_private_name_1;
+            return symbolAccessibilityResult.errorModuleName
+                ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                    ? Diagnostics.Public_method_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                    : Diagnostics.Public_method_0_of_exported_class_has_or_is_using_name_1_from_private_module_2
+                : Diagnostics.Public_method_0_of_exported_class_has_or_is_using_private_name_1;
         }
         else {
-            return symbolAccessibilityResult.errorModuleName ?
-                Diagnostics.Method_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2 :
-                Diagnostics.Method_0_of_exported_interface_has_or_is_using_private_name_1;
+            return symbolAccessibilityResult.errorModuleName
+                ? Diagnostics.Method_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2
+                : Diagnostics.Method_0_of_exported_interface_has_or_is_using_private_name_1;
         }
     }
 }
@@ -237,38 +237,38 @@ export function createGetSymbolAccessibilityDiagnosticForNode(node: DeclarationD
 
     function getVariableDeclarationTypeVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult) {
         if (node.kind === SyntaxKind.VariableDeclaration || node.kind === SyntaxKind.BindingElement) {
-            return symbolAccessibilityResult.errorModuleName ?
-                symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                    Diagnostics.Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                    Diagnostics.Exported_variable_0_has_or_is_using_name_1_from_private_module_2 :
-                Diagnostics.Exported_variable_0_has_or_is_using_private_name_1;
+            return symbolAccessibilityResult.errorModuleName
+                ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                    ? Diagnostics.Exported_variable_0_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                    : Diagnostics.Exported_variable_0_has_or_is_using_name_1_from_private_module_2
+                : Diagnostics.Exported_variable_0_has_or_is_using_private_name_1;
         }
         // This check is to ensure we don't report error on constructor parameter property as that error would be reported during parameter emit
         // The only exception here is if the constructor was marked as private. we are not emitting the constructor parameters at all.
         else if (
-            node.kind === SyntaxKind.PropertyDeclaration || node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.ElementAccessExpression || node.kind === SyntaxKind.BinaryExpression || node.kind === SyntaxKind.PropertySignature ||
-            (node.kind === SyntaxKind.Parameter && hasSyntacticModifier(node.parent, ModifierFlags.Private))
+            node.kind === SyntaxKind.PropertyDeclaration || node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.ElementAccessExpression || node.kind === SyntaxKind.BinaryExpression || node.kind === SyntaxKind.PropertySignature
+            || (node.kind === SyntaxKind.Parameter && hasSyntacticModifier(node.parent, ModifierFlags.Private))
         ) {
             // TODO(jfreeman): Deal with computed properties in error reporting.
             if (isStatic(node)) {
-                return symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                        Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                        : Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Public_static_property_0_of_exported_class_has_or_is_using_private_name_1;
             }
             else if (node.parent.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.Parameter) {
-                return symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                        Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Public_property_0_of_exported_class_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                        : Diagnostics.Public_property_0_of_exported_class_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Public_property_0_of_exported_class_has_or_is_using_private_name_1;
             }
             else {
                 // Interfaces cannot have types that cannot be named
-                return symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Property_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Property_0_of_exported_interface_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Property_0_of_exported_interface_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Property_0_of_exported_interface_has_or_is_using_private_name_1;
             }
         }
     }
@@ -288,30 +288,30 @@ export function createGetSymbolAccessibilityDiagnosticForNode(node: DeclarationD
             // Getters can infer the return type from the returned expression, but setters cannot, so the
             // "_from_external_module_1_but_cannot_be_named" case cannot occur.
             if (isStatic(node)) {
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_private_name_1;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_type_of_public_static_setter_0_from_exported_class_has_or_is_using_private_name_1;
             }
             else {
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_private_name_1;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_type_of_public_setter_0_from_exported_class_has_or_is_using_private_name_1;
             }
         }
         else {
             if (isStatic(node)) {
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                        Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_private_name_1;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                        : Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Return_type_of_public_static_getter_0_from_exported_class_has_or_is_using_private_name_1;
             }
             else {
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                        Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_private_name_1;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                        : Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Return_type_of_public_getter_0_from_exported_class_has_or_is_using_private_name_1;
             }
         }
         return {
@@ -326,55 +326,55 @@ export function createGetSymbolAccessibilityDiagnosticForNode(node: DeclarationD
         switch (node.kind) {
             case SyntaxKind.ConstructSignature:
                 // Interfaces cannot have return types that cannot be named
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1 :
-                    Diagnostics.Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_0;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1
+                    : Diagnostics.Return_type_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_0;
                 break;
 
             case SyntaxKind.CallSignature:
                 // Interfaces cannot have return types that cannot be named
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Return_type_of_call_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1 :
-                    Diagnostics.Return_type_of_call_signature_from_exported_interface_has_or_is_using_private_name_0;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Return_type_of_call_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1
+                    : Diagnostics.Return_type_of_call_signature_from_exported_interface_has_or_is_using_private_name_0;
                 break;
 
             case SyntaxKind.IndexSignature:
                 // Interfaces cannot have return types that cannot be named
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Return_type_of_index_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1 :
-                    Diagnostics.Return_type_of_index_signature_from_exported_interface_has_or_is_using_private_name_0;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Return_type_of_index_signature_from_exported_interface_has_or_is_using_name_0_from_private_module_1
+                    : Diagnostics.Return_type_of_index_signature_from_exported_interface_has_or_is_using_private_name_0;
                 break;
 
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.MethodSignature:
                 if (isStatic(node)) {
-                    diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                        symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                            Diagnostics.Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named :
-                            Diagnostics.Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_private_module_1 :
-                        Diagnostics.Return_type_of_public_static_method_from_exported_class_has_or_is_using_private_name_0;
+                    diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                        ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                            ? Diagnostics.Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named
+                            : Diagnostics.Return_type_of_public_static_method_from_exported_class_has_or_is_using_name_0_from_private_module_1
+                        : Diagnostics.Return_type_of_public_static_method_from_exported_class_has_or_is_using_private_name_0;
                 }
                 else if (node.parent.kind === SyntaxKind.ClassDeclaration) {
-                    diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                        symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                            Diagnostics.Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named :
-                            Diagnostics.Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_private_module_1 :
-                        Diagnostics.Return_type_of_public_method_from_exported_class_has_or_is_using_private_name_0;
+                    diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                        ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                            ? Diagnostics.Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named
+                            : Diagnostics.Return_type_of_public_method_from_exported_class_has_or_is_using_name_0_from_private_module_1
+                        : Diagnostics.Return_type_of_public_method_from_exported_class_has_or_is_using_private_name_0;
                 }
                 else {
                     // Interfaces cannot have return types that cannot be named
-                    diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                        Diagnostics.Return_type_of_method_from_exported_interface_has_or_is_using_name_0_from_private_module_1 :
-                        Diagnostics.Return_type_of_method_from_exported_interface_has_or_is_using_private_name_0;
+                    diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                        ? Diagnostics.Return_type_of_method_from_exported_interface_has_or_is_using_name_0_from_private_module_1
+                        : Diagnostics.Return_type_of_method_from_exported_interface_has_or_is_using_private_name_0;
                 }
                 break;
 
             case SyntaxKind.FunctionDeclaration:
-                diagnosticMessage = symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Return_type_of_exported_function_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named :
-                        Diagnostics.Return_type_of_exported_function_has_or_is_using_name_0_from_private_module_1 :
-                    Diagnostics.Return_type_of_exported_function_has_or_is_using_private_name_0;
+                diagnosticMessage = symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Return_type_of_exported_function_has_or_is_using_name_0_from_external_module_1_but_cannot_be_named
+                        : Diagnostics.Return_type_of_exported_function_has_or_is_using_name_0_from_private_module_1
+                    : Diagnostics.Return_type_of_exported_function_has_or_is_using_private_name_0;
                 break;
 
             default:
@@ -399,68 +399,68 @@ export function createGetSymbolAccessibilityDiagnosticForNode(node: DeclarationD
     function getParameterDeclarationTypeVisibilityDiagnosticMessage(symbolAccessibilityResult: SymbolAccessibilityResult): DiagnosticMessage {
         switch (node.parent.kind) {
             case SyntaxKind.Constructor:
-                return symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                        Diagnostics.Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_0_of_constructor_from_exported_class_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                        : Diagnostics.Parameter_0_of_constructor_from_exported_class_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_0_of_constructor_from_exported_class_has_or_is_using_private_name_1;
 
             case SyntaxKind.ConstructSignature:
             case SyntaxKind.ConstructorType:
                 // Interfaces cannot have parameter types that cannot be named
-                return symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_private_name_1;
 
             case SyntaxKind.CallSignature:
                 // Interfaces cannot have parameter types that cannot be named
-                return symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_0_of_call_signature_from_exported_interface_has_or_is_using_private_name_1;
 
             case SyntaxKind.IndexSignature:
                 // Interfaces cannot have parameter types that cannot be named
-                return symbolAccessibilityResult.errorModuleName ?
-                    Diagnostics.Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? Diagnostics.Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_0_of_index_signature_from_exported_interface_has_or_is_using_private_name_1;
 
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.MethodSignature:
                 if (isStatic(node.parent)) {
-                    return symbolAccessibilityResult.errorModuleName ?
-                        symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                            Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                            Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                        Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1;
+                    return symbolAccessibilityResult.errorModuleName
+                        ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                            ? Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                            : Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_name_1_from_private_module_2
+                        : Diagnostics.Parameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_name_1;
                 }
                 else if (node.parent.parent.kind === SyntaxKind.ClassDeclaration) {
-                    return symbolAccessibilityResult.errorModuleName ?
-                        symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                            Diagnostics.Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                            Diagnostics.Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_private_module_2 :
-                        Diagnostics.Parameter_0_of_public_method_from_exported_class_has_or_is_using_private_name_1;
+                    return symbolAccessibilityResult.errorModuleName
+                        ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                            ? Diagnostics.Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                            : Diagnostics.Parameter_0_of_public_method_from_exported_class_has_or_is_using_name_1_from_private_module_2
+                        : Diagnostics.Parameter_0_of_public_method_from_exported_class_has_or_is_using_private_name_1;
                 }
                 else {
                     // Interfaces cannot have parameter types that cannot be named
-                    return symbolAccessibilityResult.errorModuleName ?
-                        Diagnostics.Parameter_0_of_method_from_exported_interface_has_or_is_using_name_1_from_private_module_2 :
-                        Diagnostics.Parameter_0_of_method_from_exported_interface_has_or_is_using_private_name_1;
+                    return symbolAccessibilityResult.errorModuleName
+                        ? Diagnostics.Parameter_0_of_method_from_exported_interface_has_or_is_using_name_1_from_private_module_2
+                        : Diagnostics.Parameter_0_of_method_from_exported_interface_has_or_is_using_private_name_1;
                 }
 
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionType:
-                return symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Parameter_0_of_exported_function_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                        Diagnostics.Parameter_0_of_exported_function_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_0_of_exported_function_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Parameter_0_of_exported_function_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                        : Diagnostics.Parameter_0_of_exported_function_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_0_of_exported_function_has_or_is_using_private_name_1;
             case SyntaxKind.SetAccessor:
             case SyntaxKind.GetAccessor:
-                return symbolAccessibilityResult.errorModuleName ?
-                    symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed ?
-                        Diagnostics.Parameter_0_of_accessor_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named :
-                        Diagnostics.Parameter_0_of_accessor_has_or_is_using_name_1_from_private_module_2 :
-                    Diagnostics.Parameter_0_of_accessor_has_or_is_using_private_name_1;
+                return symbolAccessibilityResult.errorModuleName
+                    ? symbolAccessibilityResult.accessibility === SymbolAccessibility.CannotBeNamed
+                        ? Diagnostics.Parameter_0_of_accessor_has_or_is_using_name_1_from_external_module_2_but_cannot_be_named
+                        : Diagnostics.Parameter_0_of_accessor_has_or_is_using_name_1_from_private_module_2
+                    : Diagnostics.Parameter_0_of_accessor_has_or_is_using_private_name_1;
 
             default:
                 return Debug.fail(`Unknown parent for parameter: ${Debug.formatSyntaxKind(node.parent.kind)}`);
@@ -534,10 +534,10 @@ export function createGetSymbolAccessibilityDiagnosticForNode(node: DeclarationD
         // Heritage clause is written by user so it can always be named
         if (isClassDeclaration(node.parent.parent)) {
             // Class or Interface implemented/extended is inaccessible
-            diagnosticMessage = isHeritageClause(node.parent) && node.parent.token === SyntaxKind.ImplementsKeyword ?
-                Diagnostics.Implements_clause_of_exported_class_0_has_or_is_using_private_name_1 :
-                node.parent.parent.name ? Diagnostics.extends_clause_of_exported_class_0_has_or_is_using_private_name_1 :
-                Diagnostics.extends_clause_of_exported_class_has_or_is_using_private_name_0;
+            diagnosticMessage = isHeritageClause(node.parent) && node.parent.token === SyntaxKind.ImplementsKeyword
+                ? Diagnostics.Implements_clause_of_exported_class_0_has_or_is_using_private_name_1
+                : node.parent.parent.name ? Diagnostics.extends_clause_of_exported_class_0_has_or_is_using_private_name_1
+                : Diagnostics.extends_clause_of_exported_class_has_or_is_using_private_name_0;
         }
         else {
             // interface is inaccessible

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -137,8 +137,8 @@ export function flattenDestructuringAssignment(
         Debug.assert(value);
 
         if (
-            isIdentifier(value) && bindingOrAssignmentElementAssignsToName(node, value.escapedText) ||
-            bindingOrAssignmentElementContainsNonLiteralComputedName(node)
+            isIdentifier(value) && bindingOrAssignmentElementAssignsToName(node, value.escapedText)
+            || bindingOrAssignmentElementContainsNonLiteralComputedName(node)
         ) {
             // If the right-hand value of the assignment is also an assignment target then
             // we need to cache the right-hand value.
@@ -268,8 +268,8 @@ export function flattenDestructuringBinding(
     if (isVariableDeclaration(node)) {
         let initializer = getInitializerOfBindingOrAssignmentElement(node);
         if (
-            initializer && (isIdentifier(initializer) && bindingOrAssignmentElementAssignsToName(node, initializer.escapedText) ||
-                bindingOrAssignmentElementContainsNonLiteralComputedName(node))
+            initializer && (isIdentifier(initializer) && bindingOrAssignmentElementAssignsToName(node, initializer.escapedText)
+                || bindingOrAssignmentElementContainsNonLiteralComputedName(node))
         ) {
             // If the right-hand value of the assignment is also an assignment target then
             // we need to cache the right-hand value.

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -895,8 +895,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
             //   - break/continue is labeled and label is located inside the converted loop
             //   - break/continue is non-labeled and located in non-converted loop/switch statement
             const jump = node.kind === SyntaxKind.BreakStatement ? Jump.Break : Jump.Continue;
-            const canUseBreakOrContinue = (node.label && convertedLoopState.labels && convertedLoopState.labels.get(idText(node.label))) ||
-                (!node.label && (convertedLoopState.allowedNonLabeledJumps! & jump));
+            const canUseBreakOrContinue = (node.label && convertedLoopState.labels && convertedLoopState.labels.get(idText(node.label)))
+                || (!node.label && (convertedLoopState.allowedNonLabeledJumps! & jump));
 
             if (!canUseBreakOrContinue) {
                 let labelMarker: string;
@@ -1350,14 +1350,14 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
 
     /** Tests whether `node` is a generated identifier whose base text is `_super` */
     function isSyntheticSuper(node: Node): node is SyntheticSuper {
-        return isGeneratedIdentifier(node) &&
-            idText(node) === "_super";
+        return isGeneratedIdentifier(node)
+            && idText(node) === "_super";
     }
 
     /** Tests whether `node` is VariableStatement like `var _this = ...;` */
     function isThisCapturingVariableStatement(node: Node): node is ThisCapturingVariableStatement {
-        return isVariableStatement(node) && node.declarationList.declarations.length === 1 &&
-            isThisCapturingVariableDeclaration(node.declarationList.declarations[0]);
+        return isVariableStatement(node) && node.declarationList.declarations.length === 1
+            && isThisCapturingVariableDeclaration(node.declarationList.declarations[0]);
     }
 
     /** Tests whether `node` is a VariableDeclaration like in `var _this = ...` */
@@ -1372,37 +1372,37 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
 
     /** Tests whether `node` is a call like `_super.call(this, ...)` or `_super.apply(this, ...)` */
     function isTransformedSuperCall(node: Node): node is TransformedSuperCall {
-        return isCallExpression(node) &&
-            isPropertyAccessExpression(node.expression) &&
-            isSyntheticSuper(node.expression.expression) &&
-            isIdentifier(node.expression.name) &&
-            (idText(node.expression.name) === "call" || idText(node.expression.name) === "apply") &&
-            node.arguments.length >= 1 &&
-            node.arguments[0].kind === SyntaxKind.ThisKeyword;
+        return isCallExpression(node)
+            && isPropertyAccessExpression(node.expression)
+            && isSyntheticSuper(node.expression.expression)
+            && isIdentifier(node.expression.name)
+            && (idText(node.expression.name) === "call" || idText(node.expression.name) === "apply")
+            && node.arguments.length >= 1
+            && node.arguments[0].kind === SyntaxKind.ThisKeyword;
     }
 
     /** Tests whether `node` is an expression like `_super.call(this) || this` */
     function isTransformedSuperCallWithFallback(node: Node): node is TransformedSuperCallWithFallback {
-        return isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.BarBarToken &&
-            node.right.kind === SyntaxKind.ThisKeyword &&
-            isTransformedSuperCall(node.left);
+        return isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.BarBarToken
+            && node.right.kind === SyntaxKind.ThisKeyword
+            && isTransformedSuperCall(node.left);
     }
 
     /** Tests whether `node` is a call like `_super !== null && _super.apply(this, arguments)` */
     function isImplicitSuperCall(node: Node): node is ImplicitSuperCall {
-        return isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken &&
-            isBinaryExpression(node.left) && node.left.operatorToken.kind === SyntaxKind.ExclamationEqualsEqualsToken &&
-            isSyntheticSuper(node.left.left) &&
-            node.left.right.kind === SyntaxKind.NullKeyword &&
-            isTransformedSuperCall(node.right) &&
-            idText(node.right.expression.name) === "apply";
+        return isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken
+            && isBinaryExpression(node.left) && node.left.operatorToken.kind === SyntaxKind.ExclamationEqualsEqualsToken
+            && isSyntheticSuper(node.left.left)
+            && node.left.right.kind === SyntaxKind.NullKeyword
+            && isTransformedSuperCall(node.right)
+            && idText(node.right.expression.name) === "apply";
     }
 
     /** Tests whether `node` is an expression like `_super !== null && _super.apply(this, arguments) || this` */
     function isImplicitSuperCallWithFallback(node: Node): node is ImplicitSuperCallWithFallback {
-        return isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.BarBarToken &&
-            node.right.kind === SyntaxKind.ThisKeyword &&
-            isImplicitSuperCall(node.left);
+        return isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.BarBarToken
+            && node.right.kind === SyntaxKind.ThisKeyword
+            && isImplicitSuperCall(node.left);
     }
 
     /** Tests whether `node` is an expression like `_this = _super.call(this) || this` */
@@ -1416,12 +1416,12 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
     }
 
     function isTransformedSuperCallLike(node: Node): node is TransformedSuperCallLike {
-        return isTransformedSuperCall(node) ||
-            isTransformedSuperCallWithFallback(node) ||
-            isThisCapturingTransformedSuperCallWithFallback(node) ||
-            isImplicitSuperCall(node) ||
-            isImplicitSuperCallWithFallback(node) ||
-            isThisCapturingImplicitSuperCallWithFallback(node);
+        return isTransformedSuperCall(node)
+            || isTransformedSuperCallWithFallback(node)
+            || isThisCapturingTransformedSuperCallWithFallback(node)
+            || isImplicitSuperCall(node)
+            || isImplicitSuperCallWithFallback(node)
+            || isThisCapturingImplicitSuperCallWithFallback(node);
     }
 
     /**
@@ -1562,9 +1562,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         // If the original node contained a lexical `this` that must be preserved, or if we recorded a captured `this`
         // or `super`, then we cannot simplify `var _this = ...;`, but may still be able to inline standalone `_this = ...`
         // assignment statements.
-        const canElideThisCapturingVariable = !(original.transformFlags & TransformFlags.ContainsLexicalThis) &&
-            !(hierarchyFacts & HierarchyFacts.LexicalThis) &&
-            !(hierarchyFacts & HierarchyFacts.CapturedLexicalThis);
+        const canElideThisCapturingVariable = !(original.transformFlags & TransformFlags.ContainsLexicalThis)
+            && !(hierarchyFacts & HierarchyFacts.LexicalThis)
+            && !(hierarchyFacts & HierarchyFacts.CapturedLexicalThis);
 
         // find the return statement and the preceding transformed `super()` call
         for (let i = body.statements.length - 1; i > 0; i--) {
@@ -1574,8 +1574,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
                 const preceding = body.statements[i - 1];
                 let expression: Expression | undefined;
                 if (
-                    isExpressionStatement(preceding) &&
-                    isThisCapturingTransformedSuperCallWithFallback(skipOuterExpressions(preceding.expression))
+                    isExpressionStatement(preceding)
+                    && isThisCapturingTransformedSuperCallWithFallback(skipOuterExpressions(preceding.expression))
                 ) {
                     // The preceding statement is `_this = _super.call(this, ...) || this`, so we'll inline the
                     // expression.
@@ -1679,9 +1679,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         // If the original node contained a lexical `this` that must be preserved, or if we recorded a captured `this`,
         // then there is nothing we can simplify.
         if (
-            original.transformFlags & TransformFlags.ContainsLexicalThis ||
-            hierarchyFacts & HierarchyFacts.LexicalThis ||
-            hierarchyFacts & HierarchyFacts.CapturedLexicalThis
+            original.transformFlags & TransformFlags.ContainsLexicalThis
+            || hierarchyFacts & HierarchyFacts.LexicalThis
+            || hierarchyFacts & HierarchyFacts.CapturedLexicalThis
         ) {
             return body;
         }
@@ -1699,8 +1699,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
     /** Injects `_super !== null &&` preceding any instance of a synthetic `_super.apply(this, arguments)` */
     function injectSuperPresenceCheckWorker(node: Node): VisitResult<Node | undefined> {
         if (
-            isTransformedSuperCall(node) && node.arguments.length === 2 &&
-            isIdentifier(node.arguments[1]) && idText(node.arguments[1]) === "arguments"
+            isTransformedSuperCall(node) && node.arguments.length === 2
+            && isIdentifier(node.arguments[1]) && idText(node.arguments[1]) === "arguments"
         ) {
             return factory.createLogicalAnd(
                 factory.createStrictInequality(
@@ -1801,8 +1801,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         else if (statement.kind === SyntaxKind.IfStatement) {
             const ifStatement = statement as IfStatement;
             if (ifStatement.elseStatement) {
-                return isSufficientlyCoveredByReturnStatements(ifStatement.thenStatement) &&
-                    isSufficientlyCoveredByReturnStatements(ifStatement.elseStatement);
+                return isSufficientlyCoveredByReturnStatements(ifStatement.thenStatement)
+                    && isSufficientlyCoveredByReturnStatements(ifStatement.elseStatement);
             }
         }
         // A block is covered if it has a last statement which is covered.
@@ -3316,8 +3316,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         for (let i = 0; i < properties.length; i++) {
             const property = properties[i];
             if (
-                (property.transformFlags & TransformFlags.ContainsYield &&
-                    hierarchyFacts & HierarchyFacts.AsyncFunctionBody)
+                (property.transformFlags & TransformFlags.ContainsYield
+                    && hierarchyFacts & HierarchyFacts.AsyncFunctionBody)
                 || (hasComputed = Debug.checkDefined(property.name).kind === SyntaxKind.ComputedPropertyName)
             ) {
                 numInitialProperties = i;
@@ -3566,9 +3566,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         // variables declared in the loop initializer that will be changed inside the loop
         const loopOutParameters: LoopOutParameter[] = [];
         if (loopInitializer && (getCombinedNodeFlags(loopInitializer) & NodeFlags.BlockScoped)) {
-            const hasCapturedBindingsInForHead = shouldConvertInitializerOfForStatement(node) ||
-                shouldConvertConditionOfForStatement(node) ||
-                shouldConvertIncrementorOfForStatement(node);
+            const hasCapturedBindingsInForHead = shouldConvertInitializerOfForStatement(node)
+                || shouldConvertConditionOfForStatement(node)
+                || shouldConvertIncrementorOfForStatement(node);
             for (const decl of loopInitializer.declarations) {
                 processLoopVariableDeclaration(node, decl, loopParameters, loopOutParameters, hasCapturedBindingsInForHead);
             }
@@ -3940,9 +3940,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         // loop is considered simple if it does not have any return statements or break\continue that transfer control outside of the loop
         // simple loops are emitted as just 'loop()';
         // NOTE: if loop uses only 'continue' it still will be emitted as simple loop
-        const isSimpleLoop = !(state.nonLocalJumps! & ~Jump.Continue) &&
-            !state.labeledNonLocalBreaks &&
-            !state.labeledNonLocalContinues;
+        const isSimpleLoop = !(state.nonLocalJumps! & ~Jump.Continue)
+            && !state.labeledNonLocalBreaks
+            && !state.labeledNonLocalContinues;
 
         const call = factory.createCallExpression(loopFunctionExpressionName, /*typeArguments*/ undefined, map(state.loopParameters, p => p.name as Identifier));
         const callResult = containsYield
@@ -4069,8 +4069,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
                         flags |= LoopOutParameterFlags.Initializer;
                     }
                     if (
-                        container.condition && resolver.isBindingCapturedByNode(container.condition, decl) ||
-                        container.incrementor && resolver.isBindingCapturedByNode(container.incrementor, decl)
+                        container.condition && resolver.isBindingCapturedByNode(container.condition, decl)
+                        || container.incrementor && resolver.isBindingCapturedByNode(container.incrementor, decl)
                     ) {
                         flags |= LoopOutParameterFlags.Body;
                     }
@@ -4325,9 +4325,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
 
         const expression = skipOuterExpressions(node.expression);
         if (
-            expression.kind === SyntaxKind.SuperKeyword ||
-            isSuperProperty(expression) ||
-            some(node.arguments, isSpreadElement)
+            expression.kind === SyntaxKind.SuperKeyword
+            || isSuperProperty(expression)
+            || some(node.arguments, isSpreadElement)
         ) {
             return visitCallExpressionWithPotentialCapturedThisAssignment(node, /*assignToCapturedThis*/ true);
         }
@@ -4471,8 +4471,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         const returnStatement = tryCast(elementAt(funcStatements, classBodyEnd), isReturnStatement);
         for (const statement of remainingStatements) {
             if (
-                isReturnStatement(statement) && returnStatement?.expression &&
-                !isIdentifier(returnStatement.expression)
+                isReturnStatement(statement) && returnStatement?.expression
+                && !isIdentifier(returnStatement.expression)
             ) {
                 statements.push(returnStatement);
             }
@@ -4523,9 +4523,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
         // We are here either because SuperKeyword was used somewhere in the expression, or
         // because we contain a SpreadElementExpression.
         if (
-            node.transformFlags & TransformFlags.ContainsRestOrSpread ||
-            node.expression.kind === SyntaxKind.SuperKeyword ||
-            isSuperProperty(skipOuterExpressions(node.expression))
+            node.transformFlags & TransformFlags.ContainsRestOrSpread
+            || node.expression.kind === SyntaxKind.SuperKeyword
+            || isSuperProperty(skipOuterExpressions(node.expression))
         ) {
             const { target, thisArg } = factory.createCallBinding(node.expression, hoistVariableDeclaration);
             if (node.expression.kind === SyntaxKind.SuperKeyword) {
@@ -4689,8 +4689,8 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
 
         const helpers = emitHelpers();
         const startsWithSpread = segments[0].kind !== SpreadSegmentKind.None;
-        let expression: Expression = startsWithSpread ? factory.createArrayLiteralExpression() :
-            segments[0].expression;
+        let expression: Expression = startsWithSpread ? factory.createArrayLiteralExpression()
+            : segments[0].expression;
         for (let i = startsWithSpread ? 0 : 1; i < segments.length; i++) {
             const segment = segments[i];
             // If this is for an argument list, it doesn't matter if the array is packed or sparse

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -440,13 +440,13 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
             node.name,
             /*questionToken*/ undefined,
             /*typeParameters*/ undefined,
-            parameters = functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionParameterList(node) :
-                visitParameterList(node.parameters, visitor, context),
+            parameters = functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionParameterList(node)
+                : visitParameterList(node.parameters, visitor, context),
             /*type*/ undefined,
-            functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionBody(node, parameters) :
-                transformMethodBody(node),
+            functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionBody(node, parameters)
+                : transformMethodBody(node),
         );
         lexicalArgumentsBinding = savedLexicalArgumentsBinding;
         return updated;
@@ -500,13 +500,13 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
             node.asteriskToken,
             node.name,
             /*typeParameters*/ undefined,
-            parameters = functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionParameterList(node) :
-                visitParameterList(node.parameters, visitor, context),
+            parameters = functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionParameterList(node)
+                : visitParameterList(node.parameters, visitor, context),
             /*type*/ undefined,
-            functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionBody(node, parameters) :
-                visitFunctionBody(node.body, visitor, context),
+            functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionBody(node, parameters)
+                : visitFunctionBody(node.body, visitor, context),
         );
         lexicalArgumentsBinding = savedLexicalArgumentsBinding;
         return updated;
@@ -531,13 +531,13 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
             node.asteriskToken,
             node.name,
             /*typeParameters*/ undefined,
-            parameters = functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionParameterList(node) :
-                visitParameterList(node.parameters, visitor, context),
+            parameters = functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionParameterList(node)
+                : visitParameterList(node.parameters, visitor, context),
             /*type*/ undefined,
-            functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionBody(node, parameters) :
-                visitFunctionBody(node.body, visitor, context),
+            functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionBody(node, parameters)
+                : visitFunctionBody(node.body, visitor, context),
         );
         lexicalArgumentsBinding = savedLexicalArgumentsBinding;
         return updated;
@@ -558,14 +558,14 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
             node,
             visitNodes(node.modifiers, visitor, isModifier),
             /*typeParameters*/ undefined,
-            parameters = functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionParameterList(node) :
-                visitParameterList(node.parameters, visitor, context),
+            parameters = functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionParameterList(node)
+                : visitParameterList(node.parameters, visitor, context),
             /*type*/ undefined,
             node.equalsGreaterThanToken,
-            functionFlags & FunctionFlags.Async ?
-                transformAsyncFunctionBody(node, parameters) :
-                visitFunctionBody(node.body, visitor, context),
+            functionFlags & FunctionFlags.Async
+                ? transformAsyncFunctionBody(node, parameters)
+                : visitFunctionBody(node.body, visitor, context),
         );
     }
 
@@ -658,9 +658,9 @@ export function transformES2017(context: TransformationContext): (x: SourceFile 
         // Minor optimization, emit `_super` helper to capture `super` access in an arrow.
         // This step isn't needed if we eventually transform this to ES5.
         const originalMethod = getOriginalNode(node, isFunctionLikeDeclaration);
-        const emitSuperHelpers = languageVersion >= ScriptTarget.ES2015 &&
-            resolver.getNodeCheckFlags(node) & (NodeCheckFlags.MethodWithSuperPropertyAssignmentInAsync | NodeCheckFlags.MethodWithSuperPropertyAccessInAsync) &&
-            (getFunctionFlags(originalMethod) & FunctionFlags.AsyncGenerator) !== FunctionFlags.AsyncGenerator;
+        const emitSuperHelpers = languageVersion >= ScriptTarget.ES2015
+            && resolver.getNodeCheckFlags(node) & (NodeCheckFlags.MethodWithSuperPropertyAssignmentInAsync | NodeCheckFlags.MethodWithSuperPropertyAccessInAsync)
+            && (getFunctionFlags(originalMethod) & FunctionFlags.AsyncGenerator) !== FunctionFlags.AsyncGenerator;
 
         if (emitSuperHelpers) {
             enableSubstitutionForAsyncMethodsWithSuper();

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -562,9 +562,9 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
     function visitSourceFile(node: SourceFile): SourceFile {
         const ancestorFacts = enterSubtree(
             HierarchyFacts.SourceFileExcludes,
-            isEffectiveStrictModeSourceFile(node, compilerOptions) ?
-                HierarchyFacts.StrictModeSourceFileIncludes :
-                HierarchyFacts.SourceFileIncludes,
+            isEffectiveStrictModeSourceFile(node, compilerOptions)
+                ? HierarchyFacts.StrictModeSourceFileIncludes
+                : HierarchyFacts.SourceFileIncludes,
         );
         exportedVariableStatement = false;
         const visited = visitEachChild(node, visitor, context);
@@ -641,9 +641,9 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
 
     function visitCatchClause(node: CatchClause) {
         if (
-            node.variableDeclaration &&
-            isBindingPattern(node.variableDeclaration.name) &&
-            node.variableDeclaration.name.transformFlags & TransformFlags.ContainsObjectRestOrSpread
+            node.variableDeclaration
+            && isBindingPattern(node.variableDeclaration.name)
+            && node.variableDeclaration.name.transformFlags & TransformFlags.ContainsObjectRestOrSpread
         ) {
             const name = factory.getGeneratedNameForNode(node.variableDeclaration.name);
             const updatedDecl = factory.updateVariableDeclaration(node.variableDeclaration, node.variableDeclaration.name, /*exclamationToken*/ undefined, /*type*/ undefined, name);
@@ -728,14 +728,14 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
     function visitForOfStatement(node: ForOfStatement, outermostLabeledStatement: LabeledStatement | undefined): VisitResult<Statement> {
         const ancestorFacts = enterSubtree(HierarchyFacts.IterationStatementExcludes, HierarchyFacts.IterationStatementIncludes);
         if (
-            node.initializer.transformFlags & TransformFlags.ContainsObjectRestOrSpread ||
-            isAssignmentPattern(node.initializer) && containsObjectRestOrSpread(node.initializer)
+            node.initializer.transformFlags & TransformFlags.ContainsObjectRestOrSpread
+            || isAssignmentPattern(node.initializer) && containsObjectRestOrSpread(node.initializer)
         ) {
             node = transformForOfStatementWithObjectRest(node);
         }
-        const result = node.awaitModifier ?
-            transformForAwaitOfStatement(node, outermostLabeledStatement, ancestorFacts) :
-            factory.restoreEnclosingLabel(visitEachChild(node, visitor, context), outermostLabeledStatement);
+        const result = node.awaitModifier
+            ? transformForAwaitOfStatement(node, outermostLabeledStatement, ancestorFacts)
+            : factory.restoreEnclosingLabel(visitEachChild(node, visitor, context), outermostLabeledStatement);
         exitSubtree(ancestorFacts);
         return result;
     }
@@ -842,9 +842,9 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
         hoistVariableDeclaration(returnMethod);
 
         // if we are enclosed in an outer loop ensure we reset 'errorRecord' per each iteration
-        const initializer = ancestorFacts & HierarchyFacts.IterationContainer ?
-            factory.inlineExpressions([factory.createAssignment(errorRecord, factory.createVoidZero()), callValues]) :
-            callValues;
+        const initializer = ancestorFacts & HierarchyFacts.IterationContainer
+            ? factory.inlineExpressions([factory.createAssignment(errorRecord, factory.createVoidZero()), callValues])
+            : callValues;
 
         const forStatement = setEmitFlags(
             setTextRange(
@@ -1050,13 +1050,13 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
             visitNode(node.name, visitor, isPropertyName),
             visitNode(/*node*/ undefined, visitor, isQuestionToken),
             /*typeParameters*/ undefined,
-            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator ?
-                transformAsyncGeneratorFunctionParameterList(node) :
-                visitParameterList(node.parameters, parameterVisitor, context),
+            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator
+                ? transformAsyncGeneratorFunctionParameterList(node)
+                : visitParameterList(node.parameters, parameterVisitor, context),
             /*type*/ undefined,
-            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator ?
-                transformAsyncGeneratorFunctionBody(node) :
-                transformFunctionBody(node),
+            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator
+                ? transformAsyncGeneratorFunctionBody(node)
+                : transformFunctionBody(node),
         );
         enclosingFunctionFlags = savedEnclosingFunctionFlags;
         parametersWithPrecedingObjectRestOrSpread = savedParametersWithPrecedingObjectRestOrSpread;
@@ -1078,13 +1078,13 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
                 : node.asteriskToken,
             node.name,
             /*typeParameters*/ undefined,
-            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator ?
-                transformAsyncGeneratorFunctionParameterList(node) :
-                visitParameterList(node.parameters, parameterVisitor, context),
+            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator
+                ? transformAsyncGeneratorFunctionParameterList(node)
+                : visitParameterList(node.parameters, parameterVisitor, context),
             /*type*/ undefined,
-            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator ?
-                transformAsyncGeneratorFunctionBody(node) :
-                transformFunctionBody(node),
+            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator
+                ? transformAsyncGeneratorFunctionBody(node)
+                : transformFunctionBody(node),
         );
         enclosingFunctionFlags = savedEnclosingFunctionFlags;
         parametersWithPrecedingObjectRestOrSpread = savedParametersWithPrecedingObjectRestOrSpread;
@@ -1125,13 +1125,13 @@ export function transformES2018(context: TransformationContext): (x: SourceFile 
                 : node.asteriskToken,
             node.name,
             /*typeParameters*/ undefined,
-            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator ?
-                transformAsyncGeneratorFunctionParameterList(node) :
-                visitParameterList(node.parameters, parameterVisitor, context),
+            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator
+                ? transformAsyncGeneratorFunctionParameterList(node)
+                : visitParameterList(node.parameters, parameterVisitor, context),
             /*type*/ undefined,
-            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator ?
-                transformAsyncGeneratorFunctionBody(node) :
-                transformFunctionBody(node),
+            enclosingFunctionFlags & FunctionFlags.Async && enclosingFunctionFlags & FunctionFlags.Generator
+                ? transformAsyncGeneratorFunctionBody(node)
+                : transformFunctionBody(node),
         );
         enclosingFunctionFlags = savedEnclosingFunctionFlags;
         parametersWithPrecedingObjectRestOrSpread = savedParametersWithPrecedingObjectRestOrSpread;

--- a/src/compiler/transformers/es2021.ts
+++ b/src/compiler/transformers/es2021.ts
@@ -56,8 +56,8 @@ export function transformES2021(context: TransformationContext): (x: SourceFile 
 
         if (isAccessExpression(left)) {
             const propertyAccessTargetSimpleCopiable = isSimpleCopiableExpression(left.expression);
-            const propertyAccessTarget = propertyAccessTargetSimpleCopiable ? left.expression :
-                factory.createTempVariable(hoistVariableDeclaration);
+            const propertyAccessTarget = propertyAccessTargetSimpleCopiable ? left.expression
+                : factory.createTempVariable(hoistVariableDeclaration);
             const propertyAccessTargetAssignment = propertyAccessTargetSimpleCopiable ? left.expression : factory.createAssignment(
                 propertyAccessTarget,
                 left.expression,
@@ -75,8 +75,8 @@ export function transformES2021(context: TransformationContext): (x: SourceFile 
             }
             else {
                 const elementAccessArgumentSimpleCopiable = isSimpleCopiableExpression(left.argumentExpression);
-                const elementAccessArgument = elementAccessArgumentSimpleCopiable ? left.argumentExpression :
-                    factory.createTempVariable(hoistVariableDeclaration);
+                const elementAccessArgument = elementAccessArgumentSimpleCopiable ? left.argumentExpression
+                    : factory.createTempVariable(hoistVariableDeclaration);
 
                 assignmentTarget = factory.createElementAccessExpression(
                     propertyAccessTarget,

--- a/src/compiler/transformers/esDecorators.ts
+++ b/src/compiler/transformers/esDecorators.ts
@@ -546,10 +546,10 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
     }
 
     function getHelperVariableName(node: ClassLikeDeclaration | ClassElement) {
-        let declarationName = node.name && isIdentifier(node.name) && !isGeneratedIdentifier(node.name) ? idText(node.name) :
-            node.name && isPrivateIdentifier(node.name) && !isGeneratedIdentifier(node.name) ? idText(node.name).slice(1) :
-            node.name && isStringLiteral(node.name) && isIdentifierText(node.name.text, ScriptTarget.ESNext) ? node.name.text :
-            isClassLike(node) ? "class" : "member";
+        let declarationName = node.name && isIdentifier(node.name) && !isGeneratedIdentifier(node.name) ? idText(node.name)
+            : node.name && isPrivateIdentifier(node.name) && !isGeneratedIdentifier(node.name) ? idText(node.name).slice(1)
+            : node.name && isStringLiteral(node.name) && isIdentifierText(node.name.text, ScriptTarget.ESNext) ? node.name.text
+            : isClassLike(node) ? "class" : "member";
         if (isGetAccessor(node)) declarationName = `get_${declarationName}`;
         if (isSetAccessor(node)) declarationName = `set_${declarationName}`;
         if (node.name && isPrivateIdentifier(node.name)) declarationName = `private_${declarationName}`;
@@ -595,9 +595,9 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
             const needsUniqueClassThis = some(node.members, member => (isPrivateIdentifierClassElementDeclaration(member) || isAutoAccessorPropertyDeclaration(member)) && hasStaticModifier(member));
             classThis = factory.createUniqueName(
                 "_classThis",
-                needsUniqueClassThis ?
-                    GeneratedIdentifierFlags.Optimistic | GeneratedIdentifierFlags.ReservedInNestedScopes :
-                    GeneratedIdentifierFlags.Optimistic | GeneratedIdentifierFlags.FileLevel,
+                needsUniqueClassThis
+                    ? GeneratedIdentifierFlags.Optimistic | GeneratedIdentifierFlags.ReservedInNestedScopes
+                    : GeneratedIdentifierFlags.Optimistic | GeneratedIdentifierFlags.FileLevel,
             );
         }
 
@@ -643,11 +643,11 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
 
             // exit early if possible
             if (
-                staticMethodExtraInitializersName &&
-                instanceMethodExtraInitializersName &&
-                hasStaticInitializers &&
-                hasNonAmbientInstanceFields &&
-                hasStaticPrivateClassElements
+                staticMethodExtraInitializersName
+                && instanceMethodExtraInitializersName
+                && hasStaticInitializers
+                && hasNonAmbientInstanceFields
+                && hasStaticPrivateClassElements
             ) {
                 break;
             }
@@ -721,11 +721,11 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
             // Ensure we do not give the class or function an assigned name due to the variable by prefixing it
             // with `0, `.
             const unwrapped = skipOuterExpressions(extendsExpression);
-            const safeExtendsExpression = isClassExpression(unwrapped) && !unwrapped.name ||
-                    isFunctionExpression(unwrapped) && !unwrapped.name ||
-                    isArrowFunction(unwrapped) ?
-                factory.createComma(factory.createNumericLiteral(0), extendsExpression) :
-                extendsExpression;
+            const safeExtendsExpression = isClassExpression(unwrapped) && !unwrapped.name
+                    || isFunctionExpression(unwrapped) && !unwrapped.name
+                    || isArrowFunction(unwrapped)
+                ? factory.createComma(factory.createNumericLiteral(0), extendsExpression)
+                : extendsExpression;
             classDefinitionStatements.push(createLet(classInfo.classSuper, safeExtendsExpression));
             const updatedExtendsElement = factory.updateExpressionWithTypeArguments(extendsElement, classInfo.classSuper, /*typeArguments*/ undefined);
             const updatedExtendsClause = factory.updateHeritageClause(extendsClause, [updatedExtendsElement]);
@@ -937,8 +937,8 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
         //      static { ... }
         //      ...
         //  }
-        const leadingStaticBlock = leadingBlockStatements &&
-            factory.createClassStaticBlockDeclaration(factory.createBlock(leadingBlockStatements, /*multiLine*/ true));
+        const leadingStaticBlock = leadingBlockStatements
+            && factory.createClassStaticBlockDeclaration(factory.createBlock(leadingBlockStatements, /*multiLine*/ true));
 
         if (leadingStaticBlock && shouldTransformPrivateStaticElementsInClass) {
             // We use `InternalEmitFlags.TransformPrivateStaticElements` as a marker on a class static block
@@ -954,8 +954,8 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
         //      ...
         //      static { ... }
         //  }
-        const trailingStaticBlock = trailingBlockStatements &&
-            factory.createClassStaticBlockDeclaration(factory.createBlock(trailingBlockStatements, /*multiLine*/ true));
+        const trailingStaticBlock = trailingBlockStatements
+            && factory.createClassStaticBlockDeclaration(factory.createBlock(trailingBlockStatements, /*multiLine*/ true));
 
         if (leadingStaticBlock || syntheticConstructor || trailingStaticBlock) {
             const newMembers: ClassElement[] = [];
@@ -1047,8 +1047,8 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
     }
 
     function isDecoratedClassLike(node: ClassLikeDeclaration) {
-        return classOrConstructorParameterIsDecorated(/*useLegacyDecorators*/ false, node) ||
-            childIsDecorated(/*useLegacyDecorators*/ false, node);
+        return classOrConstructorParameterIsDecorated(/*useLegacyDecorators*/ false, node)
+            || childIsDecorated(/*useLegacyDecorators*/ false, node);
     }
 
     function visitClassDeclaration(node: ClassDeclaration): VisitResult<Statement> {
@@ -1274,22 +1274,22 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
             // 6. Non-static non-field (method/getter/setter/auto-accessor) element decorators are applied
             // 7. Static field (excl. auto-accessor) element decorators are applied
             // 8. Non-static field (excl. auto-accessor) element decorators are applied
-            const statements = isMethodOrAccessor(member) || isAutoAccessorPropertyDeclaration(member) ?
-                isStatic(member) ?
-                    classInfo.staticNonFieldDecorationStatements ??= [] :
-                    classInfo.nonStaticNonFieldDecorationStatements ??= [] :
-                isPropertyDeclaration(member) && !isAutoAccessorPropertyDeclaration(member) ?
-                isStatic(member) ?
-                    classInfo.staticFieldDecorationStatements ??= [] :
-                    classInfo.nonStaticFieldDecorationStatements ??= [] :
-                Debug.fail();
+            const statements = isMethodOrAccessor(member) || isAutoAccessorPropertyDeclaration(member)
+                ? isStatic(member)
+                    ? classInfo.staticNonFieldDecorationStatements ??= []
+                    : classInfo.nonStaticNonFieldDecorationStatements ??= []
+                : isPropertyDeclaration(member) && !isAutoAccessorPropertyDeclaration(member)
+                ? isStatic(member)
+                    ? classInfo.staticFieldDecorationStatements ??= []
+                    : classInfo.nonStaticFieldDecorationStatements ??= []
+                : Debug.fail();
 
-            const kind = isGetAccessorDeclaration(member) ? "getter" :
-                isSetAccessorDeclaration(member) ? "setter" :
-                isMethodDeclaration(member) ? "method" :
-                isAutoAccessorPropertyDeclaration(member) ? "accessor" :
-                isPropertyDeclaration(member) ? "field" :
-                Debug.fail();
+            const kind = isGetAccessorDeclaration(member) ? "getter"
+                : isSetAccessorDeclaration(member) ? "setter"
+                : isMethodDeclaration(member) ? "method"
+                : isAutoAccessorPropertyDeclaration(member) ? "accessor"
+                : isPropertyDeclaration(member) ? "field"
+                : Debug.fail();
 
             let propertyName: ESDecorateName;
             if (isIdentifier(member.name) || isPrivateIdentifier(member.name)) {
@@ -1377,9 +1377,9 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
                 //  _static_field_initializers = __esDecorate(null, null, _static_member_decorators, { kind: "field", name: "...", static: true, private: ..., access: { ... } }, _staticExtraInitializers);
                 //  _field_initializers = __esDecorate(null, null, _member_decorators, { kind: "field", name: "...", static: false, private: ..., access: { ... } }, _instanceExtraInitializers);
                 const esDecorateExpression = emitHelpers().createESDecorateHelper(
-                    isAutoAccessorPropertyDeclaration(member) ?
-                        factory.createThis() :
-                        factory.createNull(),
+                    isAutoAccessorPropertyDeclaration(member)
+                        ? factory.createThis()
+                        : factory.createNull(),
                     descriptor ?? factory.createNull(),
                     memberDecoratorsName,
                     context,
@@ -1791,9 +1791,9 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
             }
 
             if (isSuperProperty(node.left) && classThis && classSuper) {
-                let setterName = isElementAccessExpression(node.left) ? visitNode(node.left.argumentExpression, visitor, isExpression) :
-                    isIdentifier(node.left.name) ? factory.createStringLiteralFromNode(node.left.name) :
-                    undefined;
+                let setterName = isElementAccessExpression(node.left) ? visitNode(node.left.argumentExpression, visitor, isExpression)
+                    : isIdentifier(node.left.name) ? factory.createStringLiteralFromNode(node.left.name)
+                    : undefined;
                 if (setterName) {
                     // super.x = ...
                     // super.x += ...
@@ -1859,14 +1859,14 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
 
     function visitPreOrPostfixUnaryExpression(node: PrefixUnaryExpression | PostfixUnaryExpression, discarded: boolean) {
         if (
-            node.operator === SyntaxKind.PlusPlusToken ||
-            node.operator === SyntaxKind.MinusMinusToken
+            node.operator === SyntaxKind.PlusPlusToken
+            || node.operator === SyntaxKind.MinusMinusToken
         ) {
             const operand = skipParentheses(node.operand);
             if (isSuperProperty(operand) && classThis && classSuper) {
-                let setterName = isElementAccessExpression(operand) ? visitNode(operand.argumentExpression, visitor, isExpression) :
-                    isIdentifier(operand.name) ? factory.createStringLiteralFromNode(operand.name) :
-                    undefined;
+                let setterName = isElementAccessExpression(operand) ? visitNode(operand.argumentExpression, visitor, isExpression)
+                    : isIdentifier(operand.name) ? factory.createStringLiteralFromNode(operand.name)
+                    : undefined;
                 if (setterName) {
                     let getterName = setterName;
                     if (!isSimpleInlineableExpression(setterName)) {
@@ -1919,9 +1919,9 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
     }
 
     function visitCommaListExpression(node: CommaListExpression, discarded: boolean) {
-        const elements = discarded ?
-            visitCommaListElements(node.elements, discardedValueVisitor) :
-            visitCommaListElements(node.elements, visitor, discardedValueVisitor);
+        const elements = discarded
+            ? visitCommaListElements(node.elements, discardedValueVisitor)
+            : visitCommaListElements(node.elements, visitor, discardedValueVisitor);
         return factory.updateCommaListExpression(node, elements);
     }
 
@@ -2029,9 +2029,9 @@ export function transformESDecorators(context: TransformationContext): (x: Sourc
         }
 
         if (isSuperProperty(node) && classThis && classSuper) {
-            const propertyName = isElementAccessExpression(node) ? visitNode(node.argumentExpression, visitor, isExpression) :
-                isIdentifier(node.name) ? factory.createStringLiteralFromNode(node.name) :
-                undefined;
+            const propertyName = isElementAccessExpression(node) ? visitNode(node.argumentExpression, visitor, isExpression)
+                : isIdentifier(node.name) ? factory.createStringLiteralFromNode(node.name)
+                : undefined;
             if (propertyName) {
                 const paramName = factory.createTempVariable(/*recordTempVariable*/ undefined);
                 const expression = factory.createAssignmentTargetWrapper(

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -324,12 +324,12 @@ export function transformESNext(context: TransformationContext): (x: SourceFile 
                         factory.createVariableDeclaration(temp),
                     ], NodeFlags.Const),
                     node.expression,
-                    isBlock(node.statement) ?
-                        factory.updateBlock(node.statement, [
+                    isBlock(node.statement)
+                        ? factory.updateBlock(node.statement, [
                             usingVarStatement,
                             ...node.statement.statements,
-                        ]) :
-                        factory.createBlock([
+                        ])
+                        : factory.createBlock([
                             usingVarStatement,
                             node.statement,
                         ], /*multiLine*/ true),
@@ -850,9 +850,9 @@ function isUsingVariableDeclarationList(node: Node): node is VariableDeclaration
 }
 
 function getUsingKindOfVariableDeclarationList(node: VariableDeclarationList) {
-    return (node.flags & NodeFlags.BlockScoped) === NodeFlags.AwaitUsing ? UsingKind.Async :
-        (node.flags & NodeFlags.BlockScoped) === NodeFlags.Using ? UsingKind.Sync :
-        UsingKind.None;
+    return (node.flags & NodeFlags.BlockScoped) === NodeFlags.AwaitUsing ? UsingKind.Async
+        : (node.flags & NodeFlags.BlockScoped) === NodeFlags.Using ? UsingKind.Sync
+        : UsingKind.None;
 }
 
 function getUsingKindOfVariableStatement(node: VariableStatement) {

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -256,8 +256,8 @@ export function transformJsx(context: TransformationContext): (x: SourceFile | B
 
     function hasProto(obj: ObjectLiteralExpression) {
         return obj.properties.some(p =>
-            isPropertyAssignment(p) &&
-            (isIdentifier(p.name) && idText(p.name) === "__proto__" || isStringLiteral(p.name) && p.name.text === "__proto__")
+            isPropertyAssignment(p)
+            && (isIdentifier(p.name) && idText(p.name) === "__proto__" || isStringLiteral(p.name) && p.name.text === "__proto__")
         );
     }
 
@@ -316,8 +316,8 @@ export function transformJsx(context: TransformationContext): (x: SourceFile | B
         const childrenProp = children && children.length ? convertJsxChildrenToChildrenPropAssignment(children) : undefined;
         const keyAttr = find(node.attributes.properties, p => !!p.name && isIdentifier(p.name) && p.name.escapedText === "key") as JsxAttribute | undefined;
         const attrs = keyAttr ? filter(node.attributes.properties, p => p !== keyAttr) : node.attributes.properties;
-        const objectProperties = length(attrs) ? transformJsxAttributesToObjectProps(attrs, childrenProp) :
-            factory.createObjectLiteralExpression(childrenProp ? [childrenProp] : emptyArray); // When there are no attributes, React wants {}
+        const objectProperties = length(attrs) ? transformJsxAttributesToObjectProps(attrs, childrenProp)
+            : factory.createObjectLiteralExpression(childrenProp ? [childrenProp] : emptyArray); // When there are no attributes, React wants {}
         return visitJsxOpeningLikeElementOrFragmentJSX(
             tagName,
             objectProperties,
@@ -380,8 +380,8 @@ export function transformJsx(context: TransformationContext): (x: SourceFile | B
     function visitJsxOpeningLikeElementCreateElement(node: JsxOpeningLikeElement, children: readonly JsxChild[] | undefined, isChild: boolean, location: TextRange) {
         const tagName = getTagName(node);
         const attrs = node.attributes.properties;
-        const objectProperties = length(attrs) ? transformJsxAttributesToObjectProps(attrs) :
-            factory.createNull(); // When there are no attributes, React wants "null"
+        const objectProperties = length(attrs) ? transformJsxAttributesToObjectProps(attrs)
+            : factory.createNull(); // When there are no attributes, React wants "null"
 
         const callee = currentFileState.importSpecifier === undefined
             ? createJsxFactoryExpression(
@@ -453,8 +453,8 @@ export function transformJsx(context: TransformationContext): (x: SourceFile | B
 
     function transformJsxAttributesToObjectProps(attrs: readonly (JsxSpreadAttribute | JsxAttribute)[], children?: PropertyAssignment) {
         const target = getEmitScriptTarget(compilerOptions);
-        return target && target >= ScriptTarget.ES2018 ? factory.createObjectLiteralExpression(transformJsxAttributesToProps(attrs, children)) :
-            transformJsxAttributesToExpression(attrs, children);
+        return target && target >= ScriptTarget.ES2018 ? factory.createObjectLiteralExpression(transformJsxAttributesToProps(attrs, children))
+            : transformJsxAttributesToExpression(attrs, children);
     }
 
     function transformJsxAttributesToProps(attrs: readonly (JsxSpreadAttribute | JsxAttribute)[], children?: PropertyAssignment) {

--- a/src/compiler/transformers/legacyDecorators.ts
+++ b/src/compiler/transformers/legacyDecorators.ts
@@ -155,9 +155,9 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
             return visitEachChild(node, visitor, context);
         }
 
-        const statements = classOrConstructorParameterIsDecorated(/*useLegacyDecorators*/ true, node) ?
-            transformClassDeclarationWithClassDecorators(node, node.name) :
-            transformClassDeclarationWithoutClassDecorators(node, node.name);
+        const statements = classOrConstructorParameterIsDecorated(/*useLegacyDecorators*/ true, node)
+            ? transformClassDeclarationWithClassDecorators(node, node.name)
+            : transformClassDeclarationWithoutClassDecorators(node, node.name);
 
         return singleOrMany(statements);
     }
@@ -329,9 +329,9 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
 
         // When we transform to ES5/3 this will be moved inside an IIFE and should reference the name
         // without any block-scoped variable collision handling
-        const declName = languageVersion < ScriptTarget.ES2015 ?
-            factory.getInternalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true) :
-            factory.getLocalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true);
+        const declName = languageVersion < ScriptTarget.ES2015
+            ? factory.getInternalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true)
+            : factory.getLocalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true);
 
         //  ... = class ${name} ${heritageClauses} {
         //      ${members}
@@ -344,11 +344,11 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
 
         // If we're emitting to ES2022 or later then we need to reassign the class alias before
         // static initializers are evaluated.
-        const assignClassAliasInStaticBlock = languageVersion >= ScriptTarget.ES2022 &&
-            !!classAlias &&
-            some(members, member =>
-                isPropertyDeclaration(member) && hasSyntacticModifier(member, ModifierFlags.Static) ||
-                isClassStaticBlockDeclaration(member));
+        const assignClassAliasInStaticBlock = languageVersion >= ScriptTarget.ES2022
+            && !!classAlias
+            && some(members, member =>
+                isPropertyDeclaration(member) && hasSyntacticModifier(member, ModifierFlags.Static)
+                || isClassStaticBlockDeclaration(member));
         if (assignClassAliasInStaticBlock) {
             members = setTextRange(
                 factory.createNodeArray([
@@ -689,9 +689,9 @@ export function transformLegacyDecorators(context: TransformationContext): (x: S
 
         // When we transform to ES5/3 this will be moved inside an IIFE and should reference the name
         // without any block-scoped variable collision handling
-        const localName = languageVersion < ScriptTarget.ES2015 ?
-            factory.getInternalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true) :
-            factory.getDeclarationName(node, /*allowComments*/ false, /*allowSourceMaps*/ true);
+        const localName = languageVersion < ScriptTarget.ES2015
+            ? factory.getInternalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true)
+            : factory.getDeclarationName(node, /*allowComments*/ false, /*allowSourceMaps*/ true);
         const decorate = emitHelpers().createDecorateHelper(decoratorExpressions, localName);
         const expression = factory.createAssignment(localName, classAlias ? factory.createAssignment(classAlias, decorate) : decorate);
         setEmitFlags(expression, EmitFlags.NoComments);

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -221,10 +221,10 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
      */
     function transformSourceFile(node: SourceFile) {
         if (
-            node.isDeclarationFile ||
-            !(isEffectiveExternalModule(node, compilerOptions) ||
-                node.transformFlags & TransformFlags.ContainsDynamicImport ||
-                (isJsonSourceFile(node) && hasJsonModuleEmitEnabled(compilerOptions) && compilerOptions.outFile))
+            node.isDeclarationFile
+            || !(isEffectiveExternalModule(node, compilerOptions)
+                || node.transformFlags & TransformFlags.ContainsDynamicImport
+                || (isJsonSourceFile(node) && hasJsonModuleEmitEnabled(compilerOptions) && compilerOptions.outFile))
         ) {
             return node;
         }
@@ -358,9 +358,9 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
                                 // Add the module body function argument:
                                 //
                                 //     function (require, exports, module1, module2) ...
-                                jsonSourceFile ?
-                                    jsonSourceFile.statements.length ? jsonSourceFile.statements[0].expression : factory.createObjectLiteralExpression() :
-                                    factory.createFunctionExpression(
+                                jsonSourceFile
+                                    ? jsonSourceFile.statements.length ? jsonSourceFile.statements[0].expression : factory.createObjectLiteralExpression()
+                                    : factory.createFunctionExpression(
                                         /*modifiers*/ undefined,
                                         /*asteriskToken*/ undefined,
                                         /*name*/ undefined,
@@ -865,9 +865,9 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
 
     function visitForStatement(node: ForStatement, isTopLevel: boolean) {
         if (
-            isTopLevel && node.initializer &&
-            isVariableDeclarationList(node.initializer) &&
-            !(node.initializer.flags & NodeFlags.BlockScoped)
+            isTopLevel && node.initializer
+            && isVariableDeclarationList(node.initializer)
+            && !(node.initializer.flags & NodeFlags.BlockScoped)
         ) {
             const exportStatements = appendExportsOfVariableDeclarationList(/*statements*/ undefined, node.initializer, /*isForInOrOfInitializer*/ false);
             if (exportStatements) {
@@ -905,9 +905,9 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
                 const initializer = visitNode(node.initializer, discardedValueVisitor, isForInitializer);
                 const expression = visitNode(node.expression, visitor, isExpression);
                 const body = visitIterationBody(node.statement, topLevelNestedVisitor, context);
-                const mergedBody = isBlock(body) ?
-                    factory.updateBlock(body, [...exportStatements, ...body.statements]) :
-                    factory.createBlock([...exportStatements, body], /*multiLine*/ true);
+                const mergedBody = isBlock(body)
+                    ? factory.updateBlock(body, [...exportStatements, ...body.statements])
+                    : factory.createBlock([...exportStatements, body], /*multiLine*/ true);
                 return factory.updateForInStatement(node, initializer, expression, mergedBody);
             }
         }
@@ -931,9 +931,9 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
             const expression = visitNode(node.expression, visitor, isExpression);
             let body = visitIterationBody(node.statement, topLevelNestedVisitor, context);
             if (some(exportStatements)) {
-                body = isBlock(body) ?
-                    factory.updateBlock(body, [...exportStatements, ...body.statements]) :
-                    factory.createBlock([...exportStatements, body], /*multiLine*/ true);
+                body = isBlock(body)
+                    ? factory.updateBlock(body, [...exportStatements, ...body.statements])
+                    : factory.createBlock([...exportStatements, body], /*multiLine*/ true);
             }
             return factory.updateForOfStatement(node, node.awaitModifier, initializer, expression, body);
         }
@@ -1607,9 +1607,9 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
                 );
             }
             for (const specifier of node.exportClause.elements) {
-                const exportNeedsImportDefault = !!getESModuleInterop(compilerOptions) &&
-                    !(getInternalEmitFlags(node) & InternalEmitFlags.NeverApplyImportHelper) &&
-                    idText(specifier.propertyName || specifier.name) === "default";
+                const exportNeedsImportDefault = !!getESModuleInterop(compilerOptions)
+                    && !(getInternalEmitFlags(node) & InternalEmitFlags.NeverApplyImportHelper)
+                    && idText(specifier.propertyName || specifier.name) === "default";
                 const exportedValue = factory.createPropertyAccessExpression(
                     exportNeedsImportDefault ? emitHelpers().createImportDefaultHelper(generatedName) : generatedName,
                     specifier.propertyName || specifier.name,
@@ -1641,10 +1641,10 @@ export function transformModule(context: TransformationContext): (x: SourceFile 
                                 factory.cloneNode(node.exportClause.name),
                                 getHelperExpressionForExport(
                                     node,
-                                    moduleKind !== ModuleKind.AMD ?
-                                        createRequireCall(node) :
-                                        isExportNamespaceAsDefaultDeclaration(node) ? generatedName :
-                                        factory.createIdentifier(idText(node.exportClause.name)),
+                                    moduleKind !== ModuleKind.AMD
+                                        ? createRequireCall(node)
+                                        : isExportNamespaceAsDefaultDeclaration(node) ? generatedName
+                                        : factory.createIdentifier(idText(node.exportClause.name)),
                                 ),
                             ),
                         ),

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -394,9 +394,9 @@ export function transformSystemModule(context: TransformationContext): (x: Sourc
         insertStatementsAfterStandardPrologue(statements, endLexicalEnvironment());
 
         const exportStarFunction = addExportStarIfNeeded(statements)!; // TODO: GH#18217
-        const modifiers = node.transformFlags & TransformFlags.ContainsAwait ?
-            factory.createModifiersFromModifierFlags(ModifierFlags.Async) :
-            undefined;
+        const modifiers = node.transformFlags & TransformFlags.ContainsAwait
+            ? factory.createModifiersFromModifierFlags(ModifierFlags.Async)
+            : undefined;
         const moduleObject = factory.createObjectLiteralExpression([
             factory.createPropertyAssignment("setters", createSettersArray(exportStarFunction, dependencyGroups)),
             factory.createPropertyAssignment(

--- a/src/compiler/transformers/namedEvaluation.ts
+++ b/src/compiler/transformers/namedEvaluation.ts
@@ -57,8 +57,8 @@ import {
 export function getAssignedNameOfIdentifier(factory: NodeFactory, name: Identifier, expression: WrappedExpression<AnonymousFunctionDefinition>): StringLiteral {
     const original = getOriginalNode(skipOuterExpressions(expression));
     if (
-        (isClassDeclaration(original) || isFunctionDeclaration(original)) &&
-        !original.name && hasSyntacticModifier(original, ModifierFlags.Default)
+        (isClassDeclaration(original) || isFunctionDeclaration(original))
+        && !original.name && hasSyntacticModifier(original, ModifierFlags.Default)
     ) {
         return factory.createStringLiteral("default");
     }
@@ -144,10 +144,10 @@ export function isClassNamedEvaluationHelperBlock(node: Node): node is ClassName
     }
 
     const statement = node.body.statements[0];
-    return isExpressionStatement(statement) &&
-        isCallToHelper(statement.expression, "___setFunctionName" as __String) &&
-        (statement.expression as CallExpression).arguments.length >= 2 &&
-        (statement.expression as CallExpression).arguments[1] === node.emitNode?.assignedName;
+    return isExpressionStatement(statement)
+        && isCallToHelper(statement.expression, "___setFunctionName" as __String)
+        && (statement.expression as CallExpression).arguments.length >= 2
+        && (statement.expression as CallExpression).arguments[1] === node.emitNode?.assignedName;
 }
 
 /**
@@ -213,16 +213,16 @@ export function injectClassNamedEvaluationHelperBlockIfMissing(
     const members = factory.createNodeArray([...leading, namedEvaluationBlock, ...trailing]);
     setTextRange(members, node.members);
 
-    node = isClassDeclaration(node) ?
-        factory.updateClassDeclaration(
+    node = isClassDeclaration(node)
+        ? factory.updateClassDeclaration(
             node,
             node.modifiers,
             node.name,
             node.typeParameters,
             node.heritageClauses,
             members,
-        ) :
-        factory.updateClassExpression(
+        )
+        : factory.updateClassExpression(
             node,
             node.modifiers,
             node.name,
@@ -248,9 +248,9 @@ function finishTransformNamedEvaluation(
     const { factory } = context;
     const innerExpression = skipOuterExpressions(expression);
 
-    const updatedExpression = isClassExpression(innerExpression) ?
-        cast(injectClassNamedEvaluationHelperBlockIfMissing(context, innerExpression, assignedName), isClassExpression) :
-        context.getEmitHelperFactory().createSetFunctionNameHelper(innerExpression, assignedName);
+    const updatedExpression = isClassExpression(innerExpression)
+        ? cast(injectClassNamedEvaluationHelperBlockIfMissing(context, innerExpression, assignedName), isClassExpression)
+        : context.getEmitHelperFactory().createSetFunctionNameHelper(innerExpression, assignedName);
 
     return factory.restoreOuterExpressions(expression, updatedExpression);
 }
@@ -283,8 +283,8 @@ function transformNamedEvaluationOfShorthandAssignmentProperty(context: Transfor
     //     ...
 
     const { factory } = context;
-    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText) :
-        getAssignedNameOfIdentifier(factory, node.name, node.objectAssignmentInitializer);
+    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText)
+        : getAssignedNameOfIdentifier(factory, node.name, node.objectAssignmentInitializer);
     const objectAssignmentInitializer = finishTransformNamedEvaluation(context, node.objectAssignmentInitializer, assignedName, ignoreEmptyStringLiteral);
     return factory.updateShorthandPropertyAssignment(
         node,
@@ -309,8 +309,8 @@ function transformNamedEvaluationOfVariableDeclaration(context: TransformationCo
     //     ...
 
     const { factory } = context;
-    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText) :
-        getAssignedNameOfIdentifier(factory, node.name, node.initializer);
+    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText)
+        : getAssignedNameOfIdentifier(factory, node.name, node.initializer);
     const initializer = finishTransformNamedEvaluation(context, node.initializer, assignedName, ignoreEmptyStringLiteral);
     return factory.updateVariableDeclaration(
         node,
@@ -339,8 +339,8 @@ function transformNamedEvaluationOfParameterDeclaration(context: TransformationC
     //     ...
 
     const { factory } = context;
-    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText) :
-        getAssignedNameOfIdentifier(factory, node.name, node.initializer);
+    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText)
+        : getAssignedNameOfIdentifier(factory, node.name, node.initializer);
     const initializer = finishTransformNamedEvaluation(context, node.initializer, assignedName, ignoreEmptyStringLiteral);
     return factory.updateParameterDeclaration(
         node,
@@ -371,8 +371,8 @@ function transformNamedEvaluationOfBindingElement(context: TransformationContext
     //     ...
 
     const { factory } = context;
-    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText) :
-        getAssignedNameOfIdentifier(factory, node.name, node.initializer);
+    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText)
+        : getAssignedNameOfIdentifier(factory, node.name, node.initializer);
     const initializer = finishTransformNamedEvaluation(context, node.initializer, assignedName, ignoreEmptyStringLiteral);
     return factory.updateBindingElement(
         node,
@@ -432,8 +432,8 @@ function transformNamedEvaluationOfAssignmentExpression(context: TransformationC
     //     ...
 
     const { factory } = context;
-    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText) :
-        getAssignedNameOfIdentifier(factory, node.left, node.right);
+    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText)
+        : getAssignedNameOfIdentifier(factory, node.left, node.right);
     const right = finishTransformNamedEvaluation(context, node.right, assignedName, ignoreEmptyStringLiteral);
     return factory.updateBinaryExpression(
         node,
@@ -454,8 +454,8 @@ function transformNamedEvaluationOfExportAssignment(context: TransformationConte
     // is `""`.
 
     const { factory } = context;
-    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText) :
-        factory.createStringLiteral(node.isExportEquals ? "" : "default");
+    const assignedName = assignedNameText !== undefined ? factory.createStringLiteral(assignedNameText)
+        : factory.createStringLiteral(node.isExportEquals ? "" : "default");
     const expression = finishTransformNamedEvaluation(context, node.expression, assignedName, ignoreEmptyStringLiteral);
     return factory.updateExportAssignment(
         node,

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -519,11 +519,11 @@ export function transformTypeScript(context: TransformationContext) {
      */
     function namespaceElementVisitorWorker(node: Node): VisitResult<Node | undefined> {
         if (
-            node.kind === SyntaxKind.ExportDeclaration ||
-            node.kind === SyntaxKind.ImportDeclaration ||
-            node.kind === SyntaxKind.ImportClause ||
-            (node.kind === SyntaxKind.ImportEqualsDeclaration &&
-                (node as ImportEqualsDeclaration).moduleReference.kind === SyntaxKind.ExternalModuleReference)
+            node.kind === SyntaxKind.ExportDeclaration
+            || node.kind === SyntaxKind.ImportDeclaration
+            || node.kind === SyntaxKind.ImportClause
+            || (node.kind === SyntaxKind.ImportEqualsDeclaration
+                && (node as ImportEqualsDeclaration).moduleReference.kind === SyntaxKind.ExternalModuleReference)
         ) {
             // do not emit ES6 imports and exports since they are illegal inside a namespace
             return undefined;
@@ -838,9 +838,9 @@ export function transformTypeScript(context: TransformationContext) {
     }
 
     function visitSourceFile(node: SourceFile) {
-        const alwaysStrict = getStrictOptionValue(compilerOptions, "alwaysStrict") &&
-            !(isExternalModule(node) && moduleKind >= ModuleKind.ES2015) &&
-            !isJsonSourceFile(node);
+        const alwaysStrict = getStrictOptionValue(compilerOptions, "alwaysStrict")
+            && !(isExternalModule(node) && moduleKind >= ModuleKind.ES2015)
+            && !isJsonSourceFile(node);
 
         return factory.updateSourceFile(
             node,
@@ -881,13 +881,13 @@ export function transformTypeScript(context: TransformationContext) {
 
     function visitClassDeclaration(node: ClassDeclaration): VisitResult<Statement> {
         const facts = getClassFacts(node);
-        const promoteToIIFE = languageVersion <= ScriptTarget.ES5 &&
-            !!(facts & ClassFacts.MayNeedImmediatelyInvokedFunctionExpression);
+        const promoteToIIFE = languageVersion <= ScriptTarget.ES5
+            && !!(facts & ClassFacts.MayNeedImmediatelyInvokedFunctionExpression);
 
         if (
-            !isClassLikeDeclarationWithTypeScriptSyntax(node) &&
-            !classOrConstructorParameterIsDecorated(legacyDecorators, node) &&
-            !isExportOfNamespace(node)
+            !isClassLikeDeclarationWithTypeScriptSyntax(node)
+            && !classOrConstructorParameterIsDecorated(legacyDecorators, node)
+            && !isExportOfNamespace(node)
         ) {
             return factory.updateClassDeclaration(
                 node,
@@ -903,27 +903,27 @@ export function transformTypeScript(context: TransformationContext) {
             context.startLexicalEnvironment();
         }
 
-        const moveModifiers = promoteToIIFE ||
-            facts & ClassFacts.IsExportOfNamespace;
+        const moveModifiers = promoteToIIFE
+            || facts & ClassFacts.IsExportOfNamespace;
 
         // elide modifiers on the declaration if we are emitting an IIFE or the class is
         // a namespace export
-        let modifiers = moveModifiers ?
-            visitNodes(node.modifiers, modifierElidingVisitor, isModifierLike) :
-            visitNodes(node.modifiers, visitor, isModifierLike);
+        let modifiers = moveModifiers
+            ? visitNodes(node.modifiers, modifierElidingVisitor, isModifierLike)
+            : visitNodes(node.modifiers, visitor, isModifierLike);
 
         // inject metadata only if the class is decorated
         if (facts & ClassFacts.HasClassOrConstructorParameterDecorators) {
             modifiers = injectClassTypeMetadata(modifiers, node);
         }
 
-        const needsName = moveModifiers && !node.name ||
-            facts & ClassFacts.HasMemberDecorators ||
-            facts & ClassFacts.HasStaticInitializedProperties;
+        const needsName = moveModifiers && !node.name
+            || facts & ClassFacts.HasMemberDecorators
+            || facts & ClassFacts.HasStaticInitializedProperties;
 
-        const name = needsName ?
-            node.name ?? factory.getGeneratedNameForNode(node) :
-            node.name;
+        const name = needsName
+            ? node.name ?? factory.getGeneratedNameForNode(node)
+            : node.name;
 
         //  ${modifiers} class ${name} ${heritageClauses} {
         //      ${members}
@@ -1052,8 +1052,8 @@ export function transformTypeScript(context: TransformationContext) {
 
         let newMembers: ClassElement[] | undefined;
         const constructor = getFirstConstructorWithBody(node);
-        const parametersWithPropertyAssignments = constructor &&
-            filter(constructor.parameters, (p): p is ParameterPropertyDeclaration => isParameterPropertyDeclaration(p, constructor));
+        const parametersWithPropertyAssignments = constructor
+            && filter(constructor.parameters, (p): p is ParameterPropertyDeclaration => isParameterPropertyDeclaration(p, constructor));
 
         if (parametersWithPropertyAssignments) {
             for (const parameter of parametersWithPropertyAssignments) {
@@ -1113,9 +1113,9 @@ export function transformTypeScript(context: TransformationContext) {
     function getTypeMetadata(node: Declaration, container: ClassLikeDeclaration) {
         // Decorator metadata is not yet supported for ES decorators.
         if (!legacyDecorators) return undefined;
-        return USE_NEW_TYPE_METADATA_FORMAT ?
-            getNewTypeMetadata(node, container) :
-            getOldTypeMetadata(node, container);
+        return USE_NEW_TYPE_METADATA_FORMAT
+            ? getNewTypeMetadata(node, container)
+            : getOldTypeMetadata(node, container);
     }
 
     function getOldTypeMetadata(node: Declaration, container: ClassLikeDeclaration) {
@@ -1304,10 +1304,10 @@ export function transformTypeScript(context: TransformationContext) {
             return undefined;
         }
 
-        let modifiers = isClassLike(parent) ? !isAmbient ?
-            visitNodes(node.modifiers, visitor, isModifierLike) :
-            visitNodes(node.modifiers, modifierElidingVisitor, isModifierLike) :
-            visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
+        let modifiers = isClassLike(parent) ? !isAmbient
+            ? visitNodes(node.modifiers, visitor, isModifierLike)
+            : visitNodes(node.modifiers, modifierElidingVisitor, isModifierLike)
+            : visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
 
         modifiers = injectClassElementTypeMetadata(modifiers, node, parent);
 
@@ -1380,8 +1380,8 @@ export function transformTypeScript(context: TransformationContext) {
     }
 
     function transformConstructorBody(body: Block, constructor: ConstructorDeclaration) {
-        const parametersWithPropertyAssignments = constructor &&
-            filter(constructor.parameters, p => isParameterPropertyDeclaration(p, constructor)) as readonly ParameterPropertyDeclaration[] | undefined;
+        const parametersWithPropertyAssignments = constructor
+            && filter(constructor.parameters, p => isParameterPropertyDeclaration(p, constructor)) as readonly ParameterPropertyDeclaration[] | undefined;
         if (!some(parametersWithPropertyAssignments)) {
             return visitFunctionBody(body, visitor, context);
         }
@@ -1474,9 +1474,9 @@ export function transformTypeScript(context: TransformationContext) {
             return undefined;
         }
 
-        let modifiers = isClassLike(parent) ?
-            visitNodes(node.modifiers, visitor, isModifierLike) :
-            visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
+        let modifiers = isClassLike(parent)
+            ? visitNodes(node.modifiers, visitor, isModifierLike)
+            : visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
 
         modifiers = injectClassElementTypeMetadata(modifiers, node, parent);
 
@@ -1512,9 +1512,9 @@ export function transformTypeScript(context: TransformationContext) {
             return undefined;
         }
 
-        let modifiers = isClassLike(parent) ?
-            visitNodes(node.modifiers, visitor, isModifierLike) :
-            visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
+        let modifiers = isClassLike(parent)
+            ? visitNodes(node.modifiers, visitor, isModifierLike)
+            : visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
 
         modifiers = injectClassElementTypeMetadata(modifiers, node, parent);
 
@@ -1537,9 +1537,9 @@ export function transformTypeScript(context: TransformationContext) {
             return undefined;
         }
 
-        let modifiers = isClassLike(parent) ?
-            visitNodes(node.modifiers, visitor, isModifierLike) :
-            visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
+        let modifiers = isClassLike(parent)
+            ? visitNodes(node.modifiers, visitor, isModifierLike)
+            : visitNodes(node.modifiers, decoratorElidingVisitor, isModifierLike);
 
         modifiers = injectClassElementTypeMetadata(modifiers, node, parent);
 
@@ -1923,9 +1923,9 @@ export function transformTypeScript(context: TransformationContext) {
             ),
             valueExpression,
         );
-        const outerAssignment = isSyntacticallyString(valueExpression) ?
-            innerAssignment :
-            factory.createAssignment(
+        const outerAssignment = isSyntacticallyString(valueExpression)
+            ? innerAssignment
+            : factory.createAssignment(
                 factory.createElementAccessExpression(
                     currentNamespaceContainerName,
                     innerAssignment,
@@ -1951,9 +1951,9 @@ export function transformTypeScript(context: TransformationContext) {
     function transformEnumMemberDeclarationValue(member: EnumMember): Expression {
         const value = resolver.getConstantValue(member);
         if (value !== undefined) {
-            return typeof value === "string" ? factory.createStringLiteral(value) :
-                value < 0 ? factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, factory.createNumericLiteral(-value)) :
-                factory.createNumericLiteral(value);
+            return typeof value === "string" ? factory.createStringLiteral(value)
+                : value < 0 ? factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, factory.createNumericLiteral(-value))
+                : factory.createNumericLiteral(value);
         }
         else {
             enableSubstitutionForNonQualifiedEnumMembers();
@@ -2683,8 +2683,8 @@ export function transformTypeScript(context: TransformationContext) {
             // an identifier that is exported from a merged namespace.
             const container = resolver.getReferencedExportContainer(node, /*prefixLocals*/ false);
             if (container && container.kind !== SyntaxKind.SourceFile) {
-                const substitute = (applicableSubstitutions & TypeScriptSubstitutionFlags.NamespaceExports && container.kind === SyntaxKind.ModuleDeclaration) ||
-                    (applicableSubstitutions & TypeScriptSubstitutionFlags.NonQualifiedEnumMembers && container.kind === SyntaxKind.EnumDeclaration);
+                const substitute = (applicableSubstitutions & TypeScriptSubstitutionFlags.NamespaceExports && container.kind === SyntaxKind.ModuleDeclaration)
+                    || (applicableSubstitutions & TypeScriptSubstitutionFlags.NonQualifiedEnumMembers && container.kind === SyntaxKind.EnumDeclaration);
                 if (substitute) {
                     return setTextRange(
                         factory.createPropertyAccessExpression(factory.getGeneratedNameForNode(container), node),
@@ -2714,9 +2714,9 @@ export function transformTypeScript(context: TransformationContext) {
         if (constantValue !== undefined) {
             // track the constant value on the node for the printer in mayNeedDotDotForPropertyAccess
             setConstantValue(node, constantValue);
-            const substitute = typeof constantValue === "string" ? factory.createStringLiteral(constantValue) :
-                constantValue < 0 ? factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, factory.createNumericLiteral(-constantValue)) :
-                factory.createNumericLiteral(constantValue);
+            const substitute = typeof constantValue === "string" ? factory.createStringLiteral(constantValue)
+                : constantValue < 0 ? factory.createPrefixUnaryExpression(SyntaxKind.MinusToken, factory.createNumericLiteral(-constantValue))
+                : factory.createNumericLiteral(constantValue);
 
             if (!compilerOptions.removeComments) {
                 const originalNode = getOriginalNode(node, isAccessExpression);

--- a/src/compiler/transformers/typeSerializer.ts
+++ b/src/compiler/transformers/typeSerializer.ts
@@ -290,9 +290,9 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
                 return factory.createIdentifier("Array");
 
             case SyntaxKind.TypePredicate:
-                return (node as TypePredicateNode).assertsModifier ?
-                    factory.createVoidZero() :
-                    factory.createIdentifier("Boolean");
+                return (node as TypePredicateNode).assertsModifier
+                    ? factory.createVoidZero()
+                    : factory.createIdentifier("Boolean");
 
             case SyntaxKind.BooleanKeyword:
                 return factory.createIdentifier("Boolean");
@@ -449,37 +449,37 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
     function equateSerializedTypeNodes(left: Expression, right: Expression): boolean {
         return (
             // temp vars used in fallback
-            isGeneratedIdentifier(left) ? isGeneratedIdentifier(right) :
+            isGeneratedIdentifier(left) ? isGeneratedIdentifier(right)
                 // entity names
-                isIdentifier(left) ? isIdentifier(right)
-                    && left.escapedText === right.escapedText :
-                isPropertyAccessExpression(left) ? isPropertyAccessExpression(right)
+                : isIdentifier(left) ? isIdentifier(right)
+                    && left.escapedText === right.escapedText
+                : isPropertyAccessExpression(left) ? isPropertyAccessExpression(right)
                     && equateSerializedTypeNodes(left.expression, right.expression)
-                    && equateSerializedTypeNodes(left.name, right.name) :
+                    && equateSerializedTypeNodes(left.name, right.name)
                 // `void 0`
-                isVoidExpression(left) ? isVoidExpression(right)
+                : isVoidExpression(left) ? isVoidExpression(right)
                     && isNumericLiteral(left.expression) && left.expression.text === "0"
-                    && isNumericLiteral(right.expression) && right.expression.text === "0" :
+                    && isNumericLiteral(right.expression) && right.expression.text === "0"
                 // `"undefined"` or `"function"` in `typeof` checks
-                isStringLiteral(left) ? isStringLiteral(right)
-                    && left.text === right.text :
+                : isStringLiteral(left) ? isStringLiteral(right)
+                    && left.text === right.text
                 // used in `typeof` checks for fallback
-                isTypeOfExpression(left) ? isTypeOfExpression(right)
-                    && equateSerializedTypeNodes(left.expression, right.expression) :
+                : isTypeOfExpression(left) ? isTypeOfExpression(right)
+                    && equateSerializedTypeNodes(left.expression, right.expression)
                 // parens in `typeof` checks with temps
-                isParenthesizedExpression(left) ? isParenthesizedExpression(right)
-                    && equateSerializedTypeNodes(left.expression, right.expression) :
+                : isParenthesizedExpression(left) ? isParenthesizedExpression(right)
+                    && equateSerializedTypeNodes(left.expression, right.expression)
                 // conditionals used in fallback
-                isConditionalExpression(left) ? isConditionalExpression(right)
+                : isConditionalExpression(left) ? isConditionalExpression(right)
                     && equateSerializedTypeNodes(left.condition, right.condition)
                     && equateSerializedTypeNodes(left.whenTrue, right.whenTrue)
-                    && equateSerializedTypeNodes(left.whenFalse, right.whenFalse) :
+                    && equateSerializedTypeNodes(left.whenFalse, right.whenFalse)
                 // logical binary and assignments used in fallback
-                isBinaryExpression(left) ? isBinaryExpression(right)
+                : isBinaryExpression(left) ? isBinaryExpression(right)
                     && left.operatorToken.kind === right.operatorToken.kind
                     && equateSerializedTypeNodes(left.left, right.left)
-                    && equateSerializedTypeNodes(left.right, right.right) :
-                false
+                    && equateSerializedTypeNodes(left.right, right.right)
+                : false
         );
     }
 
@@ -626,8 +626,8 @@ export function createRuntimeTypeSerializer(context: TransformationContext): Run
     }
 
     function getGlobalConstructor(name: string, minLanguageVersion: ScriptTarget): SerializedTypeNode {
-        return languageVersion < minLanguageVersion ?
-            getGlobalConstructorWithFallback(name) :
-            factory.createIdentifier(name);
+        return languageVersion < minLanguageVersion
+            ? getGlobalConstructorWithFallback(name)
+            : factory.createIdentifier(name);
     }
 }

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -117,9 +117,9 @@ function containsDefaultReference(node: NamedImportBindings | NamedExportBinding
 }
 
 function isNamedDefaultReference(e: ImportSpecifier | ExportSpecifier): boolean {
-    return e.propertyName !== undefined ?
-        e.propertyName.escapedText === InternalSymbolName.Default :
-        e.name.escapedText === InternalSymbolName.Default;
+    return e.propertyName !== undefined
+        ? e.propertyName.escapedText === InternalSymbolName.Default
+        : e.name.escapedText === InternalSymbolName.Default;
 }
 
 /** @internal */
@@ -445,10 +445,10 @@ export class IdentifierNameMultiMap<V> extends IdentifierNameMap<V[]> {
  * @internal
  */
 export function isSimpleCopiableExpression(expression: Expression) {
-    return isStringLiteralLike(expression) ||
-        expression.kind === SyntaxKind.NumericLiteral ||
-        isKeyword(expression.kind) ||
-        isIdentifier(expression);
+    return isStringLiteralLike(expression)
+        || expression.kind === SyntaxKind.NumericLiteral
+        || isKeyword(expression.kind)
+        || isIdentifier(expression);
 }
 
 /**
@@ -708,9 +708,9 @@ function getAllDecoratorsOfAccessors(accessor: AccessorDeclaration, parent: Clas
     }
 
     const { firstAccessor, secondAccessor, getAccessor, setAccessor } = getAllAccessorDeclarations(parent.members, accessor);
-    const firstAccessorWithDecorators = hasDecorators(firstAccessor) ? firstAccessor :
-        secondAccessor && hasDecorators(secondAccessor) ? secondAccessor :
-        undefined;
+    const firstAccessorWithDecorators = hasDecorators(firstAccessor) ? firstAccessor
+        : secondAccessor && hasDecorators(secondAccessor) ? secondAccessor
+        : undefined;
 
     if (!firstAccessorWithDecorators || accessor !== firstAccessorWithDecorators) {
         return undefined;
@@ -807,9 +807,9 @@ export function getPrivateIdentifier<TData, TEntry>(
     privateEnv: PrivateEnvironment<TData, TEntry> | undefined,
     name: PrivateIdentifier,
 ) {
-    return isGeneratedPrivateIdentifier(name) ?
-        privateEnv?.generatedIdentifiers?.get(getNodeForGeneratedName(name)) :
-        privateEnv?.identifiers?.get(name.escapedText);
+    return isGeneratedPrivateIdentifier(name)
+        ? privateEnv?.generatedIdentifiers?.get(getNodeForGeneratedName(name))
+        : privateEnv?.identifiers?.get(name.escapedText);
 }
 
 /** @internal */

--- a/src/compiler/tsbuildPublic.ts
+++ b/src/compiler/tsbuildPublic.ts
@@ -608,9 +608,9 @@ function createBuildOrder<T extends BuilderProgram>(state: SolutionBuilderState<
         visit(root);
     }
 
-    return circularDiagnostics ?
-        { buildOrder: buildOrder || emptyArray, circularDiagnostics } :
-        buildOrder || emptyArray;
+    return circularDiagnostics
+        ? { buildOrder: buildOrder || emptyArray, circularDiagnostics }
+        : buildOrder || emptyArray;
 
     function visit(configFileName: ResolvedConfigFileName, inCircularContext?: boolean) {
         const projPath = toResolvedConfigFilePath(state, configFileName);
@@ -881,9 +881,9 @@ function doneInvalidatedProject<T extends BuilderProgram>(
     projectPath: ResolvedConfigFilePath,
 ) {
     state.projectPendingBuild.delete(projectPath);
-    return state.diagnostics.has(projectPath) ?
-        ExitStatus.DiagnosticsPresent_OutputsSkipped :
-        ExitStatus.Success;
+    return state.diagnostics.has(projectPath)
+        ? ExitStatus.DiagnosticsPresent_OutputsSkipped
+        : ExitStatus.Success;
 }
 
 function createUpdateOutputFileStampsProject<T extends BuilderProgram>(
@@ -984,8 +984,8 @@ function createBuildOrUpdateInvalidedProject<T extends BuilderProgram>(
         getSemanticDiagnosticsOfNextAffectedFile: (cancellationToken, ignoreSourceFile) =>
             withProgramOrUndefined(
                 program =>
-                    ((program as any as SemanticDiagnosticsBuilderProgram).getSemanticDiagnosticsOfNextAffectedFile) &&
-                    (program as any as SemanticDiagnosticsBuilderProgram).getSemanticDiagnosticsOfNextAffectedFile(cancellationToken, ignoreSourceFile),
+                    ((program as any as SemanticDiagnosticsBuilderProgram).getSemanticDiagnosticsOfNextAffectedFile)
+                    && (program as any as SemanticDiagnosticsBuilderProgram).getSemanticDiagnosticsOfNextAffectedFile(cancellationToken, ignoreSourceFile),
             ),
         emit: (targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers) => {
             if (targetSourceFile || emitOnlyDtsFiles) {
@@ -1060,9 +1060,9 @@ function createBuildOrUpdateInvalidedProject<T extends BuilderProgram>(
                 internalMap && new Set(arrayFrom(
                     internalMap.values(),
                     data =>
-                        state.host.realpath && (isPackageJsonInfo(data) || data.directoryExists) ?
-                            state.host.realpath(combinePaths(data.packageDirectory, "package.json")) :
-                            combinePaths(data.packageDirectory, "package.json"),
+                        state.host.realpath && (isPackageJsonInfo(data) || data.directoryExists)
+                            ? state.host.realpath(combinePaths(data.packageDirectory, "package.json"))
+                            : combinePaths(data.packageDirectory, "package.json"),
                 )),
             );
             state.builderPrograms.set(projectPath, program);
@@ -1359,9 +1359,9 @@ function getNextInvalidatedProjectCreateInfo<T extends BuilderProgram>(
             if (options.verbose) {
                 reportStatus(
                     state,
-                    status.upstreamProjectBlocked ?
-                        Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_was_not_built :
-                        Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_has_errors,
+                    status.upstreamProjectBlocked
+                        ? Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_was_not_built
+                        : Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_has_errors,
                     project,
                     status.upstreamProjectName,
                 );
@@ -1396,16 +1396,16 @@ function createInvalidatedProjectWithInfo<T extends BuilderProgram>(
     buildOrder: AnyBuildOrder,
 ) {
     verboseReportProjectStatus(state, info.project, info.status);
-    return info.kind !== InvalidatedProjectKind.UpdateOutputFileStamps ?
-        createBuildOrUpdateInvalidedProject(
+    return info.kind !== InvalidatedProjectKind.UpdateOutputFileStamps
+        ? createBuildOrUpdateInvalidedProject(
             state,
             info.project,
             info.projectPath,
             info.projectIndex,
             info.config,
             buildOrder as BuildOrder,
-        ) :
-        createUpdateOutputFileStampsProject(
+        )
+        : createUpdateOutputFileStampsProject(
             state,
             info.project,
             info.projectPath,
@@ -1614,16 +1614,16 @@ function getUpToDateStatusWorker<T extends BuilderProgram>(state: SolutionBuilde
 
             // Its a circular reference ignore the status of this project
             if (
-                refStatus.type === UpToDateStatusType.ComputingUpstream ||
-                refStatus.type === UpToDateStatusType.ContainerOnly
+                refStatus.type === UpToDateStatusType.ComputingUpstream
+                || refStatus.type === UpToDateStatusType.ContainerOnly
             ) { // Container only ignore this project
                 continue;
             }
 
             // An upstream project is blocked
             if (
-                refStatus.type === UpToDateStatusType.Unbuildable ||
-                refStatus.type === UpToDateStatusType.UpstreamBlocked
+                refStatus.type === UpToDateStatusType.Unbuildable
+                || refStatus.type === UpToDateStatusType.UpstreamBlocked
             ) {
                 return {
                     type: UpToDateStatusType.UpstreamBlocked,
@@ -1693,11 +1693,11 @@ function getUpToDateStatusWorker<T extends BuilderProgram>(state: SolutionBuilde
             // But if noEmit is true, affectedFilesPendingEmit will have file list even if there are no semantic errors to preserve list of files to be emitted when running with noEmit false
             // So with noEmit set to true, check on semantic diagnostics needs to be explicit as oppose to when it is false when only files pending emit is sufficient
             if (
-                (buildInfo.program as ProgramMultiFileEmitBuildInfo).changeFileSet?.length ||
-                (!project.options.noEmit ?
-                    (buildInfo.program as ProgramMultiFileEmitBuildInfo).affectedFilesPendingEmit?.length ||
-                    (buildInfo.program as ProgramMultiFileEmitBuildInfo).emitDiagnosticsPerFile?.length :
-                    some((buildInfo.program as ProgramMultiFileEmitBuildInfo).semanticDiagnosticsPerFile, isArray))
+                (buildInfo.program as ProgramMultiFileEmitBuildInfo).changeFileSet?.length
+                || (!project.options.noEmit
+                    ? (buildInfo.program as ProgramMultiFileEmitBuildInfo).affectedFilesPendingEmit?.length
+                        || (buildInfo.program as ProgramMultiFileEmitBuildInfo).emitDiagnosticsPerFile?.length
+                    : some((buildInfo.program as ProgramMultiFileEmitBuildInfo).semanticDiagnosticsPerFile, isArray))
             ) {
                 return {
                     type: UpToDateStatusType.OutOfDateBuildInfo,
@@ -1874,11 +1874,11 @@ function getUpToDateStatusWorker<T extends BuilderProgram>(state: SolutionBuilde
 
     // Up to date
     return {
-        type: pseudoUpToDate ?
-            UpToDateStatusType.UpToDateWithUpstreamTypes :
-            pseudoInputUpToDate ?
-            UpToDateStatusType.UpToDateWithInputFileText :
-            UpToDateStatusType.UpToDate,
+        type: pseudoUpToDate
+            ? UpToDateStatusType.UpToDateWithUpstreamTypes
+            : pseudoInputUpToDate
+            ? UpToDateStatusType.UpToDateWithInputFileText
+            : UpToDateStatusType.UpToDate,
         newestInputFileTime,
         newestInputFileName,
         oldestOutputFileName: oldestOutputFileName!,
@@ -1962,9 +1962,9 @@ function getLatestChangedDtsTime<T extends BuilderProgram>(state: SolutionBuilde
     if (!options.composite) return undefined;
     const entry = Debug.checkDefined(state.buildInfoCache.get(resolvedConfigPath));
     if (entry.latestChangedDtsTime !== undefined) return entry.latestChangedDtsTime || undefined;
-    const latestChangedDtsTime = entry.buildInfo && entry.buildInfo.program && entry.buildInfo.program.latestChangedDtsFile ?
-        state.host.getModifiedTime(getNormalizedAbsolutePath(entry.buildInfo.program.latestChangedDtsFile, getDirectoryPath(entry.path))) :
-        undefined;
+    const latestChangedDtsTime = entry.buildInfo && entry.buildInfo.program && entry.buildInfo.program.latestChangedDtsFile
+        ? state.host.getModifiedTime(getNormalizedAbsolutePath(entry.buildInfo.program.latestChangedDtsFile, getDirectoryPath(entry.path)))
+        : undefined;
     entry.latestChangedDtsTime = latestChangedDtsTime || false;
     return latestChangedDtsTime;
 }
@@ -2531,9 +2531,9 @@ function reportUpToDateStatus<T extends BuilderProgram>(state: SolutionBuilderSt
         case UpToDateStatusType.UpstreamBlocked:
             return reportStatus(
                 state,
-                status.upstreamProjectBlocked ?
-                    Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_was_not_built :
-                    Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_has_errors,
+                status.upstreamProjectBlocked
+                    ? Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_was_not_built
+                    : Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_has_errors,
                 relName(state, configFileName),
                 relName(state, status.upstreamProjectName),
             );

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -653,8 +653,8 @@ function createSingleLineStringWriter(): EmitTextWriter {
 
 /** @internal */
 export function changesAffectModuleResolution(oldOptions: CompilerOptions, newOptions: CompilerOptions): boolean {
-    return oldOptions.configFilePath !== newOptions.configFilePath ||
-        optionsHaveModuleResolutionChanges(oldOptions, newOptions);
+    return oldOptions.configFilePath !== newOptions.configFilePath
+        || optionsHaveModuleResolutionChanges(oldOptions, newOptions);
 }
 
 /** @internal */
@@ -747,23 +747,23 @@ export function getFullWidth(node: Node) {
 
 /** @internal */
 export function projectReferenceIsEqualTo(oldRef: ProjectReference, newRef: ProjectReference) {
-    return oldRef.path === newRef.path &&
-        !oldRef.prepend === !newRef.prepend &&
-        !oldRef.circular === !newRef.circular;
+    return oldRef.path === newRef.path
+        && !oldRef.prepend === !newRef.prepend
+        && !oldRef.circular === !newRef.circular;
 }
 
 /** @internal */
 export function moduleResolutionIsEqualTo(oldResolution: ResolvedModuleWithFailedLookupLocations, newResolution: ResolvedModuleWithFailedLookupLocations): boolean {
-    return oldResolution === newResolution ||
-        oldResolution.resolvedModule === newResolution.resolvedModule ||
-        !!oldResolution.resolvedModule &&
-            !!newResolution.resolvedModule &&
-            oldResolution.resolvedModule.isExternalLibraryImport === newResolution.resolvedModule.isExternalLibraryImport &&
-            oldResolution.resolvedModule.extension === newResolution.resolvedModule.extension &&
-            oldResolution.resolvedModule.resolvedFileName === newResolution.resolvedModule.resolvedFileName &&
-            oldResolution.resolvedModule.originalPath === newResolution.resolvedModule.originalPath &&
-            packageIdIsEqual(oldResolution.resolvedModule.packageId, newResolution.resolvedModule.packageId) &&
-            oldResolution.alternateResult === newResolution.alternateResult;
+    return oldResolution === newResolution
+        || oldResolution.resolvedModule === newResolution.resolvedModule
+        || !!oldResolution.resolvedModule
+            && !!newResolution.resolvedModule
+            && oldResolution.resolvedModule.isExternalLibraryImport === newResolution.resolvedModule.isExternalLibraryImport
+            && oldResolution.resolvedModule.extension === newResolution.resolvedModule.extension
+            && oldResolution.resolvedModule.resolvedFileName === newResolution.resolvedModule.resolvedFileName
+            && oldResolution.resolvedModule.originalPath === newResolution.resolvedModule.originalPath
+            && packageIdIsEqual(oldResolution.resolvedModule.packageId, newResolution.resolvedModule.packageId)
+            && oldResolution.alternateResult === newResolution.alternateResult;
 }
 
 /** @internal */
@@ -821,13 +821,13 @@ export function packageIdToString(packageId: PackageId): string {
 
 /** @internal */
 export function typeDirectiveIsEqualTo(oldResolution: ResolvedTypeReferenceDirectiveWithFailedLookupLocations, newResolution: ResolvedTypeReferenceDirectiveWithFailedLookupLocations): boolean {
-    return oldResolution === newResolution ||
-        oldResolution.resolvedTypeReferenceDirective === newResolution.resolvedTypeReferenceDirective ||
-        !!oldResolution.resolvedTypeReferenceDirective &&
-            !!newResolution.resolvedTypeReferenceDirective &&
-            oldResolution.resolvedTypeReferenceDirective.resolvedFileName === newResolution.resolvedTypeReferenceDirective.resolvedFileName &&
-            !!oldResolution.resolvedTypeReferenceDirective.primary === !!newResolution.resolvedTypeReferenceDirective.primary &&
-            oldResolution.resolvedTypeReferenceDirective.originalPath === newResolution.resolvedTypeReferenceDirective.originalPath;
+    return oldResolution === newResolution
+        || oldResolution.resolvedTypeReferenceDirective === newResolution.resolvedTypeReferenceDirective
+        || !!oldResolution.resolvedTypeReferenceDirective
+            && !!newResolution.resolvedTypeReferenceDirective
+            && oldResolution.resolvedTypeReferenceDirective.resolvedFileName === newResolution.resolvedTypeReferenceDirective.resolvedFileName
+            && !!oldResolution.resolvedTypeReferenceDirective.primary === !!newResolution.resolvedTypeReferenceDirective.primary
+            && oldResolution.resolvedTypeReferenceDirective.originalPath === newResolution.resolvedTypeReferenceDirective.originalPath;
 }
 
 /** @internal */
@@ -865,8 +865,8 @@ function aggregateChildData(node: Node): void {
         // A node is considered to contain a parse error if:
         //  a) the parser explicitly marked that it had an error
         //  b) any of it's children reported that it had an error.
-        const thisNodeOrAnySubNodesHasError = ((node.flags & NodeFlags.ThisNodeHasError) !== 0) ||
-            forEachChild(node, containsParseError);
+        const thisNodeOrAnySubNodesHasError = ((node.flags & NodeFlags.ThisNodeHasError) !== 0)
+            || forEachChild(node, containsParseError);
 
         // If so, mark ourselves accordingly.
         if (thisNodeOrAnySubNodesHasError) {
@@ -1086,26 +1086,26 @@ export function isRecognizedTripleSlashComment(text: string, commentPos: number,
     // Verify this is /// comment, but do the regexp match only when we first can find /// in the comment text
     // so that we don't end up computing comment string and doing match for all // comments
     if (
-        text.charCodeAt(commentPos + 1) === CharacterCodes.slash &&
-        commentPos + 2 < commentEnd &&
-        text.charCodeAt(commentPos + 2) === CharacterCodes.slash
+        text.charCodeAt(commentPos + 1) === CharacterCodes.slash
+        && commentPos + 2 < commentEnd
+        && text.charCodeAt(commentPos + 2) === CharacterCodes.slash
     ) {
         const textSubStr = text.substring(commentPos, commentEnd);
-        return fullTripleSlashReferencePathRegEx.test(textSubStr) ||
-                fullTripleSlashAMDReferencePathRegEx.test(textSubStr) ||
-                fullTripleSlashAMDModuleRegEx.test(textSubStr) ||
-                fullTripleSlashReferenceTypeReferenceDirectiveRegEx.test(textSubStr) ||
-                fullTripleSlashLibReferenceRegEx.test(textSubStr) ||
-                defaultLibReferenceRegEx.test(textSubStr) ?
-            true : false;
+        return fullTripleSlashReferencePathRegEx.test(textSubStr)
+                || fullTripleSlashAMDReferencePathRegEx.test(textSubStr)
+                || fullTripleSlashAMDModuleRegEx.test(textSubStr)
+                || fullTripleSlashReferenceTypeReferenceDirectiveRegEx.test(textSubStr)
+                || fullTripleSlashLibReferenceRegEx.test(textSubStr)
+                || defaultLibReferenceRegEx.test(textSubStr)
+            ? true : false;
     }
     return false;
 }
 
 /** @internal */
 export function isPinnedComment(text: string, start: number) {
-    return text.charCodeAt(start + 1) === CharacterCodes.asterisk &&
-        text.charCodeAt(start + 2) === CharacterCodes.exclamation;
+    return text.charCodeAt(start + 1) === CharacterCodes.asterisk
+        && text.charCodeAt(start + 2) === CharacterCodes.exclamation;
 }
 
 /** @internal */
@@ -1676,9 +1676,9 @@ export function getLiteralText(node: LiteralLikeNode, sourceFile: SourceFile | u
     // or a (possibly escaped) quoted form of the original text if it's string-like.
     switch (node.kind) {
         case SyntaxKind.StringLiteral: {
-            const escapeText = flags & GetLiteralTextFlags.JsxAttributeEscape ? escapeJsxAttributeString :
-                flags & GetLiteralTextFlags.NeverAsciiEscape || (getEmitFlags(node) & EmitFlags.NoAsciiEscaping) ? escapeString :
-                escapeNonAsciiString;
+            const escapeText = flags & GetLiteralTextFlags.JsxAttributeEscape ? escapeJsxAttributeString
+                : flags & GetLiteralTextFlags.NeverAsciiEscape || (getEmitFlags(node) & EmitFlags.NoAsciiEscaping) ? escapeString
+                : escapeNonAsciiString;
             if ((node as StringLiteral).singleQuote) {
                 return "'" + escapeText(node.text, CharacterCodes.singleQuote) + "'";
             }
@@ -1692,8 +1692,8 @@ export function getLiteralText(node: LiteralLikeNode, sourceFile: SourceFile | u
         case SyntaxKind.TemplateTail: {
             // If a NoSubstitutionTemplateLiteral appears to have a substitution in it, the original text
             // had to include a backslash: `not \${a} substitution`.
-            const escapeText = flags & GetLiteralTextFlags.NeverAsciiEscape || (getEmitFlags(node) & EmitFlags.NoAsciiEscaping) ? escapeString :
-                escapeNonAsciiString;
+            const escapeText = flags & GetLiteralTextFlags.NeverAsciiEscape || (getEmitFlags(node) & EmitFlags.NoAsciiEscaping) ? escapeString
+                : escapeNonAsciiString;
 
             const rawText = (node as TemplateLiteralLikeNode).rawText ?? escapeTemplateSubstitution(escapeText(node.text, CharacterCodes.backtick));
             switch (node.kind) {
@@ -1752,8 +1752,8 @@ export function makeIdentifierFromModuleName(moduleName: string): string {
 
 /** @internal */
 export function isBlockOrCatchScoped(declaration: Declaration) {
-    return (getCombinedNodeFlags(declaration) & NodeFlags.BlockScoped) !== 0 ||
-        isCatchClauseVariableDeclarationOrBindingElement(declaration);
+    return (getCombinedNodeFlags(declaration) & NodeFlags.BlockScoped) !== 0
+        || isCatchClauseVariableDeclarationOrBindingElement(declaration);
 }
 
 /** @internal */
@@ -1805,9 +1805,9 @@ function isShorthandAmbientModule(node: Node | undefined): boolean {
 
 /** @internal */
 export function isBlockScopedContainerTopLevel(node: Node): boolean {
-    return node.kind === SyntaxKind.SourceFile ||
-        node.kind === SyntaxKind.ModuleDeclaration ||
-        isFunctionLikeOrClassStaticBlockDeclaration(node);
+    return node.kind === SyntaxKind.SourceFile
+        || node.kind === SyntaxKind.ModuleDeclaration
+        || isFunctionLikeOrClassStaticBlockDeclaration(node);
 }
 
 /** @internal */
@@ -2403,20 +2403,20 @@ export function getLeadingCommentRangesOfNode(node: Node, sourceFileOfNode: Sour
 
 /** @internal */
 export function getJSDocCommentRanges(node: Node, text: string) {
-    const commentRanges = (node.kind === SyntaxKind.Parameter ||
-            node.kind === SyntaxKind.TypeParameter ||
-            node.kind === SyntaxKind.FunctionExpression ||
-            node.kind === SyntaxKind.ArrowFunction ||
-            node.kind === SyntaxKind.ParenthesizedExpression ||
-            node.kind === SyntaxKind.VariableDeclaration ||
-            node.kind === SyntaxKind.ExportSpecifier) ?
-        concatenate(getTrailingCommentRanges(text, node.pos), getLeadingCommentRanges(text, node.pos)) :
-        getLeadingCommentRanges(text, node.pos);
+    const commentRanges = (node.kind === SyntaxKind.Parameter
+            || node.kind === SyntaxKind.TypeParameter
+            || node.kind === SyntaxKind.FunctionExpression
+            || node.kind === SyntaxKind.ArrowFunction
+            || node.kind === SyntaxKind.ParenthesizedExpression
+            || node.kind === SyntaxKind.VariableDeclaration
+            || node.kind === SyntaxKind.ExportSpecifier)
+        ? concatenate(getTrailingCommentRanges(text, node.pos), getLeadingCommentRanges(text, node.pos))
+        : getLeadingCommentRanges(text, node.pos);
     // True if the comment starts with '/**' but not if it is '/**/'
     return filter(commentRanges, comment =>
-        text.charCodeAt(comment.pos + 1) === CharacterCodes.asterisk &&
-        text.charCodeAt(comment.pos + 2) === CharacterCodes.asterisk &&
-        text.charCodeAt(comment.pos + 3) !== CharacterCodes.slash);
+        text.charCodeAt(comment.pos + 1) === CharacterCodes.asterisk
+        && text.charCodeAt(comment.pos + 2) === CharacterCodes.asterisk
+        && text.charCodeAt(comment.pos + 3) !== CharacterCodes.slash);
 }
 
 /** @internal */
@@ -2674,8 +2674,8 @@ export function isVariableDeclarationInVariableStatement(node: VariableDeclarati
 /** @internal */
 export function isCommonJsExportedExpression(node: Node) {
     if (!isInJSFile(node)) return false;
-    return (isObjectLiteralExpression(node.parent) && isBinaryExpression(node.parent.parent) && getAssignmentDeclarationKind(node.parent.parent) === AssignmentDeclarationKind.ModuleExports) ||
-        isCommonJsExportPropertyAssignment(node.parent);
+    return (isObjectLiteralExpression(node.parent) && isBinaryExpression(node.parent.parent) && getAssignmentDeclarationKind(node.parent.parent) === AssignmentDeclarationKind.ModuleExports)
+        || isCommonJsExportPropertyAssignment(node.parent);
 }
 
 /** @internal */
@@ -2686,9 +2686,9 @@ export function isCommonJsExportPropertyAssignment(node: Node) {
 
 /** @internal */
 export function isValidESSymbolDeclaration(node: Node): boolean {
-    return (isVariableDeclaration(node) ? isVarConst(node) && isIdentifier(node.name) && isVariableDeclarationInVariableStatement(node) :
-        isPropertyDeclaration(node) ? hasEffectiveReadonlyModifier(node) && hasStaticModifier(node) :
-        isPropertySignature(node) && hasEffectiveReadonlyModifier(node)) || isCommonJsExportPropertyAssignment(node);
+    return (isVariableDeclaration(node) ? isVarConst(node) && isIdentifier(node.name) && isVariableDeclarationInVariableStatement(node)
+        : isPropertyDeclaration(node) ? hasEffectiveReadonlyModifier(node) && hasStaticModifier(node)
+        : isPropertySignature(node) && hasEffectiveReadonlyModifier(node)) || isCommonJsExportPropertyAssignment(node);
 }
 
 /** @internal */
@@ -2731,9 +2731,9 @@ export function isObjectLiteralMethod(node: Node): node is MethodDeclaration {
 
 /** @internal */
 export function isObjectLiteralOrClassExpressionMethodOrAccessor(node: Node): node is MethodDeclaration | AccessorDeclaration {
-    return (node.kind === SyntaxKind.MethodDeclaration || node.kind === SyntaxKind.GetAccessor || node.kind === SyntaxKind.SetAccessor) &&
-        (node.parent.kind === SyntaxKind.ObjectLiteralExpression ||
-            node.parent.kind === SyntaxKind.ClassExpression);
+    return (node.kind === SyntaxKind.MethodDeclaration || node.kind === SyntaxKind.GetAccessor || node.kind === SyntaxKind.SetAccessor)
+        && (node.parent.kind === SyntaxKind.ObjectLiteralExpression
+            || node.parent.kind === SyntaxKind.ClassExpression);
 }
 
 /** @internal */
@@ -2751,18 +2751,18 @@ export function forEachPropertyAssignment<T>(objectLiteral: ObjectLiteralExpress
     return forEach(objectLiteral?.properties, property => {
         if (!isPropertyAssignment(property)) return undefined;
         const propName = tryGetTextOfPropertyName(property.name);
-        return key === propName || (key2 && key2 === propName) ?
-            callback(property) :
-            undefined;
+        return key === propName || (key2 && key2 === propName)
+            ? callback(property)
+            : undefined;
     });
 }
 
 /** @internal */
 export function getPropertyArrayElementValue(objectLiteral: ObjectLiteralExpression, propKey: string, elementValue: string): StringLiteral | undefined {
     return forEachPropertyAssignment(objectLiteral, propKey, property =>
-        isArrayLiteralExpression(property.initializer) ?
-            find(property.initializer.elements, (element): element is StringLiteral => isStringLiteral(element) && element.text === elementValue) :
-            undefined);
+        isArrayLiteralExpression(property.initializer)
+            ? find(property.initializer.elements, (element): element is StringLiteral => isStringLiteral(element) && element.text === elementValue)
+            : undefined);
 }
 
 /** @internal */
@@ -2776,9 +2776,9 @@ export function getTsConfigObjectLiteralExpression(tsConfigSourceFile: TsConfigS
 /** @internal */
 export function getTsConfigPropArrayElementValue(tsConfigSourceFile: TsConfigSourceFile | undefined, propKey: string, elementValue: string): StringLiteral | undefined {
     return forEachTsConfigPropArray(tsConfigSourceFile, propKey, property =>
-        isArrayLiteralExpression(property.initializer) ?
-            find(property.initializer.elements, (element): element is StringLiteral => isStringLiteral(element) && element.text === elementValue) :
-            undefined);
+        isArrayLiteralExpression(property.initializer)
+            ? find(property.initializer.elements, (element): element is StringLiteral => isStringLiteral(element) && element.text === elementValue)
+            : undefined);
 }
 
 /** @internal */
@@ -3244,9 +3244,9 @@ export function classElementOrClassElementParameterIsDecorated(useLegacyDecorato
     let parameters: NodeArray<ParameterDeclaration> | undefined;
     if (isAccessor(node)) {
         const { firstAccessor, secondAccessor, setAccessor } = getAllAccessorDeclarations(parent.members, node);
-        const firstAccessorWithDecorators = hasDecorators(firstAccessor) ? firstAccessor :
-            secondAccessor && hasDecorators(secondAccessor) ? secondAccessor :
-            undefined;
+        const firstAccessorWithDecorators = hasDecorators(firstAccessor) ? firstAccessor
+            : secondAccessor && hasDecorators(secondAccessor) ? secondAccessor
+            : undefined;
         if (!firstAccessorWithDecorators || node !== firstAccessorWithDecorators) {
             return false;
         }
@@ -3285,9 +3285,9 @@ export function isEmptyStringLiteral(node: StringLiteral): boolean {
 export function isJSXTagName(node: Node) {
     const { parent } = node;
     if (
-        parent.kind === SyntaxKind.JsxOpeningElement ||
-        parent.kind === SyntaxKind.JsxSelfClosingElement ||
-        parent.kind === SyntaxKind.JsxClosingElement
+        parent.kind === SyntaxKind.JsxOpeningElement
+        || parent.kind === SyntaxKind.JsxSelfClosingElement
+        || parent.kind === SyntaxKind.JsxClosingElement
     ) {
         return (parent as JsxOpeningLikeElement).tagName === node;
     }
@@ -3389,14 +3389,14 @@ export function isInExpressionContext(node: Node): boolean {
             return (parent as ExpressionStatement).expression === node;
         case SyntaxKind.ForStatement:
             const forStatement = parent as ForStatement;
-            return (forStatement.initializer === node && forStatement.initializer.kind !== SyntaxKind.VariableDeclarationList) ||
-                forStatement.condition === node ||
-                forStatement.incrementor === node;
+            return (forStatement.initializer === node && forStatement.initializer.kind !== SyntaxKind.VariableDeclarationList)
+                || forStatement.condition === node
+                || forStatement.incrementor === node;
         case SyntaxKind.ForInStatement:
         case SyntaxKind.ForOfStatement:
             const forInOrOfStatement = parent as ForInOrOfStatement;
-            return (forInOrOfStatement.initializer === node && forInOrOfStatement.initializer.kind !== SyntaxKind.VariableDeclarationList) ||
-                forInOrOfStatement.expression === node;
+            return (forInOrOfStatement.initializer === node && forInOrOfStatement.initializer.kind !== SyntaxKind.VariableDeclarationList)
+                || forInOrOfStatement.expression === node;
         case SyntaxKind.TypeAssertionExpression:
         case SyntaxKind.AsExpression:
             return node === (parent as AssertionExpression).expression;
@@ -3486,11 +3486,11 @@ export function isInJSDoc(node: Node | undefined): boolean {
 
 /** @internal */
 export function isJSDocIndexSignature(node: TypeReferenceNode | ExpressionWithTypeArguments) {
-    return isTypeReferenceNode(node) &&
-        isIdentifier(node.typeName) &&
-        node.typeName.escapedText === "Object" &&
-        node.typeArguments && node.typeArguments.length === 2 &&
-        (node.typeArguments[0].kind === SyntaxKind.StringKeyword || node.typeArguments[0].kind === SyntaxKind.NumberKeyword);
+    return isTypeReferenceNode(node)
+        && isIdentifier(node.typeName)
+        && node.typeName.escapedText === "Object"
+        && node.typeArguments && node.typeArguments.length === 2
+        && (node.typeArguments[0].kind === SyntaxKind.StringKeyword || node.typeArguments[0].kind === SyntaxKind.NumberKeyword);
 }
 
 /**
@@ -3546,9 +3546,9 @@ export function isBindingElementOfBareOrAccessedRequire(node: Node): node is Bin
 }
 
 function isVariableDeclarationInitializedWithRequireHelper(node: Node, allowAccessedRequire: boolean) {
-    return isVariableDeclaration(node) &&
-        !!node.initializer &&
-        isRequireCall(allowAccessedRequire ? getLeftmostAccessExpression(node.initializer) : node.initializer, /*requireStringLiteralLikeArgument*/ true);
+    return isVariableDeclaration(node)
+        && !!node.initializer
+        && isRequireCall(allowAccessedRequire ? getLeftmostAccessExpression(node.initializer) : node.initializer, /*requireStringLiteralLikeArgument*/ true);
 }
 
 /** @internal */
@@ -3580,10 +3580,10 @@ export function isAssignmentDeclaration(decl: Declaration) {
  */
 export function getEffectiveInitializer(node: HasExpressionInitializer) {
     if (
-        isInJSFile(node) && node.initializer &&
-        isBinaryExpression(node.initializer) &&
-        (node.initializer.operatorToken.kind === SyntaxKind.BarBarToken || node.initializer.operatorToken.kind === SyntaxKind.QuestionQuestionToken) &&
-        node.name && isEntityNameExpression(node.name) && isSameEntityName(node.name, node.initializer.left)
+        isInJSFile(node) && node.initializer
+        && isBinaryExpression(node.initializer)
+        && (node.initializer.operatorToken.kind === SyntaxKind.BarBarToken || node.initializer.operatorToken.kind === SyntaxKind.QuestionQuestionToken)
+        && node.name && isEntityNameExpression(node.name) && isSameEntityName(node.name, node.initializer.left)
     ) {
         return node.initializer.right;
     }
@@ -3602,11 +3602,11 @@ export function getDeclaredExpandoInitializer(node: HasExpressionInitializer) {
 
 function hasExpandoValueProperty(node: ObjectLiteralExpression, isPrototypeAssignment: boolean) {
     return forEach(node.properties, p =>
-        isPropertyAssignment(p) &&
-        isIdentifier(p.name) &&
-        p.name.escapedText === "value" &&
-        p.initializer &&
-        getExpandoInitializer(p.initializer, isPrototypeAssignment));
+        isPropertyAssignment(p)
+        && isIdentifier(p.name)
+        && p.name.escapedText === "value"
+        && p.initializer
+        && getExpandoInitializer(p.initializer, isPrototypeAssignment));
 }
 
 /**
@@ -3618,8 +3618,8 @@ function hasExpandoValueProperty(node: ObjectLiteralExpression, isPrototypeAssig
 export function getAssignedExpandoInitializer(node: Node | undefined): Expression | undefined {
     if (node && node.parent && isBinaryExpression(node.parent) && node.parent.operatorToken.kind === SyntaxKind.EqualsToken) {
         const isPrototypeAssignment = isPrototypeAccess(node.parent.left);
-        return getExpandoInitializer(node.parent.right, isPrototypeAssignment) ||
-            getDefaultedExpandoInitializer(node.parent.left, node.parent.right, isPrototypeAssignment);
+        return getExpandoInitializer(node.parent.right, isPrototypeAssignment)
+            || getDefaultedExpandoInitializer(node.parent.left, node.parent.right, isPrototypeAssignment);
     }
     if (node && isCallExpression(node) && isBindableObjectDefinePropertyCall(node)) {
         const result = hasExpandoValueProperty(node.arguments[2], node.arguments[1].text === "prototype");
@@ -3647,9 +3647,9 @@ export function getExpandoInitializer(initializer: Node, isPrototypeAssignment: 
         return e.kind === SyntaxKind.FunctionExpression || e.kind === SyntaxKind.ArrowFunction ? initializer : undefined;
     }
     if (
-        initializer.kind === SyntaxKind.FunctionExpression ||
-        initializer.kind === SyntaxKind.ClassExpression ||
-        initializer.kind === SyntaxKind.ArrowFunction
+        initializer.kind === SyntaxKind.FunctionExpression
+        || initializer.kind === SyntaxKind.ClassExpression
+        || initializer.kind === SyntaxKind.ArrowFunction
     ) {
         return initializer as Expression;
     }
@@ -3677,9 +3677,9 @@ function getDefaultedExpandoInitializer(name: Expression, initializer: Expressio
 
 /** @internal */
 export function isDefaultedExpandoInitializer(node: BinaryExpression) {
-    const name = isVariableDeclaration(node.parent) ? node.parent.name :
-        isBinaryExpression(node.parent) && node.parent.operatorToken.kind === SyntaxKind.EqualsToken ? node.parent.left :
-        undefined;
+    const name = isVariableDeclaration(node.parent) ? node.parent.name
+        : isBinaryExpression(node.parent) && node.parent.operatorToken.kind === SyntaxKind.EqualsToken ? node.parent.left
+        : undefined;
     return name && getExpandoInitializer(node.right, isPrototypeAccess(name)) && isEntityNameExpression(name) && isSameEntityName(name, node.left);
 }
 
@@ -3716,12 +3716,12 @@ export function isSameEntityName(name: Expression, initializer: Expression): boo
         return getTextOfIdentifierOrLiteral(name) === getTextOfIdentifierOrLiteral(initializer);
     }
     if (
-        isMemberName(name) && isLiteralLikeAccess(initializer) &&
-        (initializer.expression.kind === SyntaxKind.ThisKeyword ||
-            isIdentifier(initializer.expression) &&
-                (initializer.expression.escapedText === "window" ||
-                    initializer.expression.escapedText === "self" ||
-                    initializer.expression.escapedText === "global"))
+        isMemberName(name) && isLiteralLikeAccess(initializer)
+        && (initializer.expression.kind === SyntaxKind.ThisKeyword
+            || isIdentifier(initializer.expression)
+                && (initializer.expression.escapedText === "window"
+                    || initializer.expression.escapedText === "self"
+                    || initializer.expression.escapedText === "global"))
     ) {
         return isSameEntityName(name, getNameOrArgument(initializer));
     }
@@ -3767,13 +3767,13 @@ export function getAssignmentDeclarationKind(expr: BinaryExpression | CallExpres
 
 /** @internal */
 export function isBindableObjectDefinePropertyCall(expr: CallExpression): expr is BindableObjectDefinePropertyCall {
-    return length(expr.arguments) === 3 &&
-        isPropertyAccessExpression(expr.expression) &&
-        isIdentifier(expr.expression.expression) &&
-        idText(expr.expression.expression) === "Object" &&
-        idText(expr.expression.name) === "defineProperty" &&
-        isStringOrNumericLiteralLike(expr.arguments[1]) &&
-        isBindableStaticNameExpression(expr.arguments[0], /*excludeThisKeyword*/ true);
+    return length(expr.arguments) === 3
+        && isPropertyAccessExpression(expr.expression)
+        && isIdentifier(expr.expression.expression)
+        && idText(expr.expression.expression) === "Object"
+        && idText(expr.expression.name) === "defineProperty"
+        && isStringOrNumericLiteralLike(expr.arguments[1])
+        && isBindableStaticNameExpression(expr.arguments[0], /*excludeThisKeyword*/ true);
 }
 
 /**
@@ -3811,9 +3811,9 @@ export function isBindableStaticAccessExpression(node: Node, excludeThisKeyword?
  */
 export function isBindableStaticElementAccessExpression(node: Node, excludeThisKeyword?: boolean): node is BindableStaticElementAccessExpression {
     return isLiteralLikeElementAccess(node)
-        && ((!excludeThisKeyword && node.expression.kind === SyntaxKind.ThisKeyword) ||
-            isEntityNameExpression(node.expression) ||
-            isBindableStaticAccessExpression(node.expression, /*excludeThisKeyword*/ true));
+        && ((!excludeThisKeyword && node.expression.kind === SyntaxKind.ThisKeyword)
+            || isEntityNameExpression(node.expression)
+            || isBindableStaticAccessExpression(node.expression, /*excludeThisKeyword*/ true));
 }
 
 /** @internal */
@@ -3913,10 +3913,10 @@ export function getAssignmentDeclarationPropertyAccessKind(lhs: AccessExpression
         }
         const id = nextToLast.expression;
         if (
-            (id.escapedText === "exports" ||
-                id.escapedText === "module" && getElementOrPropertyAccessName(nextToLast) === "exports") &&
+            (id.escapedText === "exports"
+                || id.escapedText === "module" && getElementOrPropertyAccessName(nextToLast) === "exports")
             // ExportsProperty does not support binding with computed names
-            isBindableStaticAccessExpression(lhs)
+            && isBindableStaticAccessExpression(lhs)
         ) {
             // exports.name = expr OR module.exports.name = expr OR exports["name"] = expr ...
             return AssignmentDeclarationKind.ExportsProperty;
@@ -3951,20 +3951,20 @@ export function isPrototypePropertyAssignment(node: Node): node is PrototypeProp
 
 /** @internal */
 export function isSpecialPropertyDeclaration(expr: PropertyAccessExpression | ElementAccessExpression): expr is PropertyAccessExpression | LiteralLikeElementAccessExpression {
-    return isInJSFile(expr) &&
-        expr.parent && expr.parent.kind === SyntaxKind.ExpressionStatement &&
-        (!isElementAccessExpression(expr) || isLiteralLikeElementAccess(expr)) &&
-        !!getJSDocTypeTag(expr.parent);
+    return isInJSFile(expr)
+        && expr.parent && expr.parent.kind === SyntaxKind.ExpressionStatement
+        && (!isElementAccessExpression(expr) || isLiteralLikeElementAccess(expr))
+        && !!getJSDocTypeTag(expr.parent);
 }
 
 /** @internal */
 export function setValueDeclaration(symbol: Symbol, node: Declaration): void {
     const { valueDeclaration } = symbol;
     if (
-        !valueDeclaration ||
-        !(node.flags & NodeFlags.Ambient && !isInJSFile(node) && !(valueDeclaration.flags & NodeFlags.Ambient)) &&
-            (isAssignmentDeclaration(valueDeclaration) && !isAssignmentDeclaration(node)) ||
-        (valueDeclaration.kind !== node.kind && isEffectiveModuleDeclaration(valueDeclaration))
+        !valueDeclaration
+        || !(node.flags & NodeFlags.Ambient && !isInJSFile(node) && !(valueDeclaration.flags & NodeFlags.Ambient))
+            && (isAssignmentDeclaration(valueDeclaration) && !isAssignmentDeclaration(node))
+        || (valueDeclaration.kind !== node.kind && isEffectiveModuleDeclaration(valueDeclaration))
     ) {
         // other kinds of value declarations take precedence over modules and assignment declarations
         symbol.valueDeclaration = node;
@@ -4117,19 +4117,19 @@ export function isTypeAlias(node: Node): node is JSDocTypedefTag | JSDocCallback
 }
 
 function getSourceOfAssignment(node: Node): Node | undefined {
-    return isExpressionStatement(node) &&
-            isBinaryExpression(node.expression) &&
-            node.expression.operatorToken.kind === SyntaxKind.EqualsToken
+    return isExpressionStatement(node)
+            && isBinaryExpression(node.expression)
+            && node.expression.operatorToken.kind === SyntaxKind.EqualsToken
         ? getRightMostAssignedExpression(node.expression)
         : undefined;
 }
 
 function getSourceOfDefaultedAssignment(node: Node): Node | undefined {
-    return isExpressionStatement(node) &&
-            isBinaryExpression(node.expression) &&
-            getAssignmentDeclarationKind(node.expression) !== AssignmentDeclarationKind.None &&
-            isBinaryExpression(node.expression.right) &&
-            (node.expression.right.operatorToken.kind === SyntaxKind.BarBarToken || node.expression.right.operatorToken.kind === SyntaxKind.QuestionQuestionToken)
+    return isExpressionStatement(node)
+            && isBinaryExpression(node.expression)
+            && getAssignmentDeclarationKind(node.expression) !== AssignmentDeclarationKind.None
+            && isBinaryExpression(node.expression.right)
+            && (node.expression.right.operatorToken.kind === SyntaxKind.BarBarToken || node.expression.right.operatorToken.kind === SyntaxKind.QuestionQuestionToken)
         ? node.expression.right.right
         : undefined;
 }
@@ -4153,9 +4153,9 @@ export function getSingleVariableOfVariableStatement(node: Node): VariableDeclar
 }
 
 function getNestedModuleDeclaration(node: Node): Node | undefined {
-    return isModuleDeclaration(node) &&
-            node.body &&
-            node.body.kind === SyntaxKind.ModuleDeclaration
+    return isModuleDeclaration(node)
+            && node.body
+            && node.body.kind === SyntaxKind.ModuleDeclaration
         ? node.body
         : undefined;
 }
@@ -4339,13 +4339,13 @@ function ownsJSDocTag(hostNode: Node, tag: JSDocTag) {
 export function getNextJSDocCommentLocation(node: Node) {
     const parent = node.parent;
     if (
-        parent.kind === SyntaxKind.PropertyAssignment ||
-        parent.kind === SyntaxKind.ExportAssignment ||
-        parent.kind === SyntaxKind.PropertyDeclaration ||
-        parent.kind === SyntaxKind.ExpressionStatement && node.kind === SyntaxKind.PropertyAccessExpression ||
-        parent.kind === SyntaxKind.ReturnStatement ||
-        getNestedModuleDeclaration(parent) ||
-        isAssignmentExpression(node)
+        parent.kind === SyntaxKind.PropertyAssignment
+        || parent.kind === SyntaxKind.ExportAssignment
+        || parent.kind === SyntaxKind.PropertyDeclaration
+        || parent.kind === SyntaxKind.ExpressionStatement && node.kind === SyntaxKind.PropertyAccessExpression
+        || parent.kind === SyntaxKind.ReturnStatement
+        || getNestedModuleDeclaration(parent)
+        || isAssignmentExpression(node)
     ) {
         return parent;
     }
@@ -4356,16 +4356,16 @@ export function getNextJSDocCommentLocation(node: Node) {
     //   */
     // var x = function(name) { return name.length; }
     else if (
-        parent.parent &&
-        (getSingleVariableOfVariableStatement(parent.parent) === node || isAssignmentExpression(parent))
+        parent.parent
+        && (getSingleVariableOfVariableStatement(parent.parent) === node || isAssignmentExpression(parent))
     ) {
         return parent.parent;
     }
     else if (
-        parent.parent && parent.parent.parent &&
-        (getSingleVariableOfVariableStatement(parent.parent.parent) ||
-            getSingleInitializerOfVariableStatementOrPropertyDeclaration(parent.parent.parent) === node ||
-            getSourceOfDefaultedAssignment(parent.parent.parent))
+        parent.parent && parent.parent.parent
+        && (getSingleVariableOfVariableStatement(parent.parent.parent)
+            || getSingleInitializerOfVariableStatementOrPropertyDeclaration(parent.parent.parent) === node
+            || getSourceOfDefaultedAssignment(parent.parent.parent))
     ) {
         return parent.parent.parent;
     }
@@ -4414,8 +4414,8 @@ export function getJSDocOverloadTags(node: Node): readonly JSDocOverloadTag[] {
 export function getHostSignatureFromJSDoc(node: Node): SignatureDeclaration | undefined {
     const host = getEffectiveJSDocHost(node);
     if (host) {
-        return isPropertySignature(host) && host.type && isFunctionLike(host.type) ? host.type :
-            isFunctionLike(host) ? host : undefined;
+        return isPropertySignature(host) && host.type && isFunctionLike(host.type) ? host.type
+            : isFunctionLike(host) ? host : undefined;
     }
     return undefined;
 }
@@ -4534,9 +4534,9 @@ export function getAssignmentTargetKind(node: Node): AssignmentKind {
     switch (target.kind) {
         case SyntaxKind.BinaryExpression:
             const binaryOperator = target.operatorToken.kind;
-            return binaryOperator === SyntaxKind.EqualsToken || isLogicalOrCoalescingAssignmentOperator(binaryOperator) ?
-                AssignmentKind.Definite :
-                AssignmentKind.Compound;
+            return binaryOperator === SyntaxKind.EqualsToken || isLogicalOrCoalescingAssignmentOperator(binaryOperator)
+                ? AssignmentKind.Definite
+                : AssignmentKind.Compound;
         case SyntaxKind.PrefixUnaryExpression:
         case SyntaxKind.PostfixUnaryExpression:
             return AssignmentKind.Compound;
@@ -4672,9 +4672,9 @@ export function skipParentheses(node: Expression, excludeJSDocTypeAssertions?: b
 export function skipParentheses(node: Node, excludeJSDocTypeAssertions?: boolean): Node;
 /** @internal */
 export function skipParentheses(node: Node, excludeJSDocTypeAssertions?: boolean): Node {
-    const flags = excludeJSDocTypeAssertions ?
-        OuterExpressionKinds.Parentheses | OuterExpressionKinds.ExcludeJSDocTypeAssertion :
-        OuterExpressionKinds.Parentheses;
+    const flags = excludeJSDocTypeAssertions
+        ? OuterExpressionKinds.Parentheses | OuterExpressionKinds.ExcludeJSDocTypeAssertion
+        : OuterExpressionKinds.Parentheses;
     return skipOuterExpressions(node, flags);
 }
 
@@ -4723,10 +4723,10 @@ export function getDeclarationFromName(name: Node): Declaration | undefined {
             }
             else {
                 const binExp = parent.parent;
-                return isBinaryExpression(binExp) &&
-                        getAssignmentDeclarationKind(binExp) !== AssignmentDeclarationKind.None &&
-                        ((binExp.left as BindableStaticNameExpression).symbol || binExp.symbol) &&
-                        getNameOfDeclaration(binExp) === name
+                return isBinaryExpression(binExp)
+                        && getAssignmentDeclarationKind(binExp) !== AssignmentDeclarationKind.None
+                        && ((binExp.left as BindableStaticNameExpression).symbol || binExp.symbol)
+                        && getNameOfDeclaration(binExp) === name
                     ? binExp
                     : undefined;
             }
@@ -4739,9 +4739,9 @@ export function getDeclarationFromName(name: Node): Declaration | undefined {
 
 /** @internal */
 export function isLiteralComputedPropertyDeclarationName(node: Node) {
-    return isStringOrNumericLiteralLike(node) &&
-        node.parent.kind === SyntaxKind.ComputedPropertyName &&
-        isDeclaration(node.parent.parent);
+    return isStringOrNumericLiteralLike(node)
+        && node.parent.kind === SyntaxKind.ComputedPropertyName
+        && isDeclaration(node.parent.parent);
 }
 
 // Return true if the given identifier is classified as an IdentifierName
@@ -4796,21 +4796,21 @@ export function isIdentifierName(node: Identifier): boolean {
 /** @internal */
 export function isAliasSymbolDeclaration(node: Node): boolean {
     if (
-        node.kind === SyntaxKind.ImportEqualsDeclaration ||
-        node.kind === SyntaxKind.NamespaceExportDeclaration ||
-        node.kind === SyntaxKind.ImportClause && !!(node as ImportClause).name ||
-        node.kind === SyntaxKind.NamespaceImport ||
-        node.kind === SyntaxKind.NamespaceExport ||
-        node.kind === SyntaxKind.ImportSpecifier ||
-        node.kind === SyntaxKind.ExportSpecifier ||
-        node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(node as ExportAssignment)
+        node.kind === SyntaxKind.ImportEqualsDeclaration
+        || node.kind === SyntaxKind.NamespaceExportDeclaration
+        || node.kind === SyntaxKind.ImportClause && !!(node as ImportClause).name
+        || node.kind === SyntaxKind.NamespaceImport
+        || node.kind === SyntaxKind.NamespaceExport
+        || node.kind === SyntaxKind.ImportSpecifier
+        || node.kind === SyntaxKind.ExportSpecifier
+        || node.kind === SyntaxKind.ExportAssignment && exportAssignmentIsAlias(node as ExportAssignment)
     ) {
         return true;
     }
 
     return isInJSFile(node) && (
-        isBinaryExpression(node) && getAssignmentDeclarationKind(node) === AssignmentDeclarationKind.ModuleExports && exportAssignmentIsAlias(node) ||
-        isPropertyAccessExpression(node)
+        isBinaryExpression(node) && getAssignmentDeclarationKind(node) === AssignmentDeclarationKind.ModuleExports && exportAssignmentIsAlias(node)
+        || isPropertyAccessExpression(node)
             && isBinaryExpression(node.parent)
             && node.parent.left === node
             && node.parent.operatorToken.kind === SyntaxKind.EqualsToken
@@ -4856,8 +4856,8 @@ export function getExportAssignmentExpression(node: ExportAssignment | BinaryExp
 
 /** @internal */
 export function getPropertyAssignmentAliasLikeExpression(node: PropertyAssignment | ShorthandPropertyAssignment | PropertyAccessExpression): Expression {
-    return node.kind === SyntaxKind.ShorthandPropertyAssignment ? node.name : node.kind === SyntaxKind.PropertyAssignment ? node.initializer :
-        (node.parent as BinaryExpression).right;
+    return node.kind === SyntaxKind.ShorthandPropertyAssignment ? node.name : node.kind === SyntaxKind.PropertyAssignment ? node.initializer
+        : (node.parent as BinaryExpression).right;
 }
 
 /** @internal */
@@ -4896,9 +4896,9 @@ export function getEffectiveImplementsTypeNodes(node: ClassLikeDeclaration): und
  * @internal
  */
 export function getAllSuperTypeNodes(node: Node): readonly TypeNode[] {
-    return isInterfaceDeclaration(node) ? getInterfaceBaseTypeNodes(node) || emptyArray :
-        isClassLike(node) ? concatenate(singleElementArray(getEffectiveBaseTypeNode(node)), getEffectiveImplementsTypeNodes(node)) || emptyArray :
-        emptyArray;
+    return isInterfaceDeclaration(node) ? getInterfaceBaseTypeNodes(node) || emptyArray
+        : isClassLike(node) ? concatenate(singleElementArray(getEffectiveBaseTypeNode(node)), getEffectiveImplementsTypeNodes(node)) || emptyArray
+        : emptyArray;
 }
 
 /** @internal */
@@ -5069,8 +5069,8 @@ export function isDynamicName(name: DeclarationName): boolean {
         return false;
     }
     const expr = isElementAccessExpression(name) ? skipParentheses(name.argumentExpression) : name.expression;
-    return !isStringOrNumericLiteralLike(expr) &&
-        !isSignedNumericLiteral(expr);
+    return !isStringOrNumericLiteralLike(expr)
+        && !isSignedNumericLiteral(expr);
 }
 
 /** @internal */
@@ -5162,8 +5162,8 @@ export function isESSymbolIdentifier(node: Node): boolean {
  * @internal
  */
 export function isProtoSetter(node: PropertyName) {
-    return isIdentifier(node) ? idText(node) === "__proto__" :
-        isStringLiteral(node) && node.text === "__proto__";
+    return isIdentifier(node) ? idText(node) === "__proto__"
+        : isStringLiteral(node) && node.text === "__proto__";
 }
 
 /** @internal */
@@ -5908,9 +5908,9 @@ function getReplacement(c: string, offset: number, input: string) {
  * @internal
  */
 export function escapeString(s: string, quoteChar?: CharacterCodes.doubleQuote | CharacterCodes.singleQuote | CharacterCodes.backtick): string {
-    const escapedCharsRegExp = quoteChar === CharacterCodes.backtick ? backtickQuoteEscapedCharsRegExp :
-        quoteChar === CharacterCodes.singleQuote ? singleQuoteEscapedCharsRegExp :
-        doubleQuoteEscapedCharsRegExp;
+    const escapedCharsRegExp = quoteChar === CharacterCodes.backtick ? backtickQuoteEscapedCharsRegExp
+        : quoteChar === CharacterCodes.singleQuote ? singleQuoteEscapedCharsRegExp
+        : doubleQuoteEscapedCharsRegExp;
     return s.replace(escapedCharsRegExp, getReplacement);
 }
 
@@ -5920,9 +5920,9 @@ export function escapeNonAsciiString(s: string, quoteChar?: CharacterCodes.doubl
     s = escapeString(s, quoteChar);
     // Replace non-ASCII characters with '\uNNNN' escapes if any exist.
     // Otherwise just return the original string.
-    return nonAsciiCharacters.test(s) ?
-        s.replace(nonAsciiCharacters, c => encodeUtf16EscapeSequence(c.charCodeAt(0))) :
-        s;
+    return nonAsciiCharacters.test(s)
+        ? s.replace(nonAsciiCharacters, c => encodeUtf16EscapeSequence(c.charCodeAt(0)))
+        : s;
 }
 
 // This consists of the first 19 unprintable ASCII characters, JSX canonical escapes, lineSeparator,
@@ -5950,8 +5950,8 @@ function getJsxAttributeStringReplacement(c: string) {
 
 /** @internal */
 export function escapeJsxAttributeString(s: string, quoteChar?: CharacterCodes.doubleQuote | CharacterCodes.singleQuote) {
-    const escapedCharsRegExp = quoteChar === CharacterCodes.singleQuote ? jsxSingleQuoteEscapedCharsRegExp :
-        jsxDoubleQuoteEscapedCharsRegExp;
+    const escapedCharsRegExp = quoteChar === CharacterCodes.singleQuote ? jsxSingleQuoteEscapedCharsRegExp
+        : jsxDoubleQuoteEscapedCharsRegExp;
     return s.replace(escapedCharsRegExp, getJsxAttributeStringReplacement);
 }
 
@@ -5971,9 +5971,9 @@ export function stripQuotes(name: string) {
 }
 
 function isQuoteOrBacktick(charCode: number) {
-    return charCode === CharacterCodes.singleQuote ||
-        charCode === CharacterCodes.doubleQuote ||
-        charCode === CharacterCodes.backtick;
+    return charCode === CharacterCodes.singleQuote
+        || charCode === CharacterCodes.doubleQuote
+        || charCode === CharacterCodes.backtick;
 }
 
 /** @internal */
@@ -6218,8 +6218,8 @@ export function getExternalModuleNameFromDeclaration(host: ResolveModuleNameReso
     // If the declaration already uses a non-relative name, and is outside the common source directory, continue to use it
     const specifier = getExternalModuleName(declaration);
     if (
-        specifier && isStringLiteralLike(specifier) && !pathIsRelative(specifier.text) &&
-        !getCanonicalAbsolutePath(host, file.path).includes(getCanonicalAbsolutePath(host, ensureTrailingDirectorySeparator(host.getCommonSourceDirectory())))
+        specifier && isStringLiteralLike(specifier) && !pathIsRelative(specifier.text)
+        && !getCanonicalAbsolutePath(host, file.path).includes(getCanonicalAbsolutePath(host, ensureTrailingDirectorySeparator(host.getCommonSourceDirectory())))
     ) {
         return undefined;
     }
@@ -6272,10 +6272,10 @@ export function getDeclarationEmitOutputFilePathWorker(fileName: string, options
 
 /** @internal */
 export function getDeclarationEmitExtensionForPath(path: string) {
-    return fileExtensionIsOneOf(path, [Extension.Mjs, Extension.Mts]) ? Extension.Dmts :
-        fileExtensionIsOneOf(path, [Extension.Cjs, Extension.Cts]) ? Extension.Dcts :
-        fileExtensionIsOneOf(path, [Extension.Json]) ? `.d.json.ts` : // Drive-by redefinition of json declaration file output name so if it's ever enabled, it behaves well
-        Extension.Dts;
+    return fileExtensionIsOneOf(path, [Extension.Mjs, Extension.Mts]) ? Extension.Dmts
+        : fileExtensionIsOneOf(path, [Extension.Cjs, Extension.Cts]) ? Extension.Dcts
+        : fileExtensionIsOneOf(path, [Extension.Json]) ? `.d.json.ts` // Drive-by redefinition of json declaration file output name so if it's ever enabled, it behaves well
+        : Extension.Dts;
 }
 
 /**
@@ -6284,10 +6284,10 @@ export function getDeclarationEmitExtensionForPath(path: string) {
  * @internal
  */
 export function getPossibleOriginalInputExtensionForExtension(path: string) {
-    return fileExtensionIsOneOf(path, [Extension.Dmts, Extension.Mjs, Extension.Mts]) ? [Extension.Mts, Extension.Mjs] :
-        fileExtensionIsOneOf(path, [Extension.Dcts, Extension.Cjs, Extension.Cts]) ? [Extension.Cts, Extension.Cjs] :
-        fileExtensionIsOneOf(path, [`.d.json.ts`]) ? [Extension.Json] :
-        [Extension.Tsx, Extension.Ts, Extension.Jsx, Extension.Js];
+    return fileExtensionIsOneOf(path, [Extension.Dmts, Extension.Mjs, Extension.Mts]) ? [Extension.Mts, Extension.Mjs]
+        : fileExtensionIsOneOf(path, [Extension.Dcts, Extension.Cjs, Extension.Cts]) ? [Extension.Cts, Extension.Cjs]
+        : fileExtensionIsOneOf(path, [`.d.json.ts`]) ? [Extension.Json]
+        : [Extension.Tsx, Extension.Ts, Extension.Jsx, Extension.Js];
 }
 
 /**
@@ -6329,8 +6329,8 @@ export function getSourceFilesToEmit(host: EmitHost, targetSourceFile?: SourceFi
         return filter(
             host.getSourceFiles(),
             sourceFile =>
-                (moduleEmitEnabled || !isExternalModule(sourceFile)) &&
-                sourceFileMayBeEmitted(sourceFile, host, forceDtsEmit),
+                (moduleEmitEnabled || !isExternalModule(sourceFile))
+                && sourceFileMayBeEmitted(sourceFile, host, forceDtsEmit),
         );
     }
     else {
@@ -6599,9 +6599,9 @@ export function getTypeAnnotationNode(node: Node): TypeNode | undefined {
  * @internal
  */
 export function getEffectiveReturnTypeNode(node: SignatureDeclaration | JSDocSignature): TypeNode | undefined {
-    return isJSDocSignature(node) ?
-        node.type && node.type.typeExpression && node.type.typeExpression.type :
-        node.type || (isInJSFile(node) ? getJSDocReturnType(node) : undefined);
+    return isJSDocSignature(node)
+        ? node.type && node.type.typeExpression && node.type.typeExpression.type
+        : node.type || (isInJSFile(node) ? getJSDocReturnType(node) : undefined);
 }
 
 /** @internal */
@@ -6634,8 +6634,8 @@ export function emitNewLineBeforeLeadingComments(lineMap: readonly number[], wri
 export function emitNewLineBeforeLeadingCommentsOfPosition(lineMap: readonly number[], writer: EmitTextWriter, pos: number, leadingComments: readonly CommentRange[] | undefined) {
     // If the leading comments start on different line than the start of node, write new line
     if (
-        leadingComments && leadingComments.length && pos !== leadingComments[0].pos &&
-        getLineOfLocalPositionFromLineMap(lineMap, pos) !== getLineOfLocalPositionFromLineMap(lineMap, leadingComments[0].pos)
+        leadingComments && leadingComments.length && pos !== leadingComments[0].pos
+        && getLineOfLocalPositionFromLineMap(lineMap, pos) !== getLineOfLocalPositionFromLineMap(lineMap, leadingComments[0].pos)
     ) {
         writer.writeLine();
     }
@@ -6645,8 +6645,8 @@ export function emitNewLineBeforeLeadingCommentsOfPosition(lineMap: readonly num
 export function emitNewLineBeforeLeadingCommentOfPosition(lineMap: readonly number[], writer: EmitTextWriter, pos: number, commentPos: number) {
     // If the leading comments start on different line than the start of node, write new line
     if (
-        pos !== commentPos &&
-        getLineOfLocalPositionFromLineMap(lineMap, pos) !== getLineOfLocalPositionFromLineMap(lineMap, commentPos)
+        pos !== commentPos
+        && getLineOfLocalPositionFromLineMap(lineMap, pos) !== getLineOfLocalPositionFromLineMap(lineMap, commentPos)
     ) {
         writer.writeLine();
     }
@@ -6993,8 +6993,8 @@ function selectSyntacticModifierFlags(flags: ModifierFlags) {
 }
 
 function selectEffectiveModifierFlags(flags: ModifierFlags) {
-    return (flags & ModifierFlags.NonCacheOnlyModifiers) |
-        ((flags & ModifierFlags.JSDocCacheOnlyModifiers) >>> 23); // shift ModifierFlags.JSDoc* to match ModifierFlags.*
+    return (flags & ModifierFlags.NonCacheOnlyModifiers)
+        | ((flags & ModifierFlags.JSDocCacheOnlyModifiers) >>> 23); // shift ModifierFlags.JSDoc* to match ModifierFlags.*
 }
 
 function getJSDocModifierFlagsNoCache(node: Node): ModifierFlags {
@@ -7247,9 +7247,9 @@ export function isPrototypeAccess(node: Node): node is BindableStaticAccessExpre
 
 /** @internal */
 export function isRightSideOfQualifiedNameOrPropertyAccess(node: Node) {
-    return (node.parent.kind === SyntaxKind.QualifiedName && (node.parent as QualifiedName).right === node) ||
-        (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).name === node) ||
-        (node.parent.kind === SyntaxKind.MetaProperty && (node.parent as MetaProperty).name === node);
+    return (node.parent.kind === SyntaxKind.QualifiedName && (node.parent as QualifiedName).right === node)
+        || (node.parent.kind === SyntaxKind.PropertyAccessExpression && (node.parent as PropertyAccessExpression).name === node)
+        || (node.parent.kind === SyntaxKind.MetaProperty && (node.parent as MetaProperty).name === node);
 }
 
 /** @internal */
@@ -7276,14 +7276,14 @@ export function isRightSideOfInstanceofExpression(node: Node) {
 
 /** @internal */
 export function isEmptyObjectLiteral(expression: Node): boolean {
-    return expression.kind === SyntaxKind.ObjectLiteralExpression &&
-        (expression as ObjectLiteralExpression).properties.length === 0;
+    return expression.kind === SyntaxKind.ObjectLiteralExpression
+        && (expression as ObjectLiteralExpression).properties.length === 0;
 }
 
 /** @internal */
 export function isEmptyArrayLiteral(expression: Node): boolean {
-    return expression.kind === SyntaxKind.ArrayLiteralExpression &&
-        (expression as ArrayLiteralExpression).elements.length === 0;
+    return expression.kind === SyntaxKind.ArrayLiteralExpression
+        && (expression as ArrayLiteralExpression).elements.length === 0;
 }
 
 /** @internal */
@@ -7725,9 +7725,9 @@ export function getDeclarationModifierFlagsFromSymbol(s: Symbol, isWrite = false
     if (getCheckFlags(s) & CheckFlags.Synthetic) {
         // NOTE: potentially unchecked cast to TransientSymbol
         const checkFlags = (s as TransientSymbol).links.checkFlags;
-        const accessModifier = checkFlags & CheckFlags.ContainsPrivate ? ModifierFlags.Private :
-            checkFlags & CheckFlags.ContainsPublic ? ModifierFlags.Public :
-            ModifierFlags.Protected;
+        const accessModifier = checkFlags & CheckFlags.ContainsPrivate ? ModifierFlags.Private
+            : checkFlags & CheckFlags.ContainsPublic ? ModifierFlags.Public
+            : ModifierFlags.Protected;
         const staticModifier = checkFlags & CheckFlags.ContainsStatic ? ModifierFlags.Static : 0;
         return accessModifier | staticModifier;
     }
@@ -7781,8 +7781,8 @@ function accessKind(node: Node): AccessKind {
             return operator === SyntaxKind.PlusPlusToken || operator === SyntaxKind.MinusMinusToken ? AccessKind.ReadWrite : AccessKind.Read;
         case SyntaxKind.BinaryExpression:
             const { left, operatorToken } = parent as BinaryExpression;
-            return left === node && isAssignmentOperator(operatorToken.kind) ?
-                operatorToken.kind === SyntaxKind.EqualsToken ? AccessKind.Write : AccessKind.ReadWrite
+            return left === node && isAssignmentOperator(operatorToken.kind)
+                ? operatorToken.kind === SyntaxKind.EqualsToken ? AccessKind.Write : AccessKind.ReadWrite
                 : AccessKind.Read;
         case SyntaxKind.PropertyAccessExpression:
             return (parent as PropertyAccessExpression).name !== node ? AccessKind.Read : accessKind(parent);
@@ -8450,19 +8450,19 @@ function getDiagnosticFilePath(diagnostic: Diagnostic): string | undefined {
 
 /** @internal */
 export function compareDiagnostics(d1: Diagnostic, d2: Diagnostic): Comparison {
-    return compareDiagnosticsSkipRelatedInformation(d1, d2) ||
-        compareRelatedInformation(d1, d2) ||
-        Comparison.EqualTo;
+    return compareDiagnosticsSkipRelatedInformation(d1, d2)
+        || compareRelatedInformation(d1, d2)
+        || Comparison.EqualTo;
 }
 
 /** @internal */
 export function compareDiagnosticsSkipRelatedInformation(d1: Diagnostic, d2: Diagnostic): Comparison {
-    return compareStringsCaseSensitive(getDiagnosticFilePath(d1), getDiagnosticFilePath(d2)) ||
-        compareValues(d1.start, d2.start) ||
-        compareValues(d1.length, d2.length) ||
-        compareValues(d1.code, d2.code) ||
-        compareMessageText(d1.messageText, d2.messageText) ||
-        Comparison.EqualTo;
+    return compareStringsCaseSensitive(getDiagnosticFilePath(d1), getDiagnosticFilePath(d2))
+        || compareValues(d1.start, d2.start)
+        || compareValues(d1.length, d2.length)
+        || compareValues(d1.code, d2.code)
+        || compareMessageText(d1.messageText, d2.messageText)
+        || Comparison.EqualTo;
 }
 
 function compareRelatedInformation(d1: Diagnostic, d2: Diagnostic): Comparison {
@@ -8597,18 +8597,18 @@ export const computedOptions = createComputedCompilerOptions({
         dependencies: ["module"],
         computeValue: compilerOptions => {
             const target = compilerOptions.target === ScriptTarget.ES3 ? undefined : compilerOptions.target;
-            return target ??
-                ((compilerOptions.module === ModuleKind.Node16 && ScriptTarget.ES2022) ||
-                    (compilerOptions.module === ModuleKind.NodeNext && ScriptTarget.ESNext) ||
-                    ScriptTarget.ES5);
+            return target
+                ?? ((compilerOptions.module === ModuleKind.Node16 && ScriptTarget.ES2022)
+                    || (compilerOptions.module === ModuleKind.NodeNext && ScriptTarget.ESNext)
+                    || ScriptTarget.ES5);
         },
     },
     module: {
         dependencies: ["target"],
         computeValue: (compilerOptions): ModuleKind => {
-            return typeof compilerOptions.module === "number" ?
-                compilerOptions.module :
-                computedOptions.target.computeValue(compilerOptions) >= ScriptTarget.ES2015 ? ModuleKind.ES2015 : ModuleKind.CommonJS;
+            return typeof compilerOptions.module === "number"
+                ? compilerOptions.module
+                : computedOptions.target.computeValue(compilerOptions) >= ScriptTarget.ES2015 ? ModuleKind.ES2015 : ModuleKind.CommonJS;
         },
     },
     moduleResolution: {
@@ -8640,9 +8640,9 @@ export const computedOptions = createComputedCompilerOptions({
     moduleDetection: {
         dependencies: ["module", "target"],
         computeValue: (compilerOptions): ModuleDetectionKind => {
-            return compilerOptions.moduleDetection ||
-                (computedOptions.module.computeValue(compilerOptions) === ModuleKind.Node16 ||
-                        computedOptions.module.computeValue(compilerOptions) === ModuleKind.NodeNext ? ModuleDetectionKind.Force : ModuleDetectionKind.Auto);
+            return compilerOptions.moduleDetection
+                || (computedOptions.module.computeValue(compilerOptions) === ModuleKind.Node16
+                        || computedOptions.module.computeValue(compilerOptions) === ModuleKind.NodeNext ? ModuleDetectionKind.Force : ModuleDetectionKind.Auto);
         },
     },
     isolatedModules: {
@@ -8915,9 +8915,9 @@ export function compilerOptionsAffectDeclarationPath(newOptions: CompilerOptions
 
 /** @internal */
 export function getCompilerOptionValue(options: CompilerOptions, option: CommandLineOption): unknown {
-    return option.strictFlag ? getStrictOptionValue(options, option.name as StrictOptionName) :
-        option.allowJsFlag ? getAllowJSCompilerOption(options) :
-        options[option.name];
+    return option.strictFlag ? getStrictOptionValue(options, option.name as StrictOptionName)
+        : option.allowJsFlag ? getAllowJSCompilerOption(options)
+        : options[option.name];
 }
 
 /** @internal */
@@ -8930,12 +8930,12 @@ export function getJSXTransformEnabled(options: CompilerOptions): boolean {
 export function getJSXImplicitImportBase(compilerOptions: CompilerOptions, file?: SourceFile): string | undefined {
     const jsxImportSourcePragmas = file?.pragmas.get("jsximportsource");
     const jsxImportSourcePragma = isArray(jsxImportSourcePragmas) ? jsxImportSourcePragmas[jsxImportSourcePragmas.length - 1] : jsxImportSourcePragmas;
-    return compilerOptions.jsx === JsxEmit.ReactJSX ||
-            compilerOptions.jsx === JsxEmit.ReactJSXDev ||
-            compilerOptions.jsxImportSource ||
-            jsxImportSourcePragma ?
-        jsxImportSourcePragma?.arguments.factory || compilerOptions.jsxImportSource || "react" :
-        undefined;
+    return compilerOptions.jsx === JsxEmit.ReactJSX
+            || compilerOptions.jsx === JsxEmit.ReactJSXDev
+            || compilerOptions.jsxImportSource
+            || jsxImportSourcePragma
+        ? jsxImportSourcePragma?.arguments.factory || compilerOptions.jsxImportSource || "react"
+        : undefined;
 }
 
 /** @internal */
@@ -9062,10 +9062,10 @@ function guessDirectorySymlink(a: string, b: string, cwd: string, getCanonicalFi
     const bParts = getPathComponents(getNormalizedAbsolutePath(b, cwd));
     let isDirectory = false;
     while (
-        aParts.length >= 2 && bParts.length >= 2 &&
-        !isNodeModulesOrScopedPackageDirectory(aParts[aParts.length - 2], getCanonicalFileName) &&
-        !isNodeModulesOrScopedPackageDirectory(bParts[bParts.length - 2], getCanonicalFileName) &&
-        getCanonicalFileName(aParts[aParts.length - 1]) === getCanonicalFileName(bParts[bParts.length - 1])
+        aParts.length >= 2 && bParts.length >= 2
+        && !isNodeModulesOrScopedPackageDirectory(aParts[aParts.length - 2], getCanonicalFileName)
+        && !isNodeModulesOrScopedPackageDirectory(bParts[bParts.length - 2], getCanonicalFileName)
+        && getCanonicalFileName(aParts[aParts.length - 1]) === getCanonicalFileName(bParts[bParts.length - 1])
     ) {
         aParts.pop();
         bParts.pop();
@@ -9380,8 +9380,8 @@ export function matchFiles(path: string, extensions: readonly string[] | undefin
             const name = combinePaths(path, current);
             const absoluteName = combinePaths(absolutePath, current);
             if (
-                (!includeDirectoryRegex || includeDirectoryRegex.test(absoluteName)) &&
-                (!excludeRegex || !excludeRegex.test(absoluteName))
+                (!includeDirectoryRegex || includeDirectoryRegex.test(absoluteName))
+                && (!excludeRegex || !excludeRegex.test(absoluteName))
             ) {
                 visitDirectory(name, absoluteName, depth);
             }
@@ -9593,15 +9593,15 @@ export function getModuleSpecifierEndingPreference(preference: UserPreferences["
 
     function inferPreference() {
         let usesJsExtensions = false;
-        const specifiers = sourceFile.imports.length ? sourceFile.imports :
-            isSourceFileJS(sourceFile) ? getRequiresAtTopOfFile(sourceFile).map(r => r.arguments[0]) :
-            emptyArray;
+        const specifiers = sourceFile.imports.length ? sourceFile.imports
+            : isSourceFileJS(sourceFile) ? getRequiresAtTopOfFile(sourceFile).map(r => r.arguments[0])
+            : emptyArray;
         for (const specifier of specifiers) {
             if (pathIsRelative(specifier.text)) {
                 if (
-                    moduleResolutionIsNodeNext &&
-                    resolutionMode === ModuleKind.CommonJS &&
-                    getModeForUsageLocation(sourceFile, specifier, compilerOptions) === ModuleKind.ESNext
+                    moduleResolutionIsNodeNext
+                    && resolutionMode === ModuleKind.CommonJS
+                    && getModeForUsageLocation(sourceFile, specifier, compilerOptions) === ModuleKind.ESNext
                 ) {
                     // We're trying to decide a preference for a CommonJS module specifier, but looking at an ESM import.
                     continue;
@@ -9856,9 +9856,9 @@ export function skipTypeChecking(sourceFile: SourceFile, options: CompilerOption
     // If skipLibCheck is enabled, skip reporting errors if file is a declaration file.
     // If skipDefaultLibCheck is enabled, skip reporting errors if file contains a
     // '/// <reference no-default-lib="true"/>' directive.
-    return (options.skipLibCheck && sourceFile.isDeclarationFile ||
-        options.skipDefaultLibCheck && sourceFile.hasNoDefaultLib) ||
-        host.isSourceOfProjectReferenceRedirect(sourceFile.fileName);
+    return (options.skipLibCheck && sourceFile.isDeclarationFile
+        || options.skipDefaultLibCheck && sourceFile.hasNoDefaultLib)
+        || host.isSourceOfProjectReferenceRedirect(sourceFile.fileName);
 }
 
 /** @internal */
@@ -9911,8 +9911,8 @@ export function parsePseudoBigInt(stringValue: string): string {
         // Find character range: 0-9 < A-F < a-f
         const digit = digitChar <= CharacterCodes._9
             ? digitChar - CharacterCodes._0
-            : 10 + digitChar -
-                (digitChar <= CharacterCodes.F ? CharacterCodes.A : CharacterCodes.a);
+            : 10 + digitChar
+                - (digitChar <= CharacterCodes.F ? CharacterCodes.A : CharacterCodes.a);
         const shiftedDigit = digit << (bitOffset & 15);
         segments[segment] |= shiftedDigit;
         const residual = shiftedDigit >>> 16;
@@ -10208,9 +10208,9 @@ export function expressionResultIsUnused(node: Expression): boolean {
         }
         // result is unused in an expression statement, `void` expression, or the initializer or incrementer of a `for` loop
         if (
-            isExpressionStatement(parent) ||
-            isVoidExpression(parent) ||
-            isForStatement(parent) && (parent.initializer === node || parent.incrementor === node)
+            isExpressionStatement(parent)
+            || isVoidExpression(parent)
+            || isForStatement(parent) && (parent.initializer === node || parent.incrementor === node)
         ) {
             return true;
         }
@@ -10252,8 +10252,8 @@ export function getContainingNodeArray(node: Node): NodeArray<Node> | undefined 
             return (node as TemplateSpan).parent.templateSpans;
         case SyntaxKind.Decorator: {
             const { parent } = node as Decorator;
-            return canHaveDecorators(parent) ? parent.modifiers :
-                undefined;
+            return canHaveDecorators(parent) ? parent.modifiers
+                : undefined;
         }
         case SyntaxKind.HeritageClause:
             return (node as HeritageClause).parent.heritageClauses;
@@ -10282,9 +10282,9 @@ export function getContainingNodeArray(node: Node): NodeArray<Node> | undefined 
             return (parent as ObjectLiteralExpressionBase<ObjectLiteralElement>).properties;
         case SyntaxKind.CallExpression:
         case SyntaxKind.NewExpression:
-            return isTypeNode(node) ? (parent as CallExpression | NewExpression).typeArguments :
-                (parent as CallExpression | NewExpression).expression === node ? undefined :
-                (parent as CallExpression | NewExpression).arguments;
+            return isTypeNode(node) ? (parent as CallExpression | NewExpression).typeArguments
+                : (parent as CallExpression | NewExpression).expression === node ? undefined
+                : (parent as CallExpression | NewExpression).arguments;
         case SyntaxKind.JsxElement:
         case SyntaxKind.JsxFragment:
             return isJsxChild(node) ? (parent as JsxElement | JsxFragment).children : undefined;
@@ -10377,9 +10377,9 @@ export function isNumericLiteralName(name: string | __String) {
 /** @internal */
 export function createPropertyNameNodeForIdentifierOrLiteral(name: string, target: ScriptTarget, singleQuote: boolean, stringNamed: boolean, isMethod: boolean) {
     const isMethodNamedNew = isMethod && name === "new";
-    return !isMethodNamedNew && isIdentifierText(name, target) ? factory.createIdentifier(name) :
-        !stringNamed && !isMethodNamedNew && isNumericLiteralName(name) && +name >= 0 ? factory.createNumericLiteral(+name) :
-        factory.createStringLiteral(name, !!singleQuote);
+    return !isMethodNamedNew && isIdentifierText(name, target) ? factory.createIdentifier(name)
+        : !stringNamed && !isMethodNamedNew && isNumericLiteralName(name) && +name >= 0 ? factory.createNumericLiteral(+name)
+        : factory.createStringLiteral(name, !!singleQuote);
 }
 
 /** @internal */
@@ -10501,9 +10501,9 @@ export function canUsePropertyAccess(name: string, languageVersion: ScriptTarget
         return false;
     }
     const firstChar = name.charCodeAt(0);
-    return firstChar === CharacterCodes.hash ?
-        name.length > 1 && isIdentifierStart(name.charCodeAt(1), languageVersion) :
-        isIdentifierStart(firstChar, languageVersion);
+    return firstChar === CharacterCodes.hash
+        ? name.length > 1 && isIdentifierStart(name.charCodeAt(1), languageVersion)
+        : isIdentifierStart(firstChar, languageVersion);
 }
 
 /** @internal */
@@ -10650,8 +10650,8 @@ export function isSyntacticallyString(expr: Expression): boolean {
             const left = (expr as BinaryExpression).left;
             const right = (expr as BinaryExpression).right;
             return (
-                (expr as BinaryExpression).operatorToken.kind === SyntaxKind.PlusToken &&
-                (isSyntacticallyString(left) || isSyntacticallyString(right))
+                (expr as BinaryExpression).operatorToken.kind === SyntaxKind.PlusToken
+                && (isSyntacticallyString(left) || isSyntacticallyString(right))
             );
         case SyntaxKind.TemplateExpression:
         case SyntaxKind.StringLiteral:

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -940,8 +940,8 @@ export function getNonAssignedNameOfDeclaration(declaration: Declaration | Expre
 
 export function getNameOfDeclaration(declaration: Declaration | Expression | undefined): DeclarationName | undefined {
     if (declaration === undefined) return undefined;
-    return getNonAssignedNameOfDeclaration(declaration) ||
-        (isFunctionExpression(declaration) || isArrowFunction(declaration) || isClassExpression(declaration) ? getAssignedName(declaration) : undefined);
+    return getNonAssignedNameOfDeclaration(declaration)
+        || (isFunctionExpression(declaration) || isArrowFunction(declaration) || isClassExpression(declaration) ? getAssignedName(declaration) : undefined);
 }
 
 /** @internal */
@@ -1298,9 +1298,9 @@ export function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeP
 }
 
 export function getEffectiveConstraintOfTypeParameter(node: TypeParameterDeclaration): TypeNode | undefined {
-    return node.constraint ? node.constraint :
-        isJSDocTemplateTag(node.parent) && node === node.parent.typeParameters[0] ? node.parent.constraint :
-        undefined;
+    return node.constraint ? node.constraint
+        : isJSDocTemplateTag(node.parent) && node === node.parent.typeParameters[0] ? node.parent.constraint
+        : undefined;
 }
 
 // #region
@@ -1328,8 +1328,8 @@ export function isCallChain(node: Node): node is CallChain {
 
 export function isOptionalChain(node: Node): node is PropertyAccessChain | ElementAccessChain | CallChain | NonNullChain {
     const kind = node.kind;
-    return !!(node.flags & NodeFlags.OptionalChain) &&
-        (kind === SyntaxKind.PropertyAccessExpression
+    return !!(node.flags & NodeFlags.OptionalChain)
+        && (kind === SyntaxKind.PropertyAccessExpression
             || kind === SyntaxKind.ElementAccessExpression
             || kind === SyntaxKind.CallExpression
             || kind === SyntaxKind.NonNullExpression);
@@ -1373,8 +1373,8 @@ export function isNullishCoalesce(node: Node) {
 }
 
 export function isConstTypeReference(node: Node) {
-    return isTypeReferenceNode(node) && isIdentifier(node.typeName) &&
-        node.typeName.escapedText === "const" && !node.typeArguments;
+    return isTypeReferenceNode(node) && isIdentifier(node.typeName)
+        && node.typeName.escapedText === "const" && !node.typeArguments;
 }
 
 export function skipPartiallyEmittedExpressions(node: Expression): Expression;
@@ -1586,10 +1586,10 @@ export function isParameterPropertyModifier(kind: SyntaxKind): boolean {
 
 /** @internal */
 export function isClassMemberModifier(idToken: SyntaxKind): boolean {
-    return isParameterPropertyModifier(idToken) ||
-        idToken === SyntaxKind.StaticKeyword ||
-        idToken === SyntaxKind.OverrideKeyword ||
-        idToken === SyntaxKind.AccessorKeyword;
+    return isParameterPropertyModifier(idToken)
+        || idToken === SyntaxKind.StaticKeyword
+        || idToken === SyntaxKind.OverrideKeyword
+        || idToken === SyntaxKind.AccessorKeyword;
 }
 
 export function isModifier(node: Node): node is Modifier {
@@ -2018,8 +2018,8 @@ export function isUnaryExpressionWithWrite(expr: Node): expr is PrefixUnaryExpre
         case SyntaxKind.PostfixUnaryExpression:
             return true;
         case SyntaxKind.PrefixUnaryExpression:
-            return (expr as PrefixUnaryExpression).operator === SyntaxKind.PlusPlusToken ||
-                (expr as PrefixUnaryExpression).operator === SyntaxKind.MinusMinusToken;
+            return (expr as PrefixUnaryExpression).operator === SyntaxKind.PlusPlusToken
+                || (expr as PrefixUnaryExpression).operator === SyntaxKind.MinusMinusToken;
         default:
             return false;
     }

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -405,8 +405,8 @@ export function visitParameterList(nodes: NodeArray<ParameterDeclaration> | unde
         // in a parameter list to the body if we detect a variable being hoisted while visiting a parameter list
         // when the emit target is greater than ES2015.
         if (
-            context.getLexicalEnvironmentFlags() & LexicalEnvironmentFlags.VariablesHoistedInParameters &&
-            getEmitScriptTarget(context.getCompilerOptions()) >= ScriptTarget.ES2015
+            context.getLexicalEnvironmentFlags() & LexicalEnvironmentFlags.VariablesHoistedInParameters
+            && getEmitScriptTarget(context.getCompilerOptions()) >= ScriptTarget.ES2015
         ) {
             updated = addDefaultValueAssignmentsIfNeeded(updated, context);
         }
@@ -435,10 +435,10 @@ function addDefaultValueAssignmentsIfNeeded(parameters: NodeArray<ParameterDecla
 function addDefaultValueAssignmentIfNeeded(parameter: ParameterDeclaration, context: TransformationContext) {
     // A rest parameter cannot have a binding pattern or an initializer,
     // so let's just ignore it.
-    return parameter.dotDotDotToken ? parameter :
-        isBindingPattern(parameter.name) ? addDefaultValueAssignmentForBindingPattern(parameter, context) :
-        parameter.initializer ? addDefaultValueAssignmentForInitializer(parameter, parameter.name, parameter.initializer, context) :
-        parameter;
+    return parameter.dotDotDotToken ? parameter
+        : isBindingPattern(parameter.name) ? addDefaultValueAssignmentForBindingPattern(parameter, context)
+        : parameter.initializer ? addDefaultValueAssignmentForInitializer(parameter, parameter.name, parameter.initializer, context)
+        : parameter;
 }
 
 function addDefaultValueAssignmentForBindingPattern(parameter: ParameterDeclaration, context: TransformationContext) {
@@ -451,8 +451,8 @@ function addDefaultValueAssignmentForBindingPattern(parameter: ParameterDeclarat
                     parameter.name,
                     /*exclamationToken*/ undefined,
                     parameter.type,
-                    parameter.initializer ?
-                        factory.createConditionalExpression(
+                    parameter.initializer
+                        ? factory.createConditionalExpression(
                             factory.createStrictEquality(
                                 factory.getGeneratedNameForNode(parameter),
                                 factory.createVoidZero(),
@@ -461,8 +461,8 @@ function addDefaultValueAssignmentForBindingPattern(parameter: ParameterDeclarat
                             parameter.initializer,
                             /*colonToken*/ undefined,
                             factory.getGeneratedNameForNode(parameter),
-                        ) :
-                        factory.getGeneratedNameForNode(parameter),
+                        )
+                        : factory.getGeneratedNameForNode(parameter),
                 ),
             ]),
         ),
@@ -1018,14 +1018,14 @@ const visitEachChildTable: VisitEachChildTable = {
     },
 
     [SyntaxKind.PropertyAccessExpression]: function visitEachChildOfPropertyAccessExpression(node, visitor, context, _nodesVisitor, nodeVisitor, tokenVisitor) {
-        return isPropertyAccessChain(node) ?
-            context.factory.updatePropertyAccessChain(
+        return isPropertyAccessChain(node)
+            ? context.factory.updatePropertyAccessChain(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
                 tokenVisitor ? nodeVisitor(node.questionDotToken, tokenVisitor, isQuestionDotToken) : node.questionDotToken,
                 Debug.checkDefined(nodeVisitor(node.name, visitor, isMemberName)),
-            ) :
-            context.factory.updatePropertyAccessExpression(
+            )
+            : context.factory.updatePropertyAccessExpression(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
                 Debug.checkDefined(nodeVisitor(node.name, visitor, isMemberName)),
@@ -1033,14 +1033,14 @@ const visitEachChildTable: VisitEachChildTable = {
     },
 
     [SyntaxKind.ElementAccessExpression]: function visitEachChildOfElementAccessExpression(node, visitor, context, _nodesVisitor, nodeVisitor, tokenVisitor) {
-        return isElementAccessChain(node) ?
-            context.factory.updateElementAccessChain(
+        return isElementAccessChain(node)
+            ? context.factory.updateElementAccessChain(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
                 tokenVisitor ? nodeVisitor(node.questionDotToken, tokenVisitor, isQuestionDotToken) : node.questionDotToken,
                 Debug.checkDefined(nodeVisitor(node.argumentExpression, visitor, isExpression)),
-            ) :
-            context.factory.updateElementAccessExpression(
+            )
+            : context.factory.updateElementAccessExpression(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
                 Debug.checkDefined(nodeVisitor(node.argumentExpression, visitor, isExpression)),
@@ -1048,15 +1048,15 @@ const visitEachChildTable: VisitEachChildTable = {
     },
 
     [SyntaxKind.CallExpression]: function visitEachChildOfCallExpression(node, visitor, context, nodesVisitor, nodeVisitor, tokenVisitor) {
-        return isCallChain(node) ?
-            context.factory.updateCallChain(
+        return isCallChain(node)
+            ? context.factory.updateCallChain(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
                 tokenVisitor ? nodeVisitor(node.questionDotToken, tokenVisitor, isQuestionDotToken) : node.questionDotToken,
                 nodesVisitor(node.typeArguments, visitor, isTypeNode),
                 nodesVisitor(node.arguments, visitor, isExpression),
-            ) :
-            context.factory.updateCallExpression(
+            )
+            : context.factory.updateCallExpression(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
                 nodesVisitor(node.typeArguments, visitor, isTypeNode),
@@ -1243,12 +1243,12 @@ const visitEachChildTable: VisitEachChildTable = {
     },
 
     [SyntaxKind.NonNullExpression]: function visitEachChildOfNonNullExpression(node, visitor, context, _nodesVisitor, nodeVisitor, _tokenVisitor) {
-        return isOptionalChain(node) ?
-            context.factory.updateNonNullChain(
+        return isOptionalChain(node)
+            ? context.factory.updateNonNullChain(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
-            ) :
-            context.factory.updateNonNullExpression(
+            )
+            : context.factory.updateNonNullExpression(
                 node,
                 Debug.checkDefined(nodeVisitor(node.expression, visitor, isExpression)),
             );

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -141,11 +141,11 @@ export function createDiagnosticReporter(system: System, pretty?: boolean): Diag
  */
 function clearScreenIfNotWatchingForFileChanges(system: System, diagnostic: Diagnostic, options: CompilerOptions): boolean {
     if (
-        system.clearScreen &&
-        !options.preserveWatchOutput &&
-        !options.extendedDiagnostics &&
-        !options.diagnostics &&
-        contains(screenStartingMessageCodes, diagnostic.code)
+        system.clearScreen
+        && !options.preserveWatchOutput
+        && !options.extendedDiagnostics
+        && !options.diagnostics
+        && contains(screenStartingMessageCodes, diagnostic.code)
     ) {
         system.clearScreen();
         return true;
@@ -172,14 +172,14 @@ function getPlainDiagnosticFollowingNewLines(diagnostic: Diagnostic, newLine: st
  * @internal
  */
 export function getLocaleTimeString(system: System) {
-    return !system.now ?
-        new Date().toLocaleTimeString() :
+    return !system.now
+        ? new Date().toLocaleTimeString()
         // On some systems / builds of Node, there's a non-breaking space between the time and AM/PM.
         // This branch is solely for testing, so just switch it to a normal space for baseline stability.
         // See:
         //     - https://github.com/nodejs/node/issues/45171
         //     - https://github.com/nodejs/node/issues/45753
-        system.now().toLocaleTimeString("en-US", { timeZone: "UTC" }).replace("\u202f", " ");
+        : system.now().toLocaleTimeString("en-US", { timeZone: "UTC" }).replace("\u202f", " ");
 }
 
 /**
@@ -188,14 +188,14 @@ export function getLocaleTimeString(system: System) {
  * @internal
  */
 export function createWatchStatusReporter(system: System, pretty?: boolean): WatchStatusReporter {
-    return pretty ?
-        (diagnostic, newLine, options) => {
+    return pretty
+        ? (diagnostic, newLine, options) => {
             clearScreenIfNotWatchingForFileChanges(system, diagnostic, options);
             let output = `[${formatColorAndReset(getLocaleTimeString(system), ForegroundColorEscapeSequences.Grey)}] `;
             output += `${flattenDiagnosticMessageText(diagnostic.messageText, system.newLine)}${newLine + newLine}`;
             system.write(output);
-        } :
-        (diagnostic, newLine, options) => {
+        }
+        : (diagnostic, newLine, options) => {
             let output = "";
 
             if (!clearScreenIfNotWatchingForFileChanges(system, diagnostic, options)) {
@@ -255,9 +255,9 @@ export function getFilesInErrorForSummary(diagnostics: readonly Diagnostic[]): (
 
 /** @internal */
 export function getWatchErrorSummaryDiagnosticMessage(errorCount: number) {
-    return errorCount === 1 ?
-        Diagnostics.Found_1_error_Watching_for_file_changes :
-        Diagnostics.Found_0_errors_Watching_for_file_changes;
+    return errorCount === 1
+        ? Diagnostics.Found_1_error_Watching_for_file_changes
+        : Diagnostics.Found_0_errors_Watching_for_file_changes;
 }
 
 function prettyPathForFileError(error: ReportFileInError, cwd: string) {
@@ -288,9 +288,9 @@ export function getErrorSummaryText(
         messageAndArgs = filesInError[0] !== undefined ? [Diagnostics.Found_1_error_in_0, firstFileReference!] : [Diagnostics.Found_1_error];
     }
     else {
-        messageAndArgs = distinctFileNamesWithLines.length === 0 ? [Diagnostics.Found_0_errors, errorCount] :
-            distinctFileNamesWithLines.length === 1 ? [Diagnostics.Found_0_errors_in_the_same_file_starting_at_Colon_1, errorCount, firstFileReference!] :
-            [Diagnostics.Found_0_errors_in_1_files, errorCount, distinctFileNamesWithLines.length];
+        messageAndArgs = distinctFileNamesWithLines.length === 0 ? [Diagnostics.Found_0_errors, errorCount]
+            : distinctFileNamesWithLines.length === 1 ? [Diagnostics.Found_0_errors_in_the_same_file_starting_at_Colon_1, errorCount, firstFileReference!]
+            : [Diagnostics.Found_0_errors_in_1_files, errorCount, distinctFileNamesWithLines.length];
     }
 
     const d = createCompilerDiagnostic(...messageAndArgs);
@@ -316,8 +316,8 @@ function createTabularErrorsDisplay(filesInError: (ReportFileInError | undefined
     fileToErrorCount.forEach(row => {
         const [file, errorCount] = row;
         const errorCountDigitsLength = Math.log(errorCount) * Math.LOG10E + 1 | 0;
-        const leftPadding = errorCountDigitsLength < leftPaddingGoal ?
-            " ".repeat(leftPaddingGoal - errorCountDigitsLength)
+        const leftPadding = errorCountDigitsLength < leftPaddingGoal
+            ? " ".repeat(leftPaddingGoal - errorCountDigitsLength)
             : "";
 
         const fileRef = prettyPathForFileError(file!, host.getCurrentDirectory());
@@ -391,9 +391,9 @@ export function explainIfFileIsRedirectAndImpliedFormat(
                 if (file.packageJsonScope) {
                     (result ??= []).push(chainDiagnosticMessages(
                         /*details*/ undefined,
-                        file.packageJsonScope.contents.packageJsonContent.type ?
-                            Diagnostics.File_is_CommonJS_module_because_0_has_field_type_whose_value_is_not_module :
-                            Diagnostics.File_is_CommonJS_module_because_0_does_not_have_field_type,
+                        file.packageJsonScope.contents.packageJsonContent.type
+                            ? Diagnostics.File_is_CommonJS_module_because_0_has_field_type_whose_value_is_not_module
+                            : Diagnostics.File_is_CommonJS_module_because_0_does_not_have_field_type,
                         toFileName(last(file.packageJsonLocations!), fileNameConvertor),
                     ));
                 }
@@ -448,19 +448,19 @@ export function fileIncludeReasonToDiagnostics(program: Program, reason: FileInc
         switch (reason.kind) {
             case FileIncludeKind.Import:
                 if (isReferenceFileLocation(referenceLocation)) {
-                    message = referenceLocation.packageId ?
-                        Diagnostics.Imported_via_0_from_file_1_with_packageId_2 :
-                        Diagnostics.Imported_via_0_from_file_1;
+                    message = referenceLocation.packageId
+                        ? Diagnostics.Imported_via_0_from_file_1_with_packageId_2
+                        : Diagnostics.Imported_via_0_from_file_1;
                 }
                 else if (referenceLocation.text === externalHelpersModuleNameText) {
-                    message = referenceLocation.packageId ?
-                        Diagnostics.Imported_via_0_from_file_1_with_packageId_2_to_import_importHelpers_as_specified_in_compilerOptions :
-                        Diagnostics.Imported_via_0_from_file_1_to_import_importHelpers_as_specified_in_compilerOptions;
+                    message = referenceLocation.packageId
+                        ? Diagnostics.Imported_via_0_from_file_1_with_packageId_2_to_import_importHelpers_as_specified_in_compilerOptions
+                        : Diagnostics.Imported_via_0_from_file_1_to_import_importHelpers_as_specified_in_compilerOptions;
                 }
                 else {
-                    message = referenceLocation.packageId ?
-                        Diagnostics.Imported_via_0_from_file_1_with_packageId_2_to_import_jsx_and_jsxs_factory_functions :
-                        Diagnostics.Imported_via_0_from_file_1_to_import_jsx_and_jsxs_factory_functions;
+                    message = referenceLocation.packageId
+                        ? Diagnostics.Imported_via_0_from_file_1_with_packageId_2_to_import_jsx_and_jsxs_factory_functions
+                        : Diagnostics.Imported_via_0_from_file_1_to_import_jsx_and_jsxs_factory_functions;
                 }
                 break;
             case FileIncludeKind.ReferenceFile:
@@ -468,9 +468,9 @@ export function fileIncludeReasonToDiagnostics(program: Program, reason: FileInc
                 message = Diagnostics.Referenced_via_0_from_file_1;
                 break;
             case FileIncludeKind.TypeReferenceDirective:
-                message = referenceLocation.packageId ?
-                    Diagnostics.Type_library_referenced_via_0_from_file_1_with_packageId_2 :
-                    Diagnostics.Type_library_referenced_via_0_from_file_1;
+                message = referenceLocation.packageId
+                    ? Diagnostics.Type_library_referenced_via_0_from_file_1_with_packageId_2
+                    : Diagnostics.Type_library_referenced_via_0_from_file_1;
                 break;
             case FileIncludeKind.LibReferenceDirective:
                 Debug.assert(!referenceLocation.packageId);
@@ -494,19 +494,19 @@ export function fileIncludeReasonToDiagnostics(program: Program, reason: FileInc
             const matchedByFiles = getMatchedFileSpec(program, fileName);
             if (matchedByFiles) return chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Part_of_files_list_in_tsconfig_json);
             const matchedByInclude = getMatchedIncludeSpec(program, fileName);
-            return isString(matchedByInclude) ?
-                chainDiagnosticMessages(
+            return isString(matchedByInclude)
+                ? chainDiagnosticMessages(
                     /*details*/ undefined,
                     Diagnostics.Matched_by_include_pattern_0_in_1,
                     matchedByInclude,
                     toFileName(options.configFile, fileNameConvertor),
-                ) :
+                )
                 // Could be additional files specified as roots or matched by default include
-                chainDiagnosticMessages(
+                : chainDiagnosticMessages(
                     /*details*/ undefined,
-                    matchedByInclude ?
-                        Diagnostics.Matched_by_default_include_pattern_Asterisk_Asterisk_Slash_Asterisk :
-                        Diagnostics.Root_file_specified_for_compilation,
+                    matchedByInclude
+                        ? Diagnostics.Matched_by_default_include_pattern_Asterisk_Asterisk_Slash_Asterisk
+                        : Diagnostics.Root_file_specified_for_compilation,
                 );
         case FileIncludeKind.SourceFromProjectReference:
         case FileIncludeKind.OutputFromProjectReference:
@@ -514,24 +514,24 @@ export function fileIncludeReasonToDiagnostics(program: Program, reason: FileInc
             const referencedResolvedRef = Debug.checkDefined(program.getResolvedProjectReferences()?.[reason.index]);
             return chainDiagnosticMessages(
                 /*details*/ undefined,
-                options.outFile ?
-                    isOutput ?
-                        Diagnostics.Output_from_referenced_project_0_included_because_1_specified :
-                        Diagnostics.Source_from_referenced_project_0_included_because_1_specified :
-                    isOutput ?
-                    Diagnostics.Output_from_referenced_project_0_included_because_module_is_specified_as_none :
-                    Diagnostics.Source_from_referenced_project_0_included_because_module_is_specified_as_none,
+                options.outFile
+                    ? isOutput
+                        ? Diagnostics.Output_from_referenced_project_0_included_because_1_specified
+                        : Diagnostics.Source_from_referenced_project_0_included_because_1_specified
+                    : isOutput
+                    ? Diagnostics.Output_from_referenced_project_0_included_because_module_is_specified_as_none
+                    : Diagnostics.Source_from_referenced_project_0_included_because_module_is_specified_as_none,
                 toFileName(referencedResolvedRef.sourceFile.fileName, fileNameConvertor),
                 options.outFile ? "--outFile" : "--out",
             );
         case FileIncludeKind.AutomaticTypeDirectiveFile: {
-            const messageAndArgs: DiagnosticAndArguments = options.types ?
-                reason.packageId ?
-                    [Diagnostics.Entry_point_of_type_library_0_specified_in_compilerOptions_with_packageId_1, reason.typeReference, packageIdToString(reason.packageId)] :
-                    [Diagnostics.Entry_point_of_type_library_0_specified_in_compilerOptions, reason.typeReference] :
-                reason.packageId ?
-                [Diagnostics.Entry_point_for_implicit_type_library_0_with_packageId_1, reason.typeReference, packageIdToString(reason.packageId)] :
-                [Diagnostics.Entry_point_for_implicit_type_library_0, reason.typeReference];
+            const messageAndArgs: DiagnosticAndArguments = options.types
+                ? reason.packageId
+                    ? [Diagnostics.Entry_point_of_type_library_0_specified_in_compilerOptions_with_packageId_1, reason.typeReference, packageIdToString(reason.packageId)]
+                    : [Diagnostics.Entry_point_of_type_library_0_specified_in_compilerOptions, reason.typeReference]
+                : reason.packageId
+                ? [Diagnostics.Entry_point_for_implicit_type_library_0_with_packageId_1, reason.typeReference, packageIdToString(reason.packageId)]
+                : [Diagnostics.Entry_point_for_implicit_type_library_0, reason.typeReference];
 
             return chainDiagnosticMessages(/*details*/ undefined, ...messageAndArgs);
         }

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -513,9 +513,9 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
     // Cache for the module resolution
     const resolutionCache = createResolutionCache(
         compilerHost,
-        configFileName ?
-            getDirectoryPath(getNormalizedAbsolutePath(configFileName, currentDirectory)) :
-            currentDirectory,
+        configFileName
+            ? getDirectoryPath(getNormalizedAbsolutePath(configFileName, currentDirectory))
+            : currentDirectory,
         /*logChangesWhenResolvingModule*/ false,
     );
     // Resolve module using host module resolution strategy if provided otherwise use resolution cache to resolve module names
@@ -529,21 +529,21 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
     if (!compilerHost.resolveTypeReferenceDirectiveReferences && !compilerHost.resolveTypeReferenceDirectives) {
         compilerHost.resolveTypeReferenceDirectiveReferences = resolutionCache.resolveTypeReferenceDirectiveReferences.bind(resolutionCache);
     }
-    compilerHost.resolveLibrary = !host.resolveLibrary ?
-        resolutionCache.resolveLibrary.bind(resolutionCache) :
-        host.resolveLibrary.bind(host);
-    compilerHost.getModuleResolutionCache = host.resolveModuleNameLiterals || host.resolveModuleNames ?
-        maybeBind(host, host.getModuleResolutionCache) :
-        (() => resolutionCache.getModuleResolutionCache());
-    const userProvidedResolution = !!host.resolveModuleNameLiterals || !!host.resolveTypeReferenceDirectiveReferences ||
-        !!host.resolveModuleNames || !!host.resolveTypeReferenceDirectives;
+    compilerHost.resolveLibrary = !host.resolveLibrary
+        ? resolutionCache.resolveLibrary.bind(resolutionCache)
+        : host.resolveLibrary.bind(host);
+    compilerHost.getModuleResolutionCache = host.resolveModuleNameLiterals || host.resolveModuleNames
+        ? maybeBind(host, host.getModuleResolutionCache)
+        : (() => resolutionCache.getModuleResolutionCache());
+    const userProvidedResolution = !!host.resolveModuleNameLiterals || !!host.resolveTypeReferenceDirectiveReferences
+        || !!host.resolveModuleNames || !!host.resolveTypeReferenceDirectives;
     // All resolutions are invalid if user provided resolutions and didnt supply hasInvalidatedResolutions
-    const customHasInvalidatedResolutions = userProvidedResolution ?
-        maybeBind(host, host.hasInvalidatedResolutions) || returnTrue :
-        returnFalse;
-    const customHasInvalidLibResolutions = host.resolveLibrary ?
-        maybeBind(host, host.hasInvalidatedLibResolutions) || returnTrue :
-        returnFalse;
+    const customHasInvalidatedResolutions = userProvidedResolution
+        ? maybeBind(host, host.hasInvalidatedResolutions) || returnTrue
+        : returnFalse;
+    const customHasInvalidLibResolutions = host.resolveLibrary
+        ? maybeBind(host, host.hasInvalidatedLibResolutions) || returnTrue
+        : returnFalse;
 
     builderProgram = readBuilderProgram(compilerOptions, compilerHost) as any as T;
     synchronizeProgram();
@@ -554,9 +554,9 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
     // Update extended config file watch
     if (configFileName) updateExtendedConfigFilesWatches(toPath(configFileName), compilerOptions, watchOptions, WatchType.ExtendedConfigFile);
 
-    return configFileName ?
-        { getCurrentProgram: getCurrentBuilderProgram, getProgram: updateProgram, close, getResolutionCache } :
-        { getCurrentProgram: getCurrentBuilderProgram, getProgram: updateProgram, updateRootFileNames, close, getResolutionCache };
+    return configFileName
+        ? { getCurrentProgram: getCurrentBuilderProgram, getProgram: updateProgram, close, getResolutionCache }
+        : { getCurrentProgram: getCurrentBuilderProgram, getProgram: updateProgram, updateRootFileNames, close, getResolutionCache };
 
     function close() {
         clearInvalidateResolutionsOfFailedLookupLocations();
@@ -987,9 +987,9 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
         }
 
         writeLog(`Loading config file: ${configFileName}`);
-        const parsedCommandLine = host.getParsedCommandLine ?
-            host.getParsedCommandLine(configFileName) :
-            getParsedCommandLineFromConfigFileHost(configFileName);
+        const parsedCommandLine = host.getParsedCommandLine
+            ? host.getParsedCommandLine(configFileName)
+            : getParsedCommandLineFromConfigFileHost(configFileName);
         if (config) {
             config.parsedCommandLine = parsedCommandLine;
             config.updateLevel = undefined;
@@ -1059,9 +1059,9 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
 
     function watchMissingFilePath(missingFilePath: Path, missingFileName: string) {
         // If watching missing referenced config file, we are already watching it so no need for separate watcher
-        return parsedConfigs?.has(missingFilePath) ?
-            noopFileWatcher :
-            watchFilePath(
+        return parsedConfigs?.has(missingFilePath)
+            ? noopFileWatcher
+            : watchFilePath(
                 missingFilePath,
                 missingFileName,
                 onMissingFileChange,

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -222,8 +222,8 @@ export function createCachedDirectoryStructureHost(host: DirectoryStructureHost,
     function fileExists(fileName: string): boolean {
         const path = toPath(fileName);
         const result = getCachedFileSystemEntriesForBaseDir(path);
-        return result && hasEntry(result.sortedAndCanonicalizedFiles, getCanonicalFileName(getBaseNameOfFileName(fileName))) ||
-            host.fileExists(fileName);
+        return result && hasEntry(result.sortedAndCanonicalizedFiles, getCanonicalFileName(getBaseNameOfFileName(fileName)))
+            || host.fileExists(fileName);
     }
 
     function directoryExists(dirPath: string): boolean {
@@ -270,9 +270,9 @@ export function createCachedDirectoryStructureHost(host: DirectoryStructureHost,
                 return rootResult || getFileSystemEntriesFromHost(dir, path);
             }
             const result = tryReadDirectory(dir, path);
-            return result !== undefined ?
-                result || getFileSystemEntriesFromHost(dir, path) :
-                emptyFileSystemEntries;
+            return result !== undefined
+                ? result || getFileSystemEntriesFromHost(dir, path)
+                : emptyFileSystemEntries;
         }
 
         function getFileSystemEntriesFromHost(dir: string, path: Path): FileSystemEntries {
@@ -582,8 +582,8 @@ export function isIgnoredFileFromWildCardWatching({
     // If the the added or created file or directory is not supported file name, ignore the file
     if (
         hasExtension(fileOrDirectoryPath) && !(
-            isSupportedSourceFileName(fileOrDirectory, options, extraFileExtensions) ||
-            isSupportedScriptKind()
+            isSupportedSourceFileName(fileOrDirectory, options, extraFileExtensions)
+            || isSupportedScriptKind()
         )
     ) {
         writeLog(`Project: ${configFileName} Detected file add/remove of non supported extension: ${fileOrDirectory}`);
@@ -615,8 +615,8 @@ export function isIgnoredFileFromWildCardWatching({
     const realProgram = isArray(program) ? undefined : isBuilderProgram(program) ? program.getProgramOrUndefined() : program;
     const builderProgram = !realProgram && !isArray(program) ? program as BuilderProgram : undefined;
     if (
-        hasSourceFile((filePathWithoutExtension + Extension.Ts) as Path) ||
-        hasSourceFile((filePathWithoutExtension + Extension.Tsx) as Path)
+        hasSourceFile((filePathWithoutExtension + Extension.Ts) as Path)
+        || hasSourceFile((filePathWithoutExtension + Extension.Tsx) as Path)
     ) {
         writeLog(`Project: ${configFileName} Detected output file: ${fileOrDirectory}`);
         return true;
@@ -624,11 +624,11 @@ export function isIgnoredFileFromWildCardWatching({
     return false;
 
     function hasSourceFile(file: Path): boolean {
-        return realProgram ?
-            !!realProgram.getSourceFileByPath(file) :
-            builderProgram ?
-            builderProgram.getState().fileInfos.has(file) :
-            !!find(program as readonly string[], rootFile => toPath(rootFile) === file);
+        return realProgram
+            ? !!realProgram.getSourceFileByPath(file)
+            : builderProgram
+            ? builderProgram.getState().fileInfos.has(file)
+            : !!find(program as readonly string[], rootFile => toPath(rootFile) === file);
     }
 
     function isSupportedScriptKind() {
@@ -694,21 +694,21 @@ export function getWatchFactory<X, Y = undefined>(host: WatchFactoryHost, watchL
         watchFile: (file, callback, pollingInterval, options) => host.watchFile(file, callback, pollingInterval, options),
         watchDirectory: (directory, callback, flags, options) => host.watchDirectory(directory, callback, (flags & WatchDirectoryFlags.Recursive) !== 0, options),
     };
-    const triggerInvokingFactory: WatchFactory<X, Y> | undefined = watchLogLevel !== WatchLogLevel.None ?
-        {
+    const triggerInvokingFactory: WatchFactory<X, Y> | undefined = watchLogLevel !== WatchLogLevel.None
+        ? {
             watchFile: createTriggerLoggingAddWatch("watchFile"),
             watchDirectory: createTriggerLoggingAddWatch("watchDirectory"),
-        } :
-        undefined;
-    const factory = watchLogLevel === WatchLogLevel.Verbose ?
-        {
+        }
+        : undefined;
+    const factory = watchLogLevel === WatchLogLevel.Verbose
+        ? {
             watchFile: createFileWatcherWithLogging,
             watchDirectory: createDirectoryWatcherWithLogging,
-        } :
-        triggerInvokingFactory || plainInvokeFactory;
-    const excludeWatcherFactory = watchLogLevel === WatchLogLevel.Verbose ?
-        createExcludeWatcherWithLogging :
-        returnNoopFileWatcher;
+        }
+        : triggerInvokingFactory || plainInvokeFactory;
+    const excludeWatcherFactory = watchLogLevel === WatchLogLevel.Verbose
+        ? createExcludeWatcherWithLogging
+        : returnNoopFileWatcher;
 
     return {
         watchFile: createExcludeHandlingAddWatch("watchFile"),
@@ -723,15 +723,15 @@ export function getWatchFactory<X, Y = undefined>(host: WatchFactoryHost, watchL
             options: WatchOptions | undefined,
             detailInfo1: X,
             detailInfo2?: Y,
-        ) => !matchesExclude(file, key === "watchFile" ? options?.excludeFiles : options?.excludeDirectories, useCaseSensitiveFileNames(), host.getCurrentDirectory?.() || "") ?
-            factory[key].call(/*thisArgs*/ undefined, file, cb, flags, options, detailInfo1, detailInfo2) :
-            excludeWatcherFactory(file, flags, options, detailInfo1, detailInfo2);
+        ) => !matchesExclude(file, key === "watchFile" ? options?.excludeFiles : options?.excludeDirectories, useCaseSensitiveFileNames(), host.getCurrentDirectory?.() || "")
+            ? factory[key].call(/*thisArgs*/ undefined, file, cb, flags, options, detailInfo1, detailInfo2)
+            : excludeWatcherFactory(file, flags, options, detailInfo1, detailInfo2);
     }
 
     function useCaseSensitiveFileNames() {
-        return typeof host.useCaseSensitiveFileNames === "boolean" ?
-            host.useCaseSensitiveFileNames :
-            host.useCaseSensitiveFileNames();
+        return typeof host.useCaseSensitiveFileNames === "boolean"
+            ? host.useCaseSensitiveFileNames
+            : host.useCaseSensitiveFileNames();
     }
 
     function createExcludeWatcherWithLogging(
@@ -826,9 +826,9 @@ export function getWatchFactory<X, Y = undefined>(host: WatchFactoryHost, watchL
 export function getFallbackOptions(options: WatchOptions | undefined): WatchOptions {
     const fallbackPolling = options?.fallbackPolling;
     return {
-        watchFile: fallbackPolling !== undefined ?
-            fallbackPolling as unknown as WatchFileKind :
-            WatchFileKind.PriorityPollingInterval,
+        watchFile: fallbackPolling !== undefined
+            ? fallbackPolling as unknown as WatchFileKind
+            : WatchFileKind.PriorityPollingInterval,
     };
 }
 

--- a/src/deprecatedCompat/deprecate.ts
+++ b/src/deprecatedCompat/deprecate.ts
@@ -54,9 +54,9 @@ export function createDeprecation(name: string, options: DeprecationOptions = {}
     const since = typeof options.since === "string" ? new Version(options.since) : options.since ?? warnAfter;
     const error = options.error || errorAfter && version.compareTo(errorAfter) >= 0;
     const warn = !warnAfter || version.compareTo(warnAfter) >= 0;
-    return error ? createErrorDeprecation(name, errorAfter, since, options.message) :
-        warn ? createWarningDeprecation(name, errorAfter, since, options.message) :
-        noop;
+    return error ? createErrorDeprecation(name, errorAfter, since, options.message)
+        : warn ? createWarningDeprecation(name, errorAfter, since, options.message)
+        : noop;
 }
 
 function wrapFunction<F extends (...args: any[]) => any>(deprecation: () => void, func: F): F {

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -149,9 +149,9 @@ function updateReportDiagnostic(
     existing: DiagnosticReporter,
     options: CompilerOptions | BuildOptions,
 ): DiagnosticReporter {
-    return shouldBePretty(sys, options) ?
-        createDiagnosticReporter(sys, /*pretty*/ true) :
-        existing;
+    return shouldBePretty(sys, options)
+        ? createDiagnosticReporter(sys, /*pretty*/ true)
+        : existing;
 }
 
 function defaultIsPretty(sys: System) {
@@ -167,9 +167,9 @@ function shouldBePretty(sys: System, options: CompilerOptions | BuildOptions) {
 
 function getOptionsForHelp(commandLine: ParsedCommandLine) {
     // Sort our options by their names, (e.g. "--noImplicitAny" comes before "--watch")
-    return !!commandLine.options.all ?
-        sort(optionDeclarations, (a, b) => compareStringsCaseInsensitive(a.name, b.name)) :
-        filter(optionDeclarations.slice(), v => !!v.showInSimplifiedHelpView);
+    return !!commandLine.options.all
+        ? sort(optionDeclarations, (a, b) => compareStringsCaseInsensitive(a.name, b.name))
+        : filter(optionDeclarations.slice(), v => !!v.showInSimplifiedHelpView);
 }
 
 function printVersion(sys: System) {
@@ -854,8 +854,8 @@ function performBuild(
             onWatchStatusChange?.(d, newLine, options, errorCount);
             if (
                 reportBuildStatistics && (
-                    d.code === Diagnostics.Found_0_errors_Watching_for_file_changes.code ||
-                    d.code === Diagnostics.Found_1_error_Watching_for_file_changes.code
+                    d.code === Diagnostics.Found_0_errors_Watching_for_file_changes.code
+                    || d.code === Diagnostics.Found_1_error_Watching_for_file_changes.code
                 )
             ) {
                 reportSolutionBuilderTimes(builder, solutionPerformance);
@@ -886,9 +886,9 @@ function performBuild(
 }
 
 function createReportErrorSummary(sys: System, options: CompilerOptions | BuildOptions): ReportEmitErrorSummary | undefined {
-    return shouldBePretty(sys, options) ?
-        (errorCount, filesInError) => sys.write(getErrorSummaryText(errorCount, filesInError, sys.newLine, sys)) :
-        undefined;
+    return shouldBePretty(sys, options)
+        ? (errorCount, filesInError) => sys.write(getErrorSummaryText(errorCount, filesInError, sys.newLine, sys))
+        : undefined;
 }
 
 function performCompilation(

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -542,9 +542,9 @@ export class SessionClient implements LanguageService {
                 locations.push({
                     textSpan: this.decodeSpan({ start, end }, fileName),
                     fileName,
-                    ...(contextStart !== undefined ?
-                        { contextSpan: this.decodeSpan({ start: contextStart, end: contextEnd! }, fileName) } :
-                        undefined),
+                    ...(contextStart !== undefined
+                        ? { contextSpan: this.decodeSpan({ start: contextStart, end: contextEnd! }, fileName) }
+                        : undefined),
                     ...prefixSuffixText,
                 });
             }
@@ -580,11 +580,11 @@ export class SessionClient implements LanguageService {
 
     findRenameLocations(fileName: string, position: number, findInStrings: boolean, findInComments: boolean, preferences: UserPreferences | boolean | undefined): RenameLocation[] {
         if (
-            !this.lastRenameEntry ||
-            this.lastRenameEntry.inputs.fileName !== fileName ||
-            this.lastRenameEntry.inputs.position !== position ||
-            this.lastRenameEntry.inputs.findInStrings !== findInStrings ||
-            this.lastRenameEntry.inputs.findInComments !== findInComments
+            !this.lastRenameEntry
+            || this.lastRenameEntry.inputs.fileName !== fileName
+            || this.lastRenameEntry.inputs.position !== position
+            || this.lastRenameEntry.inputs.findInStrings !== findInStrings
+            || this.lastRenameEntry.inputs.findInComments !== findInComments
         ) {
             const providePrefixAndSuffixTextForRename = typeof preferences === "boolean" ? preferences : preferences?.providePrefixAndSuffixTextForRename;
             const quotePreference = typeof preferences === "boolean" ? undefined : preferences?.quotePreference;

--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -397,9 +397,9 @@ export class CompilerHost implements ts.CompilerHost {
                 try {
                     const shadowRootStats = fs.shadowRoot.existsSync(canonicalFileName) ? fs.shadowRoot.statSync(canonicalFileName) : undefined!; // TODO: GH#18217
                     if (
-                        shadowRootStats.dev !== stats.dev ||
-                        shadowRootStats.ino !== stats.ino ||
-                        shadowRootStats.mtimeMs !== stats.mtimeMs
+                        shadowRootStats.dev !== stats.dev
+                        || shadowRootStats.ino !== stats.ino
+                        || shadowRootStats.mtimeMs !== stats.mtimeMs
                     ) {
                         break;
                     }
@@ -498,9 +498,9 @@ function expectedErrorDiagnosticToText({ relatedInformation, ...diagnosticRelate
 }
 
 function expectedDiagnosticToText(errorOrStatus: ExpectedDiagnostic) {
-    return ts.isArray(errorOrStatus) ?
-        `${DiagnosticKind.Status}!: ${expectedDiagnosticMessageToText(errorOrStatus)}` :
-        expectedErrorDiagnosticToText(errorOrStatus);
+    return ts.isArray(errorOrStatus)
+        ? `${DiagnosticKind.Status}!: ${expectedDiagnosticMessageToText(errorOrStatus)}`
+        : expectedErrorDiagnosticToText(errorOrStatus);
 }
 
 function diagnosticMessageChainToText({ messageText, next }: ts.DiagnosticMessageChain, indent = 0) {
@@ -513,12 +513,12 @@ function diagnosticMessageChainToText({ messageText, next }: ts.DiagnosticMessag
 }
 
 function diagnosticRelatedInformationToText({ file, start, length, messageText }: ts.DiagnosticRelatedInformation) {
-    const text = typeof messageText === "string" ?
-        messageText :
-        diagnosticMessageChainToText(messageText);
-    return file ?
-        `${file.fileName}(${start}:${length}):: ${text}` :
-        text;
+    const text = typeof messageText === "string"
+        ? messageText
+        : diagnosticMessageChainToText(messageText);
+    return file
+        ? `${file.fileName}(${start}:${length}):: ${text}`
+        : text;
 }
 
 function diagnosticToText({ kind, diagnostic: { relatedInformation, ...diagnosticRelatedInformation } }: SolutionBuilderDiagnostic) {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -418,9 +418,9 @@ export class TestState {
             this.inputFiles.forEach((file, fileName) => {
                 if (!Harness.isDefaultLibraryFile(fileName)) {
                     // all files if config file not specified, otherwise root files from the config and typings cache files are root files
-                    const isRootFile = !configParseResult ||
-                        ts.contains(configParseResult.fileNames, fileName) ||
-                        (ts.isDeclarationFileName(fileName) && ts.containsPath("/Library/Caches/typescript", fileName));
+                    const isRootFile = !configParseResult
+                        || ts.contains(configParseResult.fileNames, fileName)
+                        || (ts.isDeclarationFileName(fileName) && ts.containsPath("/Library/Caches/typescript", fileName));
                     this.languageServiceAdapterHost.addScript(fileName, file, isRootFile);
                 }
             });
@@ -549,9 +549,9 @@ export class TestState {
     }
 
     private goToMarkerOrNameOrRange(markerOrRange: MarkerOrNameOrRange) {
-        return ts.isString(markerOrRange) || isMarker(markerOrRange) ?
-            this.goToMarker(markerOrRange) :
-            this.goToRangeStart(markerOrRange);
+        return ts.isString(markerOrRange) || isMarker(markerOrRange)
+            ? this.goToMarker(markerOrRange)
+            : this.goToRangeStart(markerOrRange);
     }
 
     public goToEachMarker(markers: readonly Marker[], action: (marker: Marker, index: number) => void) {
@@ -717,8 +717,8 @@ export class TestState {
 
         for (const { start, length, messageText, file } of errors) {
             Harness.IO.log(
-                "  " + this.formatRange(file, start!, length!) + // TODO: GH#18217
-                    ", message: " + ts.flattenDiagnosticMessageText(messageText, Harness.IO.newLine()) + "\n",
+                "  " + this.formatRange(file, start!, length!) // TODO: GH#18217
+                    + ", message: " + ts.flattenDiagnosticMessageText(messageText, Harness.IO.newLine()) + "\n",
             );
         }
     }
@@ -769,10 +769,10 @@ export class TestState {
         const hasMatchingError = ts.some(
             this.getDiagnostics(range.fileName),
             ({ code, messageText, start, length }) =>
-                code === code &&
-                (!expectedMessage || expectedMessage === messageText) &&
-                ts.isNumber(start) && ts.isNumber(length) &&
-                ts.textSpansEqual(span, { start, length }),
+                code === code
+                && (!expectedMessage || expectedMessage === messageText)
+                && ts.isNumber(start) && ts.isNumber(length)
+                && ts.textSpansEqual(span, { start, length }),
         );
 
         if (!hasMatchingError) {
@@ -852,8 +852,8 @@ export class TestState {
         if (definitions?.length) {
             baseline += "\n\n";
             baseline += indentJsonBaseline(
-                "// === Details ===\n" +
-                    JSON.stringify(
+                "// === Details ===\n"
+                    + JSON.stringify(
                         definitions.map(def => ({
                             defId: defIdMap.get(def),
                             ...def,
@@ -1046,11 +1046,11 @@ export class TestState {
             else {
                 if (
                     entries.some(e =>
-                        e.source === entry.source &&
-                        e.data?.exportName === entry.data?.exportName &&
-                        e.data?.fileName === entry.data?.fileName &&
-                        e.data?.moduleSpecifier === entry.data?.moduleSpecifier &&
-                        e.data?.ambientModuleName === entry.data?.ambientModuleName
+                        e.source === entry.source
+                        && e.data?.exportName === entry.data?.exportName
+                        && e.data?.fileName === entry.data?.fileName
+                        && e.data?.moduleSpecifier === entry.data?.moduleSpecifier
+                        && e.data?.ambientModuleName === entry.data?.ambientModuleName
                     )
                 ) {
                     this.raiseError(`Duplicate completions for ${entry.name}`);
@@ -1390,8 +1390,8 @@ export class TestState {
             if (references?.length) {
                 baseline += "\n\n";
                 baseline += indentJsonBaseline(
-                    "// === Definitions ===\n" +
-                        this.getBaselineForDocumentSpansWithFileContents(
+                    "// === Definitions ===\n"
+                        + this.getBaselineForDocumentSpansWithFileContents(
                             references.map(r => r.definition),
                             {
                                 markerInfo,
@@ -1399,9 +1399,9 @@ export class TestState {
                                 skipDocumentSpanDetails: true,
                                 skipDocumentContainingOnlyMarker: true,
                             },
-                        ) +
-                        "\n\n// === Details ===\n" +
-                        JSON.stringify(
+                        )
+                        + "\n\n// === Details ===\n"
+                        + JSON.stringify(
                             references.map(r => ({
                                 defId: defIdMap.get(r.definition),
                                 ...r.definition,
@@ -1450,13 +1450,13 @@ export class TestState {
             skipDocumentContainingOnlyMarker,
             additionalSpan,
         } = options;
-        const marker: Marker | undefined = markerInfo !== undefined ?
-            ts.isString(markerInfo.markerOrRange) ?
-                this.getMarkerByName(markerInfo.markerOrRange) :
-                isMarker(markerInfo.markerOrRange) ?
-                markerInfo.markerOrRange :
-                { fileName: markerInfo.markerOrRange.fileName, position: markerInfo.markerOrRange.pos } :
-            undefined;
+        const marker: Marker | undefined = markerInfo !== undefined
+            ? ts.isString(markerInfo.markerOrRange)
+                ? this.getMarkerByName(markerInfo.markerOrRange)
+                : isMarker(markerInfo.markerOrRange)
+                ? markerInfo.markerOrRange
+                : { fileName: markerInfo.markerOrRange.fileName, position: markerInfo.markerOrRange.pos }
+            : undefined;
         const fileBaselines: string[] = [];
         let foundMarker = false;
         let foundAdditionalSpan = false;
@@ -1480,9 +1480,9 @@ export class TestState {
                     let baseline = `// === ${group[0].fileName} ===\n// Unavailable file content:\n`;
                     for (const span of group) {
                         baseline += `// textSpan: ${JSON.stringify(span.textSpan)}${span.contextSpan ? `, contextSpan: ${JSON.stringify(span.contextSpan)}` : ""}`;
-                        const text = !skipDocumentSpanDetails ?
-                            convertDocumentSpanToString(span, documentSpanId?.(span)) :
-                            documentSpanId?.(span);
+                        const text = !skipDocumentSpanDetails
+                            ? convertDocumentSpanToString(span, documentSpanId?.(span))
+                            : documentSpanId?.(span);
                         if (text) baseline += ` ${text}`;
                         baseline += "\n";
                     }
@@ -1632,8 +1632,8 @@ export class TestState {
                 for (let matchingEndPosIndex = index + 1; matchingEndPosIndex < sortedDetails.length; matchingEndPosIndex++) {
                     // Defer after the location if its same as rangeEnd
                     if (
-                        sortedDetails[matchingEndPosIndex].location === location &&
-                        sortedDetails[matchingEndPosIndex].type!.endsWith("End")
+                        sortedDetails[matchingEndPosIndex].location === location
+                        && sortedDetails[matchingEndPosIndex].type!.endsWith("End")
                     ) {
                         deferredMarkerIndex = matchingEndPosIndex;
                     }
@@ -1652,9 +1652,9 @@ export class TestState {
             if (span) {
                 switch (type) {
                     case "textStart":
-                        let text = !skipDocumentSpanDetails ?
-                            convertDocumentSpanToString(span, documentSpanId?.(span), ignoredDocumentSpanProperties) :
-                            documentSpanId?.(span);
+                        let text = !skipDocumentSpanDetails
+                            ? convertDocumentSpanToString(span, documentSpanId?.(span), ignoredDocumentSpanProperties)
+                            : documentSpanId?.(span);
                         if (span === groupedSpanForAdditionalSpan) {
                             text = `textSpan: true` + (text ? `, ${text}` : "");
                         }
@@ -1710,15 +1710,15 @@ export class TestState {
                 if (locationLine - posLine > nLines) {
                     if (newContent) {
                         readableContents = readableContents + "\n" + readableJsoncBaseline(
-                            newContent + content.slice(pos, lineStarts[posLine + TestState.nLinesContext]) +
-                                `--- (line: ${isLibFile ? "--" : posLine + TestState.nLinesContext + 1}) skipped ---`,
+                            newContent + content.slice(pos, lineStarts[posLine + TestState.nLinesContext])
+                                + `--- (line: ${isLibFile ? "--" : posLine + TestState.nLinesContext + 1}) skipped ---`,
                         );
                         if (location !== undefined) readableContents += "\n";
                         newContent = "";
                     }
                     if (location !== undefined) {
-                        newContent += `--- (line: ${isLibFile ? "--" : locationLine - TestState.nLinesContext + 1}) skipped ---\n` +
-                            content.slice(lineStarts[locationLine - TestState.nLinesContext + 1], location);
+                        newContent += `--- (line: ${isLibFile ? "--" : locationLine - TestState.nLinesContext + 1}) skipped ---\n`
+                            + content.slice(lineStarts[locationLine - TestState.nLinesContext + 1], location);
                     }
                     return;
                 }
@@ -1903,11 +1903,11 @@ export class TestState {
         options: FourSlashInterface.RenameOptions | undefined,
     ) {
         this.baselineEachMarkerOrRangeArrayOrSingle("findRenameLocations", markerOrRange, rangeText, markerOrRange => {
-            const { fileName, position } = ts.isString(markerOrRange) ?
-                this.getMarkerByName(markerOrRange) :
-                isMarker(markerOrRange) ?
-                markerOrRange :
-                { fileName: markerOrRange.fileName, position: markerOrRange.pos };
+            const { fileName, position } = ts.isString(markerOrRange)
+                ? this.getMarkerByName(markerOrRange)
+                : isMarker(markerOrRange)
+                ? markerOrRange
+                : { fileName: markerOrRange.fileName, position: markerOrRange.pos };
             const {
                 findInStrings = false,
                 findInComments = false,
@@ -1926,12 +1926,12 @@ export class TestState {
                 this.raiseError(`baselineRename failed. Could not rename at the provided position.`);
             }
 
-            const renameOptions = options ?
-                (options.findInStrings !== undefined ? `// @findInStrings: ${findInStrings}\n` : "") +
-                (options.findInComments !== undefined ? `// @findInComments: ${findInComments}\n` : "") +
-                (options.providePrefixAndSuffixTextForRename !== undefined ? `// @providePrefixAndSuffixTextForRename: ${providePrefixAndSuffixTextForRename}\n` : "") +
-                (options.quotePreference !== undefined ? `// @quotePreference: ${quotePreference}\n` : "") :
-                "";
+            const renameOptions = options
+                ? (options.findInStrings !== undefined ? `// @findInStrings: ${findInStrings}\n` : "")
+                    + (options.findInComments !== undefined ? `// @findInComments: ${findInComments}\n` : "")
+                    + (options.providePrefixAndSuffixTextForRename !== undefined ? `// @providePrefixAndSuffixTextForRename: ${providePrefixAndSuffixTextForRename}\n` : "")
+                    + (options.quotePreference !== undefined ? `// @quotePreference: ${quotePreference}\n` : "")
+                : "";
 
             return renameOptions + (renameOptions ? "\n" : "") + this.getBaselineForDocumentSpansWithFileContents(
                 locations,
@@ -2009,9 +2009,9 @@ export class TestState {
 
         if (options.text !== undefined) {
             assert.equal(
-                ts.displayPartsToString(selectedItem.prefixDisplayParts) +
-                    selectedItem.parameters.map(p => ts.displayPartsToString(p.displayParts)).join(ts.displayPartsToString(selectedItem.separatorDisplayParts)) +
-                    ts.displayPartsToString(selectedItem.suffixDisplayParts),
+                ts.displayPartsToString(selectedItem.prefixDisplayParts)
+                    + selectedItem.parameters.map(p => ts.displayPartsToString(p.displayParts)).join(ts.displayPartsToString(selectedItem.separatorDisplayParts))
+                    + ts.displayPartsToString(selectedItem.suffixDisplayParts),
                 options.text,
             );
         }
@@ -2096,12 +2096,12 @@ export class TestState {
         }
 
         if (
-            renameInfo.triggerSpan.start !== expectedRange.pos ||
-            ts.textSpanEnd(renameInfo.triggerSpan) !== expectedRange.end
+            renameInfo.triggerSpan.start !== expectedRange.pos
+            || ts.textSpanEnd(renameInfo.triggerSpan) !== expectedRange.end
         ) {
             this.raiseError(
-                "Expected triggerSpan [" + expectedRange.pos + "," + expectedRange.end + ").  Got [" +
-                    renameInfo.triggerSpan.start + "," + ts.textSpanEnd(renameInfo.triggerSpan) + ") instead.",
+                "Expected triggerSpan [" + expectedRange.pos + "," + expectedRange.end + ").  Got ["
+                    + renameInfo.triggerSpan.start + "," + ts.textSpanEnd(renameInfo.triggerSpan) + ") instead.",
             );
         }
     }
@@ -2596,9 +2596,9 @@ export class TestState {
         if (errorList.length) {
             errorList.forEach(err => {
                 Harness.IO.log(
-                    "start: " + err.start +
-                        ", length: " + err.length +
-                        ", message: " + ts.flattenDiagnosticMessageText(err.messageText, Harness.IO.newLine()),
+                    "start: " + err.start
+                        + ", length: " + err.length
+                        + ", message: " + ts.flattenDiagnosticMessageText(err.messageText, Harness.IO.newLine()),
                 );
             });
         }
@@ -2625,8 +2625,8 @@ export class TestState {
     }
 
     private getBaselineFileNameForContainingTestFile(ext = ".baseline") {
-        return this.testData.globalOptions[MetadataOptionNames.baselineFile] ||
-            ts.getBaseFileName(this.originalInputFileName).replace(ts.Extension.Ts, ext);
+        return this.testData.globalOptions[MetadataOptionNames.baselineFile]
+            || ts.getBaseFileName(this.originalInputFileName).replace(ts.Extension.Ts, ext);
     }
 
     private getSignatureHelp({ triggerReason }: FourSlashInterface.VerifySignatureHelpOptions): ts.SignatureHelpItems | undefined {
@@ -3089,9 +3089,9 @@ export class TestState {
     private verifyClassifications(expected: { classificationType: string | number; text?: string; textSpan?: TextSpan; }[], actual: (ts.ClassifiedSpan | ts.ClassifiedSpan2020)[], sourceFileText: string) {
         if (actual.length !== expected.length) {
             this.raiseError(
-                "verifyClassifications failed - expected total classifications to be " + expected.length +
-                    ", but was " + actual.length +
-                    jsonMismatchString(),
+                "verifyClassifications failed - expected total classifications to be " + expected.length
+                    + ", but was " + actual.length
+                    + jsonMismatchString(),
             );
         }
 
@@ -3101,10 +3101,10 @@ export class TestState {
 
             if (expectedType !== actualType) {
                 this.raiseError(
-                    "verifyClassifications failed - expected classifications type to be " +
-                        expectedType + ", but was " +
-                        actualType +
-                        jsonMismatchString(),
+                    "verifyClassifications failed - expected classifications type to be "
+                        + expectedType + ", but was "
+                        + actualType
+                        + jsonMismatchString(),
                 );
             }
 
@@ -3116,10 +3116,10 @@ export class TestState {
 
                 if (expectedSpan.start !== actualSpan.start || expectedLength !== actualSpan.length) {
                     this.raiseError(
-                        "verifyClassifications failed - expected span of text to be " +
-                            "{start=" + expectedSpan.start + ", length=" + expectedLength + "}, but was " +
-                            "{start=" + actualSpan.start + ", length=" + actualSpan.length + "}" +
-                            jsonMismatchString(),
+                        "verifyClassifications failed - expected span of text to be "
+                            + "{start=" + expectedSpan.start + ", length=" + expectedLength + "}, but was "
+                            + "{start=" + actualSpan.start + ", length=" + actualSpan.length + "}"
+                            + jsonMismatchString(),
                     );
                 }
             }
@@ -3127,19 +3127,19 @@ export class TestState {
             const actualText = this.activeFile.content.substr(actualSpan.start, actualSpan.length);
             if (expectedClassification.text !== actualText) {
                 this.raiseError(
-                    "verifyClassifications failed - expected classified text to be " +
-                        expectedClassification.text + ", but was " +
-                        actualText +
-                        jsonMismatchString(),
+                    "verifyClassifications failed - expected classified text to be "
+                        + expectedClassification.text + ", but was "
+                        + actualText
+                        + jsonMismatchString(),
                 );
             }
         });
 
         function jsonMismatchString() {
             const showActual = actual.map(({ classificationType, textSpan }) => ({ classificationType, text: sourceFileText.slice(textSpan.start, textSpan.start + textSpan.length) }));
-            return Harness.IO.newLine() +
-                "expected: '" + Harness.IO.newLine() + stringify(expected) + "'" + Harness.IO.newLine() +
-                "actual:   '" + Harness.IO.newLine() + stringify(showActual) + "'";
+            return Harness.IO.newLine()
+                + "expected: '" + Harness.IO.newLine() + stringify(expected) + "'" + Harness.IO.newLine()
+                + "actual:   '" + Harness.IO.newLine() + stringify(showActual) + "'";
         }
     }
 
@@ -3906,9 +3906,9 @@ export class TestState {
                 const highlights = this.getDocumentHighlightsAtCurrentPosition(ts.map(options?.filesToSearch, ts.normalizePath) || [this.activeFile.fileName]);
 
                 // Write input files
-                const filesToSearch = options ? "// filesToSearch:\n" +
-                    options.filesToSearch.map(f => "//   " + f).join("\n") + "\n\n" :
-                    "";
+                const filesToSearch = options ? "// filesToSearch:\n"
+                    + options.filesToSearch.map(f => "//   " + f).join("\n") + "\n\n"
+                    : "";
                 const baselineContent = this.getBaselineForGroupedDocumentSpansWithFileContents(
                     highlights?.map(h => h.highlightSpans.map(s => s.fileName ? s as ts.DocumentSpan : { ...s, fileName: h.fileName })) || ts.emptyArray,
                     { markerInfo: { markerOrRange, markerName: "/*HIGHLIGHTS*/" } },
@@ -3954,8 +3954,8 @@ export class TestState {
             }
 
             this.raiseError(
-                `Expected to find a fix with the name '${fixName}', but none exists.` +
-                    availableFixes.length
+                `Expected to find a fix with the name '${fixName}', but none exists.`
+                    + availableFixes.length
                     ? ` Available fixes: ${availableFixes.map(fix => `${fix.fixName} (${fix.fixId ? "with" : "without"} fix-all)`).join(", ")}`
                     : "",
             );
@@ -4220,13 +4220,13 @@ export class TestState {
         const alreadySeen = seen.has(key);
         seen.set(key, true);
 
-        const incomingCalls = direction === CallHierarchyItemDirection.Outgoing ? { result: "skip" } as const :
-            alreadySeen ? { result: "seen" } as const :
-            { result: "show", values: this.languageService.provideCallHierarchyIncomingCalls(callHierarchyItem.file, callHierarchyItem.selectionSpan.start) } as const;
+        const incomingCalls = direction === CallHierarchyItemDirection.Outgoing ? { result: "skip" } as const
+            : alreadySeen ? { result: "seen" } as const
+            : { result: "show", values: this.languageService.provideCallHierarchyIncomingCalls(callHierarchyItem.file, callHierarchyItem.selectionSpan.start) } as const;
 
-        const outgoingCalls = direction === CallHierarchyItemDirection.Incoming ? { result: "skip" } as const :
-            alreadySeen ? { result: "seen" } as const :
-            { result: "show", values: this.languageService.provideCallHierarchyOutgoingCalls(callHierarchyItem.file, callHierarchyItem.selectionSpan.start) } as const;
+        const outgoingCalls = direction === CallHierarchyItemDirection.Incoming ? { result: "skip" } as const
+            : alreadySeen ? { result: "seen" } as const
+            : { result: "show", values: this.languageService.provideCallHierarchyOutgoingCalls(callHierarchyItem.file, callHierarchyItem.selectionSpan.start) } as const;
 
         let text = "";
         text += `${prefix}╭ name: ${callHierarchyItem.name}\n`;
@@ -4242,8 +4242,8 @@ export class TestState {
             file,
             callHierarchyItem.selectionSpan,
             `${prefix}│ `,
-            incomingCalls.result !== "skip" || outgoingCalls.result !== "skip" ? `${prefix}│ ` :
-                `${trailingPrefix}╰ `,
+            incomingCalls.result !== "skip" || outgoingCalls.result !== "skip" ? `${prefix}│ `
+                : `${trailingPrefix}╰ `,
         );
 
         if (incomingCalls.result === "seen") {
@@ -4275,9 +4275,9 @@ export class TestState {
                         file,
                         incomingCall.fromSpans,
                         `${prefix}│ │ `,
-                        i < incomingCalls.values.length - 1 ? `${prefix}│ ╰ ` :
-                            outgoingCalls.result !== "skip" ? `${prefix}│ ╰ ` :
-                            `${trailingPrefix}╰ ╰ `,
+                        i < incomingCalls.values.length - 1 ? `${prefix}│ ╰ `
+                            : outgoingCalls.result !== "skip" ? `${prefix}│ ╰ `
+                            : `${trailingPrefix}╰ ╰ `,
                     );
                 }
             }
@@ -4301,8 +4301,8 @@ export class TestState {
                         file,
                         outgoingCall.fromSpans,
                         `${prefix}│ │ `,
-                        i < outgoingCalls.values.length - 1 ? `${prefix}│ ╰ ` :
-                            `${trailingPrefix}╰ ╰ `,
+                        i < outgoingCalls.values.length - 1 ? `${prefix}│ ╰ `
+                            : `${trailingPrefix}╰ ╰ `,
                     );
                 }
             }
@@ -4596,8 +4596,8 @@ function runCode(code: string, state: TestState, fileName: string): void {
 
     sourceMapSupportModule?.install({
         retrieveFile: path => {
-            return path === generatedFile ? wrappedCode :
-                undefined!;
+            return path === generatedFile ? wrappedCode
+                : undefined!;
         },
     });
 

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -760,8 +760,8 @@ export namespace Compiler {
             // When calling this function from rwc-runner, the baselinePath will have no extension.
             // As rwc test- file is stored in json which ".json" will get stripped off.
             // When calling this function from compiler-runner, the baselinePath will then has either ".ts" or ".tsx" extension
-            const outputFileName = ts.endsWith(baselinePath, ts.Extension.Ts) || ts.endsWith(baselinePath, ts.Extension.Tsx) ?
-                baselinePath.replace(/\.tsx?/, "") : baselinePath;
+            const outputFileName = ts.endsWith(baselinePath, ts.Extension.Ts) || ts.endsWith(baselinePath, ts.Extension.Tsx)
+                ? baselinePath.replace(/\.tsx?/, "") : baselinePath;
 
             if (!multifile) {
                 const fullBaseLine = generateBaseLine(isSymbolBaseLine, isSymbolBaseLine ? skipSymbolBaselines : skipTypeBaselines);
@@ -1555,8 +1555,8 @@ export function isDefaultLibraryFile(filePath: string): boolean {
 }
 
 export function isBuiltFile(filePath: string): boolean {
-    return filePath.indexOf(libFolder) === 0 ||
-        filePath.indexOf(vpath.addTrailingSeparator(vfs.builtFolder)) === 0;
+    return filePath.indexOf(libFolder) === 0
+        || filePath.indexOf(vpath.addTrailingSeparator(vfs.builtFolder)) === 0;
 }
 
 export function getDefaultLibraryFile(filePath: string, io: IO): Compiler.TestFile {

--- a/src/harness/harnessUtils.ts
+++ b/src/harness/harnessUtils.ts
@@ -116,23 +116,23 @@ export function assertInvariants(node: ts.Node | undefined, parent: ts.Node | un
 
             for (const childName in node) {
                 if (
-                    childName === "parent" ||
-                    childName === "nextContainer" ||
-                    childName === "modifiers" ||
-                    childName === "externalModuleIndicator" ||
-                    childName === "original" ||
+                    childName === "parent"
+                    || childName === "nextContainer"
+                    || childName === "modifiers"
+                    || childName === "externalModuleIndicator"
+                    || childName === "original"
                     // for now ignore jsdoc comments
-                    childName === "jsDocComment" ||
-                    childName === "checkJsDirective" ||
-                    childName === "commonJsModuleIndicator" ||
+                    || childName === "jsDocComment"
+                    || childName === "checkJsDirective"
+                    || childName === "commonJsModuleIndicator"
                     // ignore nodes added only to report grammar errors
-                    childName === "illegalInitializer" ||
-                    childName === "illegalDecorators" ||
-                    childName === "illegalModifiers" ||
-                    childName === "illegalQuestionToken" ||
-                    childName === "illegalExclamationToken" ||
-                    childName === "illegalTypeParameters" ||
-                    childName === "illegalType"
+                    || childName === "illegalInitializer"
+                    || childName === "illegalDecorators"
+                    || childName === "illegalModifiers"
+                    || childName === "illegalQuestionToken"
+                    || childName === "illegalExclamationToken"
+                    || childName === "illegalTypeParameters"
+                    || childName === "illegalType"
                 ) {
                     continue;
                 }

--- a/src/harness/incrementalUtils.ts
+++ b/src/harness/incrementalUtils.ts
@@ -257,8 +257,8 @@ export function verifyResolutionCache(
             resolution.refCount === info.length,
             `${projectName}:: Expected Resolution ref count ${info.length} but got ${resolution.refCount}`,
             () =>
-                `Expected from:: ${JSON.stringify(info, undefined, " ")}` +
-                `Actual from: ${resolution.refCount}`,
+                `Expected from:: ${JSON.stringify(info, undefined, " ")}`
+                + `Actual from: ${resolution.refCount}`,
         );
         ts.Debug.assert(
             resolutionToExpected.get(resolution)!.refCount === resolution.refCount,
@@ -570,8 +570,8 @@ function afterResolveSingleModuleNameWithoutWatching(
             expected?.length === actual?.length,
             `Expected ${caption} to not change: ${moduleName} ${containingFile}`,
             () =>
-                `Expected: ${JSON.stringify(expected, undefined, " ")}` +
-                `Actual: ${JSON.stringify(actual, undefined, " ")}`,
+                `Expected: ${JSON.stringify(expected, undefined, " ")}`
+                + `Actual: ${JSON.stringify(actual, undefined, " ")}`,
         );
     }
 }

--- a/src/harness/projectServiceStateLogger.ts
+++ b/src/harness/projectServiceStateLogger.ts
@@ -195,9 +195,9 @@ export function patchServiceForStateBaseline(service: ProjectService) {
                 open: info.isScriptOpen(),
                 version: info.textStorage.getVersion(),
                 pendingReloadFromDisk: info.textStorage.pendingReloadFromDisk,
-                sourceMapFilePath: info.sourceMapFilePath && !isString(info.sourceMapFilePath) ?
-                    { original: info.sourceMapFilePath, sourceInfos: new Set(info.sourceMapFilePath.sourceInfos) } :
-                    info.sourceMapFilePath,
+                sourceMapFilePath: info.sourceMapFilePath && !isString(info.sourceMapFilePath)
+                    ? { original: info.sourceMapFilePath, sourceInfos: new Set(info.sourceMapFilePath.sourceInfos) }
+                    : info.sourceMapFilePath,
                 declarationInfoPath: info.declarationInfoPath,
                 sourceInfos: info.sourceInfos && new Set(info.sourceInfos),
                 documentPositionMapper: info.documentPositionMapper,
@@ -324,8 +324,8 @@ export function patchServiceForStateBaseline(service: ProjectService) {
             dataDiff,
             propertyLogs,
             (value, key) =>
-                dataDiff !== Diff.New && dataValue?.get(key) !== value ?
-                    !dataValue?.has(key) ? Diff.New : Diff.Change : Diff.None,
+                dataDiff !== Diff.New && dataValue?.get(key) !== value
+                    ? !dataValue?.has(key) ? Diff.New : Diff.Change : Diff.None,
             (value, key) => `${key}: ${toStringPropertyValue(value)}`,
         );
     }
@@ -433,16 +433,16 @@ export function patchServiceForStateBaseline(service: ProjectService) {
         infoDiff: Diff,
         infoPropertyLogs: StatePropertyLog[],
     ) {
-        return !info.sourceMapFilePath || isString(info.sourceMapFilePath) ?
-            printProperty(
+        return !info.sourceMapFilePath || isString(info.sourceMapFilePath)
+            ? printProperty(
                 PrintPropertyWhen.DefinedOrChangedOrNew,
                 data,
                 "sourceMapFilePath",
                 info.sourceMapFilePath,
                 infoDiff,
                 infoPropertyLogs,
-            ) :
-            printSetPropertyValueWorker(
+            )
+            : printSetPropertyValueWorker(
                 PrintPropertyWhen.DefinedOrChangedOrNew,
                 data?.sourceMapFilePath && !isString(data?.sourceMapFilePath) ? data.sourceMapFilePath.sourceInfos : undefined,
                 "sourceMapFilePath sourceInfos",
@@ -461,8 +461,8 @@ export function patchServiceForStateBaseline(service: ProjectService) {
     }
 
     function getSourceMapper(project: Project) {
-        return project.projectKind !== ProjectKind.AutoImportProvider ?
-            project.getLanguageService(/*ensureSynchronized*/ false)?.getSourceMapper() :
-            undefined;
+        return project.projectKind !== ProjectKind.AutoImportProvider
+            ? project.getLanguageService(/*ensureSynchronized*/ false)?.getSourceMapper()
+            : undefined;
     }
 }

--- a/src/harness/typeWriter.ts
+++ b/src/harness/typeWriter.ts
@@ -124,16 +124,16 @@ export class TypeWriterWalker {
             // But this is generally expected, so we don't call those out, either
             let typeString: string;
             if (
-                !this.hadErrorBaseline &&
-                type.flags & ts.TypeFlags.Any &&
-                !ts.isBindingElement(node.parent) &&
-                !ts.isPropertyAccessOrQualifiedName(node.parent) &&
-                !ts.isLabelName(node) &&
-                !(ts.isModuleDeclaration(node.parent) && ts.isGlobalScopeAugmentation(node.parent)) &&
-                !ts.isMetaProperty(node.parent) &&
-                !this.isImportStatementName(node) &&
-                !this.isExportStatementName(node) &&
-                !this.isIntrinsicJsxTag(node)
+                !this.hadErrorBaseline
+                && type.flags & ts.TypeFlags.Any
+                && !ts.isBindingElement(node.parent)
+                && !ts.isPropertyAccessOrQualifiedName(node.parent)
+                && !ts.isLabelName(node)
+                && !(ts.isModuleDeclaration(node.parent) && ts.isGlobalScopeAugmentation(node.parent))
+                && !ts.isMetaProperty(node.parent)
+                && !this.isImportStatementName(node)
+                && !this.isExportStatementName(node)
+                && !this.isIntrinsicJsxTag(node)
             ) {
                 typeString = (type as ts.IntrinsicType).intrinsicName;
             }

--- a/src/harness/util.ts
+++ b/src/harness/util.ts
@@ -108,9 +108,9 @@ export function theory<T extends any[]>(name: string, cb: (...args: T) => void, 
 }
 
 function formatTheoryDatum(value: any) {
-    return typeof value === "function" ? value.name || "<anonymous function>" :
-        value === undefined ? "undefined" :
-        JSON.stringify(value);
+    return typeof value === "function" ? value.name || "<anonymous function>"
+        : value === undefined ? "undefined"
+        : JSON.stringify(value);
 }
 
 export interface Deferred<T> {

--- a/src/harness/vfsUtil.ts
+++ b/src/harness/vfsUtil.ts
@@ -681,9 +681,9 @@ export class FileSystem {
 
         if (isDirectory(node)) throw createIOError("EISDIR");
         if (!isFile(node)) throw createIOError("EBADF");
-        node.buffer = Buffer.isBuffer(data) ?
-            { encoding: undefined, data: data.slice() } :
-            { encoding: (encoding ?? "utf8") as BufferEncoding, data };
+        node.buffer = Buffer.isBuffer(data)
+            ? { encoding: undefined, data: data.slice() }
+            : { encoding: (encoding ?? "utf8") as BufferEncoding, data };
         // Updated the size if it's easy to get, otherwise set to undefined. _getSize will compute the correct size
         node.size = !node.buffer.encoding ? node.buffer.data.byteLength : undefined;
         node.mtimeMs = time;
@@ -697,9 +697,9 @@ export class FileSystem {
     public diff(base?: FileSystem | undefined, options: DiffOptions = {}) {
         if (!base && !options.baseIsNotShadowRoot) base = this.shadowRoot;
         const differences: FileSet = {};
-        const hasDifferences = base ?
-            FileSystem.rootDiff(differences, this, base, options) :
-            FileSystem.trackCreatedInodes(differences, this, this._getRootLinks());
+        const hasDifferences = base
+            ? FileSystem.rootDiff(differences, this, base, options)
+            : FileSystem.trackCreatedInodes(differences, this, this._getRootLinks());
         return hasDifferences ? differences : undefined;
     }
 
@@ -709,9 +709,9 @@ export class FileSystem {
      */
     public static diff(changed: FileSystem, base: FileSystem, options: DiffOptions = {}) {
         const differences: FileSet = {};
-        return FileSystem.rootDiff(differences, changed, base, options) ?
-            differences :
-            undefined;
+        return FileSystem.rootDiff(differences, changed, base, options)
+            ? differences
+            : undefined;
     }
 
     private static diffWorker(container: FileSet, changed: FileSystem, changedLinks: ReadonlyMap<string, Inode> | undefined, base: FileSystem, baseLinks: ReadonlyMap<string, Inode> | undefined, options: DiffOptions) {
@@ -772,9 +772,9 @@ export class FileSystem {
 
         // no difference if both nodes are unpopulated and point to the same mounted file system
         if (
-            !changedNode.links && !baseNode.links &&
-            changedNode.resolver && changedNode.source !== undefined &&
-            baseNode.resolver === changedNode.resolver && baseNode.source === changedNode.source
+            !changedNode.links && !baseNode.links
+            && changedNode.resolver && changedNode.source !== undefined
+            && baseNode.resolver === changedNode.resolver && baseNode.source === changedNode.source
         ) return false;
 
         // no difference if both nodes have identical children
@@ -799,9 +799,9 @@ export class FileSystem {
 
         // no difference if both nodes are unpopulated and point to the same mounted file system
         if (
-            !changedNode.buffer && !baseNode.buffer &&
-            changedNode.resolver && changedNode.source !== undefined &&
-            baseNode.resolver === changedNode.resolver && baseNode.source === changedNode.source
+            !changedNode.buffer && !baseNode.buffer
+            && changedNode.resolver && changedNode.source !== undefined
+            && baseNode.resolver === changedNode.resolver && baseNode.source === changedNode.source
         ) return false;
 
         const encoding = changedNode.buffer?.encoding ?? baseNode.buffer?.encoding ?? FileSystem.defaultEncoding;
@@ -1575,15 +1575,15 @@ function getBuiltLocal(host: FileSystemResolverHost, ignoreCase: boolean): FileS
 /* eslint-disable no-null/no-null */
 function normalizeFileSetEntry(value: FileSet[string]) {
     if (
-        value === undefined ||
-        value === null ||
-        value instanceof Directory ||
-        value instanceof File ||
-        value instanceof Link ||
-        value instanceof Symlink ||
-        value instanceof Mount ||
-        value instanceof Rmdir ||
-        value instanceof Unlink
+        value === undefined
+        || value === null
+        || value instanceof Directory
+        || value instanceof File
+        || value instanceof Link
+        || value instanceof Symlink
+        || value instanceof Mount
+        || value instanceof Rmdir
+        || value instanceof Unlink
     ) {
         return value;
     }

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -315,8 +315,8 @@ export function discoverTypings(
                     // packages. So that needs this dance here.
                     const pathComponents = getPathComponents(normalizePath(manifestPath));
                     const isScoped = pathComponents[pathComponents.length - 3][0] === "@";
-                    return isScoped && toFileNameLowerCase(pathComponents[pathComponents.length - 4]) === modulesDirName || // `node_modules/@foo/bar`
-                        !isScoped && toFileNameLowerCase(pathComponents[pathComponents.length - 3]) === modulesDirName; // `node_modules/foo`
+                    return isScoped && toFileNameLowerCase(pathComponents[pathComponents.length - 4]) === modulesDirName // `node_modules/@foo/bar`
+                        || !isScoped && toFileNameLowerCase(pathComponents[pathComponents.length - 3]) === modulesDirName; // `node_modules/foo`
                 });
 
         if (log) log(`Searching for typing names in ${packagesFolderPath}; all files: ${JSON.stringify(dependencyManifestNames)}`);
@@ -448,9 +448,9 @@ function validatePackageNameWorker(packageName: string, supportScopedPackage: bo
 
 /** @internal */
 export function renderPackageNameValidationFailure(result: PackageNameValidationResult, typing: string): string {
-    return typeof result === "object" ?
-        renderPackageNameValidationFailureWorker(typing, result.result, result.name, result.isScopeName) :
-        renderPackageNameValidationFailureWorker(typing, result, typing, /*isScopeName*/ false);
+    return typeof result === "object"
+        ? renderPackageNameValidationFailureWorker(typing, result.result, result.name, result.isScopeName)
+        : renderPackageNameValidationFailureWorker(typing, result, typing, /*isScopeName*/ false);
 }
 
 function renderPackageNameValidationFailureWorker(typing: string, result: NameValidationResult, name: string, isScopeName: boolean): string {

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1542,12 +1542,12 @@ interface Promise<T> {
 /**
  * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
  */
-type Awaited<T> = T extends null | undefined ? T : // special case for `null | undefined` when not in `--strictNullChecks` mode
-    T extends object & { then(onfulfilled: infer F, ...args: infer _): any; } ? // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
-        F extends ((value: infer V, ...args: infer _) => any) ? // if the argument to `then` is callable, extracts the first argument
-            Awaited<V> : // recursively unwrap the value
-        never : // the argument to `then` was not callable
-    T; // non-object or non-thenable
+type Awaited<T> = T extends null | undefined ? T // special case for `null | undefined` when not in `--strictNullChecks` mode
+    : T extends object & { then(onfulfilled: infer F, ...args: infer _): any; } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+        ? F extends ((value: infer V, ...args: infer _) => any) // if the argument to `then` is callable, extracts the first argument
+            ? Awaited<V> // recursively unwrap the value
+        : never // the argument to `then` was not callable
+    : T; // non-object or non-thenable
 
 interface ArrayLike<T> {
     readonly length: number;

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -467,9 +467,9 @@ export function convertWatchOptions(protocolOptions: protocol.ExternalProjectCom
         const propertyValue = protocolOptions[option.name];
         if (propertyValue === undefined) return;
         const mappedValues = watchOptionsConverters.get(option.name);
-        (watchOptions || (watchOptions = {}))[option.name] = mappedValues ?
-            isString(propertyValue) ? mappedValues.get(propertyValue.toLowerCase()) : propertyValue :
-            convertJsonOption(option, propertyValue, currentDirectory || "", errors || (errors = []));
+        (watchOptions || (watchOptions = {}))[option.name] = mappedValues
+            ? isString(propertyValue) ? mappedValues.get(propertyValue.toLowerCase()) : propertyValue
+            : convertJsonOption(option, propertyValue, currentDirectory || "", errors || (errors = []));
     });
     return watchOptions && { watchOptions, errors };
 }
@@ -722,13 +722,13 @@ export function forEachResolvedProjectReferenceProject<T>(
     function callback(ref: ResolvedProjectReference, loadKind: ProjectReferenceProjectLoadKind) {
         const configFileName = toNormalizedPath(ref.sourceFile.fileName);
         const child = project.projectService.findConfiguredProjectByProjectName(configFileName) || (
-            loadKind === ProjectReferenceProjectLoadKind.Find ?
-                undefined :
-                loadKind === ProjectReferenceProjectLoadKind.FindCreate ?
-                project.projectService.createConfiguredProject(configFileName) :
-                loadKind === ProjectReferenceProjectLoadKind.FindCreateLoad ?
-                project.projectService.createAndLoadConfiguredProject(configFileName, reason!) :
-                Debug.assertNever(loadKind)
+            loadKind === ProjectReferenceProjectLoadKind.Find
+                ? undefined
+                : loadKind === ProjectReferenceProjectLoadKind.FindCreate
+                ? project.projectService.createConfiguredProject(configFileName)
+                : loadKind === ProjectReferenceProjectLoadKind.FindCreateLoad
+                ? project.projectService.createAndLoadConfiguredProject(configFileName, reason!)
+                : Debug.assertNever(loadKind)
         );
 
         return child && cb(child);
@@ -767,8 +767,8 @@ function forEachPotentialProjectReference<T>(
     project: ConfiguredProject,
     cb: (potentialProjectReference: NormalizedPath) => T | undefined,
 ): T | undefined {
-    return project.potentialProjectReferences &&
-        forEachKey(project.potentialProjectReferences, cb);
+    return project.potentialProjectReferences
+        && forEachKey(project.potentialProjectReferences, cb);
 }
 
 function forEachAnyProjectReferenceKind<T>(
@@ -777,11 +777,11 @@ function forEachAnyProjectReferenceKind<T>(
     cbProjectRef: (projectReference: ProjectReference) => T | undefined,
     cbPotentialProjectRef: (potentialProjectReference: NormalizedPath) => T | undefined,
 ): T | undefined {
-    return project.getCurrentProgram() ?
-        project.forEachResolvedProjectReference(cb) :
-        project.isInitialLoadPending() ?
-        forEachPotentialProjectReference(project, cbPotentialProjectRef) :
-        forEach(project.getProjectReferences(), cbProjectRef);
+    return project.getCurrentProgram()
+        ? project.forEachResolvedProjectReference(cb)
+        : project.isInitialLoadPending()
+        ? forEachPotentialProjectReference(project, cbPotentialProjectRef)
+        : forEach(project.getProjectReferences(), cbProjectRef);
 }
 
 function callbackRefProject<T, P extends string>(
@@ -836,8 +836,8 @@ function isScriptInfoWatchedFromNodeModules(info: ScriptInfo) {
  * @internal
  */
 export function projectContainsInfoDirectly(project: Project, info: ScriptInfo) {
-    return project.containsScriptInfo(info) &&
-        !project.isSourceOfProjectReferenceRedirect(info.path);
+    return project.containsScriptInfo(info)
+        && !project.isSourceOfProjectReferenceRedirect(info.path);
 }
 
 /** @internal */
@@ -976,11 +976,11 @@ function createWatchFactoryHostUsingWatchEvents(service: ProjectService, canUseW
         eventType: "create" | "delete" | "update",
     ) {
         watchedFiles.idToCallbacks.get(id)?.forEach(callback => {
-            const eventKind = eventType === "create" ?
-                FileWatcherEventKind.Created :
-                eventType === "delete" ?
-                FileWatcherEventKind.Deleted :
-                FileWatcherEventKind.Changed;
+            const eventKind = eventType === "create"
+                ? FileWatcherEventKind.Created
+                : eventType === "delete"
+                ? FileWatcherEventKind.Deleted
+                : FileWatcherEventKind.Changed;
             callback(eventPath, eventKind);
         });
     }
@@ -1200,16 +1200,16 @@ export class ProjectService {
         };
 
         this.documentRegistry = createDocumentRegistryInternal(this.host.useCaseSensitiveFileNames, this.currentDirectory, this.jsDocParsingMode, this);
-        const watchLogLevel = this.logger.hasLevel(LogLevel.verbose) ? WatchLogLevel.Verbose :
-            this.logger.loggingEnabled() ? WatchLogLevel.TriggerOnly : WatchLogLevel.None;
+        const watchLogLevel = this.logger.hasLevel(LogLevel.verbose) ? WatchLogLevel.Verbose
+            : this.logger.loggingEnabled() ? WatchLogLevel.TriggerOnly : WatchLogLevel.None;
         const log: (s: string) => void = watchLogLevel !== WatchLogLevel.None ? (s => this.logger.info(s)) : noop;
         this.packageJsonCache = createPackageJsonCache(this);
-        this.watchFactory = this.serverMode !== LanguageServiceMode.Semantic ?
-            {
+        this.watchFactory = this.serverMode !== LanguageServiceMode.Semantic
+            ? {
                 watchFile: returnNoopFileWatcher,
                 watchDirectory: returnNoopFileWatcher,
-            } :
-            getWatchFactory(
+            }
+            : getWatchFactory(
                 createWatchFactoryHostUsingWatchEvents(this, opts.canUseWatchEvents) || this.host,
                 watchLogLevel,
                 log,
@@ -1466,9 +1466,9 @@ export class ProjectService {
             // - Inferred projects with a projectRootPath, if the new options apply to that
             //   project root path.
             if (
-                canonicalProjectRootPath ?
-                    project.projectRootPath === canonicalProjectRootPath :
-                    !project.projectRootPath || !this.compilerOptionsForInferredProjectsPerProjectRoot.has(project.projectRootPath)
+                canonicalProjectRootPath
+                    ? project.projectRootPath === canonicalProjectRootPath
+                    : !project.projectRootPath || !this.compilerOptionsForInferredProjectsPerProjectRoot.has(project.projectRootPath)
             ) {
                 project.setCompilerOptions(compilerOptions);
                 project.setTypeAcquisition(typeAcquisition);
@@ -1527,9 +1527,9 @@ export class ProjectService {
     private doEnsureDefaultProjectForFile(fileNameOrScriptInfo: NormalizedPath | ScriptInfo): Project {
         this.ensureProjectStructuresUptoDate();
         const scriptInfo = isString(fileNameOrScriptInfo) ? this.getScriptInfoForNormalizedPath(fileNameOrScriptInfo) : fileNameOrScriptInfo;
-        return scriptInfo ?
-            scriptInfo.getDefaultProject() :
-            (this.logErrorForScriptInfoNotFound(isString(fileNameOrScriptInfo) ? fileNameOrScriptInfo : fileNameOrScriptInfo.fileName), Errors.ThrowNoProject());
+        return scriptInfo
+            ? scriptInfo.getDefaultProject()
+            : (this.logErrorForScriptInfoNotFound(isString(fileNameOrScriptInfo) ? fileNameOrScriptInfo : fileNameOrScriptInfo.fileName), Errors.ThrowNoProject());
     }
 
     getScriptInfoEnsuringProjectsUptoDate(uncheckedFileName: string) {
@@ -1659,8 +1659,8 @@ export class ProjectService {
                 const fileOrDirectoryPath = this.toPath(fileOrDirectory);
                 const fsResult = config.cachedDirectoryStructureHost.addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
                 if (
-                    getBaseFileName(fileOrDirectoryPath) === "package.json" && !isInsideNodeModules(fileOrDirectoryPath) &&
-                    (fsResult && fsResult.fileExists || !fsResult && this.host.fileExists(fileOrDirectory))
+                    getBaseFileName(fileOrDirectoryPath) === "package.json" && !isInsideNodeModules(fileOrDirectoryPath)
+                    && (fsResult && fsResult.fileExists || !fsResult && this.host.fileExists(fileOrDirectory))
                 ) {
                     const file = this.getNormalizedAbsolutePath(fileOrDirectory);
                     this.logger.info(`Config: ${configFileName} Detected new package.json: ${file}`);
@@ -1778,9 +1778,9 @@ export class ProjectService {
             configFileExistenceInfo.exists = false;
 
             // Remove the configured project for this config file
-            const project = configFileExistenceInfo.config?.projects.has(canonicalConfigFilePath) ?
-                this.getConfiguredProjectByCanonicalConfigFilePath(canonicalConfigFilePath) :
-                undefined;
+            const project = configFileExistenceInfo.config?.projects.has(canonicalConfigFilePath)
+                ? this.getConfiguredProjectByCanonicalConfigFilePath(canonicalConfigFilePath)
+                : undefined;
             if (project) this.removeProject(project);
         }
         else {
@@ -1801,9 +1801,9 @@ export class ProjectService {
             configFileExistenceInfo.openFilesImpactedByConfigFile,
             /*clearSemanticCache*/ false,
             /*delayReload*/ true,
-            eventKind !== FileWatcherEventKind.Deleted ?
-                identity : // Reload open files if they are root of inferred project
-                returnTrue, // Reload all the open files impacted by config file
+            eventKind !== FileWatcherEventKind.Deleted
+                ? identity // Reload open files if they are root of inferred project
+                : returnTrue, // Reload all the open files impacted by config file
             "Change in config file detected",
         );
         this.delayEnsureProjectForOpenFiles();
@@ -1826,8 +1826,8 @@ export class ProjectService {
                                     mapDefinedIterator(
                                         this.filenameToScriptInfo.values(),
                                         info =>
-                                            info.isAttached(project) ?
-                                                {
+                                            info.isAttached(project)
+                                                ? {
                                                     fileName: info.fileName,
                                                     projects: info.containingProjects.map(p => p.projectName),
                                                     hasMixedContent: info.hasMixedContent,
@@ -1863,19 +1863,19 @@ export class ProjectService {
     assignOrphanScriptInfoToInferredProject(info: ScriptInfo, projectRootPath: NormalizedPath | undefined) {
         Debug.assert(info.isOrphan());
 
-        const project = this.getOrCreateInferredProjectForProjectRootPathIfEnabled(info, projectRootPath) ||
-            this.getOrCreateSingleInferredProjectIfEnabled() ||
-            this.getOrCreateSingleInferredWithoutProjectRoot(
-                info.isDynamic ?
-                    projectRootPath || this.currentDirectory :
-                    getDirectoryPath(
-                        isRootedDiskPath(info.fileName) ?
-                            info.fileName :
-                            getNormalizedAbsolutePath(
+        const project = this.getOrCreateInferredProjectForProjectRootPathIfEnabled(info, projectRootPath)
+            || this.getOrCreateSingleInferredProjectIfEnabled()
+            || this.getOrCreateSingleInferredWithoutProjectRoot(
+                info.isDynamic
+                    ? projectRootPath || this.currentDirectory
+                    : getDirectoryPath(
+                        isRootedDiskPath(info.fileName)
+                            ? info.fileName
+                            : getNormalizedAbsolutePath(
                                 info.fileName,
-                                projectRootPath ?
-                                    this.getNormalizedAbsolutePath(projectRootPath) :
-                                    this.currentDirectory,
+                                projectRootPath
+                                    ? this.getNormalizedAbsolutePath(projectRootPath)
+                                    : this.currentDirectory,
                             ),
                     ),
             );
@@ -2068,8 +2068,8 @@ export class ProjectService {
      * Returns true if the configFileExistenceInfo is needed/impacted by open files that are root of inferred project
      */
     private configFileExistenceImpactsRootOfInferredProject(configFileExistenceInfo: ConfigFileExistenceInfo) {
-        return configFileExistenceInfo.openFilesImpactedByConfigFile &&
-            forEachEntry(configFileExistenceInfo.openFilesImpactedByConfigFile, identity);
+        return configFileExistenceInfo.openFilesImpactedByConfigFile
+            && forEachEntry(configFileExistenceInfo.openFilesImpactedByConfigFile, identity);
     }
 
     /** @internal */
@@ -2116,9 +2116,9 @@ export class ProjectService {
         // Close the config file watcher if there are no more open files that are root of inferred project
         // or if there are no projects that need to watch this config file existence info
         if (
-            configFileExistenceInfo.watcher &&
-            !configFileExistenceInfo.config &&
-            !this.configFileExistenceImpactsRootOfInferredProject(configFileExistenceInfo)
+            configFileExistenceInfo.watcher
+            && !configFileExistenceInfo.config
+            && !this.configFileExistenceImpactsRootOfInferredProject(configFileExistenceInfo)
         ) {
             configFileExistenceInfo.watcher.close();
             configFileExistenceInfo.watcher = undefined;
@@ -2150,8 +2150,8 @@ export class ProjectService {
                 // and there is are no projects that need the config file existence or parsed config,
                 // remove the cached existence info
                 if (
-                    !configFileExistenceInfo.openFilesImpactedByConfigFile?.size &&
-                    !configFileExistenceInfo.config
+                    !configFileExistenceInfo.openFilesImpactedByConfigFile?.size
+                    && !configFileExistenceInfo.config
                 ) {
                     Debug.assert(!configFileExistenceInfo.watcher);
                     this.configFileExistenceInfoCache.delete(canonicalConfigFilePath);
@@ -2179,15 +2179,15 @@ export class ProjectService {
             (configFileExistenceInfo.openFilesImpactedByConfigFile ||= new Map()).set(info.path, true);
 
             // If there is no configured project for this config file, add the file watcher
-            configFileExistenceInfo.watcher ||= canWatchDirectoryOrFile(getPathComponents(getDirectoryPath(canonicalConfigFilePath) as Path)) ?
-                this.watchFactory.watchFile(
+            configFileExistenceInfo.watcher ||= canWatchDirectoryOrFile(getPathComponents(getDirectoryPath(canonicalConfigFilePath) as Path))
+                ? this.watchFactory.watchFile(
                     configFileName,
                     (_filename, eventKind) => this.onConfigFileChanged(canonicalConfigFilePath, eventKind),
                     PollingInterval.High,
                     this.hostConfiguration.watchOptions,
                     WatchType.ConfigFileForInferredRoot,
-                ) :
-                noopConfigFileWatcher;
+                )
+                : noopConfigFileWatcher;
         });
     }
 
@@ -2269,12 +2269,12 @@ export class ProjectService {
     findDefaultConfiguredProject(info: ScriptInfo) {
         if (!info.isScriptOpen()) return undefined;
         const configFileName = this.getConfigFileNameForFile(info);
-        const project = configFileName &&
-            this.findConfiguredProjectByProjectName(configFileName);
+        const project = configFileName
+            && this.findConfiguredProjectByProjectName(configFileName);
 
-        return project && projectContainsInfoDirectly(project, info) ?
-            project :
-            project?.getDefaultChildProjectFromProjectWithReferences(info);
+        return project && projectContainsInfoDirectly(project, info)
+            ? project
+            : project?.getDefaultChildProjectFromProjectWithReferences(info);
     }
 
     /**
@@ -2569,8 +2569,8 @@ export class ProjectService {
         }
 
         // Parse the config file and ensure its cached
-        const cachedDirectoryStructureHost = configFileExistenceInfo.config?.cachedDirectoryStructureHost ||
-            createCachedDirectoryStructureHost(this.host, this.host.getCurrentDirectory(), this.host.useCaseSensitiveFileNames)!;
+        const cachedDirectoryStructureHost = configFileExistenceInfo.config?.cachedDirectoryStructureHost
+            || createCachedDirectoryStructureHost(this.host, this.host.getCurrentDirectory(), this.host.useCaseSensitiveFileNames)!;
 
         // Read updated contents from disk
         const configFileContent = tryReadFile(configFilename, fileName => this.host.readFile(fileName));
@@ -2684,8 +2684,8 @@ export class ProjectService {
     stopWatchingWildCards(canonicalConfigFilePath: NormalizedPath, forProject: ConfiguredProject) {
         const configFileExistenceInfo = this.configFileExistenceInfoCache.get(canonicalConfigFilePath)!;
         if (
-            !configFileExistenceInfo.config ||
-            !configFileExistenceInfo.config.projects.get(forProject.canonicalConfigFilePath)
+            !configFileExistenceInfo.config
+            || !configFileExistenceInfo.config.projects.get(forProject.canonicalConfigFilePath)
         ) {
             return;
         }
@@ -2862,9 +2862,9 @@ export class ProjectService {
 
     private getOrCreateInferredProjectForProjectRootPathIfEnabled(info: ScriptInfo, projectRootPath: NormalizedPath | undefined): InferredProject | undefined {
         if (
-            !this.useInferredProjectPerProjectRoot ||
+            !this.useInferredProjectPerProjectRoot
             // Its a dynamic info opened without project root
-            (info.isDynamic && projectRootPath === undefined)
+            || (info.isDynamic && projectRootPath === undefined)
         ) {
             return undefined;
         }
@@ -2924,9 +2924,9 @@ export class ProjectService {
         // Reuse the project with same current directory but no roots
         for (const inferredProject of this.inferredProjects) {
             if (
-                !inferredProject.projectRootPath &&
-                inferredProject.isOrphan() &&
-                inferredProject.canonicalCurrentDirectory === expectedCurrentDirectory
+                !inferredProject.projectRootPath
+                && inferredProject.isOrphan()
+                && inferredProject.canonicalCurrentDirectory === expectedCurrentDirectory
             ) {
                 return inferredProject;
             }
@@ -3014,10 +3014,10 @@ export class ProjectService {
                 for (const project of toAddInfo.containingProjects) {
                     // Add the projects only if they can use symLink targets and not already in the list
                     if (
-                        project.languageServiceEnabled &&
-                        !project.isOrphan() &&
-                        !project.getCompilerOptions().preserveSymlinks &&
-                        !info.isAttached(project)
+                        project.languageServiceEnabled
+                        && !project.isOrphan()
+                        && !project.getCompilerOptions().preserveSymlinks
+                        && !info.isAttached(project)
                     ) {
                         if (!projects) {
                             projects = createMultiMap();
@@ -3037,9 +3037,9 @@ export class ProjectService {
         // do not watch files with mixed content - server doesn't know how to interpret it
         // do not watch files in the global cache location
         if (
-            !info.isDynamicOrHasMixedContent() &&
-            (!this.globalCacheLocationDirectoryPath ||
-                !startsWith(info.path, this.globalCacheLocationDirectoryPath))
+            !info.isDynamicOrHasMixedContent()
+            && (!this.globalCacheLocationDirectoryPath
+                || !startsWith(info.path, this.globalCacheLocationDirectoryPath))
         ) {
             const indexOfNodeModules = info.fileName.indexOf("/node_modules/");
             if (!this.host.getModifiedTime || indexOfNodeModules === -1) {
@@ -3239,8 +3239,8 @@ export class ProjectService {
      * This gets the script info for the normalized path. If the path is not rooted disk path then the open script info with project root context is preferred
      */
     getScriptInfoForNormalizedPath(fileName: NormalizedPath) {
-        return !isRootedDiskPath(fileName) && this.openFilesWithNonRootedDiskPath.get(this.toCanonicalFileName(fileName)) ||
-            this.getScriptInfoForPath(normalizedPathToPath(fileName, this.currentDirectory, this.toCanonicalFileName));
+        return !isRootedDiskPath(fileName) && this.openFilesWithNonRootedDiskPath.get(this.toCanonicalFileName(fileName))
+            || this.getScriptInfoForPath(normalizedPathToPath(fileName, this.currentDirectory, this.toCanonicalFileName));
     }
 
     getScriptInfoForPath(fileName: Path) {
@@ -3314,9 +3314,9 @@ export class ProjectService {
         else if (mapFileNameFromDeclarationInfo) {
             declarationInfo.sourceMapFilePath = {
                 watcher: this.addMissingSourceMapFile(
-                    project.currentDirectory === this.currentDirectory ?
-                        mapFileNameFromDeclarationInfo :
-                        getNormalizedAbsolutePath(mapFileNameFromDeclarationInfo, project.currentDirectory),
+                    project.currentDirectory === this.currentDirectory
+                        ? mapFileNameFromDeclarationInfo
+                        : getNormalizedAbsolutePath(mapFileNameFromDeclarationInfo, project.currentDirectory),
                     declarationInfo.path,
                 ),
                 sourceInfos: this.addSourceInfoToSourceMap(sourceFileName, project),
@@ -3431,10 +3431,10 @@ export class ProjectService {
                     this.externalProjectToConfiguredProjectMap.forEach(projects =>
                         projects.forEach(project => {
                             if (
-                                !project.isClosed() &&
-                                project.hasExternalProjectRef() &&
-                                project.pendingUpdateLevel === ProgramUpdateLevel.Full &&
-                                !this.pendingProjectUpdates.has(project.getProjectName())
+                                !project.isClosed()
+                                && project.hasExternalProjectRef()
+                                && project.pendingUpdateLevel === ProgramUpdateLevel.Full
+                                && !this.pendingProjectUpdates.has(project.getProjectName())
                             ) {
                                 project.updateGraph();
                             }
@@ -3469,9 +3469,9 @@ export class ProjectService {
 
     /** @internal */
     private getWatchOptionsFromProjectWatchOptions(projectOptions: WatchOptions | undefined) {
-        return projectOptions && this.hostConfiguration.watchOptions ?
-            { ...this.hostConfiguration.watchOptions, ...projectOptions } :
-            projectOptions || this.hostConfiguration.watchOptions;
+        return projectOptions && this.hostConfiguration.watchOptions
+            ? { ...this.hostConfiguration.watchOptions, ...projectOptions }
+            : projectOptions || this.hostConfiguration.watchOptions;
     }
 
     closeLog() {
@@ -3615,10 +3615,10 @@ export class ProjectService {
         const firstProject = info.containingProjects[0];
 
         if (
-            !firstProject.isOrphan() &&
-            isInferredProject(firstProject) &&
-            firstProject.isRoot(info) &&
-            forEach(info.containingProjects, p => p !== firstProject && !p.isOrphan())
+            !firstProject.isOrphan()
+            && isInferredProject(firstProject)
+            && firstProject.isRoot(info)
+            && forEach(info.containingProjects, p => p !== firstProject && !p.isOrphan())
         ) {
             firstProject.removeFile(info, /*fileExists*/ true, /*detachFromProject*/ true);
         }
@@ -3665,9 +3665,9 @@ export class ProjectService {
     /** @internal */
     getOriginalLocationEnsuringConfiguredProject(project: Project, location: DocumentPosition): DocumentPosition | undefined {
         const isSourceOfProjectReferenceRedirect = project.isSourceOfProjectReferenceRedirect(location.fileName);
-        const originalLocation = isSourceOfProjectReferenceRedirect ?
-            location :
-            project.getSourceMapper().tryGetSourcePosition(location);
+        const originalLocation = isSourceOfProjectReferenceRedirect
+            ? location
+            : project.getSourceMapper().tryGetSourcePosition(location);
         if (!originalLocation) return undefined;
 
         const { fileName } = originalLocation;
@@ -3868,10 +3868,10 @@ export class ProjectService {
         while (true) {
             // Skip if project is not composite
             if (
-                !project.isInitialLoadPending() &&
-                (
-                    !project.getCompilerOptions().composite ||
-                    project.getCompilerOptions().disableSolutionSearching
+                !project.isInitialLoadPending()
+                && (
+                    !project.getCompilerOptions().composite
+                    || project.getCompilerOptions().disableSolutionSearching
                 )
             ) return;
 
@@ -3884,8 +3884,8 @@ export class ProjectService {
             if (!configFileName) return;
 
             // find or delay load the project
-            const ancestor = this.findConfiguredProjectByProjectName(configFileName) ||
-                this.createConfiguredProjectWithDelayLoad(configFileName, `Creating project possibly referencing default composite project ${project.getProjectName()} of open file ${info.fileName}`);
+            const ancestor = this.findConfiguredProjectByProjectName(configFileName)
+                || this.createConfiguredProjectWithDelayLoad(configFileName, `Creating project possibly referencing default composite project ${project.getProjectName()} of open file ${info.fileName}`);
             if (ancestor.isInitialLoadPending()) {
                 // Set a potential project reference
                 ancestor.setPotentialProjectReference(project.canonicalConfigFilePath);
@@ -3929,8 +3929,8 @@ export class ProjectService {
 
             // Load this project,
             const configFileName = toNormalizedPath(child.sourceFile.fileName);
-            const childProject = project.projectService.findConfiguredProjectByProjectName(configFileName) ||
-                project.projectService.createAndLoadConfiguredProject(configFileName, `Creating project referenced by : ${project.projectName} as it references project ${referencedProject.sourceFile.fileName}`);
+            const childProject = project.projectService.findConfiguredProjectByProjectName(configFileName)
+                || project.projectService.createAndLoadConfiguredProject(configFileName, `Creating project referenced by : ${project.projectName} as it references project ${referencedProject.sourceFile.fileName}`);
             updateProjectIfDirty(childProject);
 
             // Ensure children for this project
@@ -4387,9 +4387,9 @@ export class ProjectService {
                     let project = this.findConfiguredProjectByProjectName(normalized);
                     if (!project) {
                         // errors are stored in the project, do not need to update the graph
-                        project = this.getHostPreferences().lazyConfiguredProjectsFromExternalProject ?
-                            this.createConfiguredProjectWithDelayLoad(normalized, `Creating configured project in external project: ${proj.projectFileName}`) :
-                            this.createLoadAndUpdateConfiguredProject(normalized, `Creating configured project in external project: ${proj.projectFileName}`);
+                        project = this.getHostPreferences().lazyConfiguredProjectsFromExternalProject
+                            ? this.createConfiguredProjectWithDelayLoad(normalized, `Creating configured project in external project: ${proj.projectFileName}`)
+                            : this.createLoadAndUpdateConfiguredProject(normalized, `Creating configured project in external project: ${proj.projectFileName}`);
                     }
                     if (!existingConfiguredProjects?.has(project)) {
                         // keep project alive even if no documents are opened - its lifetime is bound to the lifetime of containing external project
@@ -4475,9 +4475,9 @@ export class ProjectService {
 
         this.logger.info(`Enabling plugin ${pluginConfigEntry.name} from candidate paths: ${searchPaths.join(",")}`);
         if (
-            !pluginConfigEntry.name ||
-            isExternalModuleNameRelative(pluginConfigEntry.name) ||
-            /[\\/]\.\.?($|[\\/])/.test(pluginConfigEntry.name)
+            !pluginConfigEntry.name
+            || isExternalModuleNameRelative(pluginConfigEntry.name)
+            || /[\\/]\.\.?($|[\\/])/.test(pluginConfigEntry.name)
         ) {
             this.logger.info(`Skipped loading plugin ${pluginConfigEntry.name || JSON.stringify(pluginConfigEntry)} because only package name is allowed plugin name`);
             return;

--- a/src/server/packageJsonCache.ts
+++ b/src/server/packageJsonCache.ts
@@ -67,8 +67,8 @@ export function createPackageJsonCache(host: ProjectService): PackageJsonCache {
     }
 
     function directoryHasPackageJson(directory: Path) {
-        return packageJsons.has(combinePaths(directory, "package.json") as Path) ? Ternary.True :
-            directoriesWithoutPackageJson.has(directory) ? Ternary.False :
-            Ternary.Maybe;
+        return packageJsons.has(combinePaths(directory, "package.json") as Path) ? Ternary.True
+            : directoriesWithoutPackageJson.has(directory) ? Ternary.False
+            : Ternary.Maybe;
     }
 }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -811,8 +811,8 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     /** @internal */
     invalidateResolutionsOfFailedLookupLocations() {
         if (
-            this.clearInvalidateResolutionOfFailedLookupTimer() &&
-            this.resolutionCache.invalidateResolutionsOfFailedLookupLocations()
+            this.clearInvalidateResolutionOfFailedLookupTimer()
+            && this.resolutionCache.invalidateResolutionsOfFailedLookupLocations()
         ) {
             this.markAsDirty();
             this.projectService.delayEnsureProjectForOpenFiles();
@@ -925,9 +925,9 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
 
     /** @internal */
     shouldEmitFile(scriptInfo: ScriptInfo | undefined) {
-        return scriptInfo &&
-            !scriptInfo.isDynamicOrHasMixedContent() &&
-            !this.program!.isSourceOfProjectReferenceRedirect(scriptInfo.path);
+        return scriptInfo
+            && !scriptInfo.isDynamicOrHasMixedContent()
+            && !this.program!.isSourceOfProjectReferenceRedirect(scriptInfo.path);
     }
 
     getCompileOnSaveAffectedFileList(scriptInfo: ScriptInfo): string[] {
@@ -967,9 +967,9 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
                 const dtsFiles = outputFiles.filter(f => isDeclarationFileName(f.name));
                 if (dtsFiles.length === 1) {
                     const sourceFile = this.program!.getSourceFile(scriptInfo.fileName)!;
-                    const signature = this.projectService.host.createHash ?
-                        this.projectService.host.createHash(dtsFiles[0].text) :
-                        generateDjb2Hash(dtsFiles[0].text);
+                    const signature = this.projectService.host.createHash
+                        ? this.projectService.host.createHash(dtsFiles[0].text)
+                        : generateDjb2Hash(dtsFiles[0].text);
                     BuilderState.updateSignatureOfFile(this.builderState, signature, sourceFile.resolvedPath);
                 }
             }
@@ -1448,19 +1448,19 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
             if (!this.typingWatchers!.has(canonicalPath)) {
                 this.typingWatchers!.set(
                     canonicalPath,
-                    typingsWatcherType === TypingWatcherType.FileWatcher ?
-                        this.projectService.watchFactory.watchFile(
+                    typingsWatcherType === TypingWatcherType.FileWatcher
+                        ? this.projectService.watchFactory.watchFile(
                             path,
                             () =>
-                                !this.typingWatchers!.isInvoked ?
-                                    this.onTypingInstallerWatchInvoke() :
-                                    this.writeLog(`TypingWatchers already invoked`),
+                                !this.typingWatchers!.isInvoked
+                                    ? this.onTypingInstallerWatchInvoke()
+                                    : this.writeLog(`TypingWatchers already invoked`),
                             PollingInterval.High,
                             this.projectService.getWatchOptions(this),
                             WatchType.TypingInstallerLocationFile,
                             this,
-                        ) :
-                        this.projectService.watchFactory.watchDirectory(
+                        )
+                        : this.projectService.watchFactory.watchDirectory(
                             path,
                             f => {
                                 if (this.typingWatchers!.isInvoked) return this.writeLog(`TypingWatchers already invoked`);
@@ -1600,9 +1600,9 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
                         this.generatedFilesMap.forEach((watcher, source) => {
                             const sourceFile = this.program!.getSourceFileByPath(source);
                             if (
-                                !sourceFile ||
-                                sourceFile.resolvedPath !== source ||
-                                !this.isValidGeneratedFileWatcher(
+                                !sourceFile
+                                || sourceFile.resolvedPath !== source
+                                || !this.isValidGeneratedFileWatcher(
                                     getDeclarationEmitOutputFilePathWorker(sourceFile.fileName, this.compilerOptions, this.currentDirectory, this.program!.getCommonSourceDirectory(), this.getCanonicalFileName),
                                     watcher,
                                 )
@@ -2121,10 +2121,10 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     /** @internal */
     includePackageJsonAutoImports(): PackageJsonAutoImportPreference {
         if (
-            this.projectService.includePackageJsonAutoImports() === PackageJsonAutoImportPreference.Off ||
-            !this.languageServiceEnabled ||
-            isInsideNodeModules(this.currentDirectory) ||
-            !this.isDefaultProjectForOpenFiles()
+            this.projectService.includePackageJsonAutoImports() === PackageJsonAutoImportPreference.Off
+            || !this.languageServiceEnabled
+            || isInsideNodeModules(this.currentDirectory)
+            || !this.isDefaultProjectForOpenFiles()
         ) {
             return PackageJsonAutoImportPreference.Off;
         }
@@ -2256,9 +2256,9 @@ function extractUnresolvedImportsFromSourceFile(
         program.forEachResolvedModule(({ resolvedModule }, name) => {
             // pick unresolved non-relative names
             if (
-                (!resolvedModule || !resolutionExtensionIsTSOrJson(resolvedModule.extension)) &&
-                !isExternalModuleNameRelative(name) &&
-                !ambientModules.some(m => m === name)
+                (!resolvedModule || !resolutionExtensionIsTSOrJson(resolvedModule.extension))
+                && !isExternalModuleNameRelative(name)
+                && !ambientModules.some(m => m === name)
             ) {
                 unresolvedImports = append(unresolvedImports, parsePackageName(name).packageName);
             }
@@ -2371,8 +2371,8 @@ export class InferredProject extends Project {
         // - when useSingleInferredProject is not set and projectRootPath is not set,
         //   we can guarantee that this will be the only root
         // - other wise it has single root if it has single root script info
-        return (!this.projectRootPath && !this.projectService.useSingleInferredProject) ||
-            this.getRootScriptInfos().length === 1;
+        return (!this.projectRootPath && !this.projectService.useSingleInferredProject)
+            || this.getRootScriptInfos().length === 1;
     }
 
     override close() {
@@ -2895,8 +2895,8 @@ export class ConfiguredProject extends Project {
 
     /** @internal */
     isSolution() {
-        return this.getRootFilesMap().size === 0 &&
-            !this.canConfigFileJsonReportNoInputFiles;
+        return this.getRootFilesMap().size === 0
+            && !this.canConfigFileJsonReportNoInputFiles;
     }
 
     /**
@@ -2909,9 +2909,9 @@ export class ConfiguredProject extends Project {
             this,
             info.path,
             child =>
-                projectContainsInfoDirectly(child, info) ?
-                    child :
-                    undefined,
+                projectContainsInfoDirectly(child, info)
+                    ? child
+                    : undefined,
             ProjectReferenceProjectLoadKind.Find,
         );
     }
@@ -2946,8 +2946,8 @@ export class ConfiguredProject extends Project {
                     configFileExistenceInfo.openFilesImpactedByConfigFile,
                     (_value, infoPath) => {
                         const info = this.projectService.getScriptInfoForPath(infoPath)!;
-                        return this.containsScriptInfo(info) ||
-                            !!forEachResolvedProjectReferenceProject(
+                        return this.containsScriptInfo(info)
+                            || !!forEachResolvedProjectReferenceProject(
                                 this,
                                 info.path,
                                 child => child.containsScriptInfo(info),

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -174,9 +174,9 @@ export class TextStorage {
      * returns true if text changed
      */
     public reloadWithFileText(tempFileName?: string) {
-        const { text: newText, fileSize } = tempFileName || !this.info.isDynamicOrHasMixedContent() ?
-            this.getFileTextAndSize(tempFileName) :
-            { text: "", fileSize: undefined };
+        const { text: newText, fileSize } = tempFileName || !this.info.isDynamicOrHasMixedContent()
+            ? this.getFileTextAndSize(tempFileName)
+            : { text: "", fileSize: undefined };
         const reloaded = this.reload(newText);
         this.fileSize = fileSize; // NB: after reload since reload clears it
         this.ownFileText = !tempFileName || tempFileName === this.info.fileName;
@@ -188,9 +188,9 @@ export class TextStorage {
      * returns true when scheduling reload
      */
     public scheduleReloadIfNeeded() {
-        return !this.pendingReloadFromDisk && !this.ownFileText ?
-            this.pendingReloadFromDisk = true :
-            false;
+        return !this.pendingReloadFromDisk && !this.ownFileText
+            ? this.pendingReloadFromDisk = true
+            : false;
     }
 
     public delayReloadFromFileIntoText() {
@@ -215,20 +215,20 @@ export class TextStorage {
     }
 
     public getSnapshot(): IScriptSnapshot {
-        return this.tryUseScriptVersionCache()?.getSnapshot() ||
-            (this.textSnapshot ??= ScriptSnapshot.fromString(Debug.checkDefined(this.text)));
+        return this.tryUseScriptVersionCache()?.getSnapshot()
+            || (this.textSnapshot ??= ScriptSnapshot.fromString(Debug.checkDefined(this.text)));
     }
 
     public getAbsolutePositionAndLineText(oneBasedLine: number): AbsolutePositionAndLineText {
         const svc = this.tryUseScriptVersionCache();
         if (svc) return svc.getAbsolutePositionAndLineText(oneBasedLine);
         const lineMap = this.getLineMap();
-        return oneBasedLine <= lineMap.length ?
-            {
+        return oneBasedLine <= lineMap.length
+            ? {
                 absolutePosition: lineMap[oneBasedLine - 1],
                 lineText: this.text!.substring(lineMap[oneBasedLine - 1], lineMap[oneBasedLine]),
-            } :
-            {
+            }
+            : {
                 absolutePosition: this.text!.length,
                 lineText: undefined,
             };
@@ -251,9 +251,9 @@ export class TextStorage {
      */
     lineOffsetToPosition(line: number, offset: number, allowEdits?: true): number {
         const svc = this.tryUseScriptVersionCache();
-        return svc ?
-            svc.lineOffsetToPosition(line, offset) :
-            computePositionOfLineAndCharacter(this.getLineMap(), line - 1, offset - 1, this.text, allowEdits);
+        return svc
+            ? svc.lineOffsetToPosition(line, offset)
+            : computePositionOfLineAndCharacter(this.getLineMap(), line - 1, offset - 1, this.text, allowEdits);
     }
 
     positionToLineOffset(position: number): protocol.Location {
@@ -337,10 +337,10 @@ export class TextStorage {
 }
 
 export function isDynamicFileName(fileName: NormalizedPath) {
-    return fileName[0] === "^" ||
-        ((fileName.includes("walkThroughSnippet:/") || fileName.includes("untitled:/")) &&
-            getBaseFileName(fileName)[0] === "^") ||
-        (fileName.includes(":^") && !fileName.includes(directorySeparator));
+    return fileName[0] === "^"
+        || ((fileName.includes("walkThroughSnippet:/") || fileName.includes("untitled:/"))
+            && getBaseFileName(fileName)[0] === "^")
+        || (fileName.includes(":^") && !fileName.includes(directorySeparator));
 }
 
 /** @internal */
@@ -429,8 +429,8 @@ export class ScriptInfo {
     public open(newText: string | undefined) {
         this.textStorage.isOpen = true;
         if (
-            newText !== undefined &&
-            this.textStorage.reload(newText)
+            newText !== undefined
+            && this.textStorage.reload(newText)
         ) {
             // reload new contents only if the existing contents changed
             this.markContainingProjectsAsDirty();
@@ -587,8 +587,8 @@ export class ScriptInfo {
                             // If we havent found default configuredProject and
                             // its not the last one, find it and use that one if there
                             if (
-                                defaultConfiguredProject === undefined &&
-                                index !== this.containingProjects.length - 1
+                                defaultConfiguredProject === undefined
+                                && index !== this.containingProjects.length - 1
                             ) {
                                 defaultConfiguredProject = project.projectService.findDefaultConfiguredProject(this) || false;
                             }
@@ -605,11 +605,11 @@ export class ScriptInfo {
                     }
                 }
                 return ensurePrimaryProjectKind(
-                    defaultConfiguredProject ||
-                        firstNonSourceOfProjectReferenceRedirect ||
-                        firstConfiguredProject ||
-                        firstExternalProject ||
-                        firstInferredProject,
+                    defaultConfiguredProject
+                        || firstNonSourceOfProjectReferenceRedirect
+                        || firstConfiguredProject
+                        || firstExternalProject
+                        || firstInferredProject,
                 );
         }
     }

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -292,9 +292,9 @@ export class ScriptVersionCache {
     edit(pos: number, deleteLen: number, insertedText?: string) {
         this.changes.push(new TextChange(pos, deleteLen, insertedText));
         if (
-            this.changes.length > ScriptVersionCache.changeNumberThreshold ||
-            deleteLen > ScriptVersionCache.changeLengthThreshold ||
-            insertedText && insertedText.length > ScriptVersionCache.changeLengthThreshold
+            this.changes.length > ScriptVersionCache.changeNumberThreshold
+            || deleteLen > ScriptVersionCache.changeLengthThreshold
+            || insertedText && insertedText.length > ScriptVersionCache.changeLengthThreshold
         ) {
             this.getSnapshot();
         }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -220,8 +220,8 @@ function isDeclarationFileInJSOnlyNonConfiguredProject(project: Project, file: N
     // file has '// @ts-check').
 
     if (
-        (isInferredProject(project) || isExternalProject(project)) &&
-        project.isJsOnlyProject()
+        (isInferredProject(project) || isExternalProject(project))
+        && project.isJsOnlyProject()
     ) {
         const scriptInfo = project.getScriptInfoForNormalizedPath(file);
         return scriptInfo && !scriptInfo.isJavaScript();
@@ -642,9 +642,9 @@ function getReferencesWorker(
     perProjectResults.forEach((projectResults, project) => {
         for (const referencedSymbol of projectResults) {
             const mappedDefinitionFile = getMappedLocationForProject(documentSpanLocation(referencedSymbol.definition), project);
-            const definition: ReferencedSymbolDefinitionInfo = mappedDefinitionFile === undefined ?
-                referencedSymbol.definition :
-                {
+            const definition: ReferencedSymbolDefinitionInfo = mappedDefinitionFile === undefined
+                ? referencedSymbol.definition
+                : {
                     ...referencedSymbol.definition,
                     textSpan: createTextSpan(mappedDefinitionFile.pos, referencedSymbol.definition.textSpan.length), // Why would the length be the same in the original?
                     fileName: mappedDefinitionFile.fileName,
@@ -728,14 +728,14 @@ function getPerProjectReferences<TResult>(
 
     // Don't call these unless !!defaultDefinition
     const getGeneratedDefinition = memoize(() =>
-        defaultProject.isSourceOfProjectReferenceRedirect(defaultDefinition!.fileName) ?
-            defaultDefinition :
-            defaultProject.getLanguageService().getSourceMapper().tryGetGeneratedPosition(defaultDefinition!)
+        defaultProject.isSourceOfProjectReferenceRedirect(defaultDefinition!.fileName)
+            ? defaultDefinition
+            : defaultProject.getLanguageService().getSourceMapper().tryGetGeneratedPosition(defaultDefinition!)
     );
     const getSourceDefinition = memoize(() =>
-        defaultProject.isSourceOfProjectReferenceRedirect(defaultDefinition!.fileName) ?
-            defaultDefinition :
-            defaultProject.getLanguageService().getSourceMapper().tryGetSourcePosition(defaultDefinition!)
+        defaultProject.isSourceOfProjectReferenceRedirect(defaultDefinition!.fileName)
+            ? defaultDefinition
+            : defaultProject.getLanguageService().getSourceMapper().tryGetSourcePosition(defaultDefinition!)
     );
 
     // The keys of resultsMap allow us to check which projects have already been searched, but we also
@@ -832,8 +832,8 @@ function mapDefinitionInProject(
 ): DocumentPosition | undefined {
     // If the definition is actually from the project, definition is correct as is
     if (
-        project.containsFile(toNormalizedPath(definition.fileName)) &&
-        !isLocationProjectReferenceRedirect(project, definition)
+        project.containsFile(toNormalizedPath(definition.fileName))
+        && !isLocationProjectReferenceRedirect(project, definition)
     ) {
         return definition;
     }
@@ -854,9 +854,9 @@ function isLocationProjectReferenceRedirect(project: Project, location: Document
     // This happens when rootFile in project is one of the file from referenced project
     // Thus root is attached but program doesnt have the actual .ts file but .d.ts
     // If this is not the file we were actually looking, return rest of the toDo
-    return !!sourceFile &&
-        sourceFile.resolvedPath !== sourceFile.path &&
-        sourceFile.resolvedPath !== project.toPath(location.fileName);
+    return !!sourceFile
+        && sourceFile.resolvedPath !== sourceFile.path
+        && sourceFile.resolvedPath !== project.toPath(location.fileName);
 }
 
 function getProjectKey(project: Project) {
@@ -1408,9 +1408,9 @@ export class Session<TMessage = string> implements EventSender {
             concatenate(projectErrors, optionsErrors),
             diagnostic => !!diagnostic.file && diagnostic.file.fileName === configFile,
         );
-        return includeLinePosition ?
-            this.convertToDiagnosticsWithLinePositionFromDiagnosticFile(diagnosticsForConfigFile) :
-            map(
+        return includeLinePosition
+            ? this.convertToDiagnosticsWithLinePositionFromDiagnosticFile(diagnosticsForConfigFile)
+            : map(
                 diagnosticsForConfigFile,
                 diagnostic => formatDiagnosticToProtocol(diagnostic, /*includeFileName*/ false),
             );
@@ -1539,8 +1539,8 @@ export class Session<TMessage = string> implements EventSender {
         const unmappedDefinitions = project.getLanguageService().getDefinitionAtPosition(file, position);
         let definitions: readonly DefinitionInfo[] = this.mapDefinitionInfoLocations(unmappedDefinitions || emptyArray, project).slice();
         const needsJsResolution = this.projectService.serverMode === LanguageServiceMode.Semantic && (
-            !some(definitions, d => toNormalizedPath(d.fileName) !== file && !d.isAmbient) ||
-            some(definitions, d => !!d.failedAliasResolution)
+            !some(definitions, d => toNormalizedPath(d.fileName) !== file && !d.isAmbient)
+            || some(definitions, d => !!d.failedAliasResolution)
         );
 
         if (needsJsResolution) {
@@ -1694,14 +1694,14 @@ export class Session<TMessage = string> implements EventSender {
             return { emitSkipped: true, outputFiles: [], diagnostics: [] };
         }
         const result = project.getLanguageService().getEmitOutput(file);
-        return args.richResponse ?
-            {
+        return args.richResponse
+            ? {
                 ...result,
-                diagnostics: args.includeLinePosition ?
-                    this.convertToDiagnosticsWithLinePositionFromDiagnosticFile(result.diagnostics) :
-                    result.diagnostics.map(d => formatDiagnosticToProtocol(d, /*includeFileName*/ true)),
-            } :
-            result;
+                diagnostics: args.includeLinePosition
+                    ? this.convertToDiagnosticsWithLinePositionFromDiagnosticFile(result.diagnostics)
+                    : result.diagnostics.map(d => formatDiagnosticToProtocol(d, /*includeFileName*/ true)),
+            }
+            : result;
     }
 
     private mapJSDocTagInfo(tags: JSDocTagInfo[] | undefined, project: Project, richResponse: boolean): protocol.JSDocTagInfo[] {
@@ -1774,9 +1774,9 @@ export class Session<TMessage = string> implements EventSender {
     private toFileSpanWithContext(fileName: string, textSpan: TextSpan, contextSpan: TextSpan | undefined, project: Project): protocol.FileSpanWithContext {
         const fileSpan = this.toFileSpan(fileName, textSpan, project);
         const context = contextSpan && this.toFileSpan(fileName, contextSpan, project);
-        return context ?
-            { ...fileSpan, contextStart: context.start, contextEnd: context.end } :
-            fileSpan;
+        return context
+            ? { ...fileSpan, contextStart: context.start, contextEnd: context.end }
+            : fileSpan;
     }
 
     private getTypeDefinition(args: protocol.FileLocationRequestArgs): readonly protocol.FileSpanWithContext[] {
@@ -1802,9 +1802,9 @@ export class Session<TMessage = string> implements EventSender {
         const { file, project } = this.getFileAndProject(args);
         const position = this.getPositionInFile(args, file);
         const implementations = this.mapImplementationLocations(project.getLanguageService().getImplementationAtPosition(file, position) || emptyArray, project);
-        return simplifiedResult ?
-            implementations.map(({ fileName, textSpan, contextSpan }) => this.toFileSpanWithContext(fileName, textSpan, contextSpan, project)) :
-            implementations.map(Session.mapToOriginalLocation);
+        return simplifiedResult
+            ? implementations.map(({ fileName, textSpan, contextSpan }) => this.toFileSpanWithContext(fileName, textSpan, contextSpan, project))
+            : implementations.map(Session.mapToOriginalLocation);
     }
 
     private getSyntacticDiagnosticsSync(args: protocol.SyntacticDiagnosticsSyncRequestArgs) {
@@ -1940,9 +1940,9 @@ export class Session<TMessage = string> implements EventSender {
             }
         }
         else {
-            const scriptInfo = getScriptInfoEnsuringProjectsUptoDate ?
-                this.projectService.getScriptInfoEnsuringProjectsUptoDate(args.file) :
-                this.projectService.getScriptInfo(args.file);
+            const scriptInfo = getScriptInfoEnsuringProjectsUptoDate
+                ? this.projectService.getScriptInfoEnsuringProjectsUptoDate(args.file)
+                : this.projectService.getScriptInfo(args.file);
             if (!scriptInfo) {
                 if (ignoreNoProjectError) return emptyArray;
                 this.projectService.logErrorForScriptInfoNotFound(args.file);
@@ -2439,14 +2439,14 @@ export class Session<TMessage = string> implements EventSender {
         }
         const scriptInfo = project.getScriptInfo(file)!;
         const { emitSkipped, diagnostics } = project.emitFile(scriptInfo, (path, data, writeByteOrderMark) => this.host.writeFile(path, data, writeByteOrderMark));
-        return args.richResponse ?
-            {
+        return args.richResponse
+            ? {
                 emitSkipped,
-                diagnostics: args.includeLinePosition ?
-                    this.convertToDiagnosticsWithLinePositionFromDiagnosticFile(diagnostics) :
-                    diagnostics.map(d => formatDiagnosticToProtocol(d, /*includeFileName*/ true)),
-            } :
-            !emitSkipped;
+                diagnostics: args.includeLinePosition
+                    ? this.convertToDiagnosticsWithLinePositionFromDiagnosticFile(diagnostics)
+                    : diagnostics.map(d => formatDiagnosticToProtocol(d, /*includeFileName*/ true)),
+            }
+            : !emitSkipped;
     }
 
     private getSignatureHelpItems(args: protocol.SignatureHelpRequestArgs, simplifiedResult: boolean): protocol.SignatureHelpItems | SignatureHelpItems | undefined {
@@ -2584,9 +2584,9 @@ export class Session<TMessage = string> implements EventSender {
 
     private getNavigateToItems(args: protocol.NavtoRequestArgs, simplifiedResult: boolean): readonly protocol.NavtoItem[] | readonly NavigateToItem[] {
         const full = this.getFullNavigateToItems(args);
-        return !simplifiedResult ?
-            flatMap(full, ({ navigateToItems }) => navigateToItems) :
-            flatMap(
+        return !simplifiedResult
+            ? flatMap(full, ({ navigateToItems }) => navigateToItems)
+            : flatMap(
                 full,
                 ({ project, navigateToItems }) =>
                     navigateToItems.map(navItem => {
@@ -2697,16 +2697,16 @@ export class Session<TMessage = string> implements EventSender {
             if (!a || !b) {
                 return false;
             }
-            return a.containerKind === b.containerKind &&
-                a.containerName === b.containerName &&
-                a.fileName === b.fileName &&
-                a.isCaseSensitive === b.isCaseSensitive &&
-                a.kind === b.kind &&
-                a.kindModifiers === b.kindModifiers &&
-                a.matchKind === b.matchKind &&
-                a.name === b.name &&
-                a.textSpan.start === b.textSpan.start &&
-                a.textSpan.length === b.textSpan.length;
+            return a.containerKind === b.containerKind
+                && a.containerName === b.containerName
+                && a.fileName === b.fileName
+                && a.isCaseSensitive === b.isCaseSensitive
+                && a.kind === b.kind
+                && a.kindModifiers === b.kindModifiers
+                && a.matchKind === b.matchKind
+                && a.name === b.name
+                && a.textSpan.start === b.textSpan.start
+                && a.textSpan.length === b.textSpan.length;
         }
     }
 
@@ -3740,9 +3740,9 @@ function toProtocolTextSpan(textSpan: TextSpan, scriptInfo: ScriptInfo): protoco
 function toProtocolTextSpanWithContext(span: TextSpan, contextSpan: TextSpan | undefined, scriptInfo: ScriptInfo): protocol.TextSpanWithContext {
     const textSpan = toProtocolTextSpan(span, scriptInfo);
     const contextTextSpan = contextSpan && toProtocolTextSpan(contextSpan, scriptInfo);
-    return contextTextSpan ?
-        { ...textSpan, contextStart: contextTextSpan.start, contextEnd: contextTextSpan.end } :
-        textSpan;
+    return contextTextSpan
+        ? { ...textSpan, contextStart: contextTextSpan.start, contextEnd: contextTextSpan.end }
+        : textSpan;
 }
 
 function convertTextChangeToCodeEdit(change: TextChange, scriptInfo: ScriptInfoOrConfig): protocol.CodeEdit {

--- a/src/server/typingsCache.ts
+++ b/src/server/typingsCache.ts
@@ -83,9 +83,9 @@ function setIsEqualTo(arr1: string[] | undefined, arr2: string[] | undefined): b
 }
 
 function typeAcquisitionChanged(opt1: TypeAcquisition, opt2: TypeAcquisition): boolean {
-    return opt1.enable !== opt2.enable ||
-        !setIsEqualTo(opt1.include, opt2.include) ||
-        !setIsEqualTo(opt1.exclude, opt2.exclude);
+    return opt1.enable !== opt2.enable
+        || !setIsEqualTo(opt1.include, opt2.include)
+        || !setIsEqualTo(opt1.exclude, opt2.exclude);
 }
 
 function compilerOptionsChanged(opt1: CompilerOptions, opt2: CompilerOptions): boolean {
@@ -124,11 +124,11 @@ export class TypingsCache {
 
         const entry = this.perProjectCache.get(project.getProjectName());
         if (
-            forceRefresh ||
-            !entry ||
-            typeAcquisitionChanged(typeAcquisition, entry.typeAcquisition) ||
-            compilerOptionsChanged(project.getCompilationSettings(), entry.compilerOptions) ||
-            unresolvedImportsChanged(unresolvedImports, entry.unresolvedImports)
+            forceRefresh
+            || !entry
+            || typeAcquisitionChanged(typeAcquisition, entry.typeAcquisition)
+            || compilerOptionsChanged(project.getCompilationSettings(), entry.compilerOptions)
+            || unresolvedImportsChanged(unresolvedImports, entry.unresolvedImports)
         ) {
             // Note: entry is now poisoned since it does not really contain typings for a given combination of compiler options\typings options.
             // instead it acts as a placeholder to prevent issuing multiple requests

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -110,9 +110,9 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
     function textSpan(startNode: Node, endNode?: Node) {
         const lastDecorator = canHaveDecorators(startNode) ? findLast(startNode.modifiers, isDecorator) : undefined;
-        const start = lastDecorator ?
-            skipTrivia(sourceFile.text, lastDecorator.end) :
-            startNode.getStart(sourceFile);
+        const start = lastDecorator
+            ? skipTrivia(sourceFile.text, lastDecorator.end)
+            : startNode.getStart(sourceFile);
         return createTextSpanFromBounds(start, (endNode || startNode).getEnd());
     }
 
@@ -347,11 +347,11 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
                     // `a` or `...c` or `d: x` from
                     // `[a, b, ...c]` or `{ a, b }` or `{ d: x }` from destructuring pattern
                     if (
-                        (node.kind === SyntaxKind.Identifier ||
-                            node.kind === SyntaxKind.SpreadElement ||
-                            node.kind === SyntaxKind.PropertyAssignment ||
-                            node.kind === SyntaxKind.ShorthandPropertyAssignment) &&
-                        isArrayLiteralOrObjectLiteralDestructuringPattern(parent)
+                        (node.kind === SyntaxKind.Identifier
+                            || node.kind === SyntaxKind.SpreadElement
+                            || node.kind === SyntaxKind.PropertyAssignment
+                            || node.kind === SyntaxKind.ShorthandPropertyAssignment)
+                        && isArrayLiteralOrObjectLiteralDestructuringPattern(parent)
                     ) {
                         return textSpan(node);
                     }
@@ -415,8 +415,8 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
                         case SyntaxKind.PropertyAssignment:
                             // If this is name of property assignment, set breakpoint in the initializer
                             if (
-                                (node.parent as PropertyAssignment).name === node &&
-                                !isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent.parent)
+                                (node.parent as PropertyAssignment).name === node
+                                && !isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent.parent)
                             ) {
                                 return spanInNode((node.parent as PropertyAssignment).initializer);
                             }
@@ -482,16 +482,16 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
             // Breakpoint is possible in variableDeclaration only if there is initialization
             // or its declaration from 'for of'
             if (
-                (hasOnlyExpressionInitializer(variableDeclaration) && variableDeclaration.initializer) ||
-                hasSyntacticModifier(variableDeclaration, ModifierFlags.Export) ||
-                parent.parent.kind === SyntaxKind.ForOfStatement
+                (hasOnlyExpressionInitializer(variableDeclaration) && variableDeclaration.initializer)
+                || hasSyntacticModifier(variableDeclaration, ModifierFlags.Export)
+                || parent.parent.kind === SyntaxKind.ForOfStatement
             ) {
                 return textSpanFromVariableDeclaration(variableDeclaration);
             }
 
             if (
-                isVariableDeclarationList(variableDeclaration.parent) &&
-                variableDeclaration.parent.declarations[0] !== variableDeclaration
+                isVariableDeclarationList(variableDeclaration.parent)
+                && variableDeclaration.parent.declarations[0] !== variableDeclaration
             ) {
                 // If we cannot set breakpoint on this declaration, set it on previous one
                 // Because the variable declaration may be binding pattern and
@@ -503,8 +503,8 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
         function canHaveSpanInParameterDeclaration(parameter: ParameterDeclaration): boolean {
             // Breakpoint is possible on parameter only if it has initializer, is a rest parameter, or has public or private modifier
-            return !!parameter.initializer || parameter.dotDotDotToken !== undefined ||
-                hasSyntacticModifier(parameter, ModifierFlags.Public | ModifierFlags.Private);
+            return !!parameter.initializer || parameter.dotDotDotToken !== undefined
+                || hasSyntacticModifier(parameter, ModifierFlags.Public | ModifierFlags.Private);
         }
 
         function spanInParameterDeclaration(parameter: ParameterDeclaration): TextSpan | undefined {
@@ -531,8 +531,8 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
         }
 
         function canFunctionHaveSpanInWholeDeclaration(functionDeclaration: FunctionLikeDeclaration) {
-            return hasSyntacticModifier(functionDeclaration, ModifierFlags.Export) ||
-                (functionDeclaration.parent.kind === SyntaxKind.ClassDeclaration && functionDeclaration.kind !== SyntaxKind.Constructor);
+            return hasSyntacticModifier(functionDeclaration, ModifierFlags.Export)
+                || (functionDeclaration.parent.kind === SyntaxKind.ClassDeclaration && functionDeclaration.kind !== SyntaxKind.Constructor);
         }
 
         function spanInFunctionDeclaration(functionDeclaration: FunctionLikeDeclaration): TextSpan | undefined {
@@ -733,9 +733,9 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
 
         function spanInOpenParenToken(node: Node): TextSpan | undefined {
             if (
-                node.parent.kind === SyntaxKind.DoStatement || // Go to while keyword and do action instead
-                node.parent.kind === SyntaxKind.CallExpression ||
-                node.parent.kind === SyntaxKind.NewExpression
+                node.parent.kind === SyntaxKind.DoStatement // Go to while keyword and do action instead
+                || node.parent.kind === SyntaxKind.CallExpression
+                || node.parent.kind === SyntaxKind.NewExpression
             ) {
                 return spanInPreviousNode(node);
             }
@@ -777,9 +777,9 @@ export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: num
         function spanInColonToken(node: Node): TextSpan | undefined {
             // Is this : specifying return annotation of the function declaration
             if (
-                isFunctionLike(node.parent) ||
-                node.parent.kind === SyntaxKind.PropertyAssignment ||
-                node.parent.kind === SyntaxKind.Parameter
+                isFunctionLike(node.parent)
+                || node.parent.kind === SyntaxKind.PropertyAssignment
+                || node.parent.kind === SyntaxKind.Parameter
             ) {
                 return spanInPreviousNode(node);
             }

--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -233,15 +233,15 @@ function getCallHierarchyItemName(program: Program, node: CallHierarchyDeclarati
         return { text: `${prefix}static {}`, pos, end };
     }
 
-    const declName = isAssignedExpression(node) ? node.parent.name :
-        Debug.checkDefined(getNameOfDeclaration(node), "Expected call hierarchy item to have a name");
+    const declName = isAssignedExpression(node) ? node.parent.name
+        : Debug.checkDefined(getNameOfDeclaration(node), "Expected call hierarchy item to have a name");
 
-    let text = isIdentifier(declName) ? idText(declName) :
-        isStringOrNumericLiteralLike(declName) ? declName.text :
-        isComputedPropertyName(declName) ?
-        isStringOrNumericLiteralLike(declName.expression) ? declName.expression.text :
-            undefined :
-        undefined;
+    let text = isIdentifier(declName) ? idText(declName)
+        : isStringOrNumericLiteralLike(declName) ? declName.text
+        : isComputedPropertyName(declName)
+        ? isStringOrNumericLiteralLike(declName.expression) ? declName.expression.text
+            : undefined
+        : undefined;
     if (text === undefined) {
         const typeChecker = program.getTypeChecker();
         const symbol = typeChecker.getSymbolAtLocation(declName);
@@ -332,9 +332,9 @@ function findImplementationOrAllInitialDeclarations(typeChecker: TypeChecker, no
         return node;
     }
     if (isFunctionLikeDeclaration(node)) {
-        return findImplementation(typeChecker, node) ??
-            findAllInitialDeclarations(typeChecker, node) ??
-            node;
+        return findImplementation(typeChecker, node)
+            ?? findAllInitialDeclarations(typeChecker, node)
+            ?? node;
     }
     return findAllInitialDeclarations(typeChecker, node) ?? node;
 }
@@ -485,11 +485,11 @@ export function getIncomingCalls(program: Program, declaration: CallHierarchyDec
 
 function createCallSiteCollector(program: Program, callSites: CallSite[]): (node: Node | undefined) => void {
     function recordCallSite(node: CallExpression | NewExpression | TaggedTemplateExpression | PropertyAccessExpression | ElementAccessExpression | Decorator | JsxOpeningLikeElement | ClassStaticBlockDeclaration) {
-        const target = isTaggedTemplateExpression(node) ? node.tag :
-            isJsxOpeningLikeElement(node) ? node.tagName :
-            isAccessExpression(node) ? node :
-            isClassStaticBlockDeclaration(node) ? node :
-            node.expression;
+        const target = isTaggedTemplateExpression(node) ? node.tag
+            : isJsxOpeningLikeElement(node) ? node.tagName
+            : isAccessExpression(node) ? node
+            : isClassStaticBlockDeclaration(node) ? node
+            : node.expression;
         const declaration = resolveCallHierarchyDeclaration(program, target);
         if (declaration) {
             const range = createTextRangeFromNode(target, node.getSourceFile());

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -1126,20 +1126,20 @@ export function getEncodedSyntacticClassifications(cancellationToken: Cancellati
                 if (tokenKind === SyntaxKind.EqualsToken) {
                     // the '=' in a variable declaration is special cased here.
                     if (
-                        parent.kind === SyntaxKind.VariableDeclaration ||
-                        parent.kind === SyntaxKind.PropertyDeclaration ||
-                        parent.kind === SyntaxKind.Parameter ||
-                        parent.kind === SyntaxKind.JsxAttribute
+                        parent.kind === SyntaxKind.VariableDeclaration
+                        || parent.kind === SyntaxKind.PropertyDeclaration
+                        || parent.kind === SyntaxKind.Parameter
+                        || parent.kind === SyntaxKind.JsxAttribute
                     ) {
                         return ClassificationType.operator;
                     }
                 }
 
                 if (
-                    parent.kind === SyntaxKind.BinaryExpression ||
-                    parent.kind === SyntaxKind.PrefixUnaryExpression ||
-                    parent.kind === SyntaxKind.PostfixUnaryExpression ||
-                    parent.kind === SyntaxKind.ConditionalExpression
+                    parent.kind === SyntaxKind.BinaryExpression
+                    || parent.kind === SyntaxKind.PrefixUnaryExpression
+                    || parent.kind === SyntaxKind.PostfixUnaryExpression
+                    || parent.kind === SyntaxKind.ConditionalExpression
                 ) {
                     return ClassificationType.operator;
                 }

--- a/src/services/codefixes/addMissingAsync.ts
+++ b/src/services/codefixes/addMissingAsync.ts
@@ -116,8 +116,8 @@ function getFixableErrorSpanDeclaration(sourceFile: SourceFile, span: TextSpan |
 
 function getIsMatchingAsyncError(span: TextSpan, errorCode: number) {
     return ({ start, length, relatedInformation, code }: Diagnostic) =>
-        isNumber(start) && isNumber(length) && textSpansEqual({ start, length }, span) &&
-        code === errorCode &&
-        !!relatedInformation &&
-        some(relatedInformation, related => related.code === Diagnostics.Did_you_mean_to_mark_this_function_as_async.code);
+        isNumber(start) && isNumber(length) && textSpansEqual({ start, length }, span)
+        && code === errorCode
+        && !!relatedInformation
+        && some(relatedInformation, related => related.code === Diagnostics.Did_you_mean_to_mark_this_function_as_async.code);
 }

--- a/src/services/codefixes/addMissingAwait.ts
+++ b/src/services/codefixes/addMissingAwait.ts
@@ -150,10 +150,10 @@ function isMissingAwaitError(sourceFile: SourceFile, errorCode: number, span: Te
     const checker = program.getTypeChecker();
     const diagnostics = checker.getDiagnostics(sourceFile, cancellationToken);
     return some(diagnostics, ({ start, length, relatedInformation, code }) =>
-        isNumber(start) && isNumber(length) && textSpansEqual({ start, length }, span) &&
-        code === errorCode &&
-        !!relatedInformation &&
-        some(relatedInformation, related => related.code === Diagnostics.Did_you_forget_to_use_await.code));
+        isNumber(start) && isNumber(length) && textSpansEqual({ start, length }, span)
+        && code === errorCode
+        && !!relatedInformation
+        && some(relatedInformation, related => related.code === Diagnostics.Did_you_forget_to_use_await.code));
 }
 
 interface AwaitableInitializer {
@@ -190,13 +190,13 @@ function findAwaitableInitializers(
         const variableName = declaration && tryCast(declaration.name, isIdentifier);
         const variableStatement = getAncestor(declaration, SyntaxKind.VariableStatement);
         if (
-            !declaration || !variableStatement ||
-            declaration.type ||
-            !declaration.initializer ||
-            variableStatement.getSourceFile() !== sourceFile ||
-            hasSyntacticModifier(variableStatement, ModifierFlags.Export) ||
-            !variableName ||
-            !isInsideAwaitableBody(declaration.initializer)
+            !declaration || !variableStatement
+            || declaration.type
+            || !declaration.initializer
+            || variableStatement.getSourceFile() !== sourceFile
+            || hasSyntacticModifier(variableStatement, ModifierFlags.Export)
+            || !variableName
+            || !isInsideAwaitableBody(declaration.initializer)
         ) {
             isCompleteFix = false;
             continue;
@@ -253,14 +253,14 @@ function getIdentifiersFromErrorSpanExpression(expression: Node, checker: TypeCh
 }
 
 function symbolReferenceIsAlsoMissingAwait(reference: Identifier, diagnostics: readonly Diagnostic[], sourceFile: SourceFile, checker: TypeChecker) {
-    const errorNode = isPropertyAccessExpression(reference.parent) ? reference.parent.name :
-        isBinaryExpression(reference.parent) ? reference.parent :
-        reference;
+    const errorNode = isPropertyAccessExpression(reference.parent) ? reference.parent.name
+        : isBinaryExpression(reference.parent) ? reference.parent
+        : reference;
     const diagnostic = find(diagnostics, diagnostic =>
-        diagnostic.start === errorNode.getStart(sourceFile) &&
-        (diagnostic.start + diagnostic.length!) === errorNode.getEnd());
+        diagnostic.start === errorNode.getStart(sourceFile)
+        && (diagnostic.start + diagnostic.length!) === errorNode.getEnd());
 
-    return diagnostic && contains(errorCodes, diagnostic.code) ||
+    return diagnostic && contains(errorCodes, diagnostic.code)
         // A Promise is usually not correct in a binary expression (it's not valid
         // in an arithmetic expression and an equality comparison seems unusual),
         // but if the other side of the binary expression has an error, the side
@@ -268,17 +268,17 @@ function symbolReferenceIsAlsoMissingAwait(reference: Identifier, diagnostics: r
         // Promise as an invalid operand. So if the whole binary expression is
         // typed `any` as a result, there is a strong likelihood that this Promise
         // is accidentally missing `await`.
-        checker.getTypeAtLocation(errorNode).flags & TypeFlags.Any;
+        || checker.getTypeAtLocation(errorNode).flags & TypeFlags.Any;
 }
 
 function isInsideAwaitableBody(node: Node) {
     return node.flags & NodeFlags.AwaitContext || !!findAncestor(node, ancestor =>
-        ancestor.parent && isArrowFunction(ancestor.parent) && ancestor.parent.body === ancestor ||
-        isBlock(ancestor) && (
-                ancestor.parent.kind === SyntaxKind.FunctionDeclaration ||
-                ancestor.parent.kind === SyntaxKind.FunctionExpression ||
-                ancestor.parent.kind === SyntaxKind.ArrowFunction ||
-                ancestor.parent.kind === SyntaxKind.MethodDeclaration
+        ancestor.parent && isArrowFunction(ancestor.parent) && ancestor.parent.body === ancestor
+        || isBlock(ancestor) && (
+                ancestor.parent.kind === SyntaxKind.FunctionDeclaration
+                || ancestor.parent.kind === SyntaxKind.FunctionExpression
+                || ancestor.parent.kind === SyntaxKind.ArrowFunction
+                || ancestor.parent.kind === SyntaxKind.MethodDeclaration
             ));
 }
 

--- a/src/services/codefixes/addMissingConst.ts
+++ b/src/services/codefixes/addMissingConst.ts
@@ -48,8 +48,8 @@ registerCodeFix({
 function makeChange(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, pos: number, program: Program, fixedNodes?: Set<Node>) {
     const token = getTokenAtPosition(sourceFile, pos);
     const forInitializer = findAncestor(token, node =>
-        isForInOrOfStatement(node.parent) ? node.parent.initializer === node :
-            isPossiblyPartOfDestructuring(node) ? false : "quit");
+        isForInOrOfStatement(node.parent) ? node.parent.initializer === node
+            : isPossiblyPartOfDestructuring(node) ? false : "quit");
     if (forInitializer) return applyChange(changeTracker, forInitializer, sourceFile, fixedNodes);
 
     const parent = token.parent;
@@ -67,8 +67,8 @@ function makeChange(changeTracker: textChanges.ChangeTracker, sourceFile: Source
     }
 
     const commaExpression = findAncestor(token, node =>
-        isExpressionStatement(node.parent) ? true :
-            isPossiblyPartOfCommaSeperatedInitializer(node) ? false : "quit");
+        isExpressionStatement(node.parent) ? true
+            : isPossiblyPartOfCommaSeperatedInitializer(node) ? false : "quit");
     if (commaExpression) {
         const checker = program.getTypeChecker();
         if (!expressionCouldBeVariableDeclaration(commaExpression, checker)) {
@@ -99,9 +99,9 @@ function isPossiblyPartOfDestructuring(node: Node): boolean {
 }
 
 function arrayElementCouldBeVariableDeclaration(expression: Expression, checker: TypeChecker): boolean {
-    const identifier = isIdentifier(expression) ? expression :
-        isAssignmentExpression(expression, /*excludeCompoundAssignment*/ true) && isIdentifier(expression.left) ? expression.left :
-        undefined;
+    const identifier = isIdentifier(expression) ? expression
+        : isAssignmentExpression(expression, /*excludeCompoundAssignment*/ true) && isIdentifier(expression.left) ? expression.left
+        : undefined;
     return !!identifier && !checker.getSymbolAtLocation(identifier);
 }
 

--- a/src/services/codefixes/addMissingDeclareProperty.ts
+++ b/src/services/codefixes/addMissingDeclareProperty.ts
@@ -41,8 +41,8 @@ function makeChange(changeTracker: textChanges.ChangeTracker, sourceFile: Source
     }
     const declaration = token.parent;
     if (
-        declaration.kind === SyntaxKind.PropertyDeclaration &&
-        (!fixedNodes || tryAddToSet(fixedNodes, declaration))
+        declaration.kind === SyntaxKind.PropertyDeclaration
+        && (!fixedNodes || tryAddToSet(fixedNodes, declaration))
     ) {
         changeTracker.insertModifierBefore(sourceFile, SyntaxKind.DeclareKeyword, declaration);
     }

--- a/src/services/codefixes/addOptionalPropertyUndefined.ts
+++ b/src/services/codefixes/addOptionalPropertyUndefined.ts
@@ -99,8 +99,8 @@ function getSourceTarget(errorNode: Node | undefined, checker: TypeChecker): { s
         if (isIdentifier(name)) return { source: errorNode, target: name };
     }
     else if (
-        isPropertyAssignment(errorNode.parent) && isIdentifier(errorNode.parent.name) ||
-        isShorthandPropertyAssignment(errorNode.parent)
+        isPropertyAssignment(errorNode.parent) && isIdentifier(errorNode.parent.name)
+        || isShorthandPropertyAssignment(errorNode.parent)
     ) {
         const parentTarget = getSourceTarget(errorNode.parent.parent, checker);
         if (!parentTarget) return undefined;

--- a/src/services/codefixes/annotateWithTypeFromJSDoc.ts
+++ b/src/services/codefixes/annotateWithTypeFromJSDoc.ts
@@ -117,10 +117,10 @@ function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, de
 }
 
 function isDeclarationWithType(node: Node): node is DeclarationWithType {
-    return isFunctionLikeDeclaration(node) ||
-        node.kind === SyntaxKind.VariableDeclaration ||
-        node.kind === SyntaxKind.PropertySignature ||
-        node.kind === SyntaxKind.PropertyDeclaration;
+    return isFunctionLikeDeclaration(node)
+        || node.kind === SyntaxKind.VariableDeclaration
+        || node.kind === SyntaxKind.PropertySignature
+        || node.kind === SyntaxKind.PropertyDeclaration;
 }
 
 function transformJSDocType(node: Node): Node {

--- a/src/services/codefixes/convertFunctionToEs6Class.ts
+++ b/src/services/codefixes/convertFunctionToEs6Class.ts
@@ -115,11 +115,11 @@ function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, po
                     const firstDeclaration = member.declarations[0];
                     // only one "x.prototype = { ... }" will pass
                     if (
-                        member.declarations.length === 1 &&
-                        isPropertyAccessExpression(firstDeclaration) &&
-                        isBinaryExpression(firstDeclaration.parent) &&
-                        firstDeclaration.parent.operatorToken.kind === SyntaxKind.EqualsToken &&
-                        isObjectLiteralExpression(firstDeclaration.parent.right)
+                        member.declarations.length === 1
+                        && isPropertyAccessExpression(firstDeclaration)
+                        && isBinaryExpression(firstDeclaration.parent)
+                        && firstDeclaration.parent.operatorToken.kind === SyntaxKind.EqualsToken
+                        && isObjectLiteralExpression(firstDeclaration.parent.right)
                     ) {
                         const prototypes = firstDeclaration.parent.right;
                         createClassElement(prototypes.symbol, /*modifiers*/ undefined, memberElements);

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -141,8 +141,8 @@ function convertToAsyncFunction(changes: textChanges.ChangeTracker, sourceFile: 
 
     // if the parent of a FunctionLikeDeclaration is a variable declaration, the convertToAsync diagnostic will be reported on the variable name
     if (
-        isIdentifier(tokenAtPosition) && isVariableDeclaration(tokenAtPosition.parent) &&
-        tokenAtPosition.parent.initializer && isFunctionLikeDeclaration(tokenAtPosition.parent.initializer)
+        isIdentifier(tokenAtPosition) && isVariableDeclaration(tokenAtPosition.parent)
+        && tokenAtPosition.parent.initializer && isFunctionLikeDeclaration(tokenAtPosition.parent.initializer)
     ) {
         functionToConvert = tokenAtPosition.parent.initializer;
     }
@@ -216,8 +216,8 @@ function getAllPromiseExpressionsToReturn(func: FunctionLikeDeclaration, checker
             forEach(node.arguments, visit);
         }
         else if (
-            isPromiseReturningCallExpression(node, checker, "catch") ||
-            isPromiseReturningCallExpression(node, checker, "finally")
+            isPromiseReturningCallExpression(node, checker, "catch")
+            || isPromiseReturningCallExpression(node, checker, "finally")
         ) {
             setOfExpressionsToReturn.add(getNodeId(node));
             // if .catch() or .finally() is the last call in the chain, move leftward in the chain until we hit something else that should be returned
@@ -260,8 +260,8 @@ function getExplicitPromisedTypeOfPromiseReturningCallExpression(node: PromiseRe
     // which type argument is safe to use as an annotation.
     const promiseType = checker.getTypeAtLocation(node.expression.expression);
     if (
-        isReferenceToType(promiseType, checker.getPromiseType()) ||
-        isReferenceToType(promiseType, checker.getPromiseLikeType())
+        isReferenceToType(promiseType, checker.getPromiseType())
+        || isReferenceToType(promiseType, checker.getPromiseLikeType())
     ) {
         if (node.expression.name.escapedText === "then") {
             if (callback === elementAt(node.arguments, 0)) {
@@ -735,9 +735,9 @@ function transformCallbackArgument(func: Expression, hasContinuation: boolean, c
                     );
             }
             else {
-                const inlinedStatements = isFixablePromiseHandler(funcBody, transformer.checker) ?
-                    transformReturnStatementWithFixablePromiseHandler(transformer, factory.createReturnStatement(funcBody), hasContinuation, continuationArgName) :
-                    emptyArray;
+                const inlinedStatements = isFixablePromiseHandler(funcBody, transformer.checker)
+                    ? transformReturnStatementWithFixablePromiseHandler(transformer, factory.createReturnStatement(funcBody), hasContinuation, continuationArgName)
+                    : emptyArray;
 
                 if (inlinedStatements.length > 0) {
                     return inlinedStatements;

--- a/src/services/codefixes/convertToEsModule.ts
+++ b/src/services/codefixes/convertToEsModule.ts
@@ -397,10 +397,10 @@ function convertReExportAll(reExported: StringLiteralLike, checker: TypeChecker)
     const moduleSpecifier = reExported.text;
     const moduleSymbol = checker.getSymbolAtLocation(reExported);
     const exports = moduleSymbol ? moduleSymbol.exports! : emptyMap as ReadonlyCollection<__String>;
-    return exports.has(InternalSymbolName.ExportEquals) ? [[reExportDefault(moduleSpecifier)], true] :
-        !exports.has(InternalSymbolName.Default) ? [[reExportStar(moduleSpecifier)], false] :
+    return exports.has(InternalSymbolName.ExportEquals) ? [[reExportDefault(moduleSpecifier)], true]
+        : !exports.has(InternalSymbolName.Default) ? [[reExportStar(moduleSpecifier)], false]
         // If there's some non-default export, must include both `export *` and `export default`.
-        exports.size > 1 ? [[reExportStar(moduleSpecifier), reExportDefault(moduleSpecifier)], true] : [[reExportDefault(moduleSpecifier)], true];
+        : exports.size > 1 ? [[reExportStar(moduleSpecifier), reExportDefault(moduleSpecifier)], true] : [[reExportDefault(moduleSpecifier)], true];
 }
 function reExportStar(moduleSpecifier: string): ExportDeclaration {
     return makeExportDeclaration(/*exportSpecifiers*/ undefined, moduleSpecifier);

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -391,8 +391,8 @@ function getInfo(sourceFile: SourceFile, tokenPos: number, errorCode: number, ch
         if (makeStatic && (isPrivateIdentifier(token) || isInterfaceDeclaration(declaration))) return undefined;
 
         const declSourceFile = declaration.getSourceFile();
-        const modifierFlags = isTypeLiteralNode(declaration) ? ModifierFlags.None :
-            (makeStatic ? ModifierFlags.Static : ModifierFlags.None) | (startsWithUnderscore(token.text) ? ModifierFlags.Private : ModifierFlags.None);
+        const modifierFlags = isTypeLiteralNode(declaration) ? ModifierFlags.None
+            : (makeStatic ? ModifierFlags.Static : ModifierFlags.None) | (startsWithUnderscore(token.text) ? ModifierFlags.Private : ModifierFlags.None);
         const isJSFile = isSourceFileJS(declSourceFile);
         const call = tryCast(parent.parent, isCallExpression);
         return { kind: InfoKind.TypeLikeDeclaration, token, call, modifierFlags, parentDeclaration: declaration, declSourceFile, isJSFile };
@@ -407,8 +407,8 @@ function getInfo(sourceFile: SourceFile, tokenPos: number, errorCode: number, ch
 }
 
 function getActionsForMissingMemberDeclaration(context: CodeFixContext, info: TypeLikeDeclarationInfo): CodeFixAction[] | undefined {
-    return info.isJSFile ? singleElementArray(createActionForAddMissingMemberInJavascriptFile(context, info)) :
-        createActionsForAddMissingMemberInTypeScriptFile(context, info);
+    return info.isJSFile ? singleElementArray(createActionForAddMissingMemberInJavascriptFile(context, info))
+        : createActionsForAddMissingMemberInTypeScriptFile(context, info);
 }
 
 function createActionForAddMissingMemberInJavascriptFile(context: CodeFixContext, { parentDeclaration, declSourceFile, modifierFlags, token }: TypeLikeDeclarationInfo): CodeFixAction | undefined {
@@ -421,8 +421,8 @@ function createActionForAddMissingMemberInJavascriptFile(context: CodeFixContext
         return undefined;
     }
 
-    const diagnostic = modifierFlags & ModifierFlags.Static ? Diagnostics.Initialize_static_property_0 :
-        isPrivateIdentifier(token) ? Diagnostics.Declare_a_private_field_named_0 : Diagnostics.Initialize_property_0_in_the_constructor;
+    const diagnostic = modifierFlags & ModifierFlags.Static ? Diagnostics.Initialize_static_property_0
+        : isPrivateIdentifier(token) ? Diagnostics.Declare_a_private_field_named_0 : Diagnostics.Initialize_property_0_in_the_constructor;
 
     return createCodeFixAction(fixMissingMember, changes, [diagnostic, token.text], fixMissingMember, Diagnostics.Add_all_missing_members);
 }
@@ -739,8 +739,8 @@ function createUndefined() {
 }
 
 function isObjectLiteralType(type: Type) {
-    return (type.flags & TypeFlags.Object) &&
-        ((getObjectFlags(type) & ObjectFlags.ObjectLiteral) || (type.symbol && tryCast(singleOrUndefined(type.symbol.declarations), isTypeLiteralNode)));
+    return (type.flags & TypeFlags.Object)
+        && ((getObjectFlags(type) & ObjectFlags.ObjectLiteral) || (type.symbol && tryCast(singleOrUndefined(type.symbol.declarations), isTypeLiteralNode)));
 }
 
 function getUnmatchedAttributes(checker: TypeChecker, target: ScriptTarget, source: JsxOpeningLikeElement) {

--- a/src/services/codefixes/fixAddMissingParam.ts
+++ b/src/services/codefixes/fixAddMissingParam.ts
@@ -137,9 +137,9 @@ function getInfo(sourceFile: SourceFile, program: Program, pos: number): Signatu
 
     const nonOverloadDeclaration = lastOrUndefined(convertibleSignatureDeclarations);
     if (
-        nonOverloadDeclaration === undefined ||
-        nonOverloadDeclaration.body === undefined ||
-        isSourceFileFromLibrary(program, nonOverloadDeclaration.getSourceFile())
+        nonOverloadDeclaration === undefined
+        || nonOverloadDeclaration.body === undefined
+        || isSourceFileFromLibrary(program, nonOverloadDeclaration.getSourceFile())
     ) {
         return undefined;
     }
@@ -164,8 +164,8 @@ function getInfo(sourceFile: SourceFile, program: Program, pos: number): Signatu
         const type = checker.getWidenedType(checker.getBaseTypeOfLiteralType(checker.getTypeAtLocation(arg)));
         const parameter = pos < parametersLength ? nonOverloadDeclaration.parameters[pos] : undefined;
         if (
-            parameter &&
-            checker.isTypeAssignableTo(type, checker.getTypeAtLocation(parameter))
+            parameter
+            && checker.isTypeAssignableTo(type, checker.getTypeAtLocation(parameter))
         ) {
             pos++;
             continue;
@@ -203,9 +203,9 @@ function tryGetName(node: FunctionLikeDeclaration) {
     }
 
     if (
-        isVariableDeclaration(node.parent) && isIdentifier(node.parent.name) ||
-        isPropertyDeclaration(node.parent) ||
-        isParameter(node.parent)
+        isVariableDeclaration(node.parent) && isIdentifier(node.parent.name)
+        || isPropertyDeclaration(node.parent)
+        || isParameter(node.parent)
     ) {
         return node.parent.name;
     }

--- a/src/services/codefixes/fixAddVoidToPromise.ts
+++ b/src/services/codefixes/fixAddVoidToPromise.ts
@@ -70,8 +70,8 @@ function makeChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, 
     if (some(typeArguments)) {
         // append ` | void` to type argument
         const typeArgument = typeArguments[0];
-        const needsParens = !isUnionTypeNode(typeArgument) && !isParenthesizedTypeNode(typeArgument) &&
-            isParenthesizedTypeNode(factory.createUnionTypeNode([typeArgument, factory.createKeywordTypeNode(SyntaxKind.VoidKeyword)]).types[0]);
+        const needsParens = !isUnionTypeNode(typeArgument) && !isParenthesizedTypeNode(typeArgument)
+            && isParenthesizedTypeNode(factory.createUnionTypeNode([typeArgument, factory.createKeywordTypeNode(SyntaxKind.VoidKeyword)]).types[0]);
         if (needsParens) {
             changes.insertText(sourceFile, typeArgument.pos, "(");
         }

--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -58,9 +58,9 @@ function getReturnType(expr: FunctionDeclaration | MethodDeclaration | FunctionE
         return expr.type;
     }
     if (
-        isVariableDeclaration(expr.parent) &&
-        expr.parent.type &&
-        isFunctionTypeNode(expr.parent.type)
+        isVariableDeclaration(expr.parent)
+        && expr.parent.type
+        && isFunctionTypeNode(expr.parent.type)
     ) {
         return expr.parent.type.type;
     }

--- a/src/services/codefixes/fixExpectedComma.ts
+++ b/src/services/codefixes/fixExpectedComma.ts
@@ -51,10 +51,10 @@ interface Info {
 function getInfo(sourceFile: SourceFile, pos: number, _: number): Info | undefined {
     const node = getTokenAtPosition(sourceFile, pos);
 
-    return (node.kind === SyntaxKind.SemicolonToken &&
-            node.parent &&
-            (isObjectLiteralExpression(node.parent) ||
-                isArrayLiteralExpression(node.parent))) ? { node } : undefined;
+    return (node.kind === SyntaxKind.SemicolonToken
+            && node.parent
+            && (isObjectLiteralExpression(node.parent)
+                || isArrayLiteralExpression(node.parent))) ? { node } : undefined;
 }
 
 function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, { node }: Info): void {

--- a/src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts
+++ b/src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts
@@ -48,9 +48,9 @@ function doChanges(changes: textChanges.ChangeTracker, sourceFile: SourceFile, e
 
     // If there is already an implements clause, replace the implements keyword with a comma.
     if (
-        heritageClauses.length === 2 &&
-        heritageClauses[0].token === SyntaxKind.ExtendsKeyword &&
-        heritageClauses[1].token === SyntaxKind.ImplementsKeyword
+        heritageClauses.length === 2
+        && heritageClauses[0].token === SyntaxKind.ExtendsKeyword
+        && heritageClauses[1].token === SyntaxKind.ImplementsKeyword
     ) {
         const implementsToken = heritageClauses[1].getFirstToken()!;
         const implementsFullStart = implementsToken.getFullStart();

--- a/src/services/codefixes/fixNoPropertyAccessFromIndexSignature.ts
+++ b/src/services/codefixes/fixNoPropertyAccessFromIndexSignature.ts
@@ -41,9 +41,9 @@ function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, no
     changes.replaceNode(
         sourceFile,
         node,
-        isPropertyAccessChain(node) ?
-            factory.createElementAccessChain(node.expression, node.questionDotToken, argumentsExpression) :
-            factory.createElementAccessExpression(node.expression, argumentsExpression),
+        isPropertyAccessChain(node)
+            ? factory.createElementAccessChain(node.expression, node.questionDotToken, argumentsExpression)
+            : factory.createElementAccessExpression(node.expression, argumentsExpression),
     );
 }
 

--- a/src/services/codefixes/fixOverrideModifier.ts
+++ b/src/services/codefixes/fixOverrideModifier.ts
@@ -183,10 +183,10 @@ function doAddOverrideModifierChange(changeTracker: textChanges.ChangeTracker, s
     const abstractModifier = find(modifiers, isAbstractModifier);
     const accessibilityModifier = find(modifiers, m => isAccessibilityModifier(m.kind));
     const lastDecorator = findLast(modifiers, isDecorator);
-    const modifierPos = abstractModifier ? abstractModifier.end :
-        staticModifier ? staticModifier.end :
-        accessibilityModifier ? accessibilityModifier.end :
-        lastDecorator ? skipTrivia(sourceFile.text, lastDecorator.end) : classElement.getStart(sourceFile);
+    const modifierPos = abstractModifier ? abstractModifier.end
+        : staticModifier ? staticModifier.end
+        : accessibilityModifier ? accessibilityModifier.end
+        : lastDecorator ? skipTrivia(sourceFile.text, lastDecorator.end) : classElement.getStart(sourceFile);
     const options = accessibilityModifier || staticModifier || abstractModifier ? { prefix: " " } : { suffix: " " };
     changeTracker.insertModifierAt(sourceFile, modifierPos, SyntaxKind.OverrideKeyword, options);
 }

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -89,10 +89,10 @@ function getInfo(sourceFile: SourceFile, pos: number, context: CodeFixContextBas
     // Only fix spelling for No_overload_matches_this_call emitted on the React class component
     if (
         (
-            errorCode === Diagnostics.No_overload_matches_this_call.code ||
-            errorCode === Diagnostics.Type_0_is_not_assignable_to_type_1.code
-        ) &&
-        !isJsxAttribute(parent)
+            errorCode === Diagnostics.No_overload_matches_this_call.code
+            || errorCode === Diagnostics.Type_0_is_not_assignable_to_type_1.code
+        )
+        && !isJsxAttribute(parent)
     ) return undefined;
     const checker = context.program.getTypeChecker();
 

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -338,8 +338,8 @@ function tryDeleteParameter(
 ): void {
     if (mayDeleteParameter(checker, sourceFile, parameter, sourceFiles, program, cancellationToken, isFixAll)) {
         if (
-            parameter.modifiers && parameter.modifiers.length > 0 &&
-            (!isIdentifier(parameter.name) || FindAllReferences.Core.isSymbolReferencedInFile(parameter.name, checker, sourceFile))
+            parameter.modifiers && parameter.modifiers.length > 0
+            && (!isIdentifier(parameter.name) || FindAllReferences.Core.isSymbolReferencedInFile(parameter.name, checker, sourceFile))
         ) {
             for (const modifier of parameter.modifiers) {
                 if (isModifier(modifier)) {
@@ -422,12 +422,12 @@ function isLastParameter(func: FunctionLikeDeclaration, parameter: ParameterDecl
     const parameters = func.parameters;
     const index = parameters.indexOf(parameter);
     Debug.assert(index !== -1, "The parameter should already be in the list");
-    return isFixAll ?
-        parameters.slice(index + 1).every(p => isIdentifier(p.name) && !p.symbol.isReferenced) :
-        index === parameters.length - 1;
+    return isFixAll
+        ? parameters.slice(index + 1).every(p => isIdentifier(p.name) && !p.symbol.isReferenced)
+        : index === parameters.length - 1;
 }
 
 function mayDeleteExpression(node: Node) {
-    return ((isBinaryExpression(node.parent) && node.parent.left === node) ||
-        ((isPostfixUnaryExpression(node.parent) || isPrefixUnaryExpression(node.parent)) && node.parent.operand === node)) && isExpressionStatement(node.parent.parent);
+    return ((isBinaryExpression(node.parent) && node.parent.left === node)
+        || ((isPostfixUnaryExpression(node.parent) || isPrefixUnaryExpression(node.parent)) && node.parent.operand === node)) && isExpressionStatement(node.parent.parent);
 }

--- a/src/services/codefixes/generateAccessors.ts
+++ b/src/services/codefixes/generateAccessors.ts
@@ -283,20 +283,20 @@ function updateFieldDeclaration(changeTracker: textChanges.ChangeTracker, file: 
 }
 
 function insertAccessor(changeTracker: textChanges.ChangeTracker, file: SourceFile, accessor: AccessorDeclaration, declaration: AcceptedDeclaration, container: ContainerDeclaration) {
-    isParameterPropertyDeclaration(declaration, declaration.parent) ? changeTracker.insertMemberAtStart(file, container as ClassLikeDeclaration, accessor) :
-        isPropertyAssignment(declaration) ? changeTracker.insertNodeAfterComma(file, declaration, accessor) :
-        changeTracker.insertNodeAfter(file, declaration, accessor);
+    isParameterPropertyDeclaration(declaration, declaration.parent) ? changeTracker.insertMemberAtStart(file, container as ClassLikeDeclaration, accessor)
+        : isPropertyAssignment(declaration) ? changeTracker.insertNodeAfterComma(file, declaration, accessor)
+        : changeTracker.insertNodeAfter(file, declaration, accessor);
 }
 
 function updateReadonlyPropertyInitializerStatementConstructor(changeTracker: textChanges.ChangeTracker, file: SourceFile, constructor: ConstructorDeclaration, fieldName: string, originalName: string) {
     if (!constructor.body) return;
     constructor.body.forEachChild(function recur(node) {
         if (
-            isElementAccessExpression(node) &&
-            node.expression.kind === SyntaxKind.ThisKeyword &&
-            isStringLiteral(node.argumentExpression) &&
-            node.argumentExpression.text === originalName &&
-            isWriteAccess(node)
+            isElementAccessExpression(node)
+            && node.expression.kind === SyntaxKind.ThisKeyword
+            && isStringLiteral(node.argumentExpression)
+            && node.argumentExpression.text === originalName
+            && isWriteAccess(node)
         ) {
             changeTracker.replaceNode(file, node.argumentExpression, factory.createStringLiteral(fieldName));
         }

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -206,9 +206,9 @@ export function addNewNodeForMemberSymbol(
     const declarationName = createDeclarationName(symbol, declaration);
     const effectiveModifierFlags = declaration ? getEffectiveModifierFlags(declaration) : ModifierFlags.None;
     let modifierFlags = effectiveModifierFlags & ModifierFlags.Static;
-    modifierFlags |= effectiveModifierFlags & ModifierFlags.Public ? ModifierFlags.Public :
-        effectiveModifierFlags & ModifierFlags.Protected ? ModifierFlags.Protected :
-        ModifierFlags.None;
+    modifierFlags |= effectiveModifierFlags & ModifierFlags.Public ? ModifierFlags.Public
+        : effectiveModifierFlags & ModifierFlags.Protected ? ModifierFlags.Protected
+        : ModifierFlags.None;
     if (declaration && isAutoAccessorPropertyDeclaration(declaration)) {
         modifierFlags |= ModifierFlags.Accessor;
     }
@@ -348,8 +348,8 @@ export function addNewNodeForMemberSymbol(
     }
 
     function createBody(block: Block | undefined, quotePreference: QuotePreference, ambient?: boolean) {
-        return ambient ? undefined :
-            getSynthesizedDeepClone(block, /*includeTrivia*/ false) || createStubbedMethodBody(quotePreference);
+        return ambient ? undefined
+            : getSynthesizedDeepClone(block, /*includeTrivia*/ false) || createStubbedMethodBody(quotePreference);
     }
 
     function createTypeNode(typeNode: TypeNode | undefined) {

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -503,8 +503,8 @@ function inferTypeForVariableFromUsage(token: Identifier | PrivateIdentifier, pr
 
 function inferTypeForParametersFromUsage(func: SignatureDeclaration, sourceFile: SourceFile, program: Program, cancellationToken: CancellationToken) {
     const references = getFunctionReferences(func, sourceFile, program, cancellationToken);
-    return references && inferTypeFromReferences(program, references, cancellationToken).parameters(func) ||
-        func.parameters.map<ParameterInference>(p => ({
+    return references && inferTypeFromReferences(program, references, cancellationToken).parameters(func)
+        || func.parameters.map<ParameterInference>(p => ({
             declaration: p,
             type: isIdentifier(p.name) ? inferTypeForVariableFromUsage(p.name, program, cancellationToken) : program.getTypeChecker().getAnyType(),
         }));
@@ -519,9 +519,9 @@ function getFunctionReferences(containingFunction: SignatureDeclaration, sourceF
         case SyntaxKind.ArrowFunction:
         case SyntaxKind.FunctionExpression:
             const parent = containingFunction.parent;
-            searchToken = (isVariableDeclaration(parent) || isPropertyDeclaration(parent)) && isIdentifier(parent.name) ?
-                parent.name :
-                containingFunction.name;
+            searchToken = (isVariableDeclaration(parent) || isPropertyDeclaration(parent)) && isIdentifier(parent.name)
+                ? parent.name
+                : containingFunction.name;
             break;
         case SyntaxKind.FunctionDeclaration:
         case SyntaxKind.MethodDeclaration:
@@ -882,8 +882,8 @@ function inferTypeFromReferences(program: Program, references: readonly Identifi
             case SyntaxKind.BarBarToken:
             case SyntaxKind.QuestionQuestionToken:
                 if (
-                    node === parent.left &&
-                    (node.parent.parent.kind === SyntaxKind.VariableDeclaration || isAssignmentExpression(node.parent.parent, /*excludeCompoundAssignment*/ true))
+                    node === parent.left
+                    && (node.parent.parent.kind === SyntaxKind.VariableDeclaration || isAssignmentExpression(node.parent.parent, /*excludeCompoundAssignment*/ true))
                 ) {
                     // var x = x || {};
                     // TODO: use getFalsyflagsOfType
@@ -953,9 +953,9 @@ function inferTypeFromReferences(program: Program, references: readonly Identifi
     }
 
     function inferTypeFromPropertyAssignment(assignment: PropertyAssignment | ShorthandPropertyAssignment, usage: Usage) {
-        const nodeWithRealType = isVariableDeclaration(assignment.parent.parent) ?
-            assignment.parent.parent :
-            assignment.parent;
+        const nodeWithRealType = isVariableDeclaration(assignment.parent.parent)
+            ? assignment.parent.parent
+            : assignment.parent;
         addCandidateThisType(usage, checker.getTypeAtLocation(nodeWithRealType));
     }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1332,9 +1332,9 @@ function completionInfoFromData(
     if (keywordFilters !== KeywordCompletionFilters.None) {
         for (const keywordEntry of getKeywordCompletions(keywordFilters, !insideJsDocTagTypeExpression && isSourceFileJS(sourceFile))) {
             if (
-                isTypeOnlyLocation && isTypeKeyword(stringToToken(keywordEntry.name)!) ||
-                !isTypeOnlyLocation && isContextualKeywordInAutoImportableExpressionSpace(keywordEntry.name) ||
-                !uniqueNames.has(keywordEntry.name)
+                isTypeOnlyLocation && isTypeKeyword(stringToToken(keywordEntry.name)!)
+                || !isTypeOnlyLocation && isContextualKeywordInAutoImportableExpressionSpace(keywordEntry.name)
+                || !uniqueNames.has(keywordEntry.name)
             ) {
                 uniqueNames.add(keywordEntry.name);
                 insertSorted(entries, keywordEntry, compareCompletionEntries, /*allowDuplicates*/ true);
@@ -1621,8 +1621,8 @@ function getJSCompletionEntries(
 }
 
 function completionNameForLiteral(sourceFile: SourceFile, preferences: UserPreferences, literal: string | number | PseudoBigInt): string {
-    return typeof literal === "object" ? pseudoBigIntToString(literal) + "n" :
-        isString(literal) ? quote(sourceFile, preferences, literal) : JSON.stringify(literal);
+    return typeof literal === "object" ? pseudoBigIntToString(literal) + "n"
+        : isString(literal) ? quote(sourceFile, preferences, literal) : JSON.stringify(literal);
 }
 
 function createCompletionEntryForLiteral(sourceFile: SourceFile, preferences: UserPreferences, literal: string | number | PseudoBigInt): CompletionEntry {
@@ -1681,8 +1681,8 @@ function createCompletionEntry(
             insertText = `?.${insertText}`;
         }
 
-        const dot = findChildOfKind(propertyAccessToConvert, SyntaxKind.DotToken, sourceFile) ||
-            findChildOfKind(propertyAccessToConvert, SyntaxKind.QuestionDotToken, sourceFile);
+        const dot = findChildOfKind(propertyAccessToConvert, SyntaxKind.DotToken, sourceFile)
+            || findChildOfKind(propertyAccessToConvert, SyntaxKind.QuestionDotToken, sourceFile);
         if (!dot) {
             return undefined;
         }
@@ -1738,12 +1738,12 @@ function createCompletionEntry(
     // Completion should add a comma after "red" and provide completions for b
     if (completionKind === CompletionKind.ObjectPropertyDeclaration && contextToken && findPrecedingToken(contextToken.pos, sourceFile, contextToken)?.kind !== SyntaxKind.CommaToken) {
         if (
-            isMethodDeclaration(contextToken.parent.parent) ||
-            isGetAccessorDeclaration(contextToken.parent.parent) ||
-            isSetAccessorDeclaration(contextToken.parent.parent) ||
-            isSpreadAssignment(contextToken.parent) ||
-            findAncestor(contextToken.parent, isPropertyAssignment)?.getLastToken(sourceFile) === contextToken ||
-            isShorthandPropertyAssignment(contextToken.parent) && getLineAndCharacterOfPosition(sourceFile, contextToken.getEnd()).line !== getLineAndCharacterOfPosition(sourceFile, position).line
+            isMethodDeclaration(contextToken.parent.parent)
+            || isGetAccessorDeclaration(contextToken.parent.parent)
+            || isSetAccessorDeclaration(contextToken.parent.parent)
+            || isSpreadAssignment(contextToken.parent)
+            || findAncestor(contextToken.parent, isPropertyAssignment)?.getLastToken(sourceFile) === contextToken
+            || isShorthandPropertyAssignment(contextToken.parent) && getLineAndCharacterOfPosition(sourceFile, contextToken.getEnd()).line !== getLineAndCharacterOfPosition(sourceFile, position).line
         ) {
             source = CompletionSource.ObjectLiteralMemberWithComma;
             hasAction = true;
@@ -1751,10 +1751,10 @@ function createCompletionEntry(
     }
 
     if (
-        preferences.includeCompletionsWithClassMemberSnippets &&
-        preferences.includeCompletionsWithInsertText &&
-        completionKind === CompletionKind.MemberLike &&
-        isClassLikeMemberCompletion(symbol, location, sourceFile)
+        preferences.includeCompletionsWithClassMemberSnippets
+        && preferences.includeCompletionsWithInsertText
+        && completionKind === CompletionKind.MemberLike
+        && isClassLikeMemberCompletion(symbol, location, sourceFile)
     ) {
         let importAdder;
         const memberCompletionEntry = getEntryForMemberCompletion(
@@ -1897,21 +1897,21 @@ function isClassLikeMemberCompletion(symbol: Symbol, location: Node, sourceFile:
     `location` is a syntax list (with modifiers as children),
     and `location.parent` is a class-like declaration.
     */
-    return !!(symbol.flags & memberFlags) &&
-        (
-            isClassLike(location) ||
-            (
-                location.parent &&
-                location.parent.parent &&
-                isClassElement(location.parent) &&
-                location === location.parent.name &&
-                location.parent.getLastToken(sourceFile) === location.parent.name &&
-                isClassLike(location.parent.parent)
-            ) ||
-            (
-                location.parent &&
-                isSyntaxList(location) &&
-                isClassLike(location.parent)
+    return !!(symbol.flags & memberFlags)
+        && (
+            isClassLike(location)
+            || (
+                location.parent
+                && location.parent.parent
+                && isClassElement(location.parent)
+                && location === location.parent.name
+                && location.parent.getLastToken(sourceFile) === location.parent.name
+                && isClassLike(location.parent.parent)
+            )
+            || (
+                location.parent
+                && isSyntaxList(location)
+                && isClassLike(location.parent)
             )
         );
 }
@@ -2069,8 +2069,8 @@ function getPresentModifiers(
     position: number,
 ): { modifiers: ModifierFlags; decorators?: Decorator[]; range?: TextRange; } {
     if (
-        !contextToken ||
-        getLineAndCharacterOfPosition(sourceFile, position).line
+        !contextToken
+        || getLineAndCharacterOfPosition(sourceFile, position).line
             > getLineAndCharacterOfPosition(sourceFile, contextToken.getEnd()).line
     ) {
         return { modifiers: ModifierFlags.None };
@@ -2487,9 +2487,9 @@ function completionEntryDataToSymbolOriginInfo(data: CompletionEntryData, comple
 function getInsertTextAndReplacementSpanForImportCompletion(name: string, importStatementCompletion: ImportStatementCompletionInfo, origin: SymbolOriginInfoResolvedExport, useSemicolons: boolean, sourceFile: SourceFile, options: CompilerOptions, preferences: UserPreferences) {
     const replacementSpan = importStatementCompletion.replacementSpan;
     const quotedModuleSpecifier = escapeSnippetText(quote(sourceFile, preferences, origin.moduleSpecifier));
-    const exportKind = origin.isDefaultExport ? ExportKind.Default :
-        origin.exportName === InternalSymbolName.ExportEquals ? ExportKind.ExportEquals :
-        ExportKind.Named;
+    const exportKind = origin.isDefaultExport ? ExportKind.Default
+        : origin.exportName === InternalSymbolName.ExportEquals ? ExportKind.ExportEquals
+        : ExportKind.Named;
     const tabStop = preferences.includeCompletionsWithSnippetText ? "$1" : "";
     const importKind = codefix.getImportKind(sourceFile, exportKind, options, /*forceImportKeyword*/ true);
     const isImportSpecifierTypeOnly = importStatementCompletion.couldBeTypeOnlyImportSpecifier;
@@ -2517,8 +2517,8 @@ function quotePropertyName(sourceFile: SourceFile, preferences: UserPreferences,
 }
 
 function isRecommendedCompletionMatch(localSymbol: Symbol, recommendedCompletion: Symbol | undefined, checker: TypeChecker): boolean {
-    return localSymbol === recommendedCompletion ||
-        !!(localSymbol.flags & SymbolFlags.ExportValue) && checker.getExportSymbolOfSymbol(localSymbol) === recommendedCompletion;
+    return localSymbol === recommendedCompletion
+        || !!(localSymbol.flags & SymbolFlags.ExportValue) && checker.getExportSymbolOfSymbol(localSymbol) === recommendedCompletion;
 }
 
 function getSourceFromOrigin(origin: SymbolOriginInfo | undefined): string | undefined {
@@ -2655,14 +2655,14 @@ export function getCompletionEntriesFromSymbols(
             const symbolDeclaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
             if (
                 variableOrParameterDeclaration && symbolDeclaration && (
-                    (isTypeParameterDeclaration(variableOrParameterDeclaration) && isTypeParameterDeclaration(symbolDeclaration)) ||
-                    (isParameter(variableOrParameterDeclaration) && isParameter(symbolDeclaration))
+                    (isTypeParameterDeclaration(variableOrParameterDeclaration) && isTypeParameterDeclaration(symbolDeclaration))
+                    || (isParameter(variableOrParameterDeclaration) && isParameter(symbolDeclaration))
                 )
             ) {
                 const symbolDeclarationPos = symbolDeclaration.pos;
-                const parameters = isParameter(variableOrParameterDeclaration) ? variableOrParameterDeclaration.parent.parameters :
-                    isInferTypeNode(variableOrParameterDeclaration.parent) ? undefined :
-                    variableOrParameterDeclaration.parent.typeParameters;
+                const parameters = isParameter(variableOrParameterDeclaration) ? variableOrParameterDeclaration.parent.parameters
+                    : isInferTypeNode(variableOrParameterDeclaration.parent) ? undefined
+                    : variableOrParameterDeclaration.parent.typeParameters;
                 if (symbolDeclarationPos >= variableOrParameterDeclaration.pos && parameters && symbolDeclarationPos < parameters.end) {
                     return false;
                 }
@@ -2987,9 +2987,9 @@ function getCompletionEntryCodeActionsAndSourceDisplay(
                 sourceDisplay: undefined,
                 codeActions: [{
                     changes,
-                    description: importAdder?.hasFixes() ?
-                        diagnosticToString([Diagnostics.Includes_imports_of_types_referenced_by_0, name]) :
-                        diagnosticToString([Diagnostics.Update_modifiers_of_0, name]),
+                    description: importAdder?.hasFixes()
+                        ? diagnosticToString([Diagnostics.Includes_imports_of_types_referenced_by_0, name])
+                        : diagnosticToString([Diagnostics.Update_modifiers_of_0, name]),
                 }],
             };
         }
@@ -3157,13 +3157,13 @@ function getContextualType(previousToken: Node, position: number, sourceFile: So
             return isJsxExpression(parent) && !isJsxElement(parent.parent) && !isJsxFragment(parent.parent) ? checker.getContextualTypeForJsxAttribute(parent.parent) : undefined;
         default:
             const argInfo = SignatureHelp.getArgumentInfoForCompletions(previousToken, position, sourceFile, checker);
-            return argInfo ?
+            return argInfo
                 // At `,`, treat this as the next argument after the comma.
-                checker.getContextualTypeForArgumentAtIndex(argInfo.invocation, argInfo.argumentIndex + (previousToken.kind === SyntaxKind.CommaToken ? 1 : 0)) :
-                isEqualityOperatorKind(previousToken.kind) && isBinaryExpression(parent) && isEqualityOperatorKind(parent.operatorToken.kind) ?
+                ? checker.getContextualTypeForArgumentAtIndex(argInfo.invocation, argInfo.argumentIndex + (previousToken.kind === SyntaxKind.CommaToken ? 1 : 0))
+                : isEqualityOperatorKind(previousToken.kind) && isBinaryExpression(parent) && isEqualityOperatorKind(parent.operatorToken.kind)
                 // completion at `x ===/**/` should be for the right side
-                checker.getTypeAtLocation(parent.left) :
-                checker.getContextualType(previousToken as Expression, ContextFlags.Completions) || checker.getContextualType(previousToken as Expression);
+                ? checker.getTypeAtLocation(parent.left)
+                : checker.getContextualType(previousToken as Expression, ContextFlags.Completions) || checker.getContextualType(previousToken as Expression);
     }
 }
 
@@ -3246,10 +3246,10 @@ function getCompletionData(
             if (typeExpression) {
                 currentToken = getTokenAtPosition(sourceFile, position);
                 if (
-                    !currentToken ||
-                    (!isDeclarationName(currentToken) &&
-                        (currentToken.parent.kind !== SyntaxKind.JSDocPropertyTag ||
-                            (currentToken.parent as JSDocPropertyTag).name !== currentToken))
+                    !currentToken
+                    || (!isDeclarationName(currentToken)
+                        && (currentToken.parent.kind !== SyntaxKind.JSDocPropertyTag
+                            || (currentToken.parent as JSDocPropertyTag).name !== currentToken))
                 ) {
                     // Use as type location if inside tag's type expression
                     insideJsDocTagTypeExpression = isCurrentlyEditingNode(typeExpression);
@@ -3333,11 +3333,11 @@ function getCompletionData(
                     node = propertyAccessToConvert.expression;
                     const leftmostAccessExpression = getLeftmostAccessExpression(propertyAccessToConvert);
                     if (
-                        nodeIsMissing(leftmostAccessExpression) ||
-                        ((isCallExpression(node) || isFunctionLike(node)) &&
-                            node.end === contextToken.pos &&
-                            node.getChildCount(sourceFile) &&
-                            last(node.getChildren(sourceFile)).kind !== SyntaxKind.CloseParenToken)
+                        nodeIsMissing(leftmostAccessExpression)
+                        || ((isCallExpression(node) || isFunctionLike(node))
+                            && node.end === contextToken.pos
+                            && node.getChildCount(sourceFile)
+                            && last(node.getChildren(sourceFile)).kind !== SyntaxKind.CloseParenToken)
                     ) {
                         // This is likely dot from incorrectly parsed expression and user is starting to write spread
                         // eg: Math.min(./**/)
@@ -3429,8 +3429,8 @@ function getCompletionData(
                 case SyntaxKind.JsxAttribute:
                     // For `<div className="x" [||] ></div>`, `parent` will be JsxAttribute and `previousToken` will be its initializer
                     if (
-                        (parent as JsxAttribute).initializer === previousToken &&
-                        previousToken.end < position
+                        (parent as JsxAttribute).initializer === previousToken
+                        && previousToken.end < position
                     ) {
                         isJsxIdentifierExpected = true;
                         break;
@@ -3444,9 +3444,9 @@ function getCompletionData(
                             // For `<div x=[|f/**/|]`, `parent` will be `x` and `previousToken.parent` will be `f` (which is its own JsxAttribute)
                             // Note for `<div someBool f>` we don't want to treat this as a jsx inializer, instead it's the attribute name.
                             if (
-                                parent !== previousToken.parent &&
-                                !(parent as JsxAttribute).initializer &&
-                                findChildOfKind(parent, SyntaxKind.EqualsToken, sourceFile)
+                                parent !== previousToken.parent
+                                && !(parent as JsxAttribute).initializer
+                                && findChildOfKind(parent, SyntaxKind.EqualsToken, sourceFile)
                             ) {
                                 isJsxInitializer = previousToken as Identifier;
                             }
@@ -3601,10 +3601,10 @@ function getCompletionData(
                     const isValidAccess: (symbol: Symbol) => boolean = isNamespaceName
                         // At `namespace N.M/**/`, if this is the only declaration of `M`, don't include `M` as a completion.
                         ? symbol => !!(symbol.flags & SymbolFlags.Namespace) && !symbol.declarations?.every(d => d.parent === node.parent)
-                        : isRhsOfImportDeclaration ?
+                        : isRhsOfImportDeclaration
                         // Any kind is allowed when dotting off namespace in internal import equals declaration
-                        symbol => isValidTypeAccess(symbol) || isValidValueAccess(symbol) :
-                        isTypeLocation || insideJsDocTagTypeExpression ? isValidTypeAccess : isValidValueAccess;
+                        ? symbol => isValidTypeAccess(symbol) || isValidValueAccess(symbol)
+                        : isTypeLocation || insideJsDocTagTypeExpression ? isValidTypeAccess : isValidValueAccess;
                     for (const exportedSymbol of exportedSymbols) {
                         if (isValidAccess(exportedSymbol)) {
                             symbols.push(exportedSymbol);
@@ -3613,17 +3613,17 @@ function getCompletionData(
 
                     // If the module is merged with a value, we must get the type of the class and add its propertes (for inherited static methods).
                     if (
-                        !isTypeLocation &&
-                        !insideJsDocTagTypeExpression &&
-                        symbol.declarations &&
-                        symbol.declarations.some(d => d.kind !== SyntaxKind.SourceFile && d.kind !== SyntaxKind.ModuleDeclaration && d.kind !== SyntaxKind.EnumDeclaration)
+                        !isTypeLocation
+                        && !insideJsDocTagTypeExpression
+                        && symbol.declarations
+                        && symbol.declarations.some(d => d.kind !== SyntaxKind.SourceFile && d.kind !== SyntaxKind.ModuleDeclaration && d.kind !== SyntaxKind.EnumDeclaration)
                     ) {
                         let type = typeChecker.getTypeOfSymbolAtLocation(symbol, node).getNonOptionalType();
                         let insertQuestionDot = false;
                         if (type.isNullableType()) {
-                            const canCorrectToQuestionDot = isRightOfDot &&
-                                !isRightOfQuestionDot &&
-                                preferences.includeAutomaticOptionalChainCompletions !== false;
+                            const canCorrectToQuestionDot = isRightOfDot
+                                && !isRightOfQuestionDot
+                                && preferences.includeAutomaticOptionalChainCompletions !== false;
 
                             if (canCorrectToQuestionDot || isRightOfQuestionDot) {
                                 type = type.getNonNullableType();
@@ -3650,9 +3650,9 @@ function getCompletionData(
             if (!isTypeLocation) {
                 let insertQuestionDot = false;
                 if (type.isNullableType()) {
-                    const canCorrectToQuestionDot = isRightOfDot &&
-                        !isRightOfQuestionDot &&
-                        preferences.includeAutomaticOptionalChainCompletions !== false;
+                    const canCorrectToQuestionDot = isRightOfDot
+                        && !isRightOfQuestionDot
+                        && preferences.includeAutomaticOptionalChainCompletions !== false;
 
                     if (canCorrectToQuestionDot || isRightOfQuestionDot) {
                         type = type.getNonNullableType();
@@ -3720,9 +3720,9 @@ function getCompletionData(
                 symbols.push(firstAccessibleSymbol);
                 const moduleSymbol = firstAccessibleSymbol.parent;
                 if (
-                    !moduleSymbol ||
-                    !isExternalModuleSymbol(moduleSymbol) ||
-                    typeChecker.tryGetMemberInModuleExportsAndProperties(firstAccessibleSymbol.name, moduleSymbol) !== firstAccessibleSymbol
+                    !moduleSymbol
+                    || !isExternalModuleSymbol(moduleSymbol)
+                    || typeChecker.tryGetMemberInModuleExportsAndProperties(firstAccessibleSymbol.name, moduleSymbol) !== firstAccessibleSymbol
                 ) {
                     symbolToOriginInfoMap[index] = { kind: getNullableSymbolOriginInfoKind(SymbolOriginInfoKind.SymbolMemberNoExport) };
                 }
@@ -3877,9 +3877,9 @@ function getCompletionData(
         //   - 'contextToken' was adjusted to the token prior to 'previousToken'
         //      because we were at the end of an identifier.
         //   - 'previousToken' is defined.
-        const adjustedPosition = previousToken !== contextToken ?
-            previousToken.getStart() :
-            position;
+        const adjustedPosition = previousToken !== contextToken
+            ? previousToken.getStart()
+            : position;
 
         const scopeNode = getScopeNode(contextToken, adjustedPosition, sourceFile) || sourceFile;
         isInSnippetScope = isSnippetScope(scopeNode);
@@ -3892,8 +3892,8 @@ function getCompletionData(
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             if (
-                !typeChecker.isArgumentsSymbol(symbol) &&
-                !some(symbol.declarations, d => d.getSourceFile() === sourceFile)
+                !typeChecker.isArgumentsSymbol(symbol)
+                && !some(symbol.declarations, d => d.getSourceFile() === sourceFile)
             ) {
                 symbolToSortTextMap[getSymbolId(symbol)] = SortText.GlobalsOrKeywords;
             }
@@ -3953,17 +3953,17 @@ function getCompletionData(
     function isTypeOnlyCompletion(): boolean {
         return insideJsDocTagTypeExpression
             || !!importStatementCompletion && isTypeOnlyImportOrExportDeclaration(location.parent)
-            || !isContextTokenValueLocation(contextToken) &&
-                (isPossiblyTypeArgumentPosition(contextToken, sourceFile, typeChecker)
+            || !isContextTokenValueLocation(contextToken)
+                && (isPossiblyTypeArgumentPosition(contextToken, sourceFile, typeChecker)
                     || isPartOfTypeNode(location)
                     || isContextTokenTypeLocation(contextToken));
     }
 
     function isContextTokenValueLocation(contextToken: Node) {
-        return contextToken &&
-            ((contextToken.kind === SyntaxKind.TypeOfKeyword &&
-                (contextToken.parent.kind === SyntaxKind.TypeQuery || isTypeOfExpression(contextToken.parent))) ||
-                (contextToken.kind === SyntaxKind.AssertsKeyword && contextToken.parent.kind === SyntaxKind.TypePredicate));
+        return contextToken
+            && ((contextToken.kind === SyntaxKind.TypeOfKeyword
+                && (contextToken.parent.kind === SyntaxKind.TypeQuery || isTypeOfExpression(contextToken.parent)))
+                || (contextToken.kind === SyntaxKind.AssertsKeyword && contextToken.parent.kind === SyntaxKind.TypePredicate));
     }
 
     function isContextTokenTypeLocation(contextToken: Node): boolean {
@@ -3971,11 +3971,11 @@ function getCompletionData(
             const parentKind = contextToken.parent.kind;
             switch (contextToken.kind) {
                 case SyntaxKind.ColonToken:
-                    return parentKind === SyntaxKind.PropertyDeclaration ||
-                        parentKind === SyntaxKind.PropertySignature ||
-                        parentKind === SyntaxKind.Parameter ||
-                        parentKind === SyntaxKind.VariableDeclaration ||
-                        isFunctionLikeKind(parentKind);
+                    return parentKind === SyntaxKind.PropertyDeclaration
+                        || parentKind === SyntaxKind.PropertySignature
+                        || parentKind === SyntaxKind.Parameter
+                        || parentKind === SyntaxKind.VariableDeclaration
+                        || isFunctionLikeKind(parentKind);
 
                 case SyntaxKind.EqualsToken:
                     return parentKind === SyntaxKind.TypeAliasDeclaration || parentKind === SyntaxKind.TypeParameter;
@@ -3984,8 +3984,8 @@ function getCompletionData(
                     return parentKind === SyntaxKind.AsExpression;
 
                 case SyntaxKind.LessThanToken:
-                    return parentKind === SyntaxKind.TypeReference ||
-                        parentKind === SyntaxKind.TypeAssertionExpression;
+                    return parentKind === SyntaxKind.TypeReference
+                        || parentKind === SyntaxKind.TypeAssertionExpression;
 
                 case SyntaxKind.ExtendsKeyword:
                     return parentKind === SyntaxKind.TypeParameter;
@@ -4011,9 +4011,9 @@ function getCompletionData(
         const isAfterTypeOnlyImportSpecifierModifier = previousToken === contextToken
             && importStatementCompletion;
 
-        const lowerCaseTokenText = isAfterTypeOnlyImportSpecifierModifier ? "" :
-            previousToken && isIdentifier(previousToken) ? previousToken.text.toLowerCase() :
-            "";
+        const lowerCaseTokenText = isAfterTypeOnlyImportSpecifierModifier ? ""
+            : previousToken && isIdentifier(previousToken) ? previousToken.text.toLowerCase()
+            : "";
 
         const moduleSpecifierCache = host.getModuleSpecifierCache?.();
         const exportInfo = getExportInfoMap(sourceFile, host, program, preferences, cancellationToken);
@@ -4205,11 +4205,11 @@ function getCompletionData(
 
     function isCompletionListBlocker(contextToken: Node): boolean {
         const start = timestamp();
-        const result = isInStringOrRegularExpressionOrTemplateLiteral(contextToken) ||
-            isSolelyIdentifierDefinitionLocation(contextToken) ||
-            isDotOfNumericLiteral(contextToken) ||
-            isInJsxText(contextToken) ||
-            isBigIntLiteral(contextToken);
+        const result = isInStringOrRegularExpressionOrTemplateLiteral(contextToken)
+            || isSolelyIdentifierDefinitionLocation(contextToken)
+            || isDotOfNumericLiteral(contextToken)
+            || isInJsxText(contextToken)
+            || isBigIntLiteral(contextToken);
         log("getCompletionsAtPosition: isCompletionListBlocker: " + (timestamp() - start));
         return result;
     }
@@ -4316,8 +4316,8 @@ function getCompletionData(
         //   2. at the end position of an unterminated token.
         //   3. at the end of a regular expression (due to trailing flags like '/foo/g').
         return (isRegularExpressionLiteral(contextToken) || isStringTextContainingNode(contextToken)) && (
-            rangeContainsPositionExclusive(contextToken, position) ||
-            position === contextToken.end && (!!contextToken.isUnterminated || isRegularExpressionLiteral(contextToken))
+            rangeContainsPositionExclusive(contextToken, position)
+            || position === contextToken.end && (!!contextToken.isUnterminated || isRegularExpressionLiteral(contextToken))
         );
     }
 
@@ -4456,8 +4456,8 @@ function getCompletionData(
         if (!contextToken) return GlobalsSearch.Continue;
 
         // `import { |` or `import { a as 0, | }` or `import { type | }`
-        const namedImportsOrExports = contextToken.kind === SyntaxKind.OpenBraceToken || contextToken.kind === SyntaxKind.CommaToken ? tryCast(contextToken.parent, isNamedImportsOrExports) :
-            isTypeKeywordTokenOrIdentifier(contextToken) ? tryCast(contextToken.parent.parent, isNamedImportsOrExports) : undefined;
+        const namedImportsOrExports = contextToken.kind === SyntaxKind.OpenBraceToken || contextToken.kind === SyntaxKind.CommaToken ? tryCast(contextToken.parent, isNamedImportsOrExports)
+            : isTypeKeywordTokenOrIdentifier(contextToken) ? tryCast(contextToken.parent.parent, isNamedImportsOrExports) : undefined;
 
         if (!namedImportsOrExports) return GlobalsSearch.Continue;
 
@@ -4497,8 +4497,8 @@ function getCompletionData(
     function tryGetImportAttributesCompletionSymbols(): GlobalsSearch {
         if (contextToken === undefined) return GlobalsSearch.Continue;
 
-        const importAttributes = contextToken.kind === SyntaxKind.OpenBraceToken || contextToken.kind === SyntaxKind.CommaToken ? tryCast(contextToken.parent, isImportAttributes) :
-            contextToken.kind === SyntaxKind.ColonToken ? tryCast(contextToken.parent.parent, isImportAttributes) : undefined;
+        const importAttributes = contextToken.kind === SyntaxKind.OpenBraceToken || contextToken.kind === SyntaxKind.CommaToken ? tryCast(contextToken.parent, isImportAttributes)
+            : contextToken.kind === SyntaxKind.ColonToken ? tryCast(contextToken.parent.parent, isImportAttributes) : undefined;
         if (importAttributes === undefined) return GlobalsSearch.Continue;
 
         const existing = new Set(importAttributes.elements.map(getNameFromImportAttribute));
@@ -4548,8 +4548,8 @@ function getCompletionData(
         completionKind = CompletionKind.MemberLike;
         // Declaring new property/method/accessor
         isNewIdentifierLocation = true;
-        keywordFilters = contextToken.kind === SyntaxKind.AsteriskToken ? KeywordCompletionFilters.None :
-            isClassLike(decl) ? KeywordCompletionFilters.ClassElementKeywords : KeywordCompletionFilters.InterfaceElementKeywords;
+        keywordFilters = contextToken.kind === SyntaxKind.AsteriskToken ? KeywordCompletionFilters.None
+            : isClassLike(decl) ? KeywordCompletionFilters.ClassElementKeywords : KeywordCompletionFilters.InterfaceElementKeywords;
 
         // If you're in an interface you don't want to repeat things from super-interface. So just stop here.
         if (!isClassLike(decl)) return GlobalsSearch.Success;
@@ -4580,9 +4580,9 @@ function getCompletionData(
             const baseTypeNodes = isClassLike(decl) && classElementModifierFlags & ModifierFlags.Override ? singleElementArray(getEffectiveBaseTypeNode(decl)) : getAllSuperTypeNodes(decl);
             const baseSymbols = flatMap(baseTypeNodes, baseTypeNode => {
                 const type = typeChecker.getTypeAtLocation(baseTypeNode);
-                return classElementModifierFlags & ModifierFlags.Static ?
-                    type?.symbol && typeChecker.getPropertiesOfType(typeChecker.getTypeOfSymbolAtLocation(type.symbol, decl)) :
-                    type && typeChecker.getPropertiesOfType(type);
+                return classElementModifierFlags & ModifierFlags.Static
+                    ? type?.symbol && typeChecker.getPropertiesOfType(typeChecker.getTypeOfSymbolAtLocation(type.symbol, decl))
+                    : type && typeChecker.getPropertiesOfType(type);
             });
             symbols = concatenate(symbols, filterClassMembersList(baseSymbols, decl.members, classElementModifierFlags));
             forEach(symbols, (symbol, index) => {
@@ -4686,9 +4686,9 @@ function getCompletionData(
 
                 case SyntaxKind.CloseBraceToken:
                     if (
-                        parent &&
-                        parent.kind === SyntaxKind.JsxExpression &&
-                        parent.parent && parent.parent.kind === SyntaxKind.JsxAttribute
+                        parent
+                        && parent.kind === SyntaxKind.JsxExpression
+                        && parent.parent && parent.parent.kind === SyntaxKind.JsxAttribute
                     ) {
                         // Currently we parse JsxOpeningLikeElement as:
                         //      JsxOpeningLikeElement
@@ -4833,9 +4833,9 @@ function getCompletionData(
             // - its name of the parameter and not being edited
             // eg. constructor(a |<- this shouldnt show completion
             if (
-                !isIdentifier(contextToken) ||
-                isParameterPropertyModifier(keywordForNode(contextToken)) ||
-                isCurrentlyEditingNode(contextToken)
+                !isIdentifier(contextToken)
+                || isParameterPropertyModifier(keywordForNode(contextToken))
+                || isCurrentlyEditingNode(contextToken)
             ) {
                 return false;
             }
@@ -4901,8 +4901,8 @@ function getCompletionData(
     }
 
     function isPreviousPropertyDeclarationTerminated(contextToken: Node, position: number) {
-        return contextToken.kind !== SyntaxKind.EqualsToken &&
-            (contextToken.kind === SyntaxKind.SemicolonToken
+        return contextToken.kind !== SyntaxKind.EqualsToken
+            && (contextToken.kind === SyntaxKind.SemicolonToken
                 || !positionsAreOnSameLine(contextToken.end, position, sourceFile));
     }
 
@@ -4940,13 +4940,13 @@ function getCompletionData(
         for (const m of existingMembers) {
             // Ignore omitted expressions for missing members
             if (
-                m.kind !== SyntaxKind.PropertyAssignment &&
-                m.kind !== SyntaxKind.ShorthandPropertyAssignment &&
-                m.kind !== SyntaxKind.BindingElement &&
-                m.kind !== SyntaxKind.MethodDeclaration &&
-                m.kind !== SyntaxKind.GetAccessor &&
-                m.kind !== SyntaxKind.SetAccessor &&
-                m.kind !== SyntaxKind.SpreadAssignment
+                m.kind !== SyntaxKind.PropertyAssignment
+                && m.kind !== SyntaxKind.ShorthandPropertyAssignment
+                && m.kind !== SyntaxKind.BindingElement
+                && m.kind !== SyntaxKind.MethodDeclaration
+                && m.kind !== SyntaxKind.GetAccessor
+                && m.kind !== SyntaxKind.SetAccessor
+                && m.kind !== SyntaxKind.SpreadAssignment
             ) {
                 continue;
             }
@@ -5051,10 +5051,10 @@ function getCompletionData(
         for (const m of existingMembers) {
             // Ignore omitted expressions for missing members
             if (
-                m.kind !== SyntaxKind.PropertyDeclaration &&
-                m.kind !== SyntaxKind.MethodDeclaration &&
-                m.kind !== SyntaxKind.GetAccessor &&
-                m.kind !== SyntaxKind.SetAccessor
+                m.kind !== SyntaxKind.PropertyDeclaration
+                && m.kind !== SyntaxKind.MethodDeclaration
+                && m.kind !== SyntaxKind.GetAccessor
+                && m.kind !== SyntaxKind.SetAccessor
             ) {
                 continue;
             }
@@ -5081,10 +5081,10 @@ function getCompletionData(
         }
 
         return baseSymbols.filter(propertySymbol =>
-            !existingMemberNames.has(propertySymbol.escapedName) &&
-            !!propertySymbol.declarations &&
-            !(getDeclarationModifierFlagsFromSymbol(propertySymbol) & ModifierFlags.Private) &&
-            !(propertySymbol.valueDeclaration && isPrivateIdentifierClassElementDeclaration(propertySymbol.valueDeclaration))
+            !existingMemberNames.has(propertySymbol.escapedName)
+            && !!propertySymbol.declarations
+            && !(getDeclarationModifierFlagsFromSymbol(propertySymbol) & ModifierFlags.Private)
+            && !(propertySymbol.valueDeclaration && isPrivateIdentifierClassElementDeclaration(propertySymbol.valueDeclaration))
         );
     }
 
@@ -5146,9 +5146,9 @@ function tryGetObjectLikeCompletionContainer(contextToken: Node | undefined, pos
                 }
                 else {
                     if (
-                        isObjectLiteralExpression(contextToken.parent.parent) &&
-                        (isSpreadAssignment(contextToken.parent) || isShorthandPropertyAssignment(contextToken.parent) &&
-                                (getLineAndCharacterOfPosition(sourceFile, contextToken.getEnd()).line !== getLineAndCharacterOfPosition(sourceFile, position).line))
+                        isObjectLiteralExpression(contextToken.parent.parent)
+                        && (isSpreadAssignment(contextToken.parent) || isShorthandPropertyAssignment(contextToken.parent)
+                                && (getLineAndCharacterOfPosition(sourceFile, contextToken.getEnd()).line !== getLineAndCharacterOfPosition(sourceFile, position).line))
                     ) {
                         return contextToken.parent.parent;
                     }
@@ -5167,8 +5167,8 @@ function tryGetObjectLikeCompletionContainer(contextToken: Node | undefined, pos
                 }
                 const ancestorNode = findAncestor(parent, isPropertyAssignment);
                 if (
-                    contextToken.kind !== SyntaxKind.ColonToken && ancestorNode?.getLastToken(sourceFile) === contextToken &&
-                    isObjectLiteralExpression(ancestorNode.parent)
+                    contextToken.kind !== SyntaxKind.ColonToken && ancestorNode?.getLastToken(sourceFile) === contextToken
+                    && isObjectLiteralExpression(ancestorNode.parent)
                 ) {
                     return ancestorNode.parent;
                 }
@@ -5190,9 +5190,9 @@ function getRelevantTokens(position: number, sourceFile: SourceFile): { contextT
 function getAutoImportSymbolFromCompletionEntryData(name: string, data: CompletionEntryData, program: Program, host: LanguageServiceHost): { symbol: Symbol; origin: SymbolOriginInfoExport | SymbolOriginInfoResolvedExport; } | undefined {
     const containingProgram = data.isPackageJsonImport ? host.getPackageJsonAutoImportProvider!()! : program;
     const checker = containingProgram.getTypeChecker();
-    const moduleSymbol = data.ambientModuleName ? checker.tryFindAmbientModule(data.ambientModuleName) :
-        data.fileName ? checker.getMergedSymbol(Debug.checkDefined(containingProgram.getSourceFile(data.fileName)).symbol) :
-        undefined;
+    const moduleSymbol = data.ambientModuleName ? checker.tryFindAmbientModule(data.ambientModuleName)
+        : data.fileName ? checker.getMergedSymbol(Debug.checkDefined(containingProgram.getSourceFile(data.fileName)).symbol)
+        : undefined;
 
     if (!moduleSymbol) return undefined;
     let symbol = data.exportName === InternalSymbolName.ExportEquals
@@ -5271,8 +5271,8 @@ function getKeywordCompletions(keywordFilter: KeywordCompletionFilters, filterOu
     if (!filterOutTsOnlyKeywords) return getTypescriptKeywordCompletions(keywordFilter);
 
     const index = keywordFilter + KeywordCompletionFilters.Last + 1;
-    return _keywordCompletions[index] ||
-        (_keywordCompletions[index] = getTypescriptKeywordCompletions(keywordFilter)
+    return _keywordCompletions[index]
+        || (_keywordCompletions[index] = getTypescriptKeywordCompletions(keywordFilter)
             .filter(entry => !isTypeScriptOnlyKeyword(stringToToken(entry.name)!)));
 }
 
@@ -5416,8 +5416,8 @@ function getContextualKeywords(
 /** Get the corresponding JSDocTag node if the position is in a jsDoc comment */
 function getJsDocTagAtPosition(node: Node, position: number): JSDocTag | undefined {
     return findAncestor(node, n =>
-        isJSDocTag(n) && rangeContainsPosition(n, position) ? true :
-            isJSDoc(n) ? "quit" : false) as JSDocTag | undefined;
+        isJSDocTag(n) && rangeContainsPosition(n, position) ? true
+            : isJSDoc(n) ? "quit" : false) as JSDocTag | undefined;
 }
 
 /** @internal */
@@ -5428,8 +5428,8 @@ export function getPropertiesForObjectExpression(contextualType: Type, completio
         : contextualType;
 
     const properties = getApparentProperties(type, obj, checker);
-    return type.isClass() && containsNonPublicProperties(properties) ? [] :
-        hasCompletionsType ? filter(properties, hasDeclarationOtherThanSelf) : properties;
+    return type.isClass() && containsNonPublicProperties(properties) ? []
+        : hasCompletionsType ? filter(properties, hasDeclarationOtherThanSelf) : properties;
 
     // Filter out members whose only declaration is the object literal itself to avoid
     // self-fulfilling completions like:
@@ -5703,9 +5703,9 @@ function getImportStatementCompletionInfo(contextToken: Node, sourceFile: Source
         if (isNamedImports(parent) || isNamespaceImport(parent)) {
             if (
                 !parent.parent.isTypeOnly && (
-                    contextToken.kind === SyntaxKind.OpenBraceToken ||
-                    contextToken.kind === SyntaxKind.ImportKeyword ||
-                    contextToken.kind === SyntaxKind.CommaToken
+                    contextToken.kind === SyntaxKind.OpenBraceToken
+                    || contextToken.kind === SyntaxKind.ImportKeyword
+                    || contextToken.kind === SyntaxKind.CommaToken
                 )
             ) {
                 keywordCompletion = SyntaxKind.TypeKeyword;
@@ -5783,9 +5783,9 @@ function getSingleLineReplacementSpanForImportCompletionNode(node: ImportDeclara
 function getPotentiallyInvalidImportSpecifier(namedBindings: NamedImportBindings | undefined) {
     return find(
         tryCast(namedBindings, isNamedImports)?.elements,
-        e => !e.propertyName &&
-            isStringANonContextualKeyword(e.name.text) &&
-            findPrecedingToken(e.name.pos, namedBindings!.getSourceFile(), namedBindings)?.kind !== SyntaxKind.CommaToken,
+        e => !e.propertyName
+            && isStringANonContextualKeyword(e.name.text)
+            && findPrecedingToken(e.name.pos, namedBindings!.getSourceFile(), namedBindings)?.kind !== SyntaxKind.CommaToken,
     );
 }
 
@@ -5831,10 +5831,10 @@ function getVariableOrParameterDeclaration(contextToken: Node | undefined, locat
 }
 
 function isArrowFunctionBody(node: Node) {
-    return node.parent && isArrowFunction(node.parent) &&
-        (node.parent.body === node ||
+    return node.parent && isArrowFunction(node.parent)
+        && (node.parent.body === node
             // const a = () => /**/;
-            node.kind === SyntaxKind.EqualsGreaterThanToken);
+            || node.kind === SyntaxKind.EqualsGreaterThanToken);
 }
 
 /** True if symbol is a type or a module containing at least one type. */
@@ -5844,9 +5844,9 @@ function symbolCanBeReferencedAtTypeLocation(symbol: Symbol, checker: TypeChecke
     return nonAliasCanBeReferencedAtTypeLocation(symbol) || nonAliasCanBeReferencedAtTypeLocation(skipAlias(symbol.exportSymbol || symbol, checker));
 
     function nonAliasCanBeReferencedAtTypeLocation(symbol: Symbol): boolean {
-        return !!(symbol.flags & SymbolFlags.Type) || checker.isUnknownSymbol(symbol) ||
-            !!(symbol.flags & SymbolFlags.Module) && addToSeen(seenModules, getSymbolId(symbol)) &&
-                checker.getExportsOfModule(symbol).some(e => symbolCanBeReferencedAtTypeLocation(e, checker, seenModules));
+        return !!(symbol.flags & SymbolFlags.Type) || checker.isUnknownSymbol(symbol)
+            || !!(symbol.flags & SymbolFlags.Module) && addToSeen(seenModules, getSymbolId(symbol))
+                && checker.getExportsOfModule(symbol).some(e => symbolCanBeReferencedAtTypeLocation(e, checker, seenModules));
     }
 }
 
@@ -5884,9 +5884,9 @@ function charactersFuzzyMatchInString(identifierString: string, lowercaseCharact
         const strChar = identifierString.charCodeAt(strIndex);
         const testChar = lowercaseCharacters.charCodeAt(characterIndex);
         if (strChar === testChar || strChar === toUpperCharCode(testChar)) {
-            matchedFirstCharacter ||= prevChar === undefined || // Beginning of word
-                CharacterCodes.a <= prevChar && prevChar <= CharacterCodes.z && CharacterCodes.A <= strChar && strChar <= CharacterCodes.Z || // camelCase transition
-                prevChar === CharacterCodes._ && strChar !== CharacterCodes._; // snake_case transition
+            matchedFirstCharacter ||= prevChar === undefined // Beginning of word
+                || CharacterCodes.a <= prevChar && prevChar <= CharacterCodes.z && CharacterCodes.A <= strChar && strChar <= CharacterCodes.Z // camelCase transition
+                || prevChar === CharacterCodes._ && strChar !== CharacterCodes._; // snake_case transition
             if (matchedFirstCharacter) {
                 characterIndex++;
             }
@@ -5927,13 +5927,13 @@ function toUpperCharCode(charCode: number) {
  * ```
  */
 function isContextualKeywordInAutoImportableExpressionSpace(keyword: string) {
-    return keyword === "abstract" ||
-        keyword === "async" ||
-        keyword === "await" ||
-        keyword === "declare" ||
-        keyword === "module" ||
-        keyword === "namespace" ||
-        keyword === "type" ||
-        keyword === "satisfies" ||
-        keyword === "as";
+    return keyword === "abstract"
+        || keyword === "async"
+        || keyword === "await"
+        || keyword === "declare"
+        || keyword === "module"
+        || keyword === "namespace"
+        || keyword === "type"
+        || keyword === "satisfies"
+        || keyword === "as";
 }

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -266,9 +266,9 @@ export function createDocumentRegistryInternal(useCaseSensitiveFileNames?: boole
         const compilationSettings = getCompilationSettings(compilationSettingsOrHost);
         const host: MinimalResolutionCacheHost | undefined = compilationSettingsOrHost === compilationSettings ? undefined : compilationSettingsOrHost as MinimalResolutionCacheHost;
         const scriptTarget = scriptKind === ScriptKind.JSON ? ScriptTarget.JSON : getEmitScriptTarget(compilationSettings);
-        const sourceFileOptions: CreateSourceFileOptions = typeof languageVersionOrOptions === "object" ?
-            languageVersionOrOptions :
-            {
+        const sourceFileOptions: CreateSourceFileOptions = typeof languageVersionOrOptions === "object"
+            ? languageVersionOrOptions
+            : {
                 languageVersion: scriptTarget,
                 impliedNodeFormat: host && getImpliedNodeFormatForFile(path, host.getCompilerHost?.()?.getModuleResolutionCache?.()?.getPackageJsonInfoCache(), host, compilationSettings),
                 setExternalModuleIndicator: getSetExternalModuleIndicator(compilationSettings),
@@ -290,8 +290,8 @@ export function createDocumentRegistryInternal(useCaseSensitiveFileNames?: boole
             // It is fairly suspicious to have one path in two buckets - you'd expect dependencies to have similar configurations.
             // If this occurs unexpectedly, the fix is likely to synchronize the project settings.
             // Skip .d.ts files to reduce noise (should also cover most of node_modules).
-            const otherBucketKey = !isDeclarationFileName(path) &&
-                forEachEntry(buckets, (bucket, bucketKey) => bucketKey !== keyWithMode && bucket.has(path) && bucketKey);
+            const otherBucketKey = !isDeclarationFileName(path)
+                && forEachEntry(buckets, (bucket, bucketKey) => bucketKey !== keyWithMode && bucket.has(path) && bucketKey);
             if (otherBucketKey) {
                 tracing.instant(tracing.Phase.Session, "documentRegistryBucketOverlap", { path, key1: otherBucketKey, key2: keyWithMode });
             }

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -251,15 +251,15 @@ export function createCacheableExportInfoMap(host: CacheableExportInfoMapHost): 
                 return false;
             }
             if (
-                usableByFileName && usableByFileName !== newSourceFile.path ||
+                usableByFileName && usableByFileName !== newSourceFile.path
                 // If ATA is enabled, auto-imports uses existing imports to guess whether you want auto-imports from node.
                 // Adding or removing imports from node could change the outcome of that guess, so could change the suggestions list.
-                typeAcquisitionEnabled && consumesNodeCoreModules(oldSourceFile) !== consumesNodeCoreModules(newSourceFile) ||
+                || typeAcquisitionEnabled && consumesNodeCoreModules(oldSourceFile) !== consumesNodeCoreModules(newSourceFile)
                 // Module agumentation and ambient module changes can add or remove exports available to be auto-imported.
                 // Changes elsewhere in the file can change the *type* of an export in a module augmentation,
                 // but type info is gathered in getCompletionEntryDetails, which doesn't use the cache.
-                !arrayIsEqualTo(oldSourceFile.moduleAugmentations, newSourceFile.moduleAugmentations) ||
-                !ambientModuleDeclarationsAreEqual(oldSourceFile, newSourceFile)
+                || !arrayIsEqualTo(oldSourceFile.moduleAugmentations, newSourceFile.moduleAugmentations)
+                || !ambientModuleDeclarationsAreEqual(oldSourceFile, newSourceFile)
             ) {
                 cache.clear();
                 return true;
@@ -386,8 +386,8 @@ export function isImportableFile(
             const toFile = program.getSourceFile(toPath);
             // Determine to import using toPath only if toPath is what we were looking at
             // or there doesnt exist the file in the program by the symlink
-            return (toFile === to || !toFile) &&
-                isImportablePath(from.fileName, toPath, getCanonicalFileName, globalTypingsCache);
+            return (toFile === to || !toFile)
+                && isImportablePath(from.fileName, toPath, getCanonicalFileName, globalTypingsCache);
         },
     );
 
@@ -583,8 +583,8 @@ export function getDefaultExportInfoWorker(defaultExport: Symbol, checker: TypeC
     }
 
     if (
-        defaultExport.escapedName !== InternalSymbolName.Default &&
-        defaultExport.escapedName !== InternalSymbolName.ExportEquals
+        defaultExport.escapedName !== InternalSymbolName.Default
+        && defaultExport.escapedName !== InternalSymbolName.ExportEquals
     ) {
         return { resolvedSymbol: defaultExport, name: defaultExport.getName() };
     }

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -346,13 +346,13 @@ function getContextNodeForNodeEntry(node: Node): ContextNode | undefined {
     if (!isDeclaration(node.parent) && !isExportAssignment(node.parent)) {
         // Special property assignment in javascript
         if (isInJSFile(node)) {
-            const binaryExpression = isBinaryExpression(node.parent) ?
-                node.parent :
-                isAccessExpression(node.parent) &&
-                    isBinaryExpression(node.parent.parent) &&
-                    node.parent.parent.left === node.parent ?
-                node.parent.parent :
-                undefined;
+            const binaryExpression = isBinaryExpression(node.parent)
+                ? node.parent
+                : isAccessExpression(node.parent)
+                        && isBinaryExpression(node.parent.parent)
+                        && node.parent.parent.left === node.parent
+                ? node.parent.parent
+                : undefined;
             if (binaryExpression && getAssignmentDeclarationKind(binaryExpression) !== AssignmentDeclarationKind.None) {
                 return getContextNode(binaryExpression);
             }
@@ -363,9 +363,9 @@ function getContextNodeForNodeEntry(node: Node): ContextNode | undefined {
             return node.parent.parent;
         }
         else if (
-            isJsxSelfClosingElement(node.parent) ||
-            isLabeledStatement(node.parent) ||
-            isBreakOrContinueStatement(node.parent)
+            isJsxSelfClosingElement(node.parent)
+            || isLabeledStatement(node.parent)
+            || isBreakOrContinueStatement(node.parent)
         ) {
             return node.parent;
         }
@@ -373,31 +373,31 @@ function getContextNodeForNodeEntry(node: Node): ContextNode | undefined {
             const validImport = tryGetImportFromModuleSpecifier(node);
             if (validImport) {
                 const declOrStatement = findAncestor(validImport, node =>
-                    isDeclaration(node) ||
-                    isStatement(node) ||
-                    isJSDocTag(node))! as NamedDeclaration | Statement | JSDocTag;
-                return isDeclaration(declOrStatement) ?
-                    getContextNode(declOrStatement) :
-                    declOrStatement;
+                    isDeclaration(node)
+                    || isStatement(node)
+                    || isJSDocTag(node))! as NamedDeclaration | Statement | JSDocTag;
+                return isDeclaration(declOrStatement)
+                    ? getContextNode(declOrStatement)
+                    : declOrStatement;
             }
         }
 
         // Handle computed property name
         const propertyName = findAncestor(node, isComputedPropertyName);
-        return propertyName ?
-            getContextNode(propertyName.parent) :
-            undefined;
+        return propertyName
+            ? getContextNode(propertyName.parent)
+            : undefined;
     }
 
     if (
-        node.parent.name === node || // node is name of declaration, use parent
-        isConstructorDeclaration(node.parent) ||
-        isExportAssignment(node.parent) ||
+        node.parent.name === node // node is name of declaration, use parent
+        || isConstructorDeclaration(node.parent)
+        || isExportAssignment(node.parent)
         // Property name of the import export specifier or binding pattern, use parent
-        ((isImportOrExportSpecifier(node.parent) || isBindingElement(node.parent))
-            && node.parent.propertyName === node) ||
+        || ((isImportOrExportSpecifier(node.parent) || isBindingElement(node.parent))
+            && node.parent.propertyName === node)
         // Is default export
-        (node.kind === SyntaxKind.DefaultKeyword && hasSyntacticModifier(node.parent, ModifierFlags.ExportDefault))
+        || (node.kind === SyntaxKind.DefaultKeyword && hasSyntacticModifier(node.parent, ModifierFlags.ExportDefault))
     ) {
         return getContextNode(node.parent);
     }
@@ -410,13 +410,13 @@ export function getContextNode(node: NamedDeclaration | BinaryExpression | ForIn
     if (!node) return undefined;
     switch (node.kind) {
         case SyntaxKind.VariableDeclaration:
-            return !isVariableDeclarationList(node.parent) || node.parent.declarations.length !== 1 ?
-                node :
-                isVariableStatement(node.parent.parent) ?
-                node.parent.parent :
-                isForInOrOfStatement(node.parent.parent) ?
-                getContextNode(node.parent.parent) :
-                node.parent;
+            return !isVariableDeclarationList(node.parent) || node.parent.declarations.length !== 1
+                ? node
+                : isVariableStatement(node.parent.parent)
+                ? node.parent.parent
+                : isForInOrOfStatement(node.parent.parent)
+                ? getContextNode(node.parent.parent)
+                : node.parent;
 
         case SyntaxKind.BindingElement:
             return getContextNode(node.parent.parent as NamedDeclaration);
@@ -433,9 +433,9 @@ export function getContextNode(node: NamedDeclaration | BinaryExpression | ForIn
             return node.parent;
 
         case SyntaxKind.BinaryExpression:
-            return isExpressionStatement(node.parent) ?
-                node.parent :
-                node;
+            return isExpressionStatement(node.parent)
+                ? node.parent
+                : node;
 
         case SyntaxKind.ForOfStatement:
         case SyntaxKind.ForInStatement:
@@ -446,11 +446,11 @@ export function getContextNode(node: NamedDeclaration | BinaryExpression | ForIn
 
         case SyntaxKind.PropertyAssignment:
         case SyntaxKind.ShorthandPropertyAssignment:
-            return isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent) ?
-                getContextNode(
+            return isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent)
+                ? getContextNode(
                     findAncestor(node.parent, node => isBinaryExpression(node) || isForInOrOfStatement(node)) as BinaryExpression | ForInOrOfStatement,
-                ) :
-                node;
+                )
+                : node;
         case SyntaxKind.SwitchStatement:
             return {
                 start: find(node.getChildren(node.getSourceFile()), node => node.kind === SyntaxKind.SwitchKeyword)!,
@@ -464,12 +464,12 @@ export function getContextNode(node: NamedDeclaration | BinaryExpression | ForIn
 /** @internal */
 export function toContextSpan(textSpan: TextSpan, sourceFile: SourceFile, context: ContextNode | undefined): { contextSpan: TextSpan; } | undefined {
     if (!context) return undefined;
-    const contextSpan = isContextWithStartAndEndNode(context) ?
-        getTextSpan(context.start, sourceFile, context.end) :
-        getTextSpan(context, sourceFile);
-    return contextSpan.start !== textSpan.start || contextSpan.length !== textSpan.length ?
-        { contextSpan } :
-        undefined;
+    const contextSpan = isContextWithStartAndEndNode(context)
+        ? getTextSpan(context.start, sourceFile, context.end)
+        : getTextSpan(context, sourceFile);
+    return contextSpan.start !== textSpan.start || contextSpan.length !== textSpan.length
+        ? { contextSpan }
+        : undefined;
 }
 
 /** @internal */
@@ -777,9 +777,9 @@ function getPrefixAndSuffixText(entry: Entry, originalNode: Node, checker: TypeC
             if (isShorthandAssignment) {
                 const grandParent = parent.parent;
                 if (
-                    isObjectLiteralExpression(grandParent) &&
-                    isBinaryExpression(grandParent.parent) &&
-                    isModuleExportsAccessExpression(grandParent.parent.left)
+                    isObjectLiteralExpression(grandParent)
+                    && isBinaryExpression(grandParent.parent)
+                    && isModuleExportsAccessExpression(grandParent.parent.left)
                 ) {
                     return prefixColon;
                 }
@@ -796,9 +796,9 @@ function getPrefixAndSuffixText(entry: Entry, originalNode: Node, checker: TypeC
         }
         else if (isExportSpecifier(parent) && !parent.propertyName) {
             // If the symbol for the node is same as declared node symbol use prefix text
-            return originalNode === entry.node || checker.getSymbolAtLocation(originalNode) === checker.getSymbolAtLocation(entry.node) ?
-                { prefixText: name + " as " } :
-                { suffixText: " as " + name };
+            return originalNode === entry.node || checker.getSymbolAtLocation(originalNode) === checker.getSymbolAtLocation(entry.node)
+                ? { prefixText: name + " as " }
+                : { suffixText: " as " + name };
         }
     }
 
@@ -886,8 +886,8 @@ function getTextSpan(node: Node, sourceFile: SourceFile, endNode?: Node): TextSp
 
 /** @internal */
 export function getTextSpanOfEntry(entry: Entry) {
-    return entry.kind === EntryKind.Span ? entry.textSpan :
-        getTextSpan(entry.node, entry.node.getSourceFile());
+    return entry.kind === EntryKind.Span ? entry.textSpan
+        : getTextSpan(entry.node, entry.node.getSourceFile());
 }
 
 /**
@@ -907,8 +907,8 @@ export function isWriteAccessForReference(node: Node): boolean {
  */
 export function isDeclarationOfSymbol(node: Node, target: Symbol | undefined): boolean {
     if (!target) return false;
-    const source = getDeclarationFromName(node) ||
-        (node.kind === SyntaxKind.DefaultKeyword ? node.parent
+    const source = getDeclarationFromName(node)
+        || (node.kind === SyntaxKind.DefaultKeyword ? node.parent
             : isLiteralComputedPropertyDeclarationName(node) ? node.parent.parent
             : node.kind === SyntaxKind.ConstructorKeyword && isConstructorDeclaration(node.parent) ? node.parent.parent
             : undefined);
@@ -1046,8 +1046,8 @@ export namespace Core {
         }
 
         const aliasedSymbol = getMergedAliasedSymbolOfNamespaceExportDeclaration(node, symbol, checker);
-        const moduleReferencesOfExportTarget = aliasedSymbol &&
-            getReferencedSymbolsForModuleIfDeclaredBySourceFile(aliasedSymbol, program, sourceFiles, cancellationToken, options, sourceFilesSet);
+        const moduleReferencesOfExportTarget = aliasedSymbol
+            && getReferencedSymbolsForModuleIfDeclaredBySourceFile(aliasedSymbol, program, sourceFiles, cancellationToken, options, sourceFilesSet);
 
         const references = getReferencedSymbolsForSymbol(symbol, node, sourceFiles, sourceFilesSet, checker, cancellationToken, options);
         return mergeReferences(program, moduleReferences, references, moduleReferencesOfExportTarget);
@@ -1134,9 +1134,9 @@ export namespace Core {
                 }
                 const symbol = entry.definition.symbol;
                 const refIndex = findIndex(result, ref =>
-                    !!ref.definition &&
-                    ref.definition.type === DefinitionKind.Symbol &&
-                    ref.definition.symbol === symbol);
+                    !!ref.definition
+                    && ref.definition.type === DefinitionKind.Symbol
+                    && ref.definition.symbol === symbol);
                 if (refIndex === -1) {
                     result.push(entry);
                     continue;
@@ -1154,9 +1154,9 @@ export namespace Core {
 
                         const entry1Span = getTextSpanOfEntry(entry1);
                         const entry2Span = getTextSpanOfEntry(entry2);
-                        return entry1Span.start !== entry2Span.start ?
-                            compareValues(entry1Span.start, entry2Span.start) :
-                            compareValues(entry1Span.length, entry2Span.length);
+                        return entry1Span.start !== entry2Span.start
+                            ? compareValues(entry1Span.start, entry2Span.start)
+                            : compareValues(entry1Span.length, entry2Span.length);
                     }),
                 };
             }
@@ -1165,9 +1165,9 @@ export namespace Core {
     }
 
     function getSourceFileIndexOfEntry(program: Program, entry: Entry) {
-        const sourceFile = entry.kind === EntryKind.Span ?
-            program.getSourceFile(entry.fileName)! :
-            entry.node.getSourceFile();
+        const sourceFile = entry.kind === EntryKind.Span
+            ? program.getSourceFile(entry.fileName)!
+            : entry.node.getSourceFile();
         return program.getSourceFiles().indexOf(sourceFile);
     }
 
@@ -1227,9 +1227,9 @@ export namespace Core {
                 const sourceFile = decl.getSourceFile();
                 if (sourceFilesSet.has(sourceFile.fileName)) {
                     // At `module.exports = ...`, reference node is `module`
-                    const node = isBinaryExpression(decl) && isPropertyAccessExpression(decl.left) ? decl.left.expression :
-                        isExportAssignment(decl) ? Debug.checkDefined(findChildOfKind(decl, SyntaxKind.ExportKeyword, sourceFile)) :
-                        getNameOfDeclaration(decl) || decl;
+                    const node = isBinaryExpression(decl) && isPropertyAccessExpression(decl.left) ? decl.left.expression
+                        : isExportAssignment(decl) ? Debug.checkDefined(findChildOfKind(decl, SyntaxKind.ExportKeyword, sourceFile))
+                        : getNameOfDeclaration(decl) || decl;
                     references.push(nodeEntry(node));
                 }
             }
@@ -1806,8 +1806,8 @@ export namespace Core {
             const endPosition = position + symbolNameLength;
 
             if (
-                (position === 0 || !isIdentifierPart(text.charCodeAt(position - 1), ScriptTarget.Latest)) &&
-                (endPosition === sourceLength || !isIdentifierPart(text.charCodeAt(endPosition), ScriptTarget.Latest))
+                (position === 0 || !isIdentifierPart(text.charCodeAt(position - 1), ScriptTarget.Latest))
+                && (endPosition === sourceLength || !isIdentifierPart(text.charCodeAt(endPosition), ScriptTarget.Latest))
             ) {
                 // Found a real match.  Keep searching.
                 positions.push(position);
@@ -1840,8 +1840,8 @@ export namespace Core {
             case SyntaxKind.NoSubstitutionTemplateLiteral:
             case SyntaxKind.StringLiteral: {
                 const str = node as StringLiteralLike;
-                return (isLiteralNameOfPropertyDeclarationOrIndexAccess(str) || isNameOfModuleDeclaration(node) || isExpressionOfExternalModuleImportEqualsDeclaration(node) || (isCallExpression(node.parent) && isBindableObjectDefinePropertyCall(node.parent) && node.parent.arguments[1] === node)) &&
-                    str.text.length === searchSymbolName.length;
+                return (isLiteralNameOfPropertyDeclarationOrIndexAccess(str) || isNameOfModuleDeclaration(node) || isExpressionOfExternalModuleImportEqualsDeclaration(node) || (isCallExpression(node.parent) && isBindableObjectDefinePropertyCall(node.parent) && node.parent.arguments[1] === node))
+                    && str.text.length === searchSymbolName.length;
             }
 
             case SyntaxKind.NumericLiteral:
@@ -1942,9 +1942,9 @@ export namespace Core {
         }
 
         if (
-            isJSDocPropertyLikeTag(parent) && parent.isNameFirst &&
-            parent.typeExpression && isJSDocTypeLiteral(parent.typeExpression.type) &&
-            parent.typeExpression.type.jsDocPropertyTags && length(parent.typeExpression.type.jsDocPropertyTags)
+            isJSDocPropertyLikeTag(parent) && parent.isNameFirst
+            && parent.typeExpression && isJSDocTypeLiteral(parent.typeExpression.type)
+            && parent.typeExpression.type.jsDocPropertyTags && length(parent.typeExpression.type.jsDocPropertyTags)
         ) {
             getReferencesAtJSDocTypeLiteral(parent.typeExpression.type.jsDocPropertyTags, referenceLocation, search, state);
             return;
@@ -2484,8 +2484,8 @@ export namespace Core {
                         }
                     }
                     else {
-                        return isNoSubstitutionTemplateLiteral(ref) && !rangeIsOnSingleLine(ref, sourceFile) ? undefined :
-                            nodeEntry(ref, EntryKind.StringLiteral);
+                        return isNoSubstitutionTemplateLiteral(ref) && !rangeIsOnSingleLine(ref, sourceFile) ? undefined
+                            : nodeEntry(ref, EntryKind.StringLiteral);
                     }
                 }
             });
@@ -2747,10 +2747,10 @@ export namespace Core {
     }
 
     function isImplementation(node: Node): boolean {
-        return !!(node.flags & NodeFlags.Ambient) ? !(isInterfaceDeclaration(node) || isTypeAliasDeclaration(node)) :
-            (isVariableLike(node) ? hasInitializer(node) :
-                isFunctionLikeDeclaration(node) ? !!node.body :
-                isClassLike(node) || isModuleOrEnumDeclaration(node));
+        return !!(node.flags & NodeFlags.Ambient) ? !(isInterfaceDeclaration(node) || isTypeAliasDeclaration(node))
+            : (isVariableLike(node) ? hasInitializer(node)
+                : isFunctionLikeDeclaration(node) ? !!node.body
+                : isClassLike(node) || isModuleOrEnumDeclaration(node));
     }
 
     export function getReferenceEntriesForShorthandPropertyAssignment(node: Node, checker: TypeChecker, addReference: (node: Node) => void): void {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -253,9 +253,9 @@ export function formatSelection(start: number, end: number, sourceFile: SourceFi
 function findImmediatelyPrecedingTokenOfKind(end: number, expectedTokenKind: SyntaxKind, sourceFile: SourceFile): Node | undefined {
     const precedingToken = findPrecedingToken(end, sourceFile);
 
-    return precedingToken && precedingToken.kind === expectedTokenKind && end === precedingToken.getEnd() ?
-        precedingToken :
-        undefined;
+    return precedingToken && precedingToken.kind === expectedTokenKind && end === precedingToken.getEnd()
+        ? precedingToken
+        : undefined;
 }
 
 /**
@@ -274,10 +274,10 @@ function findImmediatelyPrecedingTokenOfKind(end: number, expectedTokenKind: Syn
 function findOutermostNodeWithinListLevel(node: Node | undefined) {
     let current = node;
     while (
-        current &&
-        current.parent &&
-        current.parent.end === node!.end &&
-        !isListElement(current.parent, current)
+        current
+        && current.parent
+        && current.parent.end === node!.end
+        && !isListElement(current.parent, current)
     ) {
         current = current.parent;
     }
@@ -549,9 +549,9 @@ function formatSpanWorker(
         // inclusive. We would expect a format-selection would delete the space (if rules apply),
         // but in order to do that, we need to process the pair ["{", "}"], but we stopped processing
         // just before getting there. This block handles this trailing edit.
-        const tokenInfo = formattingScanner.isOnEOF() ? formattingScanner.readEOFTokenRange() :
-            formattingScanner.isOnToken() ? formattingScanner.readTokenInfo(enclosingNode).token :
-            undefined;
+        const tokenInfo = formattingScanner.isOnEOF() ? formattingScanner.readEOFTokenRange()
+            : formattingScanner.isOnToken() ? formattingScanner.readTokenInfo(enclosingNode).token
+            : undefined;
 
         if (tokenInfo && tokenInfo.pos === previousRangeTriviaEnd!) {
             // We need to check that tokenInfo and previousRange are contiguous: the `originalRange`
@@ -591,8 +591,8 @@ function formatSpanWorker(
      */
     function tryComputeIndentationForListItem(startPos: number, endPos: number, parentStartLine: number, range: TextRange, inheritedIndentation: number): number {
         if (
-            rangeOverlapsWithStartEnd(range, startPos, endPos) ||
-            rangeContainsStartEnd(range, startPos, endPos) /* Not to miss zero-range nodes e.g. JsxText */
+            rangeOverlapsWithStartEnd(range, startPos, endPos)
+            || rangeContainsStartEnd(range, startPos, endPos) /* Not to miss zero-range nodes e.g. JsxText */
         ) {
             if (inheritedIndentation !== Constants.Unknown) {
                 return inheritedIndentation;
@@ -639,9 +639,9 @@ function formatSpanWorker(
                 return { indentation: indentationOnLastIndentedLine, delta: parentDynamicIndentation.getDelta(node) };
             }
             else if (
-                SmartIndenter.childStartsOnTheSameLineWithElseInIfStatement(parent, node, startLine, sourceFile) ||
-                SmartIndenter.childIsUnindentedBranchOfConditionalExpression(parent, node, startLine, sourceFile) ||
-                SmartIndenter.argumentStartsOnSameLineAsPreviousArgument(parent, node, startLine, sourceFile)
+                SmartIndenter.childStartsOnTheSameLineWithElseInIfStatement(parent, node, startLine, sourceFile)
+                || SmartIndenter.childIsUnindentedBranchOfConditionalExpression(parent, node, startLine, sourceFile)
+                || SmartIndenter.argumentStartsOnSameLineAsPreviousArgument(parent, node, startLine, sourceFile)
             ) {
                 return { indentation: parentDynamicIndentation.getIndentation(), delta };
             }
@@ -1013,9 +1013,9 @@ function formatSpanWorker(
             }
 
             if (indentToken) {
-                const tokenIndentation = (isTokenInRange && !rangeContainsError(currentTokenInfo.token)) ?
-                    dynamicIndentation.getIndentationForToken(tokenStart.line, currentTokenInfo.token.kind, container, !!isListEndToken) :
-                    Constants.Unknown;
+                const tokenIndentation = (isTokenInRange && !rangeContainsError(currentTokenInfo.token))
+                    ? dynamicIndentation.getIndentationForToken(tokenStart.line, currentTokenInfo.token.kind, container, !!isListEndToken)
+                    : Constants.Unknown;
 
                 let indentNextTokenOrTrivia = true;
                 if (currentTokenInfo.leadingTrivia) {
@@ -1395,7 +1395,7 @@ export function getRangeOfEnclosingComment(
     const leadingCommentRangesOfNextToken = getLeadingCommentRangesOfNode(tokenAtPosition, sourceFile);
     const commentRanges = concatenate(trailingRangesOfPreviousToken, leadingCommentRangesOfNextToken);
     return commentRanges && find(commentRanges, range =>
-        rangeContainsPositionExclusive(range, position) ||
+        rangeContainsPositionExclusive(range, position)
         // The end marker of a single-line comment does not include the newline character.
         // With caret at `^`, in the following case, we are inside a comment (^ denotes the cursor position):
         //
@@ -1409,7 +1409,7 @@ export function getRangeOfEnclosingComment(
         //
         // Internally, we represent the end of the comment at the newline and closing '/', respectively.
         //
-        position === range.end && (range.kind === SyntaxKind.SingleLineCommentTrivia || position === sourceFile.getFullWidth()));
+        || position === range.end && (range.kind === SyntaxKind.SingleLineCommentTrivia || position === sourceFile.getFullWidth()));
 }
 
 function getOpenTokenForList(node: Node, list: readonly Node[]) {

--- a/src/services/formatting/formattingScanner.ts
+++ b/src/services/formatting/formattingScanner.ts
@@ -161,8 +161,8 @@ export function getFormattingScanner<T>(text: string, languageVariant: LanguageV
     }
 
     function shouldRescanTemplateToken(container: Node): boolean {
-        return container.kind === SyntaxKind.TemplateMiddle ||
-            container.kind === SyntaxKind.TemplateTail;
+        return container.kind === SyntaxKind.TemplateMiddle
+            || container.kind === SyntaxKind.TemplateTail;
     }
 
     function shouldRescanJsxAttributeValue(node: Node): boolean {
@@ -178,13 +178,13 @@ export function getFormattingScanner<T>(text: string, languageVariant: LanguageV
 
         // normally scanner returns the smallest available token
         // check the kind of context node to determine if scanner should have more greedy behavior and consume more text.
-        const expectedScanAction = shouldRescanGreaterThanToken(n) ? ScanAction.RescanGreaterThanToken :
-            shouldRescanSlashToken(n) ? ScanAction.RescanSlashToken :
-            shouldRescanTemplateToken(n) ? ScanAction.RescanTemplateToken :
-            shouldRescanJsxIdentifier(n) ? ScanAction.RescanJsxIdentifier :
-            shouldRescanJsxText(n) ? ScanAction.RescanJsxText :
-            shouldRescanJsxAttributeValue(n) ? ScanAction.RescanJsxAttributeValue :
-            ScanAction.Scan;
+        const expectedScanAction = shouldRescanGreaterThanToken(n) ? ScanAction.RescanGreaterThanToken
+            : shouldRescanSlashToken(n) ? ScanAction.RescanSlashToken
+            : shouldRescanTemplateToken(n) ? ScanAction.RescanTemplateToken
+            : shouldRescanJsxIdentifier(n) ? ScanAction.RescanJsxIdentifier
+            : shouldRescanJsxText(n) ? ScanAction.RescanJsxText
+            : shouldRescanJsxAttributeValue(n) ? ScanAction.RescanJsxAttributeValue
+            : ScanAction.Scan;
 
         if (lastTokenInfo && expectedScanAction === lastScanAction) {
             // readTokenInfo was called before with the same expected scan action.

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -557,11 +557,11 @@ function isNotTypeAnnotationContext(context: FormattingContext): boolean {
 
 function isTypeAnnotationContext(context: FormattingContext): boolean {
     const contextKind = context.contextNode.kind;
-    return contextKind === SyntaxKind.PropertyDeclaration ||
-        contextKind === SyntaxKind.PropertySignature ||
-        contextKind === SyntaxKind.Parameter ||
-        contextKind === SyntaxKind.VariableDeclaration ||
-        isFunctionLikeKind(contextKind);
+    return contextKind === SyntaxKind.PropertyDeclaration
+        || contextKind === SyntaxKind.PropertySignature
+        || contextKind === SyntaxKind.Parameter
+        || contextKind === SyntaxKind.VariableDeclaration
+        || isFunctionLikeKind(contextKind);
 }
 
 function isOptionalPropertyContext(context: FormattingContext) {
@@ -573,8 +573,8 @@ function isNonOptionalPropertyContext(context: FormattingContext) {
 }
 
 function isConditionalOperatorContext(context: FormattingContext): boolean {
-    return context.contextNode.kind === SyntaxKind.ConditionalExpression ||
-        context.contextNode.kind === SyntaxKind.ConditionalType;
+    return context.contextNode.kind === SyntaxKind.ConditionalExpression
+        || context.contextNode.kind === SyntaxKind.ConditionalType;
 }
 
 function isSameLineTokenOrBeforeBlockContext(context: FormattingContext): boolean {
@@ -582,9 +582,9 @@ function isSameLineTokenOrBeforeBlockContext(context: FormattingContext): boolea
 }
 
 function isBraceWrappedContext(context: FormattingContext): boolean {
-    return context.contextNode.kind === SyntaxKind.ObjectBindingPattern ||
-        context.contextNode.kind === SyntaxKind.MappedType ||
-        isSingleLineBlockContext(context);
+    return context.contextNode.kind === SyntaxKind.ObjectBindingPattern
+        || context.contextNode.kind === SyntaxKind.MappedType
+        || isSingleLineBlockContext(context);
 }
 
 // This check is done before an open brace in a control construct, a function, or a typescript block declaration
@@ -803,10 +803,10 @@ function isNotBeforeBlockInFunctionDeclarationContext(context: FormattingContext
 }
 
 function isEndOfDecoratorContextOnSameLine(context: FormattingContext): boolean {
-    return context.TokensAreOnSameLine() &&
-        hasDecorators(context.contextNode) &&
-        nodeIsInDecoratorContext(context.currentTokenParent) &&
-        !nodeIsInDecoratorContext(context.nextTokenParent);
+    return context.TokensAreOnSameLine()
+        && hasDecorators(context.contextNode)
+        && nodeIsInDecoratorContext(context.currentTokenParent)
+        && !nodeIsInDecoratorContext(context.nextTokenParent);
 }
 
 function nodeIsInDecoratorContext(node: Node): boolean {
@@ -817,8 +817,8 @@ function nodeIsInDecoratorContext(node: Node): boolean {
 }
 
 function isStartOfVariableDeclarationList(context: FormattingContext): boolean {
-    return context.currentTokenParent.kind === SyntaxKind.VariableDeclarationList &&
-        context.currentTokenParent.getStart(context.sourceFile) === context.currentTokenSpan.pos;
+    return context.currentTokenParent.kind === SyntaxKind.VariableDeclarationList
+        && context.currentTokenParent.getStart(context.sourceFile) === context.currentTokenSpan.pos;
 }
 
 function isNotFormatOnEnter(context: FormattingContext): boolean {
@@ -865,8 +865,8 @@ function isTypeArgumentOrParameterOrAssertion(token: TextRangeWithKind, parent: 
 }
 
 function isTypeArgumentOrParameterOrAssertionContext(context: FormattingContext): boolean {
-    return isTypeArgumentOrParameterOrAssertion(context.currentTokenSpan, context.currentTokenParent) ||
-        isTypeArgumentOrParameterOrAssertion(context.nextTokenSpan, context.nextTokenParent);
+    return isTypeArgumentOrParameterOrAssertion(context.currentTokenSpan, context.currentTokenParent)
+        || isTypeArgumentOrParameterOrAssertion(context.nextTokenSpan, context.nextTokenParent);
 }
 
 function isTypeAssertionContext(context: FormattingContext): boolean {
@@ -934,15 +934,15 @@ function isSemicolonDeletionContext(context: FormattingContext): boolean {
     }
 
     if (
-        nextTokenKind === SyntaxKind.SemicolonClassElement ||
-        nextTokenKind === SyntaxKind.SemicolonToken
+        nextTokenKind === SyntaxKind.SemicolonClassElement
+        || nextTokenKind === SyntaxKind.SemicolonToken
     ) {
         return false;
     }
 
     if (
-        context.contextNode.kind === SyntaxKind.InterfaceDeclaration ||
-        context.contextNode.kind === SyntaxKind.TypeAliasDeclaration
+        context.contextNode.kind === SyntaxKind.InterfaceDeclaration
+        || context.contextNode.kind === SyntaxKind.TypeAliasDeclaration
     ) {
         // Can't remove semicolon after `foo`; it would parse as a method declaration:
         //

--- a/src/services/formatting/rulesMap.ts
+++ b/src/services/formatting/rulesMap.ts
@@ -129,11 +129,11 @@ enum RulesPosition {
 // In order to insert a rule to the end of sub-bucket (3), we get the index by adding
 // the values in the bitmap segments 3rd, 2nd, and 1st.
 function addRule(rules: Rule[], rule: Rule, specificTokens: boolean, constructionState: number[], rulesBucketIndex: number): void {
-    const position = rule.action & RuleAction.StopAction ?
-        specificTokens ? RulesPosition.StopRulesSpecific : RulesPosition.StopRulesAny :
-        rule.context !== anyContext ?
-        specificTokens ? RulesPosition.ContextRulesSpecific : RulesPosition.ContextRulesAny :
-        specificTokens ? RulesPosition.NoContextRulesSpecific : RulesPosition.NoContextRulesAny;
+    const position = rule.action & RuleAction.StopAction
+        ? specificTokens ? RulesPosition.StopRulesSpecific : RulesPosition.StopRulesAny
+        : rule.context !== anyContext
+        ? specificTokens ? RulesPosition.ContextRulesSpecific : RulesPosition.ContextRulesAny
+        : specificTokens ? RulesPosition.NoContextRulesSpecific : RulesPosition.NoContextRulesAny;
 
     const state = constructionState[rulesBucketIndex] || 0;
     rules.splice(getInsertionIndex(state, position), 0, rule);

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -259,8 +259,8 @@ export namespace SmartIndenter {
             }
 
             const containingListOrParentStart = getContainingListOrParentStart(parent, current, sourceFile);
-            const parentAndChildShareLine = containingListOrParentStart.line === currentStart.line ||
-                childStartsOnTheSameLineWithElseInIfStatement(parent, current, currentStart.line, sourceFile);
+            const parentAndChildShareLine = containingListOrParentStart.line === currentStart.line
+                || childStartsOnTheSameLineWithElseInIfStatement(parent, current, currentStart.line, sourceFile);
 
             if (useActualIndentation) {
                 // check if current node is a list item - if yes, take indentation from it
@@ -346,8 +346,8 @@ export namespace SmartIndenter {
         // actual indentation is used for statements\declarations if one of cases below is true:
         // - parent is SourceFile - by default immediate children of SourceFile are not indented except when user indents them manually
         // - parent and child are not on the same line
-        const useActualIndentation = (isDeclaration(current) || isStatementButNotDeclaration(current)) &&
-            (parent.kind === SyntaxKind.SourceFile || !parentAndChildShareLine);
+        const useActualIndentation = (isDeclaration(current) || isStatementButNotDeclaration(current))
+            && (parent.kind === SyntaxKind.SourceFile || !parentAndChildShareLine);
 
         if (!useActualIndentation) {
             return Value.Unknown;
@@ -713,8 +713,8 @@ export namespace SmartIndenter {
             case SyntaxKind.ExportDeclaration:
                 return childKind !== SyntaxKind.NamedExports;
             case SyntaxKind.ImportDeclaration:
-                return childKind !== SyntaxKind.ImportClause ||
-                    (!!(child as ImportClause).namedBindings && (child as ImportClause).namedBindings!.kind !== SyntaxKind.NamedImports);
+                return childKind !== SyntaxKind.ImportClause
+                    || (!!(child as ImportClause).namedBindings && (child as ImportClause).namedBindings!.kind !== SyntaxKind.NamedImports);
             case SyntaxKind.JsxElement:
                 return childKind !== SyntaxKind.JsxClosingElement;
             case SyntaxKind.JsxFragment:

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -121,8 +121,8 @@ function updateTsconfigFiles(program: Program, changeTracker: textChanges.Change
                 const matchers = getFileMatcherPatterns(configDir, /*excludes*/ [], includes, useCaseSensitiveFileNames, currentDirectory);
                 // If there isn't some include for this, add a new one.
                 if (
-                    getRegexFromPattern(Debug.checkDefined(matchers.includeFilePattern), useCaseSensitiveFileNames).test(oldFileOrDirPath) &&
-                    !getRegexFromPattern(Debug.checkDefined(matchers.includeFilePattern), useCaseSensitiveFileNames).test(newFileOrDirPath)
+                    getRegexFromPattern(Debug.checkDefined(matchers.includeFilePattern), useCaseSensitiveFileNames).test(oldFileOrDirPath)
+                    && !getRegexFromPattern(Debug.checkDefined(matchers.includeFilePattern), useCaseSensitiveFileNames).test(newFileOrDirPath)
                 ) {
                     changeTracker.insertNodeAfter(configFile, last(property.initializer.elements), factory.createStringLiteral(relativePath(newFileOrDirPath)));
                 }
@@ -246,9 +246,9 @@ function getSourceFileToImport(
     }
     else {
         const mode = program.getModeForUsageLocation(importingSourceFile, importLiteral);
-        const resolved = host.resolveModuleNameLiterals || !host.resolveModuleNames ?
-            program.getResolvedModuleFromModuleSpecifier(importLiteral) :
-            host.getResolvedModuleWithFailedLookupLocationsFromCache && host.getResolvedModuleWithFailedLookupLocationsFromCache(importLiteral.text, importingSourceFile.fileName, mode);
+        const resolved = host.resolveModuleNameLiterals || !host.resolveModuleNames
+            ? program.getResolvedModuleFromModuleSpecifier(importLiteral)
+            : host.getResolvedModuleWithFailedLookupLocationsFromCache && host.getResolvedModuleWithFailedLookupLocationsFromCache(importLiteral.text, importingSourceFile.fileName, mode);
         return getSourceFileToImportFromResolved(importLiteral, resolved, oldToNew, program.getSourceFiles());
     }
 }

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -265,8 +265,8 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
     //      }
     //      bar<Test>(({pr/*goto*/op1})=>{});
     if (
-        isPropertyName(node) && isBindingElement(parent) && isObjectBindingPattern(parent.parent) &&
-        (node === (parent.propertyName || parent.name))
+        isPropertyName(node) && isBindingElement(parent) && isObjectBindingPattern(parent.parent)
+        && (node === (parent.propertyName || parent.name))
     ) {
         const name = getNameFromPropertyName(node);
         const type = typeChecker.getTypeAtLocation(parent.parent);
@@ -429,9 +429,9 @@ function getFirstTypeArgumentDefinitions(typeChecker: TypeChecker, type: Type, n
     }
 
     if (
-        (getObjectFlags(type) & ObjectFlags.Mapped) &&
-        (type as MappedType).target &&
-        shouldUnwrapFirstTypeArgumentTypeDefinitionFromAlias(typeChecker, (type as MappedType).target!)
+        (getObjectFlags(type) & ObjectFlags.Mapped)
+        && (type as MappedType).target
+        && shouldUnwrapFirstTypeArgumentTypeDefinitionFromAlias(typeChecker, (type as MappedType).target!)
     ) {
         const declaration = type.aliasSymbol?.declarations?.[0];
 
@@ -462,9 +462,9 @@ export function getTypeDefinitionAtPosition(typeChecker: TypeChecker, sourceFile
     const fromReturnType = returnType && definitionFromType(returnType, typeChecker, node, failedAliasResolution);
 
     // If a function returns 'void' or some other type with no definition, just return the function definition.
-    const [resolvedType, typeDefinitions] = fromReturnType && fromReturnType.length !== 0 ?
-        [returnType, fromReturnType] :
-        [typeAtLocation, definitionFromType(typeAtLocation, typeChecker, node, failedAliasResolution)];
+    const [resolvedType, typeDefinitions] = fromReturnType && fromReturnType.length !== 0
+        ? [returnType, fromReturnType]
+        : [typeAtLocation, definitionFromType(typeAtLocation, typeChecker, node, failedAliasResolution)];
 
     return typeDefinitions.length ? [...getFirstTypeArgumentDefinitions(typeChecker, resolvedType, node, failedAliasResolution), ...typeDefinitions]
         : !(symbol.flags & SymbolFlags.Value) && symbol.flags & SymbolFlags.Type ? getDefinitionFromSymbol(typeChecker, skipAlias(symbol, typeChecker), node, failedAliasResolution)
@@ -479,9 +479,9 @@ function tryGetReturnTypeOfFunction(symbol: Symbol, type: Type, checker: TypeChe
     // If the type is just a function's inferred type,
     // go-to-type should go to the return type instead, since go-to-definition takes you to the function anyway.
     if (
-        type.symbol === symbol ||
+        type.symbol === symbol
         // At `const f = () => {}`, the symbol is `f` and the type symbol is at `() => {}`
-        symbol.valueDeclaration && type.symbol && isVariableDeclaration(symbol.valueDeclaration) && symbol.valueDeclaration.initializer === type.symbol.valueDeclaration as Node
+        || symbol.valueDeclaration && type.symbol && isVariableDeclaration(symbol.valueDeclaration) && symbol.valueDeclaration.initializer === type.symbol.valueDeclaration as Node
     ) {
         const sigs = type.getCallSignatures();
         if (sigs.length === 1) return checker.getReturnTypeOfSignature(first(sigs));
@@ -498,9 +498,9 @@ export function getDefinitionAndBoundSpan(program: Program, sourceFile: SourceFi
     }
 
     // Check if position is on triple slash reference.
-    const comment = findReferenceInPosition(sourceFile.referencedFiles, position) ||
-        findReferenceInPosition(sourceFile.typeReferenceDirectives, position) ||
-        findReferenceInPosition(sourceFile.libReferenceDirectives, position);
+    const comment = findReferenceInPosition(sourceFile.referencedFiles, position)
+        || findReferenceInPosition(sourceFile.typeReferenceDirectives, position)
+        || findReferenceInPosition(sourceFile.libReferenceDirectives, position);
 
     if (comment) {
         return { definitions, textSpan: createTextSpanFromRange(comment) };

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -450,8 +450,8 @@ function findNamespaceReExports(sourceFileLike: SourceFileLike, name: Identifier
     return !!forEachPossibleImportOrExportStatement(sourceFileLike, statement => {
         if (!isExportDeclaration(statement)) return;
         const { exportClause, moduleSpecifier } = statement;
-        return !moduleSpecifier && exportClause && isNamedExports(exportClause) &&
-            exportClause.elements.some(element => checker.getExportSpecifierLocalTargetSymbol(element) === namespaceImportSymbol);
+        return !moduleSpecifier && exportClause && isNamedExports(exportClause)
+            && exportClause.elements.some(element => checker.getExportSpecifierLocalTargetSymbol(element) === namespaceImportSymbol);
     });
 }
 
@@ -717,8 +717,8 @@ function getExportEqualsLocalSymbol(importedSymbol: Symbol, checker: TypeChecker
 function getExportNode(parent: Node, node: Node): Node | undefined {
     const declaration = isVariableDeclaration(parent) ? parent : isBindingElement(parent) ? walkUpBindingElementsAndPatterns(parent) : undefined;
     if (declaration) {
-        return (parent as VariableDeclaration | BindingElement).name !== node ? undefined :
-            isCatchClause(declaration.parent) ? undefined : isVariableStatement(declaration.parent.parent) ? declaration.parent.parent : undefined;
+        return (parent as VariableDeclaration | BindingElement).name !== node ? undefined
+            : isCatchClause(declaration.parent) ? undefined : isVariableStatement(declaration.parent.parent) ? declaration.parent.parent : undefined;
     }
     else {
         return parent;

--- a/src/services/inlayHints.ts
+++ b/src/services/inlayHints.ts
@@ -262,8 +262,8 @@ export function provideInlayHints(context: InlayHintsContext): InlayHint[] {
 
     function visitVariableLikeDeclaration(decl: VariableDeclaration | PropertyDeclaration) {
         if (
-            decl.initializer === undefined && !(isPropertyDeclaration(decl) && !(checker.getTypeAtLocation(decl).flags & TypeFlags.Any)) ||
-            isBindingPattern(decl.name) || (isVariableDeclaration(decl) && !isHintableDeclaration(decl))
+            decl.initializer === undefined && !(isPropertyDeclaration(decl) && !(checker.getTypeAtLocation(decl).flags & TypeFlags.Any))
+            || isBindingPattern(decl.name) || (isVariableDeclaration(decl) && !isHintableDeclaration(decl))
         ) {
             return;
         }

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -270,8 +270,8 @@ function getJSDocPropertyTagsInfo(nodes: readonly JSDocTag[] | undefined, checke
 }
 
 function tryGetJSDocPropertyTags(node: JSDocTag) {
-    return isJSDocPropertyLikeTag(node) && node.isNameFirst && node.typeExpression &&
-            isJSDocTypeLiteral(node.typeExpression.type) ? node.typeExpression.type.jsDocPropertyTags : undefined;
+    return isJSDocPropertyLikeTag(node) && node.isNameFirst && node.typeExpression
+            && isJSDocTypeLiteral(node.typeExpression.type) ? node.typeExpression.type.jsDocPropertyTags : undefined;
 }
 
 function getDisplayPartsFromComment(comment: string | readonly JSDocComment[], checker: TypeChecker | undefined): SymbolDisplayPart[] {
@@ -290,8 +290,8 @@ function getCommentDisplayParts(tag: JSDocTag, checker?: TypeChecker): SymbolDis
     switch (kind) {
         case SyntaxKind.JSDocThrowsTag:
             const typeExpression = (tag as JSDocThrowsTag).typeExpression;
-            return typeExpression ? withNode(typeExpression) :
-                comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
+            return typeExpression ? withNode(typeExpression)
+                : comment === undefined ? undefined : getDisplayPartsFromComment(comment, checker);
         case SyntaxKind.JSDocImplementsTag:
             return withNode((tag as JSDocImplementsTag).class);
         case SyntaxKind.JSDocAugmentsTag:
@@ -505,8 +505,8 @@ export function getDocCommentTemplateAtPosition(newLine: string, sourceFile: Sou
 
     const indentationStr = getIndentationStringAtPosition(sourceFile, position);
     const isJavaScriptFile = hasJSFileExtension(sourceFile.fileName);
-    const tags = (parameters ? parameterDocComments(parameters || [], isJavaScriptFile, indentationStr, newLine) : "") +
-        (hasReturn ? returnsDocComment(indentationStr, newLine) : "");
+    const tags = (parameters ? parameterDocComments(parameters || [], isJavaScriptFile, indentationStr, newLine) : "")
+        + (hasReturn ? returnsDocComment(indentationStr, newLine) : "");
 
     // A doc comment consists of the following
     // * The opening comment line
@@ -625,8 +625,8 @@ function getCommentOwnerInfoWorker(commentOwner: Node, options: DocCommentTempla
 }
 
 function hasReturn(node: Node, options: DocCommentTemplateOptions | undefined) {
-    return !!options?.generateReturnInDocTemplate &&
-        (isFunctionTypeNode(node) || isArrowFunction(node) && isExpression(node.body)
+    return !!options?.generateReturnInDocTemplate
+        && (isFunctionTypeNode(node) || isArrowFunction(node) && isExpression(node.body)
             || isFunctionLikeDeclaration(node) && node.body && isBlock(node.body) && !!forEachReturnStatement(node.body, n => n));
 }
 

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -445,8 +445,8 @@ function addChildrenRecursively(node: Node | undefined): void {
 
         case SyntaxKind.ExportAssignment: {
             const expression = (node as ExportAssignment).expression;
-            const child = isObjectLiteralExpression(expression) || isCallExpression(expression) ? expression :
-                isArrowFunction(expression) || isFunctionExpression(expression) ? expression.body : undefined;
+            const child = isObjectLiteralExpression(expression) || isCallExpression(expression) ? expression
+                : isArrowFunction(expression) || isFunctionExpression(expression) ? expression.body : undefined;
             if (child) {
                 startNode(node);
                 addChildrenRecursively(child);
@@ -479,9 +479,9 @@ function addChildrenRecursively(node: Node | undefined): void {
                     const binaryExpression = node as BinaryExpression;
                     const assignmentTarget = binaryExpression.left as PropertyAccessExpression;
 
-                    const prototypeAccess = special === AssignmentDeclarationKind.PrototypeProperty ?
-                        assignmentTarget.expression as PropertyAccessExpression :
-                        assignmentTarget;
+                    const prototypeAccess = special === AssignmentDeclarationKind.PrototypeProperty
+                        ? assignmentTarget.expression as PropertyAccessExpression
+                        : assignmentTarget;
 
                     let depth = 0;
                     let className: PropertyNameLiteral;
@@ -517,9 +517,9 @@ function addChildrenRecursively(node: Node | undefined): void {
                 case AssignmentDeclarationKind.ObjectDefinePropertyValue:
                 case AssignmentDeclarationKind.ObjectDefinePrototypeProperty: {
                     const defineCall = node as BindableObjectDefinePropertyCall;
-                    const className = special === AssignmentDeclarationKind.ObjectDefinePropertyValue ?
-                        defineCall.arguments[0] :
-                        (defineCall.arguments[0] as PropertyAccessExpression).expression as EntityNameExpression;
+                    const className = special === AssignmentDeclarationKind.ObjectDefinePropertyValue
+                        ? defineCall.arguments[0]
+                        : (defineCall.arguments[0] as PropertyAccessExpression).expression as EntityNameExpression;
 
                     const memberName = defineCall.arguments[1];
                     const [depth, classNameIdentifier] = startNestedNodes(node, className);
@@ -536,8 +536,8 @@ function addChildrenRecursively(node: Node | undefined): void {
                     const assignmentTarget = binaryExpression.left as PropertyAccessExpression | BindableElementAccessExpression;
                     const targetFunction = assignmentTarget.expression;
                     if (
-                        isIdentifier(targetFunction) && getElementOrPropertyAccessName(assignmentTarget) !== "prototype" &&
-                        trackedEs5Classes && trackedEs5Classes.has(targetFunction.text)
+                        isIdentifier(targetFunction) && getElementOrPropertyAccessName(assignmentTarget) !== "prototype"
+                        && trackedEs5Classes && trackedEs5Classes.has(targetFunction.text)
                     ) {
                         if (isFunctionExpression(binaryExpression.right) || isArrowFunction(binaryExpression.right)) {
                             addNodeWithRecursiveChild(node, binaryExpression.right, targetFunction);
@@ -628,13 +628,13 @@ function tryMergeEs5Class(a: NavigationBarNode, b: NavigationBarNode, bIndex: nu
     function isPossibleConstructor(node: Node) {
         return isFunctionExpression(node) || isFunctionDeclaration(node) || isVariableDeclaration(node);
     }
-    const bAssignmentDeclarationKind = isBinaryExpression(b.node) || isCallExpression(b.node) ?
-        getAssignmentDeclarationKind(b.node) :
-        AssignmentDeclarationKind.None;
+    const bAssignmentDeclarationKind = isBinaryExpression(b.node) || isCallExpression(b.node)
+        ? getAssignmentDeclarationKind(b.node)
+        : AssignmentDeclarationKind.None;
 
-    const aAssignmentDeclarationKind = isBinaryExpression(a.node) || isCallExpression(a.node) ?
-        getAssignmentDeclarationKind(a.node) :
-        AssignmentDeclarationKind.None;
+    const aAssignmentDeclarationKind = isBinaryExpression(a.node) || isCallExpression(a.node)
+        ? getAssignmentDeclarationKind(a.node)
+        : AssignmentDeclarationKind.None;
 
     // We treat this as an es5 class and merge the nodes in in one of several cases
     if (
@@ -652,9 +652,9 @@ function tryMergeEs5Class(a: NavigationBarNode, b: NavigationBarNode, bIndex: nu
             (!isClassDeclaration(a.node) && !isClassDeclaration(b.node)) // If neither outline node is a class
             || isPossibleConstructor(a.node) || isPossibleConstructor(b.node) // If either function is a constructor function
         ) {
-            const ctorFunction = isPossibleConstructor(a.node) ? a.node :
-                isPossibleConstructor(b.node) ? b.node :
-                undefined;
+            const ctorFunction = isPossibleConstructor(a.node) ? a.node
+                : isPossibleConstructor(b.node) ? b.node
+                : undefined;
 
             if (ctorFunction !== undefined) {
                 const ctorNode = setTextRange(

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -364,8 +364,8 @@ function removeUnusedImports(oldImports: readonly ImportDeclaration[], sourceFil
 
     function isDeclarationUsed(identifier: Identifier) {
         // The JSX factory symbol is always used if JSX elements are present - even if they are not allowed.
-        return jsxElementsPresent && (identifier.text === jsxNamespace || jsxFragmentFactory && identifier.text === jsxFragmentFactory) && jsxModeNeedsExplicitImport(compilerOptions.jsx) ||
-            FindAllReferences.Core.isSymbolReferencedInFile(identifier, typeChecker, sourceFile);
+        return jsxElementsPresent && (identifier.text === jsxNamespace || jsxFragmentFactory && identifier.text === jsxFragmentFactory) && jsxModeNeedsExplicitImport(compilerOptions.jsx)
+            || FindAllReferences.Core.isSymbolReferencedInFile(identifier, typeChecker, sourceFile);
     }
 }
 
@@ -505,10 +505,10 @@ function coalesceImportsWorker(importGroup: readonly ImportDeclaration[], compar
                 : factory.createNamedImports(sortedImportSpecifiers);
 
             if (
-                sourceFile &&
-                newNamedImports &&
-                firstNamedImport?.importClause.namedBindings &&
-                !rangeIsOnSingleLine(firstNamedImport.importClause.namedBindings, sourceFile)
+                sourceFile
+                && newNamedImports
+                && firstNamedImport?.importClause.namedBindings
+                && !rangeIsOnSingleLine(firstNamedImport.importClause.namedBindings, sourceFile)
             ) {
                 setEmitFlags(newNamedImports, EmitFlags.MultiLine);
             }
@@ -587,9 +587,9 @@ function coalesceExportsWorker(exportGroup: readonly ExportDeclaration[], specif
                 exportDecl.modifiers,
                 exportDecl.isTypeOnly,
                 exportDecl.exportClause && (
-                    isNamedExports(exportDecl.exportClause) ?
-                        factory.updateNamedExports(exportDecl.exportClause, sortedExportSpecifiers) :
-                        factory.updateNamespaceExport(exportDecl.exportClause, exportDecl.exportClause.name)
+                    isNamedExports(exportDecl.exportClause)
+                        ? factory.updateNamedExports(exportDecl.exportClause, sortedExportSpecifiers)
+                        : factory.updateNamespaceExport(exportDecl.exportClause, exportDecl.exportClause.name)
                 ),
                 exportDecl.moduleSpecifier,
                 exportDecl.attributes,
@@ -659,9 +659,9 @@ function compareImportOrExportSpecifiers<T extends ImportOrExportSpecifier>(s1: 
 function compareModuleSpecifiersWorker(m1: Expression | undefined, m2: Expression | undefined, comparer: Comparer<string>) {
     const name1 = m1 === undefined ? undefined : getExternalModuleName(m1);
     const name2 = m2 === undefined ? undefined : getExternalModuleName(m2);
-    return compareBooleans(name1 === undefined, name2 === undefined) ||
-        compareBooleans(isExternalModuleNameRelative(name1!), isExternalModuleNameRelative(name2!)) ||
-        comparer(name1!, name2!);
+    return compareBooleans(name1 === undefined, name2 === undefined)
+        || compareBooleans(isExternalModuleNameRelative(name1!), isExternalModuleNameRelative(name2!))
+        || comparer(name1!, name2!);
 }
 
 function getModuleNamesFromDecls(decls: readonly AnyImportOrRequireStatement[]): string[] {
@@ -842,9 +842,9 @@ function getOrganizeImportsUnicodeStringComparer(ignoreCase: boolean, preference
     const caseFirst = preferences.organizeImportsCaseFirst ?? false;
     const numeric = preferences.organizeImportsNumericCollation ?? false;
     const accents = preferences.organizeImportsAccentCollation ?? true;
-    const sensitivity = ignoreCase ?
-        accents ? "accent" : "base" :
-        accents ? "variant" : "case";
+    const sensitivity = ignoreCase
+        ? accents ? "accent" : "base"
+        : accents ? "variant" : "case";
 
     const collator = new Intl.Collator(resolvedLocale, {
         usage: "sort",
@@ -869,9 +869,9 @@ function getOrganizeImportsLocale(preferences: UserPreferences): string {
 
 function getOrganizeImportsStringComparer(preferences: UserPreferences, ignoreCase: boolean): Comparer<string> {
     const collation = preferences.organizeImportsCollation ?? "ordinal";
-    return collation === "unicode" ?
-        getOrganizeImportsUnicodeStringComparer(ignoreCase, preferences) :
-        getOrganizeImportsOrdinalStringComparer(ignoreCase);
+    return collation === "unicode"
+        ? getOrganizeImportsUnicodeStringComparer(ignoreCase, preferences)
+        : getOrganizeImportsOrdinalStringComparer(ignoreCase);
 }
 
 /** @internal */

--- a/src/services/patternMatcher.ts
+++ b/src/services/patternMatcher.ts
@@ -336,8 +336,8 @@ function tryCamelCaseMatch(candidate: string, candidateParts: TextSpan[], chunk:
                 // only continue trying to consumer pattern parts if the last part and this
                 // part are both upper case.
                 if (
-                    !isUpperCaseLetter(chunk.text.charCodeAt(chunkCharacterSpans[currentChunkSpan - 1].start)) ||
-                    !isUpperCaseLetter(chunk.text.charCodeAt(chunkCharacterSpans[currentChunkSpan].start))
+                    !isUpperCaseLetter(chunk.text.charCodeAt(chunkCharacterSpans[currentChunkSpan - 1].start))
+                    || !isUpperCaseLetter(chunk.text.charCodeAt(chunkCharacterSpans[currentChunkSpan].start))
                 ) {
                     break;
                 }
@@ -507,11 +507,11 @@ function breakIntoSpans(identifier: string, word: boolean): TextSpan[] {
         const hasTransitionFromUpperToLower = word && transitionFromUpperToLower(identifier, i, wordStart);
 
         if (
-            charIsPunctuation(identifier.charCodeAt(i - 1)) ||
-            charIsPunctuation(identifier.charCodeAt(i)) ||
-            lastIsDigit !== currentIsDigit ||
-            hasTransitionFromLowerToUpper ||
-            hasTransitionFromUpperToLower
+            charIsPunctuation(identifier.charCodeAt(i - 1))
+            || charIsPunctuation(identifier.charCodeAt(i))
+            || lastIsDigit !== currentIsDigit
+            || hasTransitionFromLowerToUpper
+            || hasTransitionFromUpperToLower
         ) {
             if (!isAllPunctuation(identifier, wordStart, i)) {
                 result.push(createTextSpan(wordStart, i - wordStart));

--- a/src/services/preProcess.ts
+++ b/src/services/preProcess.ts
@@ -119,10 +119,10 @@ export function preProcessFile(sourceText: string, readImportFiles = true, detec
                     const skipTypeKeyword = scanner.lookAhead(() => {
                         const token = scanner.scan();
                         return token !== SyntaxKind.FromKeyword && (
-                            token === SyntaxKind.AsteriskToken ||
-                            token === SyntaxKind.OpenBraceToken ||
-                            token === SyntaxKind.Identifier ||
-                            isKeyword(token)
+                            token === SyntaxKind.AsteriskToken
+                            || token === SyntaxKind.OpenBraceToken
+                            || token === SyntaxKind.Identifier
+                            || isKeyword(token)
                         );
                     });
                     if (skipTypeKeyword) {
@@ -208,8 +208,8 @@ export function preProcessFile(sourceText: string, readImportFiles = true, detec
             if (token === SyntaxKind.TypeKeyword) {
                 const skipTypeKeyword = scanner.lookAhead(() => {
                     const token = scanner.scan();
-                    return token === SyntaxKind.AsteriskToken ||
-                        token === SyntaxKind.OpenBraceToken;
+                    return token === SyntaxKind.AsteriskToken
+                        || token === SyntaxKind.OpenBraceToken;
                 });
                 if (skipTypeKeyword) {
                     token = nextToken();
@@ -250,8 +250,8 @@ export function preProcessFile(sourceText: string, readImportFiles = true, detec
                 if (token === SyntaxKind.TypeKeyword) {
                     const skipTypeKeyword = scanner.lookAhead(() => {
                         const token = scanner.scan();
-                        return token === SyntaxKind.Identifier ||
-                            isKeyword(token);
+                        return token === SyntaxKind.Identifier
+                            || isKeyword(token);
                     });
                     if (skipTypeKeyword) {
                         token = nextToken();
@@ -280,8 +280,8 @@ export function preProcessFile(sourceText: string, readImportFiles = true, detec
             if (token === SyntaxKind.OpenParenToken) {
                 token = nextToken();
                 if (
-                    token === SyntaxKind.StringLiteral ||
-                    allowTemplateLiterals && token === SyntaxKind.NoSubstitutionTemplateLiteral
+                    token === SyntaxKind.StringLiteral
+                    || allowTemplateLiterals && token === SyntaxKind.NoSubstitutionTemplateLiteral
                 ) {
                     //  require("mod");
                     recordModuleName();
@@ -398,12 +398,12 @@ export function preProcessFile(sourceText: string, readImportFiles = true, detec
 
             // check if at least one of alternative have moved scanner forward
             if (
-                tryConsumeDeclare() ||
-                tryConsumeImport() ||
-                tryConsumeExport() ||
-                (detectJavaScriptImports && (
-                    tryConsumeRequireCall(/*skipCurrentToken*/ false, /*allowTemplateLiterals*/ true) ||
-                    tryConsumeDefine()
+                tryConsumeDeclare()
+                || tryConsumeImport()
+                || tryConsumeExport()
+                || (detectJavaScriptImports && (
+                    tryConsumeRequireCall(/*skipCurrentToken*/ false, /*allowTemplateLiterals*/ true)
+                    || tryConsumeDefine()
                 ))
             ) {
                 continue;

--- a/src/services/refactorProvider.ts
+++ b/src/services/refactorProvider.ts
@@ -27,9 +27,9 @@ export function registerRefactor(name: string, refactor: Refactor) {
 /** @internal */
 export function getApplicableRefactors(context: RefactorContext, includeInteractiveActions?: boolean): ApplicableRefactorInfo[] {
     return arrayFrom(flatMapIterator(refactors.values(), refactor =>
-        context.cancellationToken && context.cancellationToken.isCancellationRequested() ||
-            !refactor.kinds?.some(kind => refactorKindBeginsWith(kind, context.kind)) ? undefined :
-            refactor.getAvailableActions(context, includeInteractiveActions)));
+        context.cancellationToken && context.cancellationToken.isCancellationRequested()
+            || !refactor.kinds?.some(kind => refactorKindBeginsWith(kind, context.kind)) ? undefined
+            : refactor.getAvailableActions(context, includeInteractiveActions)));
 }
 
 /** @internal */

--- a/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
+++ b/src/services/refactors/convertArrowFunctionOrFunctionExpression.ts
@@ -107,8 +107,8 @@ function getRefactorActionsToConvertFunctionExpressions(context: RefactorContext
     const possibleActions: RefactorActionInfo[] = [];
     const errors: RefactorActionInfo[] = [];
     if (refactorKindBeginsWith(toNamedFunctionAction.kind, kind)) {
-        const error = selectedVariableDeclaration || (isArrowFunction(func) && isVariableDeclaration(func.parent)) ?
-            undefined : getLocaleSpecificMessage(Diagnostics.Could_not_convert_to_named_function);
+        const error = selectedVariableDeclaration || (isArrowFunction(func) && isVariableDeclaration(func.parent))
+            ? undefined : getLocaleSpecificMessage(Diagnostics.Could_not_convert_to_named_function);
         if (error) {
             errors.push({ ...toNamedFunctionAction, notApplicableReason: error });
         }
@@ -118,8 +118,8 @@ function getRefactorActionsToConvertFunctionExpressions(context: RefactorContext
     }
 
     if (refactorKindBeginsWith(toAnonymousFunctionAction.kind, kind)) {
-        const error = !selectedVariableDeclaration && isArrowFunction(func) ?
-            undefined : getLocaleSpecificMessage(Diagnostics.Could_not_convert_to_anonymous_function);
+        const error = !selectedVariableDeclaration && isArrowFunction(func)
+            ? undefined : getLocaleSpecificMessage(Diagnostics.Could_not_convert_to_anonymous_function);
         if (error) {
             errors.push({ ...toAnonymousFunctionAction, notApplicableReason: error });
         }
@@ -141,8 +141,8 @@ function getRefactorActionsToConvertFunctionExpressions(context: RefactorContext
     return [{
         name: refactorName,
         description: refactorDescription,
-        actions: possibleActions.length === 0 && context.preferences.provideRefactorNotApplicableReason ?
-            errors : possibleActions,
+        actions: possibleActions.length === 0 && context.preferences.provideRefactorNotApplicableReason
+            ? errors : possibleActions,
     }];
 }
 
@@ -204,11 +204,11 @@ function getFunctionInfo(file: SourceFile, startPosition: number, program: Progr
 
     const maybeFunc = getContainingFunction(token);
     if (
-        maybeFunc &&
-        (isFunctionExpression(maybeFunc) || isArrowFunction(maybeFunc)) &&
-        !rangeContainsRange(maybeFunc.body, token) &&
-        !containingThis(maybeFunc.body) &&
-        !typeChecker.containsArgumentsReference(maybeFunc)
+        maybeFunc
+        && (isFunctionExpression(maybeFunc) || isArrowFunction(maybeFunc))
+        && !rangeContainsRange(maybeFunc.body, token)
+        && !containingThis(maybeFunc.body)
+        && !typeChecker.containsArgumentsReference(maybeFunc)
     ) {
         if (isFunctionExpression(maybeFunc) && isFunctionReferencedInFile(file, typeChecker, maybeFunc)) return undefined;
         return { selectedVariableDeclaration: false, func: maybeFunc };

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -83,9 +83,9 @@ function getNodeOrParentOfParentheses(file: SourceFile, startPosition: number) {
     const isNonStringBinary = !treeToArray(nestedBinary).isValidConcatenation;
 
     if (
-        isNonStringBinary &&
-        isParenthesizedExpression(nestedBinary.parent) &&
-        isBinaryExpression(nestedBinary.parent.parent)
+        isNonStringBinary
+        && isParenthesizedExpression(nestedBinary.parent)
+        && isBinaryExpression(nestedBinary.parent.parent)
     ) {
         return nestedBinary.parent.parent;
     }

--- a/src/services/refactors/convertToOptionalChainExpression.ts
+++ b/src/services/refactors/convertToOptionalChainExpression.ts
@@ -158,8 +158,8 @@ function getConditionalInfo(expression: ConditionalExpression, checker: TypeChec
     }
     else if (isBinaryExpression(condition)) {
         const occurrences = getOccurrencesInExpression(finalExpression.expression, condition);
-        return occurrences ? { finalExpression, occurrences, expression } :
-            { error: getLocaleSpecificMessage(Diagnostics.Could_not_find_matching_access_expressions) };
+        return occurrences ? { finalExpression, occurrences, expression }
+            : { error: getLocaleSpecificMessage(Diagnostics.Could_not_find_matching_access_expressions) };
     }
 }
 
@@ -172,8 +172,8 @@ function getBinaryInfo(expression: BinaryExpression): OptionalChainInfo | Refact
     if (!finalExpression) return { error: getLocaleSpecificMessage(Diagnostics.Could_not_find_convertible_access_expression) };
 
     const occurrences = getOccurrencesInExpression(finalExpression.expression, expression.left);
-    return occurrences ? { finalExpression, occurrences, expression } :
-        { error: getLocaleSpecificMessage(Diagnostics.Could_not_find_matching_access_expressions) };
+    return occurrences ? { finalExpression, occurrences, expression }
+        : { error: getLocaleSpecificMessage(Diagnostics.Could_not_find_matching_access_expressions) };
 }
 
 /**
@@ -218,8 +218,8 @@ function chainStartsWith(chain: Node, subchain: Node): boolean {
     }
     // check that the chains match at each access. Call chains in subchain are not valid.
     while (
-        (isPropertyAccessExpression(chain) && isPropertyAccessExpression(subchain)) ||
-        (isElementAccessExpression(chain) && isElementAccessExpression(subchain))
+        (isPropertyAccessExpression(chain) && isPropertyAccessExpression(subchain))
+        || (isElementAccessExpression(chain) && isElementAccessExpression(subchain))
     ) {
         if (getTextOfChainNode(chain) !== getTextOfChainNode(subchain)) return false;
         chain = chain.expression;
@@ -313,19 +313,19 @@ function convertOccurrences(checker: TypeChecker, toConvert: Expression, occurre
         const isOccurrence = lastOccurrence?.getText() === toConvert.expression.getText();
         if (isOccurrence) occurrences.pop();
         if (isCallExpression(toConvert)) {
-            return isOccurrence ?
-                factory.createCallChain(chain, factory.createToken(SyntaxKind.QuestionDotToken), toConvert.typeArguments, toConvert.arguments) :
-                factory.createCallChain(chain, toConvert.questionDotToken, toConvert.typeArguments, toConvert.arguments);
+            return isOccurrence
+                ? factory.createCallChain(chain, factory.createToken(SyntaxKind.QuestionDotToken), toConvert.typeArguments, toConvert.arguments)
+                : factory.createCallChain(chain, toConvert.questionDotToken, toConvert.typeArguments, toConvert.arguments);
         }
         else if (isPropertyAccessExpression(toConvert)) {
-            return isOccurrence ?
-                factory.createPropertyAccessChain(chain, factory.createToken(SyntaxKind.QuestionDotToken), toConvert.name) :
-                factory.createPropertyAccessChain(chain, toConvert.questionDotToken, toConvert.name);
+            return isOccurrence
+                ? factory.createPropertyAccessChain(chain, factory.createToken(SyntaxKind.QuestionDotToken), toConvert.name)
+                : factory.createPropertyAccessChain(chain, toConvert.questionDotToken, toConvert.name);
         }
         else if (isElementAccessExpression(toConvert)) {
-            return isOccurrence ?
-                factory.createElementAccessChain(chain, factory.createToken(SyntaxKind.QuestionDotToken), toConvert.argumentExpression) :
-                factory.createElementAccessChain(chain, toConvert.questionDotToken, toConvert.argumentExpression);
+            return isOccurrence
+                ? factory.createElementAccessChain(chain, factory.createToken(SyntaxKind.QuestionDotToken), toConvert.argumentExpression)
+                : factory.createElementAccessChain(chain, toConvert.questionDotToken, toConvert.argumentExpression);
         }
     }
     return toConvert;

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -644,9 +644,9 @@ export function getRangeToExtract(sourceFile: SourceFile, span: TextSpan, invoke
         if (rangeFacts & RangeFacts.UsesThis) {
             const container = getThisContainer(nodeToCheck, /*includeArrowFunctions*/ false, /*includeClassComputedPropertyName*/ false);
             if (
-                container.kind === SyntaxKind.FunctionDeclaration ||
-                (container.kind === SyntaxKind.MethodDeclaration && container.parent.kind === SyntaxKind.ObjectLiteralExpression) ||
-                container.kind === SyntaxKind.FunctionExpression
+                container.kind === SyntaxKind.FunctionDeclaration
+                || (container.kind === SyntaxKind.MethodDeclaration && container.parent.kind === SyntaxKind.ObjectLiteralExpression)
+                || container.kind === SyntaxKind.FunctionExpression
             ) {
                 rangeFacts |= RangeFacts.UsesThisInFunction;
             }
@@ -840,8 +840,8 @@ function getStatementOrExpressionRange(node: Node): Statement[] | Expression | u
 }
 
 function isScope(node: Node): node is Scope {
-    return isArrowFunction(node) ? isFunctionBody(node.body) :
-        isFunctionLikeDeclaration(node) || isSourceFile(node) || isModuleBlock(node) || isClassLike(node);
+    return isArrowFunction(node) ? isFunctionBody(node.body)
+        : isFunctionLikeDeclaration(node) || isSourceFile(node) || isModuleBlock(node) || isClassLike(node);
 }
 
 /**
@@ -1556,10 +1556,10 @@ function getContainingVariableDeclarationIfInList(node: Node, scope: Scope) {
     let prevNode;
     while (node !== undefined && node !== scope) {
         if (
-            isVariableDeclaration(node) &&
-            node.initializer === prevNode &&
-            isVariableDeclarationList(node.parent) &&
-            node.parent.declarations.length > 1
+            isVariableDeclaration(node)
+            && node.initializer === prevNode
+            && isVariableDeclarationList(node.parent)
+            && node.parent.declarations.length > 1
         ) {
             return node;
         }
@@ -1954,9 +1954,9 @@ function collectReadsAndWrites(
             if (value.usage === Usage.Write) {
                 hasWrite = true;
                 if (
-                    value.symbol.flags & SymbolFlags.ClassMember &&
-                    value.symbol.valueDeclaration &&
-                    hasEffectiveModifier(value.symbol.valueDeclaration, ModifierFlags.Readonly)
+                    value.symbol.flags & SymbolFlags.ClassMember
+                    && value.symbol.valueDeclaration
+                    && hasEffectiveModifier(value.symbol.valueDeclaration, ModifierFlags.Readonly)
                 ) {
                     readonlyClassPropertyWrite = value.symbol.valueDeclaration;
                 }
@@ -2214,8 +2214,8 @@ function isExtractableExpression(node: Node): boolean {
 
     switch (node.kind) {
         case SyntaxKind.StringLiteral:
-            return parent.kind !== SyntaxKind.ImportDeclaration &&
-                parent.kind !== SyntaxKind.ImportSpecifier;
+            return parent.kind !== SyntaxKind.ImportDeclaration
+                && parent.kind !== SyntaxKind.ImportSpecifier;
 
         case SyntaxKind.SpreadElement:
         case SyntaxKind.ObjectBindingPattern:
@@ -2223,16 +2223,16 @@ function isExtractableExpression(node: Node): boolean {
             return false;
 
         case SyntaxKind.Identifier:
-            return parent.kind !== SyntaxKind.BindingElement &&
-                parent.kind !== SyntaxKind.ImportSpecifier &&
-                parent.kind !== SyntaxKind.ExportSpecifier;
+            return parent.kind !== SyntaxKind.BindingElement
+                && parent.kind !== SyntaxKind.ImportSpecifier
+                && parent.kind !== SyntaxKind.ExportSpecifier;
     }
     return true;
 }
 
 function isInJSXContent(node: Node) {
-    return isStringLiteralJsxAttribute(node) ||
-        (isJsxElement(node) || isJsxSelfClosingElement(node) || isJsxFragment(node)) && (isJsxElement(node.parent) || isJsxFragment(node.parent));
+    return isStringLiteralJsxAttribute(node)
+        || (isJsxElement(node) || isJsxSelfClosingElement(node) || isJsxFragment(node)) && (isJsxElement(node.parent) || isJsxFragment(node.parent));
 }
 
 function isStringLiteralJsxAttribute(node: Node): node is StringLiteral {

--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -106,8 +106,8 @@ registerRefactor(refactorName, {
             const refactorInfo: ApplicableRefactorInfo[] = [{
                 name: refactorName,
                 description: getLocaleSpecificMessage(Diagnostics.Extract_type),
-                actions: info.isJS ?
-                    [extractToTypeDefAction] : append([extractToTypeAliasAction], info.typeElements && extractToInterfaceAction),
+                actions: info.isJS
+                    ? [extractToTypeDefAction] : append([extractToTypeAliasAction], info.typeElements && extractToInterfaceAction),
             }];
             return refactorInfo.map(info => ({
                 ...info,
@@ -225,8 +225,8 @@ function getFirstTypeAt(file: SourceFile, startPosition: number, range: TextRang
         const current = f();
         const overlappingRange = nodeOverlapsWithStartEnd(current, file, range.pos, range.end);
         const firstType = findAncestor(current, node =>
-            node.parent && isTypeNode(node) && !rangeContainsSkipTrivia(range, node.parent, file) &&
-            (isCursorRequest || overlappingRange));
+            node.parent && isTypeNode(node) && !rangeContainsSkipTrivia(range, node.parent, file)
+            && (isCursorRequest || overlappingRange));
         if (firstType) {
             return firstType;
         }

--- a/src/services/refactors/inferFunctionReturnType.ts
+++ b/src/services/refactors/inferFunctionReturnType.ts
@@ -106,8 +106,8 @@ function getInfo(context: RefactorContext): FunctionInfo | RefactorErrorInfo | u
 
     const token = getTouchingPropertyName(context.file, context.startPosition);
     const declaration = findAncestor(token, n =>
-        isBlock(n) || n.parent && isArrowFunction(n.parent) && (n.kind === SyntaxKind.EqualsGreaterThanToken || n.parent.body === n) ? "quit" :
-            isConvertibleDeclaration(n)) as ConvertibleDeclaration | undefined;
+        isBlock(n) || n.parent && isArrowFunction(n.parent) && (n.kind === SyntaxKind.EqualsGreaterThanToken || n.parent.body === n) ? "quit"
+            : isConvertibleDeclaration(n)) as ConvertibleDeclaration | undefined;
     if (!declaration || !declaration.body || declaration.type) {
         return { error: getLocaleSpecificMessage(Diagnostics.Return_type_must_be_inferred_from_a_function) };
     }

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -449,8 +449,8 @@ export function updateImportsInOtherFiles(
 function getNamespaceLikeImport(node: SupportedImport): Identifier | undefined {
     switch (node.kind) {
         case SyntaxKind.ImportDeclaration:
-            return node.importClause && node.importClause.namedBindings && node.importClause.namedBindings.kind === SyntaxKind.NamespaceImport ?
-                node.importClause.namedBindings.name : undefined;
+            return node.importClause && node.importClause.namedBindings && node.importClause.namedBindings.kind === SyntaxKind.NamespaceImport
+                ? node.importClause.namedBindings.name : undefined;
         case SyntaxKind.ImportEqualsDeclaration:
             return node.name;
         case SyntaxKind.VariableDeclaration:
@@ -610,9 +610,9 @@ function makeVariableStatement(name: BindingName, type: TypeNode | undefined, in
 export function addExports(sourceFile: SourceFile, toMove: readonly Statement[], needExport: Set<Symbol>, useEs6Exports: boolean): readonly Statement[] {
     return flatMap(toMove, statement => {
         if (
-            isTopLevelDeclarationStatement(statement) &&
-            !isExported(sourceFile, statement, useEs6Exports) &&
-            forEachTopLevelDeclaration(statement, d => needExport.has(Debug.checkDefined(tryCast(d, canHaveSymbol)?.symbol)))
+            isTopLevelDeclarationStatement(statement)
+            && !isExported(sourceFile, statement, useEs6Exports)
+            && forEachTopLevelDeclaration(statement, d => needExport.has(Debug.checkDefined(tryCast(d, canHaveSymbol)?.symbol)))
         ) {
             const exports = addExport(getSynthesizedDeepClone(statement), useEs6Exports);
             if (exports) return exports;
@@ -625,8 +625,8 @@ function isExported(sourceFile: SourceFile, decl: TopLevelDeclarationStatement, 
     if (useEs6Exports) {
         return !isExpressionStatement(decl) && hasSyntacticModifier(decl, ModifierFlags.Export) || !!(name && sourceFile.symbol && sourceFile.symbol.exports?.has(name.escapedText));
     }
-    return !!sourceFile.symbol && !!sourceFile.symbol.exports &&
-        getNamesToExportInCommonJS(decl).some(name => sourceFile.symbol.exports!.has(escapeLeadingUnderscores(name)));
+    return !!sourceFile.symbol && !!sourceFile.symbol.exports
+        && getNamesToExportInCommonJS(decl).some(name => sourceFile.symbol.exports!.has(escapeLeadingUnderscores(name)));
 }
 
 /** @internal */
@@ -652,8 +652,8 @@ function deleteUnusedImportsInDeclaration(sourceFile: SourceFile, importDecl: Im
     if (!importDecl.importClause) return;
     const { name, namedBindings } = importDecl.importClause;
     const defaultUnused = !name || isUnused(name);
-    const namedBindingsUnused = !namedBindings ||
-        (namedBindings.kind === SyntaxKind.NamespaceImport ? isUnused(namedBindings.name) : namedBindings.elements.length !== 0 && namedBindings.elements.every(e => isUnused(e.name)));
+    const namedBindingsUnused = !namedBindings
+        || (namedBindings.kind === SyntaxKind.NamespaceImport ? isUnused(namedBindings.name) : namedBindings.elements.length !== 0 && namedBindings.elements.every(e => isUnused(e.name)));
     if (defaultUnused && namedBindingsUnused) {
         changes.delete(sourceFile, importDecl);
     }
@@ -1159,8 +1159,8 @@ function isInImport(decl: Declaration) {
 }
 
 function isVariableDeclarationInImport(decl: VariableDeclaration) {
-    return isSourceFile(decl.parent.parent.parent) &&
-        !!decl.initializer && isRequireCall(decl.initializer, /*requireStringLiteralLikeArgument*/ true);
+    return isSourceFile(decl.parent.parent.parent)
+        && !!decl.initializer && isRequireCall(decl.initializer, /*requireStringLiteralLikeArgument*/ true);
 }
 
 /** @internal */
@@ -1210,8 +1210,8 @@ function moveStatementsToTargetFile(changes: textChanges.ChangeTracker, program:
                 forEachTopLevelDeclaration(node, declaration => {
                     const targetDeclarations = canHaveSymbol(declaration) ? targetExports.get(declaration.symbol.escapedName)?.declarations : undefined;
                     const exportDeclaration = firstDefined(targetDeclarations, d =>
-                        isExportDeclaration(d) ? d :
-                            isExportSpecifier(d) ? tryCast(d.parent.parent, isExportDeclaration) : undefined);
+                        isExportDeclaration(d) ? d
+                            : isExportSpecifier(d) ? tryCast(d.parent.parent, isExportDeclaration) : undefined);
                     if (exportDeclaration && exportDeclaration.moduleSpecifier) {
                         targetToSourceExports.set(exportDeclaration, (targetToSourceExports.get(exportDeclaration) || new Set()).add(declaration));
                     }
@@ -1267,8 +1267,8 @@ function getExistingLocals(sourceFile: SourceFile, statements: readonly Statemen
     for (const moduleSpecifier of sourceFile.imports) {
         const declaration = importFromModuleSpecifier(moduleSpecifier);
         if (
-            isImportDeclaration(declaration) && declaration.importClause &&
-            declaration.importClause.namedBindings && isNamedImports(declaration.importClause.namedBindings)
+            isImportDeclaration(declaration) && declaration.importClause
+            && declaration.importClause.namedBindings && isNamedImports(declaration.importClause.namedBindings)
         ) {
             for (const e of declaration.importClause.namedBindings.elements) {
                 const symbol = checker.getSymbolAtLocation(e.propertyName || e.name);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -334,10 +334,10 @@ import * as classifier2020 from "./classifier2020";
 export const servicesVersion = "0.8";
 
 function createNode<TKind extends SyntaxKind>(kind: TKind, pos: number, end: number, parent: Node): NodeObject | TokenObject<TKind> | IdentifierObject | PrivateIdentifierObject {
-    const node = isNodeKind(kind) ? new NodeObject(kind, pos, end) :
-        kind === SyntaxKind.Identifier ? new IdentifierObject(SyntaxKind.Identifier, pos, end) :
-        kind === SyntaxKind.PrivateIdentifier ? new PrivateIdentifierObject(SyntaxKind.PrivateIdentifier, pos, end) :
-        new TokenObject(kind, pos, end);
+    const node = isNodeKind(kind) ? new NodeObject(kind, pos, end)
+        : kind === SyntaxKind.Identifier ? new IdentifierObject(SyntaxKind.Identifier, pos, end)
+        : kind === SyntaxKind.PrivateIdentifier ? new PrivateIdentifierObject(SyntaxKind.PrivateIdentifier, pos, end)
+        : new TokenObject(kind, pos, end);
     node.parent = parent;
     node.flags = parent.flags & NodeFlags.ContextFlags;
     return node;
@@ -439,9 +439,9 @@ class NodeObject implements Node {
         }
 
         const child = find(children, kid => kid.kind < SyntaxKind.FirstJSDocNode || kid.kind > SyntaxKind.LastJSDocNode)!;
-        return child.kind < SyntaxKind.FirstNode ?
-            child :
-            child.getFirstToken(sourceFile);
+        return child.kind < SyntaxKind.FirstNode
+            ? child
+            : child.getFirstToken(sourceFile);
     }
 
     public getLastToken(sourceFile?: SourceFileLike): Node | undefined {
@@ -1781,9 +1781,9 @@ export function createLanguageService(
             const existing = parsedCommandLines?.get(path);
             if (existing !== undefined) return existing || undefined;
 
-            const result = host.getParsedCommandLine ?
-                host.getParsedCommandLine(fileName) :
-                getParsedCommandLineOfConfigFileUsingSourceFile(fileName);
+            const result = host.getParsedCommandLine
+                ? host.getParsedCommandLine(fileName)
+                : getParsedCommandLineOfConfigFileUsingSourceFile(fileName);
             (parsedCommandLines ||= new Map()).set(path, result || false);
             return result;
         }
@@ -2280,8 +2280,8 @@ export function createLanguageService(
                 // If parent of the module declaration which is parent of this node is module declaration and its body is the module declaration that this node is name of
                 // Then this name is name from dotted module
                 if (
-                    nodeForStartPos.parent.parent.kind === SyntaxKind.ModuleDeclaration &&
-                    (nodeForStartPos.parent.parent as ModuleDeclaration).body === nodeForStartPos.parent
+                    nodeForStartPos.parent.parent.kind === SyntaxKind.ModuleDeclaration
+                    && (nodeForStartPos.parent.parent as ModuleDeclaration).body === nodeForStartPos.parent
                 ) {
                     // Use parent module declarations name for start pos
                     nodeForStartPos = (nodeForStartPos.parent.parent as ModuleDeclaration).name;
@@ -2824,8 +2824,8 @@ export function createLanguageService(
     }
 
     function isUnclosedTag({ openingElement, closingElement, parent }: JsxElement): boolean {
-        return !tagNamesAreEquivalent(openingElement.tagName, closingElement.tagName) ||
-            isJsxElement(parent) && tagNamesAreEquivalent(openingElement.tagName, parent.openingElement.tagName) && isUnclosedTag(parent);
+        return !tagNamesAreEquivalent(openingElement.tagName, closingElement.tagName)
+            || isJsxElement(parent) && tagNamesAreEquivalent(openingElement.tagName, parent.openingElement.tagName) && isUnclosedTag(parent);
     }
 
     function isUnclosedFragment({ closingFragment, parent }: JsxFragment): boolean {
@@ -2975,9 +2975,9 @@ export function createLanguageService(
         }
 
         function isLetterOrDigit(char: number): boolean {
-            return (char >= CharacterCodes.a && char <= CharacterCodes.z) ||
-                (char >= CharacterCodes.A && char <= CharacterCodes.Z) ||
-                (char >= CharacterCodes._0 && char <= CharacterCodes._9);
+            return (char >= CharacterCodes.a && char <= CharacterCodes.z)
+                || (char >= CharacterCodes.A && char <= CharacterCodes.Z)
+                || (char >= CharacterCodes._0 && char <= CharacterCodes._9);
         }
 
         function isNodeModulesFile(path: string): boolean {
@@ -3038,9 +3038,9 @@ export function createLanguageService(
         const files = mapDefined(allFiles, file => {
             const fileNameExtension = extensionFromPath(file.fileName);
             const isValidSourceFile = !program?.isSourceFileFromExternalLibrary(sourceFile) && !(
-                sourceFile === getValidSourceFile(file.fileName) ||
-                extension === Extension.Ts && fileNameExtension === Extension.Dts ||
-                extension === Extension.Dts && startsWith(getBaseFileName(file.fileName), "lib.") && fileNameExtension === Extension.Dts
+                sourceFile === getValidSourceFile(file.fileName)
+                || extension === Extension.Ts && fileNameExtension === Extension.Dts
+                || extension === Extension.Dts && startsWith(getBaseFileName(file.fileName), "lib.") && fileNameExtension === Extension.Dts
             );
             return isValidSourceFile && (extension === fileNameExtension || (extension === Extension.Tsx && fileNameExtension === Extension.Ts || extension === Extension.Jsx && fileNameExtension === Extension.Js) && !toMoveContainsJsx) ? file.fileName : undefined;
         });
@@ -3235,10 +3235,10 @@ function initializeNameTable(sourceFile: SourceFile): void {
  * "a['propname']" then we want to store "propname" in the name table.
  */
 function literalIsName(node: StringLiteralLike | NumericLiteral): boolean {
-    return isDeclarationName(node) ||
-        node.parent.kind === SyntaxKind.ExternalModuleReference ||
-        isArgumentOfElementAccessExpression(node) ||
-        isLiteralComputedPropertyDeclarationName(node);
+    return isDeclarationName(node)
+        || node.parent.kind === SyntaxKind.ExternalModuleReference
+        || isArgumentOfElementAccessExpression(node)
+        || isLiteralComputedPropertyDeclarationName(node);
 }
 
 /**
@@ -3261,9 +3261,9 @@ function getContainingObjectLiteralElementWorker(node: Node): ObjectLiteralEleme
         // falls through
 
         case SyntaxKind.Identifier:
-            return isObjectLiteralElement(node.parent) &&
-                    (node.parent.parent.kind === SyntaxKind.ObjectLiteralExpression || node.parent.parent.kind === SyntaxKind.JsxAttributes) &&
-                    node.parent.name === node ? node.parent : undefined;
+            return isObjectLiteralElement(node.parent)
+                    && (node.parent.parent.kind === SyntaxKind.ObjectLiteralExpression || node.parent.parent.kind === SyntaxKind.JsxAttributes)
+                    && node.parent.name === node ? node.parent : undefined;
     }
     return undefined;
 }
@@ -3314,10 +3314,10 @@ export function getPropertySymbolsFromContextualType(node: ObjectLiteralElementW
 }
 
 function isArgumentOfElementAccessExpression(node: Node) {
-    return node &&
-        node.parent &&
-        node.parent.kind === SyntaxKind.ElementAccessExpression &&
-        (node.parent as ElementAccessExpression).argumentExpression === node;
+    return node
+        && node.parent
+        && node.parent.kind === SyntaxKind.ElementAccessExpression
+        && (node.parent as ElementAccessExpression).argumentExpression === node;
 }
 
 /**

--- a/src/services/smartSelection.ts
+++ b/src/services/smartSelection.ts
@@ -158,9 +158,9 @@ export function getSmartSelectionRange(pos: number, sourceFile: SourceFile): Sel
             if (
                 !selectionRange || (
                     // Skip ranges that are identical to the parent
-                    !textSpansEqual(textSpan, selectionRange.textSpan) &&
+                    !textSpansEqual(textSpan, selectionRange.textSpan)
                     // Skip ranges that don't contain the original position
-                    textSpanIntersectsWithPosition(textSpan, pos)
+                    && textSpanIntersectsWithPosition(textSpan, pos)
                 )
             ) {
                 selectionRange = { textSpan, ...selectionRange && { parent: selectionRange } };
@@ -236,13 +236,13 @@ function getSelectionChildren(node: Node): readonly Node[] {
         Debug.assertEqual(closeBraceToken.kind, SyntaxKind.CloseBraceToken);
         // Group `-/+readonly` and `-/+?`
         const groupedWithPlusMinusTokens = groupChildren(children, child =>
-            child === node.readonlyToken || child.kind === SyntaxKind.ReadonlyKeyword ||
-            child === node.questionToken || child.kind === SyntaxKind.QuestionToken);
+            child === node.readonlyToken || child.kind === SyntaxKind.ReadonlyKeyword
+            || child === node.questionToken || child.kind === SyntaxKind.QuestionToken);
         // Group type parameter with surrounding brackets
         const groupedWithBrackets = groupChildren(groupedWithPlusMinusTokens, ({ kind }) =>
-            kind === SyntaxKind.OpenBracketToken ||
-            kind === SyntaxKind.TypeParameter ||
-            kind === SyntaxKind.CloseBracketToken);
+            kind === SyntaxKind.OpenBracketToken
+            || kind === SyntaxKind.TypeParameter
+            || kind === SyntaxKind.CloseBracketToken);
         return [
             openBraceToken,
             // Pivot on `:`

--- a/src/services/sourcemaps.ts
+++ b/src/services/sourcemaps.ts
@@ -115,9 +115,9 @@ export function getSourceMapper(host: SourceMapperHost): SourceMapper {
         const options = program.getCompilerOptions();
         const outPath = options.outFile;
 
-        const declarationPath = outPath ?
-            removeFileExtension(outPath) + Extension.Dts :
-            getDeclarationEmitOutputFilePathWorker(info.fileName, program.getCompilerOptions(), currentDirectory, program.getCommonSourceDirectory(), getCanonicalFileName);
+        const declarationPath = outPath
+            ? removeFileExtension(outPath) + Extension.Dts
+            : getDeclarationEmitOutputFilePathWorker(info.fileName, program.getCompilerOptions(), currentDirectory, program.getCommonSourceDirectory(), getCanonicalFileName);
         if (declarationPath === undefined) return undefined;
 
         const newLoc = getDocumentPositionMapper(declarationPath, info.fileName).getGeneratedPosition(info);
@@ -153,9 +153,9 @@ export function getSourceMapper(host: SourceMapperHost): SourceMapper {
 
     // This can be called from source mapper in either source program or program that includes generated file
     function getSourceFileLike(fileName: string) {
-        return !host.getSourceFileLike ?
-            getSourceFile(fileName) || getOrCreateSourceFileLike(fileName) :
-            host.getSourceFileLike(fileName);
+        return !host.getSourceFileLike
+            ? getSourceFile(fileName) || getOrCreateSourceFileLike(fileName)
+            : host.getSourceFileLike(fileName);
     }
 
     function toLineColumnOffset(fileName: string, position: number): LineAndCharacter {

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -553,8 +553,8 @@ function stringLiteralCompletionsForObjectLiteral(checker: TypeChecker, objectLi
 function getStringLiteralTypes(type: Type | undefined, uniques = new Map<string, true>()): readonly StringLiteralType[] {
     if (!type) return emptyArray;
     type = skipConstraint(type);
-    return type.isUnion() ? flatMap(type.types, t => getStringLiteralTypes(t, uniques)) :
-        type.isStringLiteral() && !(type.flags & TypeFlags.EnumLiteral) && addToSeen(uniques, type.value) ? [type] : emptyArray;
+    return type.isUnion() ? flatMap(type.types, t => getStringLiteralTypes(t, uniques))
+        : type.isStringLiteral() && !(type.flags & TypeFlags.EnumLiteral) && addToSeen(uniques, type.value) ? [type] : emptyArray;
 }
 
 interface NameAndKind {
@@ -642,9 +642,9 @@ function getSupportedExtensionsForModuleResolution(compilerOptions: CompilerOpti
 
     const extensions = [...getSupportedExtensions(compilerOptions), ambientModulesExtensions];
     const moduleResolution = getEmitModuleResolutionKind(compilerOptions);
-    return moduleResolutionUsesNodeModules(moduleResolution) ?
-        getSupportedExtensionsWithJsonIfResolveJsonModule(compilerOptions, extensions) :
-        extensions;
+    return moduleResolutionUsesNodeModules(moduleResolution)
+        ? getSupportedExtensionsWithJsonIfResolveJsonModule(compilerOptions, extensions)
+        : extensions;
 }
 
 /**
@@ -801,9 +801,9 @@ function getFilenameWithExtensionOption(name: string, compilerOptions: CompilerO
     }
 
     if (
-        !isExportsWildcard &&
-        (allowedEndings[0] === ModuleSpecifierEnding.Minimal || allowedEndings[0] === ModuleSpecifierEnding.Index) &&
-        fileExtensionIsOneOf(name, [Extension.Js, Extension.Jsx, Extension.Ts, Extension.Tsx, Extension.Dts])
+        !isExportsWildcard
+        && (allowedEndings[0] === ModuleSpecifierEnding.Minimal || allowedEndings[0] === ModuleSpecifierEnding.Index)
+        && fileExtensionIsOneOf(name, [Extension.Js, Extension.Jsx, Extension.Ts, Extension.Tsx, Extension.Dts])
     ) {
         return { name: removeFileExtension(name), extension: tryGetExtensionFromPath(name) };
     }

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -69,10 +69,10 @@ export function computeSuggestionDiagnostics(sourceFile: SourceFile, program: Pr
     const isCommonJSFile = sourceFile.impliedNodeFormat === ModuleKind.CommonJS || fileExtensionIsOneOf(sourceFile.fileName, [Extension.Cts, Extension.Cjs]);
 
     if (
-        !isCommonJSFile &&
-        sourceFile.commonJsModuleIndicator &&
-        (programContainsEsModules(program) || compilerOptionsIndicateEsModules(program.getCompilerOptions())) &&
-        containsTopLevelCommonjs(sourceFile)
+        !isCommonJSFile
+        && sourceFile.commonJsModuleIndicator
+        && (programContainsEsModules(program) || compilerOptionsIndicateEsModules(program.getCompilerOptions()))
+        && containsTopLevelCommonjs(sourceFile)
     ) {
         diags.push(createDiagnosticForNode(getErrorNodeFromCommonJsIndicator(sourceFile.commonJsModuleIndicator), Diagnostics.File_is_a_CommonJS_module_it_may_be_converted_to_an_ES_module));
     }
@@ -107,10 +107,10 @@ export function computeSuggestionDiagnostics(sourceFile: SourceFile, program: Pr
         }
         else {
             if (
-                isVariableStatement(node) &&
-                node.parent === sourceFile &&
-                node.declarationList.flags & NodeFlags.Const &&
-                node.declarationList.declarations.length === 1
+                isVariableStatement(node)
+                && node.parent === sourceFile
+                && node.declarationList.flags & NodeFlags.Const
+                && node.declarationList.declarations.length === 1
             ) {
                 const init = node.declarationList.declarations[0].initializer;
                 if (init && isRequireCall(init, /*requireStringLiteralLikeArgument*/ true)) {
@@ -182,11 +182,11 @@ function addConvertToAsyncFunctionDiagnostics(node: FunctionLikeDeclaration, che
 }
 
 function isConvertibleFunction(node: FunctionLikeDeclaration, checker: TypeChecker) {
-    return !isAsyncFunction(node) &&
-        node.body &&
-        isBlock(node.body) &&
-        hasReturnStatementWithPromiseHandler(node.body, checker) &&
-        returnsPromise(node, checker);
+    return !isAsyncFunction(node)
+        && node.body
+        && isBlock(node.body)
+        && hasReturnStatementWithPromiseHandler(node.body, checker)
+        && returnsPromise(node, checker);
 }
 
 /** @internal */
@@ -235,9 +235,9 @@ export function isFixablePromiseHandler(node: Node, checker: TypeChecker): boole
 
 function isPromiseHandler(node: Node): node is CallExpression & { readonly expression: PropertyAccessExpression; } {
     return isCallExpression(node) && (
-        hasPropertyAccessExpressionWithName(node, "then") ||
-        hasPropertyAccessExpressionWithName(node, "catch") ||
-        hasPropertyAccessExpressionWithName(node, "finally")
+        hasPropertyAccessExpressionWithName(node, "then")
+        || hasPropertyAccessExpressionWithName(node, "catch")
+        || hasPropertyAccessExpressionWithName(node, "finally")
     );
 }
 
@@ -272,8 +272,8 @@ function isFixablePromiseArgument(arg: Expression, checker: TypeChecker): boolea
             if (!symbol) {
                 return false;
             }
-            return checker.isUndefinedSymbol(symbol) ||
-                some(skipAlias(symbol, checker).declarations, d => isFunctionLike(d) || hasInitializer(d) && !!d.initializer && isFunctionLike(d.initializer));
+            return checker.isUndefinedSymbol(symbol)
+                || some(skipAlias(symbol, checker).declarations, d => isFunctionLike(d) || hasInitializer(d) && !!d.initializer && isFunctionLike(d.initializer));
         }
         default:
             return false;

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -122,8 +122,8 @@ export function getSymbolKind(typeChecker: TypeChecker, symbol: Symbol, location
 
     const flags = getCombinedLocalAndExportSymbolFlags(symbol);
     if (flags & SymbolFlags.Class) {
-        return getDeclarationOfKind(symbol, SyntaxKind.ClassExpression) ?
-            ScriptElementKind.localClassElement : ScriptElementKind.classElement;
+        return getDeclarationOfKind(symbol, SyntaxKind.ClassExpression)
+            ? ScriptElementKind.localClassElement : ScriptElementKind.classElement;
     }
     if (flags & SymbolFlags.Enum) return ScriptElementKind.enumElement;
     if (flags & SymbolFlags.TypeAlias) return ScriptElementKind.typeElement;
@@ -392,8 +392,8 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
             }
         }
         else if (
-            (isNameOfFunctionDeclaration(location) && !(symbolFlags & SymbolFlags.Accessor)) || // name of function declaration
-            (location.kind === SyntaxKind.ConstructorKeyword && location.parent.kind === SyntaxKind.Constructor)
+            (isNameOfFunctionDeclaration(location) && !(symbolFlags & SymbolFlags.Accessor)) // name of function declaration
+            || (location.kind === SyntaxKind.ConstructorKeyword && location.parent.kind === SyntaxKind.Constructor)
         ) { // At constructor keyword of constructor declaration
             // get the signature from the declaration and write it
             const functionDeclaration = location.parent as SignatureDeclaration;
@@ -417,8 +417,8 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
                 else {
                     // (function/method) symbol(..signature)
                     addPrefixForAnyFunctionOrVar(
-                        functionDeclaration.kind === SyntaxKind.CallSignature &&
-                            !(type.symbol.flags & SymbolFlags.TypeLiteral || type.symbol.flags & SymbolFlags.ObjectLiteral) ? type.symbol : symbol,
+                        functionDeclaration.kind === SyntaxKind.CallSignature
+                            && !(type.symbol.flags & SymbolFlags.TypeLiteral || type.symbol.flags & SymbolFlags.ObjectLiteral) ? type.symbol : symbol,
                         symbolKind,
                     );
                 }
@@ -550,8 +550,8 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
                 const resolvedNode = resolvedSymbol.declarations[0];
                 const declarationName = getNameOfDeclaration(resolvedNode);
                 if (declarationName && !hasAddedSymbolInfo) {
-                    const isExternalModuleDeclaration = isModuleWithStringLiteralName(resolvedNode) &&
-                        hasSyntacticModifier(resolvedNode, ModifierFlags.Ambient);
+                    const isExternalModuleDeclaration = isModuleWithStringLiteralName(resolvedNode)
+                        && hasSyntacticModifier(resolvedNode, ModifierFlags.Ambient);
                     const shouldUseAliasName = symbol.name !== "default" && !isExternalModuleDeclaration;
                     const resolvedInfo = getSymbolDisplayPartsDocumentationAndSymbolKindWorker(
                         typeChecker,
@@ -633,17 +633,17 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
                 }
                 // For properties, variables and local vars: show the type
                 if (
-                    symbolKind === ScriptElementKind.memberVariableElement ||
-                    symbolKind === ScriptElementKind.memberAccessorVariableElement ||
-                    symbolKind === ScriptElementKind.memberGetAccessorElement ||
-                    symbolKind === ScriptElementKind.memberSetAccessorElement ||
-                    symbolKind === ScriptElementKind.jsxAttribute ||
-                    symbolFlags & SymbolFlags.Variable ||
-                    symbolKind === ScriptElementKind.localVariableElement ||
-                    symbolKind === ScriptElementKind.indexSignatureElement ||
-                    symbolKind === ScriptElementKind.variableUsingElement ||
-                    symbolKind === ScriptElementKind.variableAwaitUsingElement ||
-                    isThisExpression
+                    symbolKind === ScriptElementKind.memberVariableElement
+                    || symbolKind === ScriptElementKind.memberAccessorVariableElement
+                    || symbolKind === ScriptElementKind.memberGetAccessorElement
+                    || symbolKind === ScriptElementKind.memberSetAccessorElement
+                    || symbolKind === ScriptElementKind.jsxAttribute
+                    || symbolFlags & SymbolFlags.Variable
+                    || symbolKind === ScriptElementKind.localVariableElement
+                    || symbolKind === ScriptElementKind.indexSignatureElement
+                    || symbolKind === ScriptElementKind.variableUsingElement
+                    || symbolKind === ScriptElementKind.variableAwaitUsingElement
+                    || isThisExpression
                 ) {
                     displayParts.push(punctuationPart(SyntaxKind.ColonToken));
                     displayParts.push(spacePart());
@@ -668,12 +668,12 @@ function getSymbolDisplayPartsDocumentationAndSymbolKindWorker(typeChecker: Type
                     }
                 }
                 else if (
-                    symbolFlags & SymbolFlags.Function ||
-                    symbolFlags & SymbolFlags.Method ||
-                    symbolFlags & SymbolFlags.Constructor ||
-                    symbolFlags & SymbolFlags.Signature ||
-                    symbolFlags & SymbolFlags.Accessor ||
-                    symbolKind === ScriptElementKind.memberFunctionElement
+                    symbolFlags & SymbolFlags.Function
+                    || symbolFlags & SymbolFlags.Method
+                    || symbolFlags & SymbolFlags.Constructor
+                    || symbolFlags & SymbolFlags.Signature
+                    || symbolFlags & SymbolFlags.Accessor
+                    || symbolKind === ScriptElementKind.memberFunctionElement
                 ) {
                     const allSignatures = type.getNonNullableType().getCallSignatures();
                     if (allSignatures.length) {

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -720,8 +720,8 @@ export class ChangeTracker {
     private createJSDocText(sourceFile: SourceFile, node: HasJSDoc) {
         const comments = flatMap(node.jsDoc, jsDoc => isString(jsDoc.comment) ? factory.createJSDocText(jsDoc.comment) : jsDoc.comment) as JSDocComment[];
         const jsDoc = singleOrUndefined(node.jsDoc);
-        return jsDoc && positionsAreOnSameLine(jsDoc.pos, jsDoc.end, sourceFile) && length(comments) === 0 ? undefined :
-            factory.createNodeArray(intersperse(comments, factory.createJSDocText("\n")));
+        return jsDoc && positionsAreOnSameLine(jsDoc.pos, jsDoc.end, sourceFile) && length(comments) === 0 ? undefined
+            : factory.createNodeArray(intersperse(comments, factory.createJSDocText("\n")));
     }
 
     public replaceJSDocComment(sourceFile: SourceFile, node: HasJSDoc, tags: readonly JSDocTag[]) {
@@ -1194,9 +1194,9 @@ function updateJSDocHost(parent: HasJSDoc): HasJSDoc {
     if (parent.kind !== SyntaxKind.ArrowFunction) {
         return parent;
     }
-    const jsDocNode = parent.parent.kind === SyntaxKind.PropertyDeclaration ?
-        parent.parent as HasJSDoc :
-        parent.parent.parent as HasJSDoc;
+    const jsDocNode = parent.parent.kind === SyntaxKind.PropertyDeclaration
+        ? parent.parent as HasJSDoc
+        : parent.parent.parent as HasJSDoc;
     jsDocNode.jsDoc = parent.jsDoc;
     return jsDocNode;
 }
@@ -1272,9 +1272,9 @@ namespace changesToText {
 
             const textChanges = mapDefined(normalized, c => {
                 const span = createTextSpanFromRange(c.range);
-                const targetSourceFile = c.kind === ChangeKind.ReplaceWithSingleNode ? getSourceFileOfNode(getOriginalNode(c.node)) ?? c.sourceFile :
-                    c.kind === ChangeKind.ReplaceWithMultipleNodes ? getSourceFileOfNode(getOriginalNode(c.nodes[0])) ?? c.sourceFile :
-                    c.sourceFile;
+                const targetSourceFile = c.kind === ChangeKind.ReplaceWithSingleNode ? getSourceFileOfNode(getOriginalNode(c.node)) ?? c.sourceFile
+                    : c.kind === ChangeKind.ReplaceWithMultipleNodes ? getSourceFileOfNode(getOriginalNode(c.nodes[0])) ?? c.sourceFile
+                    : c.sourceFile;
                 const newText = computeNewText(c, targetSourceFile, sourceFile, newLineCharacter, formatContext, validate);
                 // Filter out redundant changes.
                 if (span.length === newText.length && stringContainsAt(targetSourceFile.text, newText, span.start)) {
@@ -1674,9 +1674,9 @@ namespace deleteDeclaration {
             case SyntaxKind.Parameter: {
                 const oldFunction = node.parent;
                 if (
-                    isArrowFunction(oldFunction) &&
-                    oldFunction.parameters.length === 1 &&
-                    !findChildOfKind(oldFunction, SyntaxKind.OpenParenToken, sourceFile)
+                    isArrowFunction(oldFunction)
+                    && oldFunction.parameters.length === 1
+                    && !findChildOfKind(oldFunction, SyntaxKind.OpenParenToken, sourceFile)
                 ) {
                     // Lambdas with exactly one parameter are special because, after removal, there
                     // must be an empty parameter list (i.e. `()`) and this won't necessarily be the

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -168,8 +168,8 @@ let commandLineOptionsStringToEnum: CommandLineOptionOfCustomType[];
  */
 export function fixupCompilerOptions(options: CompilerOptions, diagnostics: Diagnostic[]): CompilerOptions {
     // Lazily create this value to fix module loading errors.
-    commandLineOptionsStringToEnum = commandLineOptionsStringToEnum ||
-        filter(optionDeclarations, o => typeof o.type === "object" && !forEachEntry(o.type, v => typeof v !== "number")) as CommandLineOptionOfCustomType[];
+    commandLineOptionsStringToEnum = commandLineOptionsStringToEnum
+        || filter(optionDeclarations, o => typeof o.type === "object" && !forEachEntry(o.type, v => typeof v !== "number")) as CommandLineOptionOfCustomType[];
 
     options = cloneCompilerOptions(options);
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -550,8 +550,8 @@ function isPropertyAccessNamespaceReference(node: Node): boolean {
 
     if (!isLastClause && root.parent.kind === SyntaxKind.ExpressionWithTypeArguments && root.parent.parent.kind === SyntaxKind.HeritageClause) {
         const decl = root.parent.parent.parent;
-        return (decl.kind === SyntaxKind.ClassDeclaration && (root.parent.parent as HeritageClause).token === SyntaxKind.ImplementsKeyword) ||
-            (decl.kind === SyntaxKind.InterfaceDeclaration && (root.parent.parent as HeritageClause).token === SyntaxKind.ExtendsKeyword);
+        return (decl.kind === SyntaxKind.ClassDeclaration && (root.parent.parent as HeritageClause).token === SyntaxKind.ImplementsKeyword)
+            || (decl.kind === SyntaxKind.InterfaceDeclaration && (root.parent.parent as HeritageClause).token === SyntaxKind.ExtendsKeyword);
     }
 
     return false;
@@ -732,8 +732,8 @@ export function isLiteralNameOfPropertyDeclarationOrIndexAccess(node: StringLite
 
 /** @internal */
 export function isExpressionOfExternalModuleImportEqualsDeclaration(node: Node) {
-    return isExternalModuleImportEqualsDeclaration(node.parent.parent) &&
-        getExternalModuleImportEqualsDeclarationExpression(node.parent.parent) === node;
+    return isExternalModuleImportEqualsDeclaration(node.parent.parent)
+        && getExternalModuleImportEqualsDeclarationExpression(node.parent.parent) === node;
 }
 
 /** @internal */
@@ -1029,8 +1029,8 @@ function isCompletedNode(n: Node | undefined, sourceFile: SourceFile): boolean {
             return isCompletedNode((n as IfStatement).thenStatement, sourceFile);
 
         case SyntaxKind.ExpressionStatement:
-            return isCompletedNode((n as ExpressionStatement).expression, sourceFile) ||
-                hasChildOfKind(n, SyntaxKind.SemicolonToken, sourceFile);
+            return isCompletedNode((n as ExpressionStatement).expression, sourceFile)
+                || hasChildOfKind(n, SyntaxKind.SemicolonToken, sourceFile);
 
         case SyntaxKind.ArrayLiteralExpression:
         case SyntaxKind.ArrayBindingPattern:
@@ -1333,16 +1333,16 @@ function getAdjustedLocation(node: Node, forRename: boolean): Node {
     // NOTE: If the node is a modifier, we don't adjust its location if it is the `default` modifier as that is handled
     // specially by `getSymbolAtLocation`.
     if (
-        isModifier(node) && (forRename || node.kind !== SyntaxKind.DefaultKeyword) ? canHaveModifiers(parent) && contains(parent.modifiers, node) :
-            node.kind === SyntaxKind.ClassKeyword ? isClassDeclaration(parent) || isClassExpression(node) :
-            node.kind === SyntaxKind.FunctionKeyword ? isFunctionDeclaration(parent) || isFunctionExpression(node) :
-            node.kind === SyntaxKind.InterfaceKeyword ? isInterfaceDeclaration(parent) :
-            node.kind === SyntaxKind.EnumKeyword ? isEnumDeclaration(parent) :
-            node.kind === SyntaxKind.TypeKeyword ? isTypeAliasDeclaration(parent) :
-            node.kind === SyntaxKind.NamespaceKeyword || node.kind === SyntaxKind.ModuleKeyword ? isModuleDeclaration(parent) :
-            node.kind === SyntaxKind.ImportKeyword ? isImportEqualsDeclaration(parent) :
-            node.kind === SyntaxKind.GetKeyword ? isGetAccessorDeclaration(parent) :
-            node.kind === SyntaxKind.SetKeyword && isSetAccessorDeclaration(parent)
+        isModifier(node) && (forRename || node.kind !== SyntaxKind.DefaultKeyword) ? canHaveModifiers(parent) && contains(parent.modifiers, node)
+            : node.kind === SyntaxKind.ClassKeyword ? isClassDeclaration(parent) || isClassExpression(node)
+            : node.kind === SyntaxKind.FunctionKeyword ? isFunctionDeclaration(parent) || isFunctionExpression(node)
+            : node.kind === SyntaxKind.InterfaceKeyword ? isInterfaceDeclaration(parent)
+            : node.kind === SyntaxKind.EnumKeyword ? isEnumDeclaration(parent)
+            : node.kind === SyntaxKind.TypeKeyword ? isTypeAliasDeclaration(parent)
+            : node.kind === SyntaxKind.NamespaceKeyword || node.kind === SyntaxKind.ModuleKeyword ? isModuleDeclaration(parent)
+            : node.kind === SyntaxKind.ImportKeyword ? isImportEqualsDeclaration(parent)
+            : node.kind === SyntaxKind.GetKeyword ? isGetAccessorDeclaration(parent)
+            : node.kind === SyntaxKind.SetKeyword && isSetAccessorDeclaration(parent)
     ) {
         const location = getAdjustedLocationForDeclaration(parent, forRename);
         if (location) {
@@ -1351,8 +1351,8 @@ function getAdjustedLocation(node: Node, forRename: boolean): Node {
     }
     // /**/<var|let|const> [|name|] ...
     if (
-        (node.kind === SyntaxKind.VarKeyword || node.kind === SyntaxKind.ConstKeyword || node.kind === SyntaxKind.LetKeyword) &&
-        isVariableDeclarationList(parent) && parent.declarations.length === 1
+        (node.kind === SyntaxKind.VarKeyword || node.kind === SyntaxKind.ConstKeyword || node.kind === SyntaxKind.LetKeyword)
+        && isVariableDeclarationList(parent) && parent.declarations.length === 1
     ) {
         const decl = parent.declarations[0];
         if (isIdentifier(decl.name)) {
@@ -1387,10 +1387,10 @@ function getAdjustedLocation(node: Node, forRename: boolean): Node {
     // export * /**/as [|name|] ...
     if (node.kind === SyntaxKind.AsKeyword) {
         if (
-            isImportSpecifier(parent) && parent.propertyName ||
-            isExportSpecifier(parent) && parent.propertyName ||
-            isNamespaceImport(parent) ||
-            isNamespaceExport(parent)
+            isImportSpecifier(parent) && parent.propertyName
+            || isExportSpecifier(parent) && parent.propertyName
+            || isNamespaceImport(parent)
+            || isNamespaceExport(parent)
         ) {
             return parent.name;
         }
@@ -1467,15 +1467,15 @@ function getAdjustedLocation(node: Node, forRename: boolean): Node {
     }
     // /**/keyof [|T|]
     if (
-        node.kind === SyntaxKind.KeyOfKeyword && isTypeOperatorNode(parent) && parent.operator === SyntaxKind.KeyOfKeyword &&
-        isTypeReferenceNode(parent.type)
+        node.kind === SyntaxKind.KeyOfKeyword && isTypeOperatorNode(parent) && parent.operator === SyntaxKind.KeyOfKeyword
+        && isTypeReferenceNode(parent.type)
     ) {
         return parent.type.typeName;
     }
     // /**/readonly [|name|][]
     if (
-        node.kind === SyntaxKind.ReadonlyKeyword && isTypeOperatorNode(parent) && parent.operator === SyntaxKind.ReadonlyKeyword &&
-        isArrayTypeNode(parent.type) && isTypeReferenceNode(parent.type.elementType)
+        node.kind === SyntaxKind.ReadonlyKeyword && isTypeOperatorNode(parent) && parent.operator === SyntaxKind.ReadonlyKeyword
+        && isArrayTypeNode(parent.type) && isTypeReferenceNode(parent.type.elementType)
     ) {
         return parent.type.elementType.typeName;
     }
@@ -1491,12 +1491,12 @@ function getAdjustedLocation(node: Node, forRename: boolean): Node {
         // /**/yield obj.[|name|]
         // /**/delete obj.[|name|]
         if (
-            node.kind === SyntaxKind.NewKeyword && isNewExpression(parent) ||
-            node.kind === SyntaxKind.VoidKeyword && isVoidExpression(parent) ||
-            node.kind === SyntaxKind.TypeOfKeyword && isTypeOfExpression(parent) ||
-            node.kind === SyntaxKind.AwaitKeyword && isAwaitExpression(parent) ||
-            node.kind === SyntaxKind.YieldKeyword && isYieldExpression(parent) ||
-            node.kind === SyntaxKind.DeleteKeyword && isDeleteExpression(parent)
+            node.kind === SyntaxKind.NewKeyword && isNewExpression(parent)
+            || node.kind === SyntaxKind.VoidKeyword && isVoidExpression(parent)
+            || node.kind === SyntaxKind.TypeOfKeyword && isTypeOfExpression(parent)
+            || node.kind === SyntaxKind.AwaitKeyword && isAwaitExpression(parent)
+            || node.kind === SyntaxKind.YieldKeyword && isYieldExpression(parent)
+            || node.kind === SyntaxKind.DeleteKeyword && isDeleteExpression(parent)
         ) {
             if (parent.expression) {
                 return skipOuterExpressions(parent.expression);
@@ -1514,8 +1514,8 @@ function getAdjustedLocation(node: Node, forRename: boolean): Node {
         // for (... /**/in [|name|])
         // for (... /**/of [|name|])
         if (
-            node.kind === SyntaxKind.InKeyword && isForInStatement(parent) ||
-            node.kind === SyntaxKind.OfKeyword && isForOfStatement(parent)
+            node.kind === SyntaxKind.InKeyword && isForInStatement(parent)
+            || node.kind === SyntaxKind.OfKeyword && isForOfStatement(parent)
         ) {
             return skipOuterExpressions(parent.expression);
         }
@@ -1715,9 +1715,9 @@ export function findNextToken(previousToken: Node, parent: Node, sourceFile: Sou
         return firstDefined(n.getChildren(sourceFile), child => {
             const shouldDiveInChildNode =
                 // previous token is enclosed somewhere in the child
-                (child.pos <= previousToken.pos && child.end > previousToken.end) ||
+                (child.pos <= previousToken.pos && child.end > previousToken.end)
                 // previous token ends exactly at the beginning of child
-                (child.pos === previousToken.end);
+                || (child.pos === previousToken.end);
             return shouldDiveInChildNode && nodeHasTokens(child, sourceFile) ? find(child) : undefined;
         });
     }
@@ -1767,9 +1767,9 @@ export function findPrecedingToken(position: number, sourceFile: SourceFileLike,
             // 2) `position` is within the same span: we recurse on `child`.
             if (position < child.end) {
                 const start = child.getStart(sourceFile, /*includeJsDoc*/ !excludeJsdoc);
-                const lookInPreviousChild = (start >= position) || // cursor in the leading trivia
-                    !nodeHasTokens(child, sourceFile) ||
-                    isWhiteSpaceOnlyJsxText(child);
+                const lookInPreviousChild = (start >= position) // cursor in the leading trivia
+                    || !nodeHasTokens(child, sourceFile)
+                    || isWhiteSpaceOnlyJsxText(child);
 
                 if (lookInPreviousChild) {
                     // actual start of the node is past the position - previous token should be at the end of previous child
@@ -1997,17 +1997,17 @@ export function findPrecedingMatchingToken(token: Node, matchingTokenKind: Synta
 
 /** @internal */
 export function removeOptionality(type: Type, isOptionalExpression: boolean, isOptionalChain: boolean) {
-    return isOptionalExpression ? type.getNonNullableType() :
-        isOptionalChain ? type.getNonOptionalType() :
-        type;
+    return isOptionalExpression ? type.getNonNullableType()
+        : isOptionalChain ? type.getNonOptionalType()
+        : type;
 }
 
 /** @internal */
 export function isPossiblyTypeArgumentPosition(token: Node, sourceFile: SourceFile, checker: TypeChecker): boolean {
     const info = getPossibleTypeArgumentsInfo(token, sourceFile);
-    return info !== undefined && (isPartOfTypeNode(info.called) ||
-        getPossibleGenericSignatures(info.called, info.nTypeArguments, checker).length !== 0 ||
-        isPossiblyTypeArgumentPosition(info.called, sourceFile, checker));
+    return info !== undefined && (isPartOfTypeNode(info.called)
+        || getPossibleGenericSignatures(info.called, info.nTypeArguments, checker).length !== 0
+        || isPossiblyTypeArgumentPosition(info.called, sourceFile, checker));
 }
 
 /** @internal */
@@ -2221,8 +2221,8 @@ export function isStringAndEmptyAnonymousObjectIntersection(type: Type) {
     }
 
     const { types, checker } = type;
-    return types.length === 2 &&
-        (areIntersectedTypesAvoidingStringReduction(checker, types[0], types[1]) || areIntersectedTypesAvoidingStringReduction(checker, types[1], types[0]));
+    return types.length === 2
+        && (areIntersectedTypesAvoidingStringReduction(checker, types[0], types[1]) || areIntersectedTypesAvoidingStringReduction(checker, types[1], types[0]));
 }
 
 /** @internal */
@@ -2253,15 +2253,15 @@ export function cloneCompilerOptions(options: CompilerOptions): CompilerOptions 
 /** @internal */
 export function isArrayLiteralOrObjectLiteralDestructuringPattern(node: Node) {
     if (
-        node.kind === SyntaxKind.ArrayLiteralExpression ||
-        node.kind === SyntaxKind.ObjectLiteralExpression
+        node.kind === SyntaxKind.ArrayLiteralExpression
+        || node.kind === SyntaxKind.ObjectLiteralExpression
     ) {
         // [a,b,c] from:
         // [a, b, c] = someExpression;
         if (
-            node.parent.kind === SyntaxKind.BinaryExpression &&
-            (node.parent as BinaryExpression).left === node &&
-            (node.parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken
+            node.parent.kind === SyntaxKind.BinaryExpression
+            && (node.parent as BinaryExpression).left === node
+            && (node.parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken
         ) {
             return true;
         }
@@ -2269,8 +2269,8 @@ export function isArrayLiteralOrObjectLiteralDestructuringPattern(node: Node) {
         // [a, b, c] from:
         // for([a, b, c] of expression)
         if (
-            node.parent.kind === SyntaxKind.ForOfStatement &&
-            (node.parent as ForOfStatement).initializer === node
+            node.parent.kind === SyntaxKind.ForOfStatement
+            && (node.parent as ForOfStatement).initializer === node
         ) {
             return true;
         }
@@ -2532,8 +2532,8 @@ export function getQuotePreference(sourceFile: SourceFile, preferences: UserPref
     }
     else {
         // ignore synthetic import added when importHelpers: true
-        const firstModuleSpecifier = sourceFile.imports &&
-            find(sourceFile.imports, n => isStringLiteral(n) && !nodeIsSynthesized(n.parent)) as StringLiteral;
+        const firstModuleSpecifier = sourceFile.imports
+            && find(sourceFile.imports, n => isStringLiteral(n) && !nodeIsSynthesized(n.parent)) as StringLiteral;
         return firstModuleSpecifier ? quotePreferenceFromString(firstModuleSpecifier, sourceFile) : QuotePreference.Double;
     }
 }
@@ -2571,10 +2571,10 @@ export function symbolEscapedNameNoDefault(symbol: Symbol): __String | undefined
 /** @internal */
 export function isModuleSpecifierLike(node: Node): node is StringLiteralLike {
     return isStringLiteralLike(node) && (
-        isExternalModuleReference(node.parent) ||
-        isImportDeclaration(node.parent) ||
-        isRequireCall(node.parent, /*requireStringLiteralLikeArgument*/ false) && node.parent.arguments[0] === node ||
-        isImportCall(node.parent) && node.parent.arguments[0] === node
+        isExternalModuleReference(node.parent)
+        || isImportDeclaration(node.parent)
+        || isRequireCall(node.parent, /*requireStringLiteralLikeArgument*/ false) && node.parent.arguments[0] === node
+        || isImportCall(node.parent) && node.parent.arguments[0] === node
     );
 }
 
@@ -2583,10 +2583,10 @@ export type ObjectBindingElementWithoutPropertyName = BindingElement & { name: I
 
 /** @internal */
 export function isObjectBindingElementWithoutPropertyName(bindingElement: Node): bindingElement is ObjectBindingElementWithoutPropertyName {
-    return isBindingElement(bindingElement) &&
-        isObjectBindingPattern(bindingElement.parent) &&
-        isIdentifier(bindingElement.name) &&
-        !bindingElement.propertyName;
+    return isBindingElement(bindingElement)
+        && isObjectBindingPattern(bindingElement.parent)
+        && isIdentifier(bindingElement.name)
+        && !bindingElement.propertyName;
 }
 
 /** @internal */
@@ -2609,8 +2609,8 @@ export function getParentNodeInSpan(node: Node | undefined, file: SourceFile, sp
 }
 
 function spanContainsNode(span: TextSpan, node: Node, file: SourceFile): boolean {
-    return textSpanContainsPosition(span, node.getStart(file)) &&
-        node.getEnd() <= textSpanEnd(span);
+    return textSpanContainsPosition(span, node.getStart(file))
+        && node.getEnd() <= textSpanEnd(span);
 }
 
 /** @internal */
@@ -2633,8 +2633,8 @@ export function insertImports(changes: textChanges.ChangeTracker, sourceFile: So
             const insertionIndex = OrganizeImports.getImportDeclarationInsertionIndex(existingImportStatements, newImport, comparer);
             if (insertionIndex === 0) {
                 // If the first import is top-of-file, insert after the leading comment which is likely the header.
-                const options = existingImportStatements[0] === sourceFile.statements[0] ?
-                    { leadingTriviaOption: textChanges.LeadingTriviaOption.Exclude } : {};
+                const options = existingImportStatements[0] === sourceFile.statements[0]
+                    ? { leadingTriviaOption: textChanges.LeadingTriviaOption.Exclude } : {};
                 changes.insertNodeBefore(sourceFile, existingImportStatements[0], newImport, /*blankLineBetween*/ false, options);
             }
             else {
@@ -2666,8 +2666,8 @@ export function textSpansEqual(a: TextSpan | undefined, b: TextSpan | undefined)
 }
 /** @internal */
 export function documentSpansEqual(a: DocumentSpan, b: DocumentSpan, useCaseSensitiveFileNames: boolean): boolean {
-    return (useCaseSensitiveFileNames ? equateStringsCaseSensitive : equateStringsCaseInsensitive)(a.fileName, b.fileName) &&
-        textSpansEqual(a.textSpan, b.textSpan);
+    return (useCaseSensitiveFileNames ? equateStringsCaseSensitive : equateStringsCaseInsensitive)(a.fileName, b.fileName)
+        && textSpansEqual(a.textSpan, b.textSpan);
 }
 
 /** @internal */
@@ -2747,9 +2747,9 @@ export function getMappedContextSpan(documentSpan: DocumentSpan, sourceMapper: S
         sourceMapper,
         fileExists,
     );
-    return contextSpanStart && contextSpanEnd ?
-        { start: contextSpanStart.pos, length: contextSpanEnd.pos - contextSpanStart.pos } :
-        undefined;
+    return contextSpanStart && contextSpanEnd
+        ? { start: contextSpanStart.pos, length: contextSpanEnd.pos - contextSpanStart.pos }
+        : undefined;
 }
 
 // #endregion
@@ -3030,9 +3030,9 @@ const lineFeed = "\n";
  * @internal
  */
 export function getNewLineOrDefaultFromHost(host: FormattingHost, formatSettings: FormatCodeSettings | undefined) {
-    return formatSettings?.newLineCharacter ||
-        host.getNewLine?.() ||
-        lineFeed;
+    return formatSettings?.newLineCharacter
+        || host.getNewLine?.()
+        || lineFeed;
 }
 
 /** @internal */
@@ -3176,9 +3176,9 @@ function getSynthesizedDeepCloneWorker<T extends Node>(node: T, replaceNode?: (n
 
     if (visited === node) {
         // This only happens for leaf nodes - internal nodes always see their children change.
-        const clone = isStringLiteral(node) ? setOriginalNode(factory.createStringLiteralFromNode(node), node) as Node as T :
-            isNumericLiteral(node) ? setOriginalNode(factory.createNumericLiteral(node.text, node.numericLiteralFlags), node) as Node as T :
-            factory.cloneNode(node);
+        const clone = isStringLiteral(node) ? setOriginalNode(factory.createStringLiteralFromNode(node), node) as Node as T
+            : isNumericLiteral(node) ? setOriginalNode(factory.createNumericLiteral(node.text, node.numericLiteralFlags), node) as Node as T
+            : factory.cloneNode(node);
         return setTextRange(clone, node);
     }
 
@@ -3805,8 +3805,8 @@ export function createPackageJsonImportFilter(fromFile: SourceFile, preferences:
             return true;
         }
 
-        const result = moduleSpecifierIsCoveredByPackageJson(declaringNodeModuleName) ||
-            moduleSpecifierIsCoveredByPackageJson(declaredModuleSpecifier);
+        const result = moduleSpecifierIsCoveredByPackageJson(declaringNodeModuleName)
+            || moduleSpecifierIsCoveredByPackageJson(declaredModuleSpecifier);
         ambientModuleCache.set(moduleSymbol, result);
         return result;
     }
@@ -4043,8 +4043,8 @@ function getDefaultLikeExportNameFromDeclaration(symbol: Symbol): string | undef
 function getSymbolParentOrFail(symbol: Symbol) {
     return Debug.checkDefined(
         symbol.parent,
-        `Symbol parent was undefined. Flags: ${Debug.formatSymbolFlags(symbol.flags)}. ` +
-            `Declarations: ${
+        `Symbol parent was undefined. Flags: ${Debug.formatSymbolFlags(symbol.flags)}. `
+            + `Declarations: ${
                 symbol.declarations?.map(d => {
                     const kind = Debug.formatSyntaxKind(d.kind);
                     const inJS = isInJSFile(d);

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -331,8 +331,8 @@ class CompilerTest {
     }
 
     public verifyTypesAndSymbols() {
-        const noTypesAndSymbols = this.harnessSettings.noTypesAndSymbols &&
-            this.harnessSettings.noTypesAndSymbols.toLowerCase() === "true";
+        const noTypesAndSymbols = this.harnessSettings.noTypesAndSymbols
+            && this.harnessSettings.noTypesAndSymbols.toLowerCase() === "true";
         if (noTypesAndSymbols) {
             return;
         }

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -241,9 +241,9 @@ class ProjectTestCase {
         const resolutionInfo: ProjectRunnerTestCaseResolutionInfo & ts.CompilerOptions = JSON.parse(JSON.stringify(this.testCase));
         resolutionInfo.resolvedInputFiles = this.compilerResult.program!.getSourceFiles()
             .map(({ fileName: input }) =>
-                vpath.beneath(vfs.builtFolder, input, this.vfs.ignoreCase) || vpath.beneath(vfs.testLibFolder, input, this.vfs.ignoreCase) ? Utils.removeTestPathPrefixes(input) :
-                    vpath.isAbsolute(input) ? vpath.relative(cwd, input, ignoreCase) :
-                    input
+                vpath.beneath(vfs.builtFolder, input, this.vfs.ignoreCase) || vpath.beneath(vfs.testLibFolder, input, this.vfs.ignoreCase) ? Utils.removeTestPathPrefixes(input)
+                    : vpath.isAbsolute(input) ? vpath.relative(cwd, input, ignoreCase)
+                    : input
             );
 
         resolutionInfo.emittedFiles = this.compilerResult.outputFiles!
@@ -427,8 +427,8 @@ class ProjectTestCase {
 }
 
 function moduleNameToString(moduleKind: ts.ModuleKind) {
-    return moduleKind === ts.ModuleKind.AMD ? "amd" :
-        moduleKind === ts.ModuleKind.CommonJS ? "node" : "none";
+    return moduleKind === ts.ModuleKind.AMD ? "amd"
+        : moduleKind === ts.ModuleKind.CommonJS ? "node" : "none";
 }
 
 function getErrorsBaseline(compilerResult: CompileProjectFilesResult) {
@@ -442,9 +442,9 @@ function getErrorsBaseline(compilerResult: CompileProjectFilesResult) {
     }
 
     const inputFiles = inputSourceFiles.map<Harness.Compiler.TestFile>(sourceFile => ({
-        unitName: ts.isRootedDiskPath(sourceFile.fileName) ?
-            Harness.RunnerBase.removeFullPaths(sourceFile.fileName) :
-            sourceFile.fileName,
+        unitName: ts.isRootedDiskPath(sourceFile.fileName)
+            ? Harness.RunnerBase.removeFullPaths(sourceFile.fileName)
+            : sourceFile.fileName,
         content: sourceFile.text,
     }));
 

--- a/src/testRunner/unittests/config/showConfig.ts
+++ b/src/testRunner/unittests/config/showConfig.ts
@@ -192,8 +192,8 @@ describe("unittests:: config:: showConfig", () => {
             }
         }
 
-        const configObject = optionValue &&
-            (isCompilerOptions ? { compilerOptions: optionValue } : { watchOptions: optionValue });
+        const configObject = optionValue
+            && (isCompilerOptions ? { compilerOptions: optionValue } : { watchOptions: optionValue });
         showTSConfigCorrectly(`Shows tsconfig for single option/${option.name}`, args, configObject);
     }
 });

--- a/src/testRunner/unittests/helpers/baseline.ts
+++ b/src/testRunner/unittests/helpers/baseline.ts
@@ -31,9 +31,9 @@ export function commandLineCallbacks(
             if (isAnyProgram(program)) {
                 baselineBuildInfo(program.getCompilerOptions(), sys, originalReadCall);
                 (programs || (programs = [])).push(
-                    ts.isBuilderProgram(program) ?
-                        [program.getProgram(), program] :
-                        [program],
+                    ts.isBuilderProgram(program)
+                        ? [program.getProgram(), program]
+                        : [program],
                 );
             }
             else {
@@ -177,18 +177,18 @@ function generateBuildInfoProgramBaseline(sys: ts.System, buildInfoPath: string,
     if (buildInfo.program && ts.isProgramBundleEmitBuildInfo(buildInfo.program)) {
         const fileInfos: ReadableProgramBundleEmitBuildInfo["fileInfos"] = {};
         buildInfo.program?.fileInfos?.forEach((fileInfo, index) =>
-            fileInfos[toFileName(index + 1 as ts.ProgramBuildInfoFileId)] = ts.isString(fileInfo) ?
-                fileInfo :
-                toReadableFileInfo(fileInfo, ts.identity)
+            fileInfos[toFileName(index + 1 as ts.ProgramBuildInfoFileId)] = ts.isString(fileInfo)
+                ? fileInfo
+                : toReadableFileInfo(fileInfo, ts.identity)
         );
         const pendingEmit = buildInfo.program.pendingEmit;
         program = {
             ...buildInfo.program,
             fileInfos,
             root: buildInfo.program.root.map(toReadableProgramBuildInfoRoot),
-            pendingEmit: pendingEmit === undefined ?
-                undefined :
-                [
+            pendingEmit: pendingEmit === undefined
+                ? undefined
+                : [
                     toReadableBuilderFileEmit(ts.toProgramEmitPending(pendingEmit, buildInfo.program.options)),
                     pendingEmit,
                 ],
@@ -211,9 +211,9 @@ function generateBuildInfoProgramBaseline(sys: ts.System, buildInfoPath: string,
             affectedFilesPendingEmit: buildInfo.program.affectedFilesPendingEmit?.map(value => toReadableProgramBuilderInfoFilePendingEmit(value, fullEmitForOptions!)),
             changeFileSet: buildInfo.program.changeFileSet?.map(toFileName),
             emitSignatures: buildInfo.program.emitSignatures?.map(s =>
-                ts.isNumber(s) ?
-                    toFileName(s) :
-                    [toFileName(s[0]), s[1]]
+                ts.isNumber(s)
+                    ? toFileName(s)
+                    : [toFileName(s[0]), s[1]]
             ),
             latestChangedDtsFile: buildInfo.program.latestChangedDtsFile,
         };
@@ -284,9 +284,9 @@ function generateBuildInfoProgramBaseline(sys: ts.System, buildInfoPath: string,
 
     function toReadableProgramBuildInfoDiagnosticsPerFile(diagnostics: ts.ProgramBuildInfoDiagnostic[] | undefined): readonly ReadableProgramBuildInfoDiagnostic[] | undefined {
         return diagnostics?.map(d =>
-            ts.isNumber(d) ?
-                toFileName(d) :
-                [toFileName(d[0]), d[1]]
+            ts.isNumber(d)
+                ? toFileName(d)
+                : [toFileName(d[0]), d[1]]
         );
     }
 }

--- a/src/testRunner/unittests/helpers/libraryResolution.ts
+++ b/src/testRunner/unittests/helpers/libraryResolution.ts
@@ -93,7 +93,7 @@ export function getServerHostForLibResolution(libRedirection?: true) {
 }
 
 export function getCommandLineArgsForLibResolution(withoutConfig: true | undefined) {
-    return withoutConfig ?
-        ["project1/core.d.ts", "project1/utils.d.ts", "project1/file.ts", "project1/index.ts", "project1/file2.ts", "--lib", "es5,dom", "--traceResolution", "--explainFiles"] :
-        ["-p", "project1", "--explainFiles"];
+    return withoutConfig
+        ? ["project1/core.d.ts", "project1/utils.d.ts", "project1/file.ts", "project1/index.ts", "project1/file2.ts", "--lib", "es5,dom", "--traceResolution", "--explainFiles"]
+        : ["-p", "project1", "--explainFiles"];
 }

--- a/src/testRunner/unittests/helpers/tsc.ts
+++ b/src/testRunner/unittests/helpers/tsc.ts
@@ -80,9 +80,9 @@ export function testTscCompileLike(input: TestTscCompileLike) {
     additionalBaseline?.(sys);
     fs.makeReadonly();
     sys.baseLine = () => {
-        const baseFsPatch = diffWithInitial ?
-            inputFs.diff(initialFs, { includeChangedFileWithSameContent: true }) :
-            inputFs.diff(/*base*/ undefined, { baseIsNotShadowRoot: true });
+        const baseFsPatch = diffWithInitial
+            ? inputFs.diff(initialFs, { includeChangedFileWithSameContent: true })
+            : inputFs.diff(/*base*/ undefined, { baseIsNotShadowRoot: true });
         const patch = fs.diff(inputFs, { includeChangedFileWithSameContent: true });
         return {
             file: tscBaselineName(scenario, subScenario, commandLineArgs),
@@ -532,8 +532,8 @@ export function verifyTsc({
                 });
                 return {
                     file,
-                    text: `currentDirectory:: ${sys.getCurrentDirectory()} useCaseSensitiveFileNames: ${sys.useCaseSensitiveFileNames}\r\n` +
-                        texts.join("\r\n"),
+                    text: `currentDirectory:: ${sys.getCurrentDirectory()} useCaseSensitiveFileNames: ${sys.useCaseSensitiveFileNames}\r\n`
+                        + texts.join("\r\n"),
                 };
             },
         }));

--- a/src/testRunner/unittests/helpers/tsserver.ts
+++ b/src/testRunner/unittests/helpers/tsserver.ts
@@ -94,9 +94,9 @@ export type TestSessionRequest<T extends ts.server.protocol.Request> = Pick<T, "
 
 function getTestSessionPartialOptionsAndHost(optsOrHost: TestSessionConstructorOptions): TestSessionPartialOptionsAndHost {
     // eslint-disable-next-line local/no-in-operator
-    return "host" in optsOrHost ?
-        optsOrHost :
-        { host: optsOrHost };
+    return "host" in optsOrHost
+        ? optsOrHost
+        : { host: optsOrHost };
 }
 export class TestSession extends ts.server.Session {
     private seq = 0;
@@ -109,12 +109,12 @@ export class TestSession extends ts.server.Session {
         const opts = getTestSessionPartialOptionsAndHost(optsOrHost);
         opts.logger = opts.logger || createLoggerWithInMemoryLogs(opts.host);
         const typingsInstaller = !opts.disableAutomaticTypingAcquisition ? new TestTypingsInstallerAdapter(opts) : undefined;
-        const cancellationToken = opts.useCancellationToken ?
-            new TestServerCancellationToken(
+        const cancellationToken = opts.useCancellationToken
+            ? new TestServerCancellationToken(
                 opts.logger,
                 ts.isNumber(opts.useCancellationToken) ? opts.useCancellationToken : undefined,
-            ) :
-            ts.server.nullCancellationToken;
+            )
+            : ts.server.nullCancellationToken;
         super({
             cancellationToken,
             useSingleInferredProject: false,
@@ -313,16 +313,16 @@ export function openFilesForSession(
     for (const file of files) {
         session.executeCommandSeq<ts.server.protocol.OpenRequest>({
             command: ts.server.protocol.CommandTypes.Open,
-            arguments: ts.isString(file) ?
-                { file } :
-                "file" in file ? // eslint-disable-line local/no-in-operator
-                {
+            arguments: ts.isString(file)
+                ? { file }
+                : "file" in file // eslint-disable-line local/no-in-operator
+                ? {
                     file: typeof file.file === "string" ? file.file : file.file.path,
                     projectRootPath: file.projectRootPath,
                     fileContent: file.content,
                     scriptKindName: file.scriptKindName,
-                } :
-                { file: file.path },
+                }
+                : { file: file.path },
         });
     }
 }
@@ -356,9 +356,9 @@ export function setCompilerOptionsForInferredProjectsRequestForSession(
 ) {
     session.executeCommandSeq<ts.server.protocol.SetCompilerOptionsForInferredProjectsRequest>({
         command: ts.server.protocol.CommandTypes.CompilerOptionsForInferredProjects,
-        arguments: "options" in options ? // eslint-disable-line local/no-in-operator
-            options as ts.server.protocol.SetCompilerOptionsForInferredProjectsArgs :
-            { options },
+        arguments: "options" in options // eslint-disable-line local/no-in-operator
+            ? options as ts.server.protocol.SetCompilerOptionsForInferredProjectsArgs
+            : { options },
     });
 }
 

--- a/src/testRunner/unittests/helpers/typingsInstaller.ts
+++ b/src/testRunner/unittests/helpers/typingsInstaller.ts
@@ -105,11 +105,11 @@ export class TestTypingsInstallerWorker extends ts.server.typingsInstaller.Typin
         testTypingInstaller.session.host.ensureFileOrFolder({
             path: getTypesRegistryFileLocation(testTypingInstaller.globalTypingsCacheLocation),
             content: jsonToReadableText(createTypesRegistryFileContent(
-                testTypingInstaller.typesRegistry ?
-                    ts.isString(testTypingInstaller.typesRegistry) ?
-                        [testTypingInstaller.typesRegistry] :
-                        testTypingInstaller.typesRegistry :
-                    ts.emptyArray,
+                testTypingInstaller.typesRegistry
+                    ? ts.isString(testTypingInstaller.typesRegistry)
+                        ? [testTypingInstaller.typesRegistry]
+                        : testTypingInstaller.typesRegistry
+                    : ts.emptyArray,
             )),
         });
         this.log.writeLine(`Updated ${typesRegistryPackageName} npm package`);
@@ -196,9 +196,9 @@ export class TestTypingsInstallerAdapter extends ts.server.TypingsInstallerAdapt
         const globalTypingsCacheLocation = options.globalTypingsCacheLocation || options.host.getHostSpecificPath("/a/data");
         super(
             /*telemetryEnabled*/ false,
-            options.throttledRequests === undefined ?
-                { ...options.logger!, hasLevel: ts.returnFalse } :
-                options.logger!,
+            options.throttledRequests === undefined
+                ? { ...options.logger!, hasLevel: ts.returnFalse }
+                : options.logger!,
             options.host,
             globalTypingsCacheLocation,
             (...args) => this.session.event(...args),

--- a/src/testRunner/unittests/helpers/vfs.ts
+++ b/src/testRunner/unittests/helpers/vfs.ts
@@ -14,9 +14,9 @@ export interface FsOptions {
 export type FsOptionsOrLibContentsToAppend = FsOptions | string;
 
 function valueOfFsOptions(options: FsOptionsOrLibContentsToAppend | undefined, key: keyof FsOptions) {
-    return typeof options === "string" ?
-        key === "libContentToAppend" ? options : undefined :
-        options?.[key];
+    return typeof options === "string"
+        ? key === "libContentToAppend" ? options : undefined
+        : options?.[key];
 }
 
 /**

--- a/src/testRunner/unittests/helpers/virtualFileSystemWithWatch.ts
+++ b/src/testRunner/unittests/helpers/virtualFileSystemWithWatch.ts
@@ -210,9 +210,9 @@ class Callbacks {
                 this.serializedKeys.delete(key);
             });
         }
-        return `${this.callbackType} callback:: count: ${this.map.size}` +
-            (deleted.length ? "\r\n" + deleted.join("\r\n") : "") +
-            (details.length ? "\r\n" + details.join("\r\n") : "");
+        return `${this.callbackType} callback:: count: ${this.map.size}`
+            + (deleted.length ? "\r\n" + deleted.join("\r\n") : "")
+            + (details.length ? "\r\n" + details.join("\r\n") : "");
     }
 
     private invokeCallback(timeoutId: number) {
@@ -463,9 +463,9 @@ export class TestServerHost implements server.ServerHost, FormatDiagnosticsHost,
         if (isArray(fileOrFolderOrSymLinkList)) {
             fileOrFolderOrSymLinkList.forEach(f =>
                 this.ensureFileOrFolder(
-                    !this.windowsStyleRoot ?
-                        f :
-                        { ...f, path: this.getHostSpecificPath(f.path) },
+                    !this.windowsStyleRoot
+                        ? f
+                        : { ...f, path: this.getHostSpecificPath(f.path) },
                 )
             );
         }

--- a/src/testRunner/unittests/incrementalParser.ts
+++ b/src/testRunner/unittests/incrementalParser.ts
@@ -122,13 +122,13 @@ function insertCode(source: string, index: number, toInsert: string) {
 
 describe("unittests:: Incremental Parser", () => {
     it("Inserting into method", () => {
-        const source = "class C {\r\n" +
-            "    public foo1() { }\r\n" +
-            "    public foo2() {\r\n" +
-            "        return 1;\r\n" +
-            "    }\r\n" +
-            "    public foo3() { }\r\n" +
-            "}";
+        const source = "class C {\r\n"
+            + "    public foo1() { }\r\n"
+            + "    public foo2() {\r\n"
+            + "        return 1;\r\n"
+            + "    }\r\n"
+            + "    public foo3() { }\r\n"
+            + "}";
 
         const oldText = ts.ScriptSnapshot.fromString(source);
         const semicolonIndex = source.indexOf(";");
@@ -138,13 +138,13 @@ describe("unittests:: Incremental Parser", () => {
     });
 
     it("Deleting from method", () => {
-        const source = "class C {\r\n" +
-            "    public foo1() { }\r\n" +
-            "    public foo2() {\r\n" +
-            "        return 1 + 1;\r\n" +
-            "    }\r\n" +
-            "    public foo3() { }\r\n" +
-            "}";
+        const source = "class C {\r\n"
+            + "    public foo1() { }\r\n"
+            + "    public foo2() {\r\n"
+            + "        return 1 + 1;\r\n"
+            + "    }\r\n"
+            + "    public foo3() { }\r\n"
+            + "}";
 
         const index = source.indexOf("+ 1");
         const oldText = ts.ScriptSnapshot.fromString(source);
@@ -213,11 +213,11 @@ describe("unittests:: Incremental Parser", () => {
 
     it("Parameter 1", () => {
         // Should be able to reuse all the parameters.
-        const source = "class C {\r\n" +
-            "    public foo2(a, b, c, d) {\r\n" +
-            "        return 1;\r\n" +
-            "    }\r\n" +
-            "}";
+        const source = "class C {\r\n"
+            + "    public foo2(a, b, c, d) {\r\n"
+            + "        return 1;\r\n"
+            + "    }\r\n"
+            + "}";
 
         const semicolonIndex = source.indexOf(";");
         const oldText = ts.ScriptSnapshot.fromString(source);
@@ -807,22 +807,22 @@ module m3 { }\
     });
 
     it("Type after incomplete enum 1", () => {
-        const source = "function foo() {\r\n" +
-            "            function getOccurrencesAtPosition() {\r\n" +
-            "            switch (node) {\r\n" +
-            "                enum \r\n" +
-            "            }\r\n" +
-            "                \r\n" +
-            "                return undefined;\r\n" +
-            "                \r\n" +
-            "                function keywordToReferenceEntry() {\r\n" +
-            "                }\r\n" +
-            "            }\r\n" +
-            "                \r\n" +
-            "            return {\r\n" +
-            "                getEmitOutput: (fileName): Bar => null,\r\n" +
-            "            };\r\n" +
-            "        }";
+        const source = "function foo() {\r\n"
+            + "            function getOccurrencesAtPosition() {\r\n"
+            + "            switch (node) {\r\n"
+            + "                enum \r\n"
+            + "            }\r\n"
+            + "                \r\n"
+            + "                return undefined;\r\n"
+            + "                \r\n"
+            + "                function keywordToReferenceEntry() {\r\n"
+            + "                }\r\n"
+            + "            }\r\n"
+            + "                \r\n"
+            + "            return {\r\n"
+            + "                getEmitOutput: (fileName): Bar => null,\r\n"
+            + "            };\r\n"
+            + "        }";
 
         const index = source.indexOf("enum ") + "enum ".length;
         insertCode(source, index, "Fo");

--- a/src/testRunner/unittests/programApi.ts
+++ b/src/testRunner/unittests/programApi.ts
@@ -35,10 +35,10 @@ describe("unittests:: programApi:: Program.getMissingFilePaths", () => {
 
     const referenceFile = new documents.TextDocument(
         referenceFileName,
-        '/// <reference path="d:/imaginary/nonexistent1.ts"/>\n' + // Absolute
-            '/// <reference path="./nonexistent2.ts"/>\n' + // Relative
-            '/// <reference path="nonexistent3.ts"/>\n' + // Unqualified
-            '/// <reference path="nonexistent4"/>\n', // No extension
+        '/// <reference path="d:/imaginary/nonexistent1.ts"/>\n' // Absolute
+            + '/// <reference path="./nonexistent2.ts"/>\n' // Relative
+            + '/// <reference path="nonexistent3.ts"/>\n' // Unqualified
+            + '/// <reference path="nonexistent4"/>\n', // No extension
     );
 
     const testCompilerHost = new fakes.CompilerHost(

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -359,8 +359,8 @@ function testConvertToAsyncFunction(it: Mocha.PendingTestFunction, caption: stri
 
         const diagnostics = languageService.getSuggestionDiagnostics(f.path);
         const diagnostic = ts.find(diagnostics, diagnostic =>
-            diagnostic.messageText === ts.Diagnostics.This_may_be_converted_to_an_async_function.message &&
-            diagnostic.start === context.span.start && diagnostic.length === context.span.length);
+            diagnostic.messageText === ts.Diagnostics.This_may_be_converted_to_an_async_function.message
+            && diagnostic.start === context.span.start && diagnostic.length === context.span.length);
         const actions = ts.codefix.getFixes(context);
         const action = ts.find(actions, action => action.description === ts.Diagnostics.Convert_to_async_function.message);
 

--- a/src/testRunner/unittests/services/extract/helpers.ts
+++ b/src/testRunner/unittests/services/extract/helpers.ts
@@ -23,9 +23,9 @@ export type TestProjectServicePartialOptionsAndHost = Partial<Omit<TestProjectSe
 export class TestProjectService extends ts.server.ProjectService {
     constructor(optsOrHost: TestServerHost | TestProjectServicePartialOptionsAndHost) {
         // eslint-disable-next-line local/no-in-operator
-        const opts = "host" in optsOrHost ?
-            optsOrHost :
-            { host: optsOrHost };
+        const opts = "host" in optsOrHost
+            ? optsOrHost
+            : { host: optsOrHost };
         super({
             logger: createHasErrorMessageLogger(),
             session: undefined,
@@ -59,8 +59,8 @@ export function extractTest(source: string): Test {
 
     while (pos < source.length) {
         if (
-            source.charCodeAt(pos) === ts.CharacterCodes.openBracket &&
-            (source.charCodeAt(pos + 1) === ts.CharacterCodes.hash || source.charCodeAt(pos + 1) === ts.CharacterCodes.$)
+            source.charCodeAt(pos) === ts.CharacterCodes.openBracket
+            && (source.charCodeAt(pos + 1) === ts.CharacterCodes.hash || source.charCodeAt(pos + 1) === ts.CharacterCodes.$)
         ) {
             const saved = pos;
             pos += 2;

--- a/src/testRunner/unittests/services/preProcessFile.ts
+++ b/src/testRunner/unittests/services/preProcessFile.ts
@@ -126,13 +126,13 @@ describe("unittests:: services:: PreProcessFile:", () => {
 
         it("Correctly return ES6 imports", () => {
             test(
-                'import * as ns from "m1";' + "\n" +
-                    'import def, * as ns from "m2";' + "\n" +
-                    'import def from "m3";' + "\n" +
-                    'import {a} from "m4";' + "\n" +
-                    'import {a as A} from "m5";' + "\n" +
-                    'import {a as A, b, c as C} from "m6";' + "\n" +
-                    'import def , {a, b, c as C} from "m7";' + "\n",
+                'import * as ns from "m1";' + "\n"
+                    + 'import def, * as ns from "m2";' + "\n"
+                    + 'import def from "m3";' + "\n"
+                    + 'import {a} from "m4";' + "\n"
+                    + 'import {a as A} from "m5";' + "\n"
+                    + 'import {a as A, b, c as C} from "m6";' + "\n"
+                    + 'import def , {a, b, c as C} from "m7";' + "\n",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
@@ -157,20 +157,20 @@ describe("unittests:: services:: PreProcessFile:", () => {
         it("Correctly ignore commented imports following template expression", () => {
             /* eslint-disable no-template-curly-in-string */
             test(
-                "/**" + "\n" +
-                    " * Before" + "\n" +
-                    " * ```" + "\n" +
-                    ' * import * as a from "a";' + "\n" +
-                    " * ```" + "\n" +
-                    " */" + "\n" +
-                    "type Foo = `${string}`;" + "\n" +
-                    "/**" + "\n" +
-                    " * After" + "\n" +
-                    " * ```" + "\n" +
-                    ' * import { B } from "b";' + "\n" +
-                    ' * import * as c from "c";' + "\n" +
-                    " * ```" + "\n" +
-                    " */",
+                "/**" + "\n"
+                    + " * Before" + "\n"
+                    + " * ```" + "\n"
+                    + ' * import * as a from "a";' + "\n"
+                    + " * ```" + "\n"
+                    + " */" + "\n"
+                    + "type Foo = `${string}`;" + "\n"
+                    + "/**" + "\n"
+                    + " * After" + "\n"
+                    + " * ```" + "\n"
+                    + ' * import { B } from "b";' + "\n"
+                    + ' * import * as c from "c";' + "\n"
+                    + " * ```" + "\n"
+                    + " */",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ true,
                 {
@@ -216,9 +216,9 @@ describe("unittests:: services:: PreProcessFile:", () => {
         it("Correctly returns dynamic imports from template expression", () => {
             /* eslint-disable no-template-curly-in-string */
             test(
-                "`${(<div>Text `` ${} text {} " + "\n" +
-                    '${import("a")} {import("b")} ' + "\n" +
-                    '${/* A comment */} ${/* import("ignored") */} </div>)}`',
+                "`${(<div>Text `` ${} text {} " + "\n"
+                    + '${import("a")} {import("b")} ' + "\n"
+                    + '${/* A comment */} ${/* import("ignored") */} </div>)}`',
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ true,
                 {
@@ -276,8 +276,8 @@ describe("unittests:: services:: PreProcessFile:", () => {
         it("Correctly returns dynamic imports from template expression and imports following it", () => {
             /* eslint-disable no-template-curly-in-string */
             test(
-                'const x = `hello ${await import("a").default}`;' + "\n\n" +
-                    'import { y } from "b";',
+                'const x = `hello ${await import("a").default}`;' + "\n\n"
+                    + 'import { y } from "b";',
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ true,
                 {
@@ -298,10 +298,10 @@ describe("unittests:: services:: PreProcessFile:", () => {
         it("Correctly returns dynamic imports from template expressions and other imports", () => {
             /* eslint-disable no-template-curly-in-string */
             test(
-                'const x = `x ${await import("a").default}`;' + "\n\n" +
-                    'import { y } from "b";' + "\n" +
-                    'const y = `y ${import("c")}`;' + "\n\n" +
-                    'import { d } from "d";',
+                'const x = `x ${await import("a").default}`;' + "\n\n"
+                    + 'import { y } from "b";' + "\n"
+                    + 'const y = `y ${import("c")}`;' + "\n\n"
+                    + 'import { d } from "d";',
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ true,
                 {
@@ -334,10 +334,10 @@ describe("unittests:: services:: PreProcessFile:", () => {
 
         it("Correctly return ES6 exports", () => {
             test(
-                'export * from "m1";' + "\n" +
-                    'export {a} from "m2";' + "\n" +
-                    'export {a as A} from "m3";' + "\n" +
-                    'export {a as A, b, c as C} from "m4";' + "\n",
+                'export * from "m1";' + "\n"
+                    + 'export {a} from "m2";' + "\n"
+                    + 'export {a as A} from "m3";' + "\n"
+                    + 'export {a as A, b, c as C} from "m4";' + "\n",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
@@ -358,18 +358,18 @@ describe("unittests:: services:: PreProcessFile:", () => {
 
         it("Correctly handles import types", () => {
             test(
-                'import type * as ns from "m1";' + "\n" +
-                    'import type def, * as ns from "m2";' + "\n" +
-                    'import type def from "m3";' + "\n" +
-                    'import type {a} from "m4";' + "\n" +
-                    'import type {a as A} from "m5";' + "\n" +
-                    'import type {a as A, b, c as C} from "m6";' + "\n" +
-                    'import type def , {a, b, c as C} from "m7";' + "\n" +
-                    'import type from "m8";' + "\n" +
-                    'import type T = require("m9");' + "\n" +
-                    'import type = require("m10");' + "\n" +
-                    'export import type T = require("m11");' + "\n" +
-                    'export import type = require("m12");' + "\n",
+                'import type * as ns from "m1";' + "\n"
+                    + 'import type def, * as ns from "m2";' + "\n"
+                    + 'import type def from "m3";' + "\n"
+                    + 'import type {a} from "m4";' + "\n"
+                    + 'import type {a as A} from "m5";' + "\n"
+                    + 'import type {a as A, b, c as C} from "m6";' + "\n"
+                    + 'import type def , {a, b, c as C} from "m7";' + "\n"
+                    + 'import type from "m8";' + "\n"
+                    + 'import type T = require("m9");' + "\n"
+                    + 'import type = require("m10");' + "\n"
+                    + 'export import type T = require("m11");' + "\n"
+                    + 'export import type = require("m12");' + "\n",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
@@ -398,10 +398,10 @@ describe("unittests:: services:: PreProcessFile:", () => {
 
         it("Correctly handles export types", () => {
             test(
-                'export type * from "m1";' + "\n" +
-                    'export type {a} from "m2";' + "\n" +
-                    'export type {a as A} from "m3";' + "\n" +
-                    'export type {a as A, b, c as C} from "m4";' + "\n",
+                'export type * from "m1";' + "\n"
+                    + 'export type {a} from "m2";' + "\n"
+                    + 'export type {a as A} from "m3";' + "\n"
+                    + 'export type {a as A, b, c as C} from "m4";' + "\n",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
@@ -422,9 +422,9 @@ describe("unittests:: services:: PreProcessFile:", () => {
 
         it("Correctly handles import type node", () => {
             test(
-                'const x: import("m1") = { x: 0, y: 0 };' + "\n" +
-                    'let y: import("m2").Bar.I = { a: "", b: 0 };' + "\n" +
-                    'let shim: typeof import("m3") = { Bar: Bar2 };' + "\n",
+                'const x: import("m1") = { x: 0, y: 0 };' + "\n"
+                    + 'let y: import("m2").Bar.I = { a: "", b: 0 };' + "\n"
+                    + 'let shim: typeof import("m3") = { Bar: Bar2 };' + "\n",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
@@ -790,10 +790,10 @@ describe("unittests:: services:: PreProcessFile:", () => {
 
         it("Correctly handles dynamic imports with template literals", () => {
             test(
-                "const m1 = import('mod1');" + "\n" +
-                    "const m2 = import(`mod2`);" + "\n" +
-                    "Promise.all([import('mod3'), import(`mod4`)]);" + "\n" +
-                    "import(/* webpackChunkName: 'module5' */ `mod5`);" + "\n",
+                "const m1 = import('mod1');" + "\n"
+                    + "const m2 = import(`mod2`);" + "\n"
+                    + "Promise.all([import('mod3'), import(`mod4`)]);" + "\n"
+                    + "import(/* webpackChunkName: 'module5' */ `mod5`);" + "\n",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
@@ -815,9 +815,9 @@ describe("unittests:: services:: PreProcessFile:", () => {
 
         it("Correctly handles require calls with template literals in JS files", () => {
             test(
-                "const m1 = require(`mod1`);" + "\n" +
-                    "f(require(`mod2`));" + "\n" +
-                    "const a = { x: require(`mod3`) };" + "\n",
+                "const m1 = require(`mod1`);" + "\n"
+                    + "f(require(`mod2`));" + "\n"
+                    + "const a = { x: require(`mod3`) };" + "\n",
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ true,
                 {

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -152,9 +152,9 @@ var x = 0;`,
 
     transpilesCorrectly(
         "Rename dependencies - System",
-        `import {foo} from "SomeName";\n` +
-            `declare function use(a: any);\n` +
-            `use(foo);`,
+        `import {foo} from "SomeName";\n`
+            + `declare function use(a: any);\n`
+            + `use(foo);`,
         {
             options: { compilerOptions: { module: ts.ModuleKind.System, newLine: ts.NewLineKind.LineFeed }, renamedDependencies: { SomeName: "SomeOtherName" } },
         },
@@ -162,9 +162,9 @@ var x = 0;`,
 
     transpilesCorrectly(
         "Rename dependencies - AMD",
-        `import {foo} from "SomeName";\n` +
-            `declare function use(a: any);\n` +
-            `use(foo);`,
+        `import {foo} from "SomeName";\n`
+            + `declare function use(a: any);\n`
+            + `use(foo);`,
         {
             options: { compilerOptions: { module: ts.ModuleKind.AMD, newLine: ts.NewLineKind.LineFeed }, renamedDependencies: { SomeName: "SomeOtherName" } },
         },
@@ -172,9 +172,9 @@ var x = 0;`,
 
     transpilesCorrectly(
         "Rename dependencies - UMD",
-        `import {foo} from "SomeName";\n` +
-            `declare function use(a: any);\n` +
-            `use(foo);`,
+        `import {foo} from "SomeName";\n`
+            + `declare function use(a: any);\n`
+            + `use(foo);`,
         {
             options: { compilerOptions: { module: ts.ModuleKind.UMD, newLine: ts.NewLineKind.LineFeed }, renamedDependencies: { SomeName: "SomeOtherName" } },
         },
@@ -182,19 +182,19 @@ var x = 0;`,
 
     transpilesCorrectly(
         "Transpile with emit decorators and emit metadata",
-        `import {db} from './db';\n` +
-            `function someDecorator(target) {\n` +
-            `    return target;\n` +
-            `} \n` +
-            `@someDecorator\n` +
-            `class MyClass {\n` +
-            `    db: db;\n` +
-            `    constructor(db: db) {\n` +
-            `        this.db = db;\n` +
-            `        this.db.doSomething(); \n` +
-            `    }\n` +
-            `}\n` +
-            `export {MyClass}; \n`,
+        `import {db} from './db';\n`
+            + `function someDecorator(target) {\n`
+            + `    return target;\n`
+            + `} \n`
+            + `@someDecorator\n`
+            + `class MyClass {\n`
+            + `    db: db;\n`
+            + `    constructor(db: db) {\n`
+            + `        this.db = db;\n`
+            + `        this.db.doSomething(); \n`
+            + `    }\n`
+            + `}\n`
+            + `export {MyClass}; \n`,
         {
             options: {
                 compilerOptions: {
@@ -530,12 +530,12 @@ var x = 0;`,
 
     transpilesCorrectly(
         "Correctly serialize metadata when transpile with CommonJS option",
-        `import * as ng from "angular2/core";` +
-            `declare function foo(...args: any[]);` +
-            `@foo` +
-            `export class MyClass1 {` +
-            `    constructor(private _elementRef: ng.ElementRef){}` +
-            `}`,
+        `import * as ng from "angular2/core";`
+            + `declare function foo(...args: any[]);`
+            + `@foo`
+            + `export class MyClass1 {`
+            + `    constructor(private _elementRef: ng.ElementRef){}`
+            + `}`,
         {
             options: {
                 compilerOptions: {
@@ -552,12 +552,12 @@ var x = 0;`,
 
     transpilesCorrectly(
         "Correctly serialize metadata when transpile with System option",
-        `import * as ng from "angular2/core";` +
-            `declare function foo(...args: any[]);` +
-            `@foo` +
-            `export class MyClass1 {` +
-            `    constructor(private _elementRef: ng.ElementRef){}` +
-            `}`,
+        `import * as ng from "angular2/core";`
+            + `declare function foo(...args: any[]);`
+            + `@foo`
+            + `export class MyClass1 {`
+            + `    constructor(private _elementRef: ng.ElementRef){}`
+            + `}`,
         {
             options: {
                 compilerOptions: {
@@ -601,8 +601,8 @@ export * as alias from './file';`,
 
     transpilesCorrectly(
         "Elides import equals referenced only by export type",
-        `import IFoo = Namespace.IFoo;` +
-            `export type { IFoo };`,
+        `import IFoo = Namespace.IFoo;`
+            + `export type { IFoo };`,
         {
             options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
         },
@@ -610,8 +610,8 @@ export * as alias from './file';`,
 
     transpilesCorrectly(
         "Does not elide import equals referenced only by export type",
-        `import IFoo = Namespace.IFoo;` +
-            `export type { IFoo };`,
+        `import IFoo = Namespace.IFoo;`
+            + `export type { IFoo };`,
         {
             options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
             testVerbatimModuleSyntax: "only",
@@ -620,8 +620,8 @@ export * as alias from './file';`,
 
     transpilesCorrectly(
         "Elides import equals referenced only by type only export specifier",
-        `import IFoo = Namespace.IFoo;` +
-            `export { type IFoo };`,
+        `import IFoo = Namespace.IFoo;`
+            + `export { type IFoo };`,
         {
             options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
         },
@@ -629,8 +629,8 @@ export * as alias from './file';`,
 
     transpilesCorrectly(
         "Does not elide import equals referenced only by type only export specifier",
-        `import IFoo = Namespace.IFoo;` +
-            `export { type IFoo };`,
+        `import IFoo = Namespace.IFoo;`
+            + `export { type IFoo };`,
         {
             options: { compilerOptions: { module: ts.ModuleKind.CommonJS } },
             testVerbatimModuleSyntax: "only",

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -660,16 +660,16 @@ module MyModule {
             if (ts.isClassLike(node)) {
                 const newMembers = [ts.factory.createPropertyDeclaration([ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)], "newField", /*questionOrExclamationToken*/ undefined, /*type*/ undefined, ts.factory.createStringLiteral("x"))];
                 ts.setSyntheticLeadingComments(newMembers[0], [{ kind: ts.SyntaxKind.MultiLineCommentTrivia, text: "comment", pos: -1, end: -1, hasTrailingNewLine: true }]);
-                return ts.isClassDeclaration(node) ?
-                    ts.factory.updateClassDeclaration(
+                return ts.isClassDeclaration(node)
+                    ? ts.factory.updateClassDeclaration(
                         node,
                         node.modifiers,
                         node.name,
                         node.typeParameters,
                         node.heritageClauses,
                         newMembers,
-                    ) :
-                    ts.factory.updateClassExpression(
+                    )
+                    : ts.factory.updateClassExpression(
                         node,
                         node.modifiers,
                         node.name,

--- a/src/testRunner/unittests/tsbuild/emitDeclarationOnly.ts
+++ b/src/testRunner/unittests/tsbuild/emitDeclarationOnly.ts
@@ -72,9 +72,9 @@ describe("unittests:: tsbuild:: on project with emitDeclarationOnly set to true"
             fs: () => projFs,
             scenario: "emitDeclarationOnly",
             commandLineArgs: ["--b", "/src", "--verbose"],
-            modifyFs: disableMap ?
-                (fs => replaceText(fs, "/src/tsconfig.json", `"declarationMap": true,`, "")) :
-                undefined,
+            modifyFs: disableMap
+                ? (fs => replaceText(fs, "/src/tsconfig.json", `"declarationMap": true,`, ""))
+                : undefined,
             edits: [{
                 caption: "incremental-declaration-changes",
                 edit: fs => replaceText(fs, "/src/src/a.ts", "b: B;", "b: B; foo: any;"),

--- a/src/testRunner/unittests/tsbuildWatch/projectsBuilding.ts
+++ b/src/testRunner/unittests/tsbuildWatch/projectsBuilding.ts
@@ -34,9 +34,9 @@ describe("unittests:: tsbuildWatch:: watchMode:: projectsBuilding", () => {
                 path: `/user/username/projects/myproject/pkg${index}/tsconfig.json`,
                 content: jsonToReadableText({
                     compilerOptions: { composite: true },
-                    references: index === 0 ?
-                        undefined :
-                        [{ path: `../pkg0` }],
+                    references: index === 0
+                        ? undefined
+                        : [{ path: `../pkg0` }],
                 }),
             },
         ];

--- a/src/testRunner/unittests/tsc/cancellationToken.ts
+++ b/src/testRunner/unittests/tsc/cancellationToken.ts
@@ -135,13 +135,13 @@ describe("unittests:: tsc:: builder cancellationToken", () => {
             }
 
             function createIncrementalProgram() {
-                builderProgram = useBuildInfo ?
-                    ts.createIncrementalProgram({
+                builderProgram = useBuildInfo
+                    ? ts.createIncrementalProgram({
                         rootNames: parsedConfig.fileNames,
                         options: parsedConfig.options,
                         host,
-                    }) :
-                    builderProgram = builderProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+                    })
+                    : builderProgram = builderProgram = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
                         parsedConfig.fileNames,
                         parsedConfig.options,
                         host,

--- a/src/testRunner/unittests/tsc/declarationEmit.ts
+++ b/src/testRunner/unittests/tsc/declarationEmit.ts
@@ -21,9 +21,9 @@ describe("unittests:: tsc:: declarationEmit::", () => {
     }
 
     function changeCaseFile(file: FileOrFolderOrSymLink, testPath: (path: string) => boolean, replacePath: (path: string) => string): FileOrFolderOrSymLink {
-        return !isSymLink(file) || !testPath(file.symLink) ?
-            testPath(file.path) ? { ...file, path: replacePath(file.path) } : file :
-            { path: testPath(file.path) ? replacePath(file.path) : file.path, symLink: replacePath(file.symLink) };
+        return !isSymLink(file) || !testPath(file.symLink)
+            ? testPath(file.path) ? { ...file, path: replacePath(file.path) } : file
+            : { path: testPath(file.path) ? replacePath(file.path) : file.path, symLink: replacePath(file.symLink) };
     }
 
     function verifyDeclarationEmit({ subScenario, files, rootProject, changeCaseFileTestPath }: VerifyDeclarationEmitInput) {

--- a/src/testRunner/unittests/tsc/incremental.ts
+++ b/src/testRunner/unittests/tsc/incremental.ts
@@ -191,9 +191,9 @@ const a: string = 10;`,
                 ...noChangeRun,
                 caption: "No Change run with noEmit",
                 commandLineArgs: ["--p", "src/project", "--noEmit"],
-                discrepancyExplanation: compilerOptions.composite ?
-                    discrepancyExplanation :
-                    undefined,
+                discrepancyExplanation: compilerOptions.composite
+                    ? discrepancyExplanation
+                    : undefined,
             };
             const noChangeRunWithEmit: TestTscEdit = {
                 ...noChangeRun,
@@ -219,9 +219,9 @@ const a: string = 10;`,
                         caption: "Introduce error but still noEmit",
                         commandLineArgs: ["--p", "src/project", "--noEmit"],
                         edit: fs => replaceText(fs, "/src/project/src/class.ts", "prop", "prop1"),
-                        discrepancyExplanation: compilerOptions.composite ?
-                            discrepancyExplanation :
-                            undefined,
+                        discrepancyExplanation: compilerOptions.composite
+                            ? discrepancyExplanation
+                            : undefined,
                     },
                     {
                         caption: "Fix error and emit",
@@ -243,9 +243,9 @@ const a: string = 10;`,
                         caption: "Fix error and no emit",
                         commandLineArgs: ["--p", "src/project", "--noEmit"],
                         edit: fs => replaceText(fs, "/src/project/src/class.ts", "prop1", "prop"),
-                        discrepancyExplanation: compilerOptions.composite ?
-                            discrepancyExplanation :
-                            undefined,
+                        discrepancyExplanation: compilerOptions.composite
+                            ? discrepancyExplanation
+                            : undefined,
                     },
                     noChangeRunWithEmit,
                     noChangeRunWithNoEmit,
@@ -269,9 +269,9 @@ const a: string = 10;`,
                     {
                         caption: "Fix error and no emit",
                         edit: fs => replaceText(fs, "/src/project/src/class.ts", "prop1", "prop"),
-                        discrepancyExplanation: compilerOptions.composite ?
-                            discrepancyExplanation :
-                            undefined,
+                        discrepancyExplanation: compilerOptions.composite
+                            ? discrepancyExplanation
+                            : undefined,
                     },
                     noChangeRunWithEmit,
                 ],

--- a/src/testRunner/unittests/tscWatch/emit.ts
+++ b/src/testRunner/unittests/tscWatch/emit.ts
@@ -70,9 +70,9 @@ describe("unittests:: tsc-watch:: emit with outFile or out setting", () => {
                 const configFile: File = {
                     path: "/a/b/project/tsconfig.json",
                     content: jsonToReadableText({
-                        compilerOptions: useOutFile ?
-                            { outFile: "../output/common.js", target: "es5" } :
-                            { outDir: "../output", target: "es5" },
+                        compilerOptions: useOutFile
+                            ? { outFile: "../output/common.js", target: "es5" }
+                            : { outDir: "../output", target: "es5" },
                         files: [file1.path, file2.path, file3.path, file4.path],
                     }),
                 };
@@ -144,9 +144,9 @@ describe("unittests:: tsc-watch:: emit for configured projects", () => {
                 const additionalFiles = getAdditionalFileOrFolder?.() || ts.emptyArray;
                 const files = [moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2, configFile, libFile, ...additionalFiles];
                 return createWatchedSystem(
-                    firstReloadFileList ?
-                        ts.map(firstReloadFileList, fileName => ts.find(files, file => file.path === fileName)!) :
-                        files,
+                    firstReloadFileList
+                        ? ts.map(firstReloadFileList, fileName => ts.find(files, file => file.path === fileName)!)
+                        : files,
                 );
             },
             edits: changes,

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -1019,9 +1019,9 @@ declare const eval: any`,
         function verifyTypesLoad(includeTypeRoots: boolean) {
             verifyTscWatch({
                 scenario,
-                subScenario: includeTypeRoots ?
-                    "types should not load from config file path if config exists but does not specifies typeRoots" :
-                    "types should load from config file path if config exists",
+                subScenario: includeTypeRoots
+                    ? "types should not load from config file path if config exists but does not specifies typeRoots"
+                    : "types should load from config file path if config exists",
                 commandLineArgs: ["-w", "-p", configFilePath],
                 sys: () => {
                     const f1 = {

--- a/src/testRunner/unittests/tsserver/configuredProjects.ts
+++ b/src/testRunner/unittests/tsserver/configuredProjects.ts
@@ -668,15 +668,15 @@ declare var console: {
                 bar,
                 libFile,
                 { path: `/user/username/projects/myproject/src/sub` },
-                withExclude ?
-                    {
+                withExclude
+                    ? {
                         path: config.path,
                         content: jsonToReadableText({
                             include: ["./src"],
                             exclude: ["./src/sub"],
                         }),
-                    } :
-                    config,
+                    }
+                    : config,
             ]);
             const session = new TestSession(host);
             session.executeCommandSeq<ts.server.protocol.OpenRequest>({
@@ -703,9 +703,9 @@ declare var console: {
             }
             verifyGetErrRequest({
                 session,
-                files: errorOnNewFileBeforeOldFile ?
-                    [fooBar, foo] :
-                    [foo, fooBar],
+                files: errorOnNewFileBeforeOldFile
+                    ? [fooBar, foo]
+                    : [foo, fooBar],
                 existingTimeouts: !withExclude,
             });
             baselineTsserverLogs("configuredProjects", `creating new file and then open it ${openFileBeforeCreating ? "before" : "after"} watcher is invoked, ask errors on it ${errorOnNewFileBeforeOldFile ? "before" : "after"} old one${withExclude ? " without file being in config" : ""}`, session);
@@ -1056,9 +1056,9 @@ describe("unittests:: tsserver:: ConfiguredProjects:: when reading tsconfig file
         const session = new TestSession(host);
         const originalReadFile = host.readFile;
         host.readFile = f => {
-            return f === configFile.path ?
-                undefined :
-                originalReadFile.call(host, f);
+            return f === configFile.path
+                ? undefined
+                : originalReadFile.call(host, f);
         };
         openFilesForSession([file1], session);
 

--- a/src/testRunner/unittests/tsserver/plugins.ts
+++ b/src/testRunner/unittests/tsserver/plugins.ts
@@ -340,14 +340,14 @@ describe("unittests:: tsserver:: plugins:: supportedExtensions::", () => {
                         const proxy = Harness.LanguageService.makeDefaultProxy(info);
                         const originalScriptKind = info.languageServiceHost.getScriptKind!.bind(info.languageServiceHost);
                         info.languageServiceHost.getScriptKind = fileName =>
-                            ts.fileExtensionIs(fileName, ".vue") ?
-                                ts.ScriptKind.TS :
-                                originalScriptKind(fileName);
+                            ts.fileExtensionIs(fileName, ".vue")
+                                ? ts.ScriptKind.TS
+                                : originalScriptKind(fileName);
                         const originalGetScriptSnapshot = info.languageServiceHost.getScriptSnapshot.bind(info.languageServiceHost);
                         info.languageServiceHost.getScriptSnapshot = fileName =>
-                            ts.fileExtensionIs(fileName, ".vue") ?
-                                ts.ScriptSnapshot.fromString(`export const y = "${info.languageServiceHost.readFile(fileName)}";`) :
-                                originalGetScriptSnapshot(fileName);
+                            ts.fileExtensionIs(fileName, ".vue")
+                                ? ts.ScriptSnapshot.fromString(`export const y = "${info.languageServiceHost.readFile(fileName)}";`)
+                                : originalGetScriptSnapshot(fileName);
                         return proxy;
                     },
                     getExternalFiles: createGetExternalFiles(() => session),
@@ -392,14 +392,14 @@ describe("unittests:: tsserver:: plugins:: supportedExtensions::", () => {
                         const proxy = Harness.LanguageService.makeDefaultProxy(info);
                         const originalScriptKind = info.languageServiceHost.getScriptKind!.bind(info.languageServiceHost);
                         info.languageServiceHost.getScriptKind = fileName =>
-                            fileName === bVue.path ?
-                                currentVueScriptKind :
-                                originalScriptKind(fileName);
+                            fileName === bVue.path
+                                ? currentVueScriptKind
+                                : originalScriptKind(fileName);
                         const originalGetScriptSnapshot = info.languageServiceHost.getScriptSnapshot.bind(info.languageServiceHost);
                         info.languageServiceHost.getScriptSnapshot = fileName =>
-                            fileName === bVue.path ?
-                                ts.ScriptSnapshot.fromString(`import { y } from "${bVue.content}";`) : // Change the text so that imports change and we need to reconstruct program
-                                originalGetScriptSnapshot(fileName);
+                            fileName === bVue.path
+                                ? ts.ScriptSnapshot.fromString(`import { y } from "${bVue.content}";`) // Change the text so that imports change and we need to reconstruct program
+                                : originalGetScriptSnapshot(fileName);
                         return proxy;
                     },
                     getExternalFiles: createGetExternalFiles(() => session),

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -381,9 +381,9 @@ function foo() {
             const aConfig = config("A", extraOptions, ["../B"]);
             const bConfig = config("B", extraOptions);
             const files = [libFile, bPackageJson, aConfig, bConfig, aTest, bFoo, bBar, bSymlink];
-            const host = alreadyBuilt ?
-                createHostWithSolutionBuild(files, [aConfig.path]) :
-                createServerHost(files);
+            const host = alreadyBuilt
+                ? createHostWithSolutionBuild(files, [aConfig.path])
+                : createServerHost(files);
 
             // Create symlink in node module
             const session = new TestSession(host);
@@ -1626,10 +1626,10 @@ const b: B = new B();`,
             dtsMapPresent: boolean,
         ) {
             // Mangled to stay under windows path length limit
-            const subScenario = `when proj ${projectAlreadyLoaded ? "is" : "is not"} loaded` +
-                ` and refd proj loading is ${disableReferencedProjectLoad ? "disabled" : "enabled"}` +
-                ` and proj ref redirects are ${disableSourceOfProjectReferenceRedirect ? "disabled" : "enabled"}` +
-                ` and a decl map is ${dtsMapPresent ? "present" : "missing"}`;
+            const subScenario = `when proj ${projectAlreadyLoaded ? "is" : "is not"} loaded`
+                + ` and refd proj loading is ${disableReferencedProjectLoad ? "disabled" : "enabled"}`
+                + ` and proj ref redirects are ${disableSourceOfProjectReferenceRedirect ? "disabled" : "enabled"}`
+                + ` and a decl map is ${dtsMapPresent ? "present" : "missing"}`;
             const compilerOptions: ts.CompilerOptions = {
                 disableReferencedProjectLoad,
                 disableSourceOfProjectReferenceRedirect,

--- a/src/testRunner/unittests/tsserver/projectReferencesSourcemap.ts
+++ b/src/testRunner/unittests/tsserver/projectReferencesSourcemap.ts
@@ -212,11 +212,11 @@ fn5();
     }
 
     function setup(type: SessionType, openFiles: readonly File[], action: Action | Action[], max?: number, onHostCreate?: OnHostCreate) {
-        const session = type === SessionType.NoReference ? createSessionWithoutProjectReferences(onHostCreate) :
-            type === SessionType.ProjectReference ? createSessionWithProjectReferences(onHostCreate) :
-            type === SessionType.DisableSourceOfProjectReferenceRedirect ?
-            createSessionWithDisabledProjectReferences(onHostCreate) :
-            ts.Debug.assertNever(type);
+        const session = type === SessionType.NoReference ? createSessionWithoutProjectReferences(onHostCreate)
+            : type === SessionType.ProjectReference ? createSessionWithProjectReferences(onHostCreate)
+            : type === SessionType.DisableSourceOfProjectReferenceRedirect
+            ? createSessionWithDisabledProjectReferences(onHostCreate)
+            : ts.Debug.assertNever(type);
         openFilesForSession(openFiles, session);
         runActions(session, action, max);
         return session;

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -91,8 +91,8 @@ function parseLoggingEnvironmentString(logEnvStr: string | undefined): LogOption
         let pathStart = args[initialIndex];
         let extraPartCounter = 0;
         if (
-            pathStart.charCodeAt(0) === CharacterCodes.doubleQuote &&
-            pathStart.charCodeAt(pathStart.length - 1) !== CharacterCodes.doubleQuote
+            pathStart.charCodeAt(0) === CharacterCodes.doubleQuote
+            && pathStart.charCodeAt(pathStart.length - 1) !== CharacterCodes.doubleQuote
         ) {
             for (let i = initialIndex + 1; i < args.length; i++) {
                 pathStart += " ";
@@ -710,12 +710,12 @@ function startNodeSession(options: StartSessionOptions, logger: ts.server.Logger
     function getGlobalTypingsCacheLocation() {
         switch (process.platform) {
             case "win32": {
-                const basePath = process.env.LOCALAPPDATA ||
-                    process.env.APPDATA ||
-                    (os.homedir && os.homedir()) ||
-                    process.env.USERPROFILE ||
-                    (process.env.HOMEDRIVE && process.env.HOMEPATH && normalizeSlashes(process.env.HOMEDRIVE + process.env.HOMEPATH)) ||
-                    os.tmpdir();
+                const basePath = process.env.LOCALAPPDATA
+                    || process.env.APPDATA
+                    || (os.homedir && os.homedir())
+                    || process.env.USERPROFILE
+                    || (process.env.HOMEDRIVE && process.env.HOMEPATH && normalizeSlashes(process.env.HOMEDRIVE + process.env.HOMEPATH))
+                    || os.tmpdir();
                 return combinePaths(combinePaths(normalizeSlashes(basePath), "Microsoft/TypeScript"), versionMajorMinor);
             }
             case "openbsd":
@@ -737,10 +737,10 @@ function startNodeSession(options: StartSessionOptions, logger: ts.server.Logger
             return process.env.XDG_CACHE_HOME;
         }
         const usersDir = platformIsDarwin ? "Users" : "home";
-        const homePath = (os.homedir && os.homedir()) ||
-            process.env.HOME ||
-            ((process.env.LOGNAME || process.env.USER) && `/${usersDir}/${process.env.LOGNAME || process.env.USER}`) ||
-            os.tmpdir();
+        const homePath = (os.homedir && os.homedir())
+            || process.env.HOME
+            || ((process.env.LOGNAME || process.env.USER) && `/${usersDir}/${process.env.LOGNAME || process.env.USER}`)
+            || os.tmpdir();
         const cacheFolder = platformIsDarwin
             ? "Library/Caches"
             : ".cache";

--- a/src/typingsInstallerCore/typingsInstaller.ts
+++ b/src/typingsInstallerCore/typingsInstaller.ts
@@ -241,9 +241,9 @@ export abstract class TypingsInstaller {
         }) || projectRootPath;
         if (cwd) {
             this.installWorker(-1, [packageName], cwd, success => {
-                const message = success ?
-                    `Package ${packageName} installed.` :
-                    `There was an error installing ${packageName}.`;
+                const message = success
+                    ? `Package ${packageName} installed.`
+                    : `There was an error installing ${packageName}.`;
                 const response: PackageInstalledResponse = {
                     kind: ActionPackageInstalled,
                     projectName,


### PR DESCRIPTION
This is probably going to be too divisive, but this is an "opinionated" change I left out of the dprint PR for later discussion.

operatorPosition=nextLine is the default in both dprint and prettier, but we weren't consistent one way or another so I had dprint set to maintain the original ordering to minimize the diff to only definitely desired (or unconfigurable) changes.

I personally find operators on the left/next line a lot more readable, especially when we have these large chained conditionals. On long lines, it's kind of annoying to be reading an expression and not know if it's going to be `&&` or `||` until the end, which for me at least negatively affects my comprehension when reading code I don't understand (which is all the time).

This change affects ~6500 lines. The opposite change, operatorPosition=sameLine, is only ~4200, so it could certainly be argued that we have preferred the latter slightly. But, I think it's largely just "who wrote the code and how much of it".