### PR TITLE
Make formatting settings in settings template apply to all filetypes

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -4,7 +4,7 @@
     // To use the locally built compiler, after 'npm run build':
     // "typescript.tsdk": "built/local"
 
-    "[typescript][javascript][yaml]": {
+    "[typescript][javascript][yaml][github-actions-workflow]": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "dprint.dprint"
     },

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -4,10 +4,11 @@
     // To use the locally built compiler, after 'npm run build':
     // "typescript.tsdk": "built/local"
 
-    "[typescript][javascript][yaml][github-actions-workflow]": {
-        "editor.formatOnSave": true,
-        "editor.defaultFormatter": "dprint.dprint"
-    },
+    // Enables dprint formatting on all supported files. Setting this as the
+    // default for all file types is safe as dprint will just ignore any file
+    // it doesn't support or has explicitly excluded in .dprint.jsonc.
+    "editor.defaultFormatter": "dprint.dprint",
+    "editor.formatOnSave": true,
 
     // To ignore commits listed in .git-blame-ignore-revs in GitLens:
     "gitlens.advanced.blame.customArguments": [


### PR DESCRIPTION
If you have the GitHub Actions extension installed, the filetype for these files stops being yaml and starts being "github-actions-workflow", which prevents formatting. Add it to the template in case people want to format those in the editor.