### PR TITLE
Remove lib.d.ts line info in inlay hint baselines

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -839,6 +839,15 @@ export class TestState {
         const fileName = this.activeFile.fileName;
         const hints = this.languageService.provideInlayHints(fileName, span, preferences);
         const annotations = ts.map(hints.sort(sortHints), hint => {
+            if (hint.displayParts) {
+                hint.displayParts = ts.map(hint.displayParts, part => {
+                    if (part.file && /lib(?:.*)\.d\.ts$/.test(part.file)) {
+                        part.span!.start = -1;
+                    }
+                    return part;
+                });
+            }
+
             const span = { start: hint.position, length: hint.text.length };
             const { character, line } = this.languageServiceAdapterHost.positionToLineAndCharacter(fileName, span.start);
             const underline = " ".repeat(character) + "^";


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Had some issues in #55141 because of including line information from `lib.d.ts` files, so this PR attempts to make those baselines more robust.