### PR TITLE
error on duplicate symbols in classes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12683,7 +12683,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // or if we have another early-bound symbol declaration with the same name and
                 // conflicting flags.
                 const earlySymbol = earlySymbols && earlySymbols.get(memberName);
-                if (lateSymbol.flags & getExcludedSymbolFlags(symbolFlags) || earlySymbol) {
+                // Duplicate property declarations of classes are checked in checkClassForDuplicateDeclarations.
+                if (!(parent.flags & SymbolFlags.Class) && (lateSymbol.flags & getExcludedSymbolFlags(symbolFlags) || earlySymbol)) {
                     // If we have an existing early-bound member, combine its declarations so that we can
                     // report an error at each declaration.
                     const declarations = earlySymbol ? concatenate(earlySymbol.declarations, lateSymbol.declarations) : lateSymbol.declarations;
@@ -38878,7 +38879,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     isStaticMember ? staticNames :
                     instanceNames;
 
-                const memberName = name && getPropertyNameForPropertyNameNode(name);
+                const memberName = name && getEffectivePropertyNameForPropertyNameNode(name);
                 if (memberName) {
                     switch (member.kind) {
                         case SyntaxKind.GetAccessor:
@@ -38947,7 +38948,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             const memberNameNode = member.name;
             const isStaticMember = isStatic(member);
             if (isStaticMember && memberNameNode) {
-                const memberName = getPropertyNameForPropertyNameNode(memberNameNode);
+                const memberName = getEffectivePropertyNameForPropertyNameNode(memberNameNode);
                 switch (memberName) {
                     case "name":
                     case "length":

--- a/tests/baselines/reference/mappedTypeProperties.errors.txt
+++ b/tests/baselines/reference/mappedTypeProperties.errors.txt
@@ -6,7 +6,11 @@ mappedTypeProperties.ts(23,5): error TS7061: A mapped type may not declare prope
 mappedTypeProperties.ts(27,5): error TS7061: A mapped type may not declare properties or methods.
 mappedTypeProperties.ts(31,5): error TS7061: A mapped type may not declare properties or methods.
 mappedTypeProperties.ts(34,5): error TS7061: A mapped type may not declare properties or methods.
+mappedTypeProperties.ts(34,6): error TS2304: Cannot find name 'P'.
+mappedTypeProperties.ts(34,11): error TS2693: 'PlaceType' only refers to a type, but is being used as a value here.
 mappedTypeProperties.ts(37,5): error TS7061: A mapped type may not declare properties or methods.
+mappedTypeProperties.ts(37,6): error TS2304: Cannot find name 'P'.
+mappedTypeProperties.ts(37,11): error TS2693: 'PlaceType' only refers to a type, but is being used as a value here.
 mappedTypeProperties.ts(40,5): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
 mappedTypeProperties.ts(40,6): error TS2304: Cannot find name 'P'.
 mappedTypeProperties.ts(40,6): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
@@ -14,7 +18,7 @@ mappedTypeProperties.ts(40,11): error TS2322: Type 'string' is not assignable to
 mappedTypeProperties.ts(40,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 
 
-==== mappedTypeProperties.ts (14 errors) ====
+==== mappedTypeProperties.ts (18 errors) ====
     export type PlaceType = 'openSky' | 'roofed' | 'garage'
     type Before = {
         model: 'hour' | 'day';
@@ -65,11 +69,19 @@ mappedTypeProperties.ts(40,17): error TS2363: The right-hand side of an arithmet
         [P in PlaceType]: any
         ~~~~~~~~~~~~~~~~
 !!! error TS7061: A mapped type may not declare properties or methods.
+         ~
+!!! error TS2304: Cannot find name 'P'.
+              ~~~~~~~~~
+!!! error TS2693: 'PlaceType' only refers to a type, but is being used as a value here.
     }
     const D = class {
         [P in PlaceType]: any
         ~~~~~~~~~~~~~~~~
 !!! error TS7061: A mapped type may not declare properties or methods.
+         ~
+!!! error TS2304: Cannot find name 'P'.
+              ~~~~~~~~~
+!!! error TS2693: 'PlaceType' only refers to a type, but is being used as a value here.
     }
     const E = class {
         [P in 'a' | 'b']: any

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).errors.txt
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).errors.txt
@@ -1,47 +1,88 @@
-staticPropertyNameConflicts.ts(3,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName'.
-staticPropertyNameConflicts.ts(8,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn'.
-staticPropertyNameConflicts.ts(14,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength'.
-staticPropertyNameConflicts.ts(19,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
-staticPropertyNameConflicts.ts(25,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
-staticPropertyNameConflicts.ts(30,12): error TS2300: Duplicate identifier 'prototype'.
-staticPropertyNameConflicts.ts(30,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
-staticPropertyNameConflicts.ts(36,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller'.
-staticPropertyNameConflicts.ts(41,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
-staticPropertyNameConflicts.ts(47,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments'.
-staticPropertyNameConflicts.ts(52,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn'.
-staticPropertyNameConflicts.ts(62,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName_Anonymous'.
-staticPropertyNameConflicts.ts(67,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn_Anonymous'.
-staticPropertyNameConflicts.ts(73,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength_Anonymous'.
-staticPropertyNameConflicts.ts(78,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn_Anonymous'.
-staticPropertyNameConflicts.ts(84,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous'.
-staticPropertyNameConflicts.ts(89,12): error TS2300: Duplicate identifier 'prototype'.
-staticPropertyNameConflicts.ts(89,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous'.
-staticPropertyNameConflicts.ts(95,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller_Anonymous'.
-staticPropertyNameConflicts.ts(100,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn_Anonymous'.
-staticPropertyNameConflicts.ts(106,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments_Anonymous'.
-staticPropertyNameConflicts.ts(111,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn_Anonymous'.
-staticPropertyNameConflicts.ts(121,16): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName'.
-staticPropertyNameConflicts.ts(128,16): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn'.
-staticPropertyNameConflicts.ts(135,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(136,16): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength'.
-staticPropertyNameConflicts.ts(142,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(143,16): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
-staticPropertyNameConflicts.ts(150,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(151,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
-staticPropertyNameConflicts.ts(157,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(158,16): error TS2300: Duplicate identifier 'prototype'.
-staticPropertyNameConflicts.ts(158,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
-staticPropertyNameConflicts.ts(165,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(166,16): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller'.
-staticPropertyNameConflicts.ts(172,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(173,16): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
-staticPropertyNameConflicts.ts(180,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(181,16): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments'.
-staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn'.
+staticPropertyNameConflicts.ts(11,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName'.
+staticPropertyNameConflicts.ts(16,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName2'.
+staticPropertyNameConflicts.ts(21,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn'.
+staticPropertyNameConflicts.ts(26,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn2'.
+staticPropertyNameConflicts.ts(32,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength'.
+staticPropertyNameConflicts.ts(37,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength2'.
+staticPropertyNameConflicts.ts(42,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
+staticPropertyNameConflicts.ts(47,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn2'.
+staticPropertyNameConflicts.ts(53,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
+staticPropertyNameConflicts.ts(58,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype2'.
+staticPropertyNameConflicts.ts(63,12): error TS2300: Duplicate identifier 'prototype'.
+staticPropertyNameConflicts.ts(63,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
+staticPropertyNameConflicts.ts(68,12): error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+staticPropertyNameConflicts.ts(68,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn2'.
+staticPropertyNameConflicts.ts(74,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller'.
+staticPropertyNameConflicts.ts(79,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller2'.
+staticPropertyNameConflicts.ts(84,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
+staticPropertyNameConflicts.ts(89,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn2'.
+staticPropertyNameConflicts.ts(95,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments'.
+staticPropertyNameConflicts.ts(100,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments2'.
+staticPropertyNameConflicts.ts(105,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn'.
+staticPropertyNameConflicts.ts(110,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn2'.
+staticPropertyNameConflicts.ts(119,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName_Anonymous'.
+staticPropertyNameConflicts.ts(124,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName_Anonymous2'.
+staticPropertyNameConflicts.ts(129,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn_Anonymous'.
+staticPropertyNameConflicts.ts(134,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn_Anonymous2'.
+staticPropertyNameConflicts.ts(140,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength_Anonymous'.
+staticPropertyNameConflicts.ts(145,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength_Anonymous2'.
+staticPropertyNameConflicts.ts(150,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn_Anonymous'.
+staticPropertyNameConflicts.ts(155,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn_Anonymous2'.
+staticPropertyNameConflicts.ts(161,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous'.
+staticPropertyNameConflicts.ts(166,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous2'.
+staticPropertyNameConflicts.ts(171,12): error TS2300: Duplicate identifier 'prototype'.
+staticPropertyNameConflicts.ts(171,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous'.
+staticPropertyNameConflicts.ts(176,12): error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+staticPropertyNameConflicts.ts(176,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous2'.
+staticPropertyNameConflicts.ts(182,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller_Anonymous'.
+staticPropertyNameConflicts.ts(187,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller_Anonymous2'.
+staticPropertyNameConflicts.ts(192,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn_Anonymous'.
+staticPropertyNameConflicts.ts(197,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn_Anonymous2'.
+staticPropertyNameConflicts.ts(203,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments_Anonymous'.
+staticPropertyNameConflicts.ts(208,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments_Anonymous2'.
+staticPropertyNameConflicts.ts(213,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn_Anonymous'.
+staticPropertyNameConflicts.ts(218,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn_Anonymous2'.
+staticPropertyNameConflicts.ts(228,16): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName'.
+staticPropertyNameConflicts.ts(234,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'ExportedStaticName'.
+staticPropertyNameConflicts.ts(240,16): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn'.
+staticPropertyNameConflicts.ts(246,12): error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'ExportedStaticNameFn'.
+staticPropertyNameConflicts.ts(252,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(253,16): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength'.
+staticPropertyNameConflicts.ts(259,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'ExportedStaticLength'.
+staticPropertyNameConflicts.ts(264,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(265,16): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
+staticPropertyNameConflicts.ts(271,12): error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'ExportedStaticLengthFn'.
+staticPropertyNameConflicts.ts(277,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(278,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
+staticPropertyNameConflicts.ts(284,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototype'.
+staticPropertyNameConflicts.ts(289,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(290,16): error TS2300: Duplicate identifier 'prototype'.
+staticPropertyNameConflicts.ts(290,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
+staticPropertyNameConflicts.ts(296,12): error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+staticPropertyNameConflicts.ts(296,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototypeFn'.
+staticPropertyNameConflicts.ts(302,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(303,16): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller'.
+staticPropertyNameConflicts.ts(309,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'ExportedStaticCaller'.
+staticPropertyNameConflicts.ts(314,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(315,16): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
+staticPropertyNameConflicts.ts(321,12): error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'ExportedStaticCallerFn'.
+staticPropertyNameConflicts.ts(327,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(328,16): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments'.
+staticPropertyNameConflicts.ts(334,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'ExportedStaticArguments'.
+staticPropertyNameConflicts.ts(339,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(340,16): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn'.
+staticPropertyNameConflicts.ts(346,12): error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'ExportedStaticArgumentsFn'.
 
 
-==== staticPropertyNameConflicts.ts (41 errors) ====
+==== staticPropertyNameConflicts.ts (74 errors) ====
+    const FunctionPropertyNames = {
+        name: 'name',
+        length: 'length',
+        prototype: 'prototype',
+        caller: 'caller',
+        arguments: 'arguments',
+    } as const;
+    
     // name
     class StaticName {
         static name: number; // error without useDefineForClassFields
@@ -50,11 +91,25 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         name: string; // ok
     }
     
+    class StaticName2 {
+        static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName2'.
+        [FunctionPropertyNames.name]: number; // ok
+    }
+    
     class StaticNameFn {
         static name() {} // error without useDefineForClassFields
                ~~~~
 !!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn'.
         name() {} // ok
+    }
+    
+    class StaticNameFn2 {
+        static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn2'.
+        [FunctionPropertyNames.name]() {} // ok
     }
     
     // length
@@ -65,11 +120,25 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         length: string; // ok
     }
     
+    class StaticLength2 {
+        static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength2'.
+        [FunctionPropertyNames.length]: number; // ok
+    }
+    
     class StaticLengthFn {
         static length() {} // error without useDefineForClassFields
                ~~~~~~
 !!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
         length() {} // ok
+    }
+    
+    class StaticLengthFn2 {
+        static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn2'.
+        [FunctionPropertyNames.length]() {} // ok
     }
     
     // prototype
@@ -78,6 +147,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
                ~~~~~~~~~
 !!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
         prototype: string; // ok
+    }
+    
+    class StaticPrototype2 {
+        static [FunctionPropertyNames.prototype]: number; // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype2'.
+        [FunctionPropertyNames.prototype]: string; // ok
     }
     
     class StaticPrototypeFn {
@@ -89,6 +165,15 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         prototype() {} // ok
     }
     
+    class StaticPrototypeFn2 {
+        static [FunctionPropertyNames.prototype]() {} // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn2'.
+        [FunctionPropertyNames.prototype]() {} // ok
+    }
+    
     // caller
     class StaticCaller {
         static caller: number; // error without useDefineForClassFields
@@ -97,11 +182,25 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         caller: string; // ok
     }
     
+    class StaticCaller2 {
+        static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller2'.
+        [FunctionPropertyNames.caller]: string; // ok
+    }
+    
     class StaticCallerFn {
         static caller() {} // error without useDefineForClassFields
                ~~~~~~
 !!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
         caller() {} // ok
+    }
+    
+    class StaticCallerFn2 {
+        static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn2'.
+        [FunctionPropertyNames.caller]() {} // ok
     }
     
     // arguments
@@ -112,6 +211,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         arguments: string; // ok
     }
     
+    class StaticArguments2 {
+        static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments2'.
+        [FunctionPropertyNames.arguments]: string; // ok
+    }
+    
     class StaticArgumentsFn {
         static arguments() {} // error without useDefineForClassFields
                ~~~~~~~~~
@@ -119,6 +225,12 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         arguments() {} // ok
     }
     
+    class StaticArgumentsFn2 {
+        static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn2'.
+        [FunctionPropertyNames.arguments]() {} // ok
+    }
     
     
     // === Static properties on anonymous classes ===
@@ -131,11 +243,25 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         name: string; // ok
     }
     
+    var StaticName_Anonymous2 = class {
+        static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticName_Anonymous2'.
+        [FunctionPropertyNames.name]: string; // ok
+    }
+    
     var StaticNameFn_Anonymous = class {
         static name() {} // error without useDefineForClassFields
                ~~~~
 !!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn_Anonymous'.
         name() {} // ok
+    }
+    
+    var StaticNameFn_Anonymous2 = class {
+        static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn_Anonymous2'.
+        [FunctionPropertyNames.name]() {} // ok
     }
     
     // length
@@ -146,11 +272,25 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         length: string; // ok
     }
     
+    var StaticLength_Anonymous2 = class {
+        static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLength_Anonymous2'.
+        [FunctionPropertyNames.length]: string; // ok
+    }
+    
     var StaticLengthFn_Anonymous = class {
         static length() {} // error without useDefineForClassFields
                ~~~~~~
 !!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn_Anonymous'.
         length() {} // ok
+    }
+    
+    var StaticLengthFn_Anonymous2 = class {
+        static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn_Anonymous2'.
+        [FunctionPropertyNames.length]() {} // ok
     }
     
     // prototype
@@ -159,6 +299,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
                ~~~~~~~~~
 !!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous'.
         prototype: string; // ok
+    }
+    
+    var StaticPrototype_Anonymous2 = class {
+        static [FunctionPropertyNames.prototype]: number; // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous2'.
+        [FunctionPropertyNames.prototype]: string; // ok
     }
     
     var StaticPrototypeFn_Anonymous = class {
@@ -170,6 +317,15 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         prototype() {} // ok
     }
     
+    var StaticPrototypeFn_Anonymous2 = class {
+        static [FunctionPropertyNames.prototype]() {} // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous2'.
+        [FunctionPropertyNames.prototype]() {} // ok
+    }
+    
     // caller
     var StaticCaller_Anonymous = class {
         static caller: number; // error without useDefineForClassFields
@@ -178,11 +334,25 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         caller: string; // ok
     }
     
+    var StaticCaller_Anonymous2 = class {
+        static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCaller_Anonymous2'.
+        [FunctionPropertyNames.caller]: string; // ok
+    }
+    
     var StaticCallerFn_Anonymous = class {
         static caller() {} // error without useDefineForClassFields
                ~~~~~~
 !!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn_Anonymous'.
         caller() {} // ok
+    }
+    
+    var StaticCallerFn_Anonymous2 = class {
+        static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn_Anonymous2'.
+        [FunctionPropertyNames.caller]() {} // ok
     }
     
     // arguments
@@ -193,11 +363,25 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         arguments: string; // ok
     }
     
+    var StaticArguments_Anonymous2 = class {
+        static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArguments_Anonymous2'.
+        [FunctionPropertyNames.arguments]: string; // ok
+    }
+    
     var StaticArgumentsFn_Anonymous = class {
         static arguments() {} // error without useDefineForClassFields
                ~~~~~~~~~
 !!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn_Anonymous'.
         arguments() {} // ok
+    }
+    
+    var StaticArgumentsFn_Anonymous2 = class {
+        static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'StaticArgumentsFn_Anonymous2'.
+        [FunctionPropertyNames.arguments]() {} // ok
     }
     
     
@@ -213,6 +397,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         }
     }
     
+    export class ExportedStaticName {
+        static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'ExportedStaticName'.
+        [FunctionPropertyNames.name]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_2 {
         class StaticNameFn {
             static name() {} // error without useDefineForClassFields
@@ -220,6 +411,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
 !!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'StaticNameFn'.
             name() {} // ok
         }
+    }
+    
+    export class ExportedStaticNameFn {
+        static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'name' conflicts with built-in property 'Function.name' of constructor function 'ExportedStaticNameFn'.
+        [FunctionPropertyNames.name]() {} // ok
     }
     
     // length
@@ -234,6 +432,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         }
     }
     
+    export class ExportedStaticLength {
+        static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'ExportedStaticLength'.
+        [FunctionPropertyNames.length]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_4 {
         export default class StaticLengthFn {
                ~~~~~~~
@@ -243,6 +448,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
 !!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'StaticLengthFn'.
             length() {} // ok
         }
+    }
+    
+    export class ExportedStaticLengthFn {
+        static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'length' conflicts with built-in property 'Function.length' of constructor function 'ExportedStaticLengthFn'.
+        [FunctionPropertyNames.length]() {} // ok
     }
     
     // prototype
@@ -255,6 +467,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
 !!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
             prototype: string; // ok
         }
+    }
+    
+    export class ExportedStaticPrototype {
+        static [FunctionPropertyNames.prototype]: number; // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototype'.
+        [FunctionPropertyNames.prototype]: string; // ok
     }
     
     module TestOnDefaultExportedClass_6 {
@@ -270,6 +489,15 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         }
     }
     
+    export class ExportedStaticPrototypeFn {
+        static [FunctionPropertyNames.prototype]() {} // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototypeFn'.
+        [FunctionPropertyNames.prototype]() {} // ok
+    }
+    
     // caller
     module TestOnDefaultExportedClass_7 {
         export default class StaticCaller {
@@ -282,6 +510,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         }
     }
     
+    export class ExportedStaticCaller {
+        static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'ExportedStaticCaller'.
+        [FunctionPropertyNames.caller]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_8 {
         export default class StaticCallerFn {
                ~~~~~~~
@@ -291,6 +526,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
 !!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'StaticCallerFn'.
             caller() {} // ok
         }
+    }
+    
+    export class ExportedStaticCallerFn {
+        static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'caller' conflicts with built-in property 'Function.caller' of constructor function 'ExportedStaticCallerFn'.
+        [FunctionPropertyNames.caller]() {} // ok
     }
     
     // arguments
@@ -305,6 +547,13 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         }
     }
     
+    export class ExportedStaticArguments {
+        static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'ExportedStaticArguments'.
+        [FunctionPropertyNames.arguments]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_10 {
         export default class StaticArgumentsFn {
                ~~~~~~~
@@ -316,3 +565,9 @@ staticPropertyNameConflicts.ts(188,16): error TS2699: Static property 'arguments
         }
     }
     
+    export class ExportedStaticArgumentsFn {
+        static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'arguments' conflicts with built-in property 'Function.arguments' of constructor function 'ExportedStaticArgumentsFn'.
+        [FunctionPropertyNames.arguments]() {} // ok
+    }

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).js
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).js
@@ -1,15 +1,33 @@
 //// [tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts] ////
 
 //// [staticPropertyNameConflicts.ts]
+const FunctionPropertyNames = {
+    name: 'name',
+    length: 'length',
+    prototype: 'prototype',
+    caller: 'caller',
+    arguments: 'arguments',
+} as const;
+
 // name
 class StaticName {
     static name: number; // error without useDefineForClassFields
     name: string; // ok
 }
 
+class StaticName2 {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: number; // ok
+}
+
 class StaticNameFn {
     static name() {} // error without useDefineForClassFields
     name() {} // ok
+}
+
+class StaticNameFn2 {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -18,9 +36,19 @@ class StaticLength {
     length: string; // ok
 }
 
+class StaticLength2 {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: number; // ok
+}
+
 class StaticLengthFn {
     static length() {} // error without useDefineForClassFields
     length() {} // ok
+}
+
+class StaticLengthFn2 {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -29,9 +57,19 @@ class StaticPrototype {
     prototype: string; // ok
 }
 
+class StaticPrototype2 {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 class StaticPrototypeFn {
     static prototype() {} // always an error
     prototype() {} // ok
+}
+
+class StaticPrototypeFn2 {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -40,9 +78,19 @@ class StaticCaller {
     caller: string; // ok
 }
 
+class StaticCaller2 {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 class StaticCallerFn {
     static caller() {} // error without useDefineForClassFields
     caller() {} // ok
+}
+
+class StaticCallerFn2 {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -51,11 +99,20 @@ class StaticArguments {
     arguments: string; // ok
 }
 
+class StaticArguments2 {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 class StaticArgumentsFn {
     static arguments() {} // error without useDefineForClassFields
     arguments() {} // ok
 }
 
+class StaticArgumentsFn2 {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
+}
 
 
 // === Static properties on anonymous classes ===
@@ -66,9 +123,19 @@ var StaticName_Anonymous = class {
     name: string; // ok
 }
 
+var StaticName_Anonymous2 = class {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: string; // ok
+}
+
 var StaticNameFn_Anonymous = class {
     static name() {} // error without useDefineForClassFields
     name() {} // ok
+}
+
+var StaticNameFn_Anonymous2 = class {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -77,9 +144,19 @@ var StaticLength_Anonymous = class {
     length: string; // ok
 }
 
+var StaticLength_Anonymous2 = class {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: string; // ok
+}
+
 var StaticLengthFn_Anonymous = class {
     static length() {} // error without useDefineForClassFields
     length() {} // ok
+}
+
+var StaticLengthFn_Anonymous2 = class {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -88,9 +165,19 @@ var StaticPrototype_Anonymous = class {
     prototype: string; // ok
 }
 
+var StaticPrototype_Anonymous2 = class {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 var StaticPrototypeFn_Anonymous = class {
     static prototype() {} // always an error
     prototype() {} // ok
+}
+
+var StaticPrototypeFn_Anonymous2 = class {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -99,9 +186,19 @@ var StaticCaller_Anonymous = class {
     caller: string; // ok
 }
 
+var StaticCaller_Anonymous2 = class {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 var StaticCallerFn_Anonymous = class {
     static caller() {} // error without useDefineForClassFields
     caller() {} // ok
+}
+
+var StaticCallerFn_Anonymous2 = class {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -110,9 +207,19 @@ var StaticArguments_Anonymous = class {
     arguments: string; // ok
 }
 
+var StaticArguments_Anonymous2 = class {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 var StaticArgumentsFn_Anonymous = class {
     static arguments() {} // error without useDefineForClassFields
     arguments() {} // ok
+}
+
+var StaticArgumentsFn_Anonymous2 = class {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
 }
 
 
@@ -126,11 +233,21 @@ module TestOnDefaultExportedClass_1 {
     }
 }
 
+export class ExportedStaticName {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: string; // ok
+}
+
 module TestOnDefaultExportedClass_2 {
     class StaticNameFn {
         static name() {} // error without useDefineForClassFields
         name() {} // ok
     }
+}
+
+export class ExportedStaticNameFn {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -141,11 +258,21 @@ module TestOnDefaultExportedClass_3 {
     }
 }
 
+export class ExportedStaticLength {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: string; // ok
+}
+
 module TestOnDefaultExportedClass_4 {
     export default class StaticLengthFn {
         static length() {} // error without useDefineForClassFields
         length() {} // ok
     }
+}
+
+export class ExportedStaticLengthFn {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -156,11 +283,21 @@ module TestOnDefaultExportedClass_5 {
     }
 }
 
+export class ExportedStaticPrototype {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 module TestOnDefaultExportedClass_6 {
     export default class StaticPrototypeFn {
         static prototype() {} // always an error
         prototype() {} // ok
     }
+}
+
+export class ExportedStaticPrototypeFn {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -171,11 +308,21 @@ module TestOnDefaultExportedClass_7 {
     }
 }
 
+export class ExportedStaticCaller {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 module TestOnDefaultExportedClass_8 {
     export default class StaticCallerFn {
         static caller() {} // error without useDefineForClassFields
         caller() {} // ok
     }
+}
+
+export class ExportedStaticCallerFn {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -186,6 +333,11 @@ module TestOnDefaultExportedClass_9 {
     }
 }
 
+export class ExportedStaticArguments {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 module TestOnDefaultExportedClass_10 {
     export default class StaticArgumentsFn {
         static arguments() {} // error without useDefineForClassFields
@@ -193,14 +345,35 @@ module TestOnDefaultExportedClass_10 {
     }
 }
 
+export class ExportedStaticArgumentsFn {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
+}
 
 //// [staticPropertyNameConflicts.js]
+"use strict";
+var _a, _b, _c, _d, _e;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ExportedStaticArgumentsFn = exports.ExportedStaticArguments = exports.ExportedStaticCallerFn = exports.ExportedStaticCaller = exports.ExportedStaticPrototypeFn = exports.ExportedStaticPrototype = exports.ExportedStaticLengthFn = exports.ExportedStaticLength = exports.ExportedStaticNameFn = exports.ExportedStaticName = void 0;
+var FunctionPropertyNames = {
+    name: 'name',
+    length: 'length',
+    prototype: 'prototype',
+    caller: 'caller',
+    arguments: 'arguments',
+};
 // name
 var StaticName = /** @class */ (function () {
     function StaticName() {
     }
     return StaticName;
 }());
+var StaticName2 = /** @class */ (function () {
+    function StaticName2() {
+    }
+    return StaticName2;
+}());
+FunctionPropertyNames.name, FunctionPropertyNames.name;
 var StaticNameFn = /** @class */ (function () {
     function StaticNameFn() {
     }
@@ -208,12 +381,25 @@ var StaticNameFn = /** @class */ (function () {
     StaticNameFn.prototype.name = function () { }; // ok
     return StaticNameFn;
 }());
+var StaticNameFn2 = /** @class */ (function () {
+    function StaticNameFn2() {
+    }
+    StaticNameFn2[FunctionPropertyNames.name] = function () { }; // error without useDefineForClassFields
+    StaticNameFn2.prototype[FunctionPropertyNames.name] = function () { }; // ok
+    return StaticNameFn2;
+}());
 // length
 var StaticLength = /** @class */ (function () {
     function StaticLength() {
     }
     return StaticLength;
 }());
+var StaticLength2 = /** @class */ (function () {
+    function StaticLength2() {
+    }
+    return StaticLength2;
+}());
+FunctionPropertyNames.length, FunctionPropertyNames.length;
 var StaticLengthFn = /** @class */ (function () {
     function StaticLengthFn() {
     }
@@ -221,12 +407,25 @@ var StaticLengthFn = /** @class */ (function () {
     StaticLengthFn.prototype.length = function () { }; // ok
     return StaticLengthFn;
 }());
+var StaticLengthFn2 = /** @class */ (function () {
+    function StaticLengthFn2() {
+    }
+    StaticLengthFn2[FunctionPropertyNames.length] = function () { }; // error without useDefineForClassFields
+    StaticLengthFn2.prototype[FunctionPropertyNames.length] = function () { }; // ok
+    return StaticLengthFn2;
+}());
 // prototype
 var StaticPrototype = /** @class */ (function () {
     function StaticPrototype() {
     }
     return StaticPrototype;
 }());
+var StaticPrototype2 = /** @class */ (function () {
+    function StaticPrototype2() {
+    }
+    return StaticPrototype2;
+}());
+FunctionPropertyNames.prototype, FunctionPropertyNames.prototype;
 var StaticPrototypeFn = /** @class */ (function () {
     function StaticPrototypeFn() {
     }
@@ -234,12 +433,25 @@ var StaticPrototypeFn = /** @class */ (function () {
     StaticPrototypeFn.prototype.prototype = function () { }; // ok
     return StaticPrototypeFn;
 }());
+var StaticPrototypeFn2 = /** @class */ (function () {
+    function StaticPrototypeFn2() {
+    }
+    StaticPrototypeFn2[FunctionPropertyNames.prototype] = function () { }; // always an error
+    StaticPrototypeFn2.prototype[FunctionPropertyNames.prototype] = function () { }; // ok
+    return StaticPrototypeFn2;
+}());
 // caller
 var StaticCaller = /** @class */ (function () {
     function StaticCaller() {
     }
     return StaticCaller;
 }());
+var StaticCaller2 = /** @class */ (function () {
+    function StaticCaller2() {
+    }
+    return StaticCaller2;
+}());
+FunctionPropertyNames.caller, FunctionPropertyNames.caller;
 var StaticCallerFn = /** @class */ (function () {
     function StaticCallerFn() {
     }
@@ -247,18 +459,38 @@ var StaticCallerFn = /** @class */ (function () {
     StaticCallerFn.prototype.caller = function () { }; // ok
     return StaticCallerFn;
 }());
+var StaticCallerFn2 = /** @class */ (function () {
+    function StaticCallerFn2() {
+    }
+    StaticCallerFn2[FunctionPropertyNames.caller] = function () { }; // error without useDefineForClassFields
+    StaticCallerFn2.prototype[FunctionPropertyNames.caller] = function () { }; // ok
+    return StaticCallerFn2;
+}());
 // arguments
 var StaticArguments = /** @class */ (function () {
     function StaticArguments() {
     }
     return StaticArguments;
 }());
+var StaticArguments2 = /** @class */ (function () {
+    function StaticArguments2() {
+    }
+    return StaticArguments2;
+}());
+FunctionPropertyNames.arguments, FunctionPropertyNames.arguments;
 var StaticArgumentsFn = /** @class */ (function () {
     function StaticArgumentsFn() {
     }
     StaticArgumentsFn.arguments = function () { }; // error without useDefineForClassFields
     StaticArgumentsFn.prototype.arguments = function () { }; // ok
     return StaticArgumentsFn;
+}());
+var StaticArgumentsFn2 = /** @class */ (function () {
+    function StaticArgumentsFn2() {
+    }
+    StaticArgumentsFn2[FunctionPropertyNames.arguments] = function () { }; // error without useDefineForClassFields
+    StaticArgumentsFn2.prototype[FunctionPropertyNames.arguments] = function () { }; // ok
+    return StaticArgumentsFn2;
 }());
 // === Static properties on anonymous classes ===
 // name
@@ -267,6 +499,14 @@ var StaticName_Anonymous = /** @class */ (function () {
     }
     return class_1;
 }());
+var StaticName_Anonymous2 = (_a = /** @class */ (function () {
+        function class_2() {
+        }
+        return class_2;
+    }()),
+    FunctionPropertyNames.name,
+    FunctionPropertyNames.name,
+    _a);
 var StaticNameFn_Anonymous = /** @class */ (function () {
     function StaticNameFn_Anonymous() {
     }
@@ -274,12 +514,27 @@ var StaticNameFn_Anonymous = /** @class */ (function () {
     StaticNameFn_Anonymous.prototype.name = function () { }; // ok
     return StaticNameFn_Anonymous;
 }());
+var StaticNameFn_Anonymous2 = /** @class */ (function () {
+    function StaticNameFn_Anonymous2() {
+    }
+    StaticNameFn_Anonymous2[FunctionPropertyNames.name] = function () { }; // error without useDefineForClassFields
+    StaticNameFn_Anonymous2.prototype[FunctionPropertyNames.name] = function () { }; // ok
+    return StaticNameFn_Anonymous2;
+}());
 // length
 var StaticLength_Anonymous = /** @class */ (function () {
-    function class_2() {
+    function class_3() {
     }
-    return class_2;
+    return class_3;
 }());
+var StaticLength_Anonymous2 = (_b = /** @class */ (function () {
+        function class_4() {
+        }
+        return class_4;
+    }()),
+    FunctionPropertyNames.length,
+    FunctionPropertyNames.length,
+    _b);
 var StaticLengthFn_Anonymous = /** @class */ (function () {
     function StaticLengthFn_Anonymous() {
     }
@@ -287,12 +542,27 @@ var StaticLengthFn_Anonymous = /** @class */ (function () {
     StaticLengthFn_Anonymous.prototype.length = function () { }; // ok
     return StaticLengthFn_Anonymous;
 }());
+var StaticLengthFn_Anonymous2 = /** @class */ (function () {
+    function StaticLengthFn_Anonymous2() {
+    }
+    StaticLengthFn_Anonymous2[FunctionPropertyNames.length] = function () { }; // error without useDefineForClassFields
+    StaticLengthFn_Anonymous2.prototype[FunctionPropertyNames.length] = function () { }; // ok
+    return StaticLengthFn_Anonymous2;
+}());
 // prototype
 var StaticPrototype_Anonymous = /** @class */ (function () {
-    function class_3() {
+    function class_5() {
     }
-    return class_3;
+    return class_5;
 }());
+var StaticPrototype_Anonymous2 = (_c = /** @class */ (function () {
+        function class_6() {
+        }
+        return class_6;
+    }()),
+    FunctionPropertyNames.prototype,
+    FunctionPropertyNames.prototype,
+    _c);
 var StaticPrototypeFn_Anonymous = /** @class */ (function () {
     function StaticPrototypeFn_Anonymous() {
     }
@@ -300,12 +570,27 @@ var StaticPrototypeFn_Anonymous = /** @class */ (function () {
     StaticPrototypeFn_Anonymous.prototype.prototype = function () { }; // ok
     return StaticPrototypeFn_Anonymous;
 }());
+var StaticPrototypeFn_Anonymous2 = /** @class */ (function () {
+    function StaticPrototypeFn_Anonymous2() {
+    }
+    StaticPrototypeFn_Anonymous2[FunctionPropertyNames.prototype] = function () { }; // always an error
+    StaticPrototypeFn_Anonymous2.prototype[FunctionPropertyNames.prototype] = function () { }; // ok
+    return StaticPrototypeFn_Anonymous2;
+}());
 // caller
 var StaticCaller_Anonymous = /** @class */ (function () {
-    function class_4() {
+    function class_7() {
     }
-    return class_4;
+    return class_7;
 }());
+var StaticCaller_Anonymous2 = (_d = /** @class */ (function () {
+        function class_8() {
+        }
+        return class_8;
+    }()),
+    FunctionPropertyNames.caller,
+    FunctionPropertyNames.caller,
+    _d);
 var StaticCallerFn_Anonymous = /** @class */ (function () {
     function StaticCallerFn_Anonymous() {
     }
@@ -313,18 +598,40 @@ var StaticCallerFn_Anonymous = /** @class */ (function () {
     StaticCallerFn_Anonymous.prototype.caller = function () { }; // ok
     return StaticCallerFn_Anonymous;
 }());
+var StaticCallerFn_Anonymous2 = /** @class */ (function () {
+    function StaticCallerFn_Anonymous2() {
+    }
+    StaticCallerFn_Anonymous2[FunctionPropertyNames.caller] = function () { }; // error without useDefineForClassFields
+    StaticCallerFn_Anonymous2.prototype[FunctionPropertyNames.caller] = function () { }; // ok
+    return StaticCallerFn_Anonymous2;
+}());
 // arguments
 var StaticArguments_Anonymous = /** @class */ (function () {
-    function class_5() {
+    function class_9() {
     }
-    return class_5;
+    return class_9;
 }());
+var StaticArguments_Anonymous2 = (_e = /** @class */ (function () {
+        function class_10() {
+        }
+        return class_10;
+    }()),
+    FunctionPropertyNames.arguments,
+    FunctionPropertyNames.arguments,
+    _e);
 var StaticArgumentsFn_Anonymous = /** @class */ (function () {
     function StaticArgumentsFn_Anonymous() {
     }
     StaticArgumentsFn_Anonymous.arguments = function () { }; // error without useDefineForClassFields
     StaticArgumentsFn_Anonymous.prototype.arguments = function () { }; // ok
     return StaticArgumentsFn_Anonymous;
+}());
+var StaticArgumentsFn_Anonymous2 = /** @class */ (function () {
+    function StaticArgumentsFn_Anonymous2() {
+    }
+    StaticArgumentsFn_Anonymous2[FunctionPropertyNames.arguments] = function () { }; // error without useDefineForClassFields
+    StaticArgumentsFn_Anonymous2.prototype[FunctionPropertyNames.arguments] = function () { }; // ok
+    return StaticArgumentsFn_Anonymous2;
 }());
 // === Static properties on default exported classes ===
 // name
@@ -336,6 +643,13 @@ var TestOnDefaultExportedClass_1;
         return StaticName;
     }());
 })(TestOnDefaultExportedClass_1 || (TestOnDefaultExportedClass_1 = {}));
+var ExportedStaticName = /** @class */ (function () {
+    function ExportedStaticName() {
+    }
+    return ExportedStaticName;
+}());
+exports.ExportedStaticName = ExportedStaticName;
+FunctionPropertyNames.name, FunctionPropertyNames.name;
 var TestOnDefaultExportedClass_2;
 (function (TestOnDefaultExportedClass_2) {
     var StaticNameFn = /** @class */ (function () {
@@ -346,6 +660,14 @@ var TestOnDefaultExportedClass_2;
         return StaticNameFn;
     }());
 })(TestOnDefaultExportedClass_2 || (TestOnDefaultExportedClass_2 = {}));
+var ExportedStaticNameFn = /** @class */ (function () {
+    function ExportedStaticNameFn() {
+    }
+    ExportedStaticNameFn[FunctionPropertyNames.name] = function () { }; // error without useDefineForClassFields
+    ExportedStaticNameFn.prototype[FunctionPropertyNames.name] = function () { }; // ok
+    return ExportedStaticNameFn;
+}());
+exports.ExportedStaticNameFn = ExportedStaticNameFn;
 // length
 var TestOnDefaultExportedClass_3;
 (function (TestOnDefaultExportedClass_3) {
@@ -356,6 +678,13 @@ var TestOnDefaultExportedClass_3;
     }());
     TestOnDefaultExportedClass_3.StaticLength = StaticLength;
 })(TestOnDefaultExportedClass_3 || (TestOnDefaultExportedClass_3 = {}));
+var ExportedStaticLength = /** @class */ (function () {
+    function ExportedStaticLength() {
+    }
+    return ExportedStaticLength;
+}());
+exports.ExportedStaticLength = ExportedStaticLength;
+FunctionPropertyNames.length, FunctionPropertyNames.length;
 var TestOnDefaultExportedClass_4;
 (function (TestOnDefaultExportedClass_4) {
     var StaticLengthFn = /** @class */ (function () {
@@ -367,6 +696,14 @@ var TestOnDefaultExportedClass_4;
     }());
     TestOnDefaultExportedClass_4.StaticLengthFn = StaticLengthFn;
 })(TestOnDefaultExportedClass_4 || (TestOnDefaultExportedClass_4 = {}));
+var ExportedStaticLengthFn = /** @class */ (function () {
+    function ExportedStaticLengthFn() {
+    }
+    ExportedStaticLengthFn[FunctionPropertyNames.length] = function () { }; // error without useDefineForClassFields
+    ExportedStaticLengthFn.prototype[FunctionPropertyNames.length] = function () { }; // ok
+    return ExportedStaticLengthFn;
+}());
+exports.ExportedStaticLengthFn = ExportedStaticLengthFn;
 // prototype
 var TestOnDefaultExportedClass_5;
 (function (TestOnDefaultExportedClass_5) {
@@ -377,6 +714,13 @@ var TestOnDefaultExportedClass_5;
     }());
     TestOnDefaultExportedClass_5.StaticPrototype = StaticPrototype;
 })(TestOnDefaultExportedClass_5 || (TestOnDefaultExportedClass_5 = {}));
+var ExportedStaticPrototype = /** @class */ (function () {
+    function ExportedStaticPrototype() {
+    }
+    return ExportedStaticPrototype;
+}());
+exports.ExportedStaticPrototype = ExportedStaticPrototype;
+FunctionPropertyNames.prototype, FunctionPropertyNames.prototype;
 var TestOnDefaultExportedClass_6;
 (function (TestOnDefaultExportedClass_6) {
     var StaticPrototypeFn = /** @class */ (function () {
@@ -388,6 +732,14 @@ var TestOnDefaultExportedClass_6;
     }());
     TestOnDefaultExportedClass_6.StaticPrototypeFn = StaticPrototypeFn;
 })(TestOnDefaultExportedClass_6 || (TestOnDefaultExportedClass_6 = {}));
+var ExportedStaticPrototypeFn = /** @class */ (function () {
+    function ExportedStaticPrototypeFn() {
+    }
+    ExportedStaticPrototypeFn[FunctionPropertyNames.prototype] = function () { }; // always an error
+    ExportedStaticPrototypeFn.prototype[FunctionPropertyNames.prototype] = function () { }; // ok
+    return ExportedStaticPrototypeFn;
+}());
+exports.ExportedStaticPrototypeFn = ExportedStaticPrototypeFn;
 // caller
 var TestOnDefaultExportedClass_7;
 (function (TestOnDefaultExportedClass_7) {
@@ -398,6 +750,13 @@ var TestOnDefaultExportedClass_7;
     }());
     TestOnDefaultExportedClass_7.StaticCaller = StaticCaller;
 })(TestOnDefaultExportedClass_7 || (TestOnDefaultExportedClass_7 = {}));
+var ExportedStaticCaller = /** @class */ (function () {
+    function ExportedStaticCaller() {
+    }
+    return ExportedStaticCaller;
+}());
+exports.ExportedStaticCaller = ExportedStaticCaller;
+FunctionPropertyNames.caller, FunctionPropertyNames.caller;
 var TestOnDefaultExportedClass_8;
 (function (TestOnDefaultExportedClass_8) {
     var StaticCallerFn = /** @class */ (function () {
@@ -409,6 +768,14 @@ var TestOnDefaultExportedClass_8;
     }());
     TestOnDefaultExportedClass_8.StaticCallerFn = StaticCallerFn;
 })(TestOnDefaultExportedClass_8 || (TestOnDefaultExportedClass_8 = {}));
+var ExportedStaticCallerFn = /** @class */ (function () {
+    function ExportedStaticCallerFn() {
+    }
+    ExportedStaticCallerFn[FunctionPropertyNames.caller] = function () { }; // error without useDefineForClassFields
+    ExportedStaticCallerFn.prototype[FunctionPropertyNames.caller] = function () { }; // ok
+    return ExportedStaticCallerFn;
+}());
+exports.ExportedStaticCallerFn = ExportedStaticCallerFn;
 // arguments
 var TestOnDefaultExportedClass_9;
 (function (TestOnDefaultExportedClass_9) {
@@ -419,6 +786,13 @@ var TestOnDefaultExportedClass_9;
     }());
     TestOnDefaultExportedClass_9.StaticArguments = StaticArguments;
 })(TestOnDefaultExportedClass_9 || (TestOnDefaultExportedClass_9 = {}));
+var ExportedStaticArguments = /** @class */ (function () {
+    function ExportedStaticArguments() {
+    }
+    return ExportedStaticArguments;
+}());
+exports.ExportedStaticArguments = ExportedStaticArguments;
+FunctionPropertyNames.arguments, FunctionPropertyNames.arguments;
 var TestOnDefaultExportedClass_10;
 (function (TestOnDefaultExportedClass_10) {
     var StaticArgumentsFn = /** @class */ (function () {
@@ -430,3 +804,11 @@ var TestOnDefaultExportedClass_10;
     }());
     TestOnDefaultExportedClass_10.StaticArgumentsFn = StaticArgumentsFn;
 })(TestOnDefaultExportedClass_10 || (TestOnDefaultExportedClass_10 = {}));
+var ExportedStaticArgumentsFn = /** @class */ (function () {
+    function ExportedStaticArgumentsFn() {
+    }
+    ExportedStaticArgumentsFn[FunctionPropertyNames.arguments] = function () { }; // error without useDefineForClassFields
+    ExportedStaticArgumentsFn.prototype[FunctionPropertyNames.arguments] = function () { }; // ok
+    return ExportedStaticArgumentsFn;
+}());
+exports.ExportedStaticArgumentsFn = ExportedStaticArgumentsFn;

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).symbols
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).symbols
@@ -1,218 +1,558 @@
 //// [tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts] ////
 
 === staticPropertyNameConflicts.ts ===
+const FunctionPropertyNames = {
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+
+    name: 'name',
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    length: 'length',
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    prototype: 'prototype',
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    caller: 'caller',
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    arguments: 'arguments',
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+} as const;
+>const : Symbol(const)
+
 // name
 class StaticName {
->StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 0, 0))
+>StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 6, 11))
 
     static name: number; // error without useDefineForClassFields
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 1, 18))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 9, 18))
 
     name: string; // ok
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 2, 24))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 10, 24))
+}
+
+class StaticName2 {
+>StaticName2 : Symbol(StaticName2, Decl(staticPropertyNameConflicts.ts, 12, 1))
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticName2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 14, 19))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]: number; // ok
+>[FunctionPropertyNames.name] : Symbol(StaticName2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 15, 48))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 class StaticNameFn {
->StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 4, 1))
+>StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 17, 1))
 
     static name() {} // error without useDefineForClassFields
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 6, 20))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 19, 20))
 
     name() {} // ok
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 7, 20))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 20, 20))
+}
+
+class StaticNameFn2 {
+>StaticNameFn2 : Symbol(StaticNameFn2, Decl(staticPropertyNameConflicts.ts, 22, 1))
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 24, 21))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 25, 44))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 // length
 class StaticLength {
->StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 9, 1))
+>StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 27, 1))
 
     static length: number; // error without useDefineForClassFields
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 12, 20))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 30, 20))
 
     length: string; // ok
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 13, 26))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 31, 26))
+}
+
+class StaticLength2 {
+>StaticLength2 : Symbol(StaticLength2, Decl(staticPropertyNameConflicts.ts, 33, 1))
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLength2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 35, 21))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]: number; // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLength2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 36, 50))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 class StaticLengthFn {
->StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 15, 1))
+>StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 38, 1))
 
     static length() {} // error without useDefineForClassFields
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 17, 22))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 40, 22))
 
     length() {} // ok
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 18, 22))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 41, 22))
+}
+
+class StaticLengthFn2 {
+>StaticLengthFn2 : Symbol(StaticLengthFn2, Decl(staticPropertyNameConflicts.ts, 43, 1))
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 45, 23))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 46, 46))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 // prototype
 class StaticPrototype {
->StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 20, 1))
+>StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 48, 1))
 
     static prototype: number; // always an error
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 23, 23))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 51, 23))
 
     prototype: string; // ok
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 24, 29))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 52, 29))
+}
+
+class StaticPrototype2 {
+>StaticPrototype2 : Symbol(StaticPrototype2, Decl(staticPropertyNameConflicts.ts, 54, 1))
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 56, 24))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 57, 53))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 class StaticPrototypeFn {
->StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 26, 1))
+>StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 59, 1))
 
     static prototype() {} // always an error
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 28, 25))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 61, 25))
 
     prototype() {} // ok
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 29, 25))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 62, 25))
+}
+
+class StaticPrototypeFn2 {
+>StaticPrototypeFn2 : Symbol(StaticPrototypeFn2, Decl(staticPropertyNameConflicts.ts, 64, 1))
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 66, 26))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 67, 49))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 // caller
 class StaticCaller {
->StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 31, 1))
+>StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 69, 1))
 
     static caller: number; // error without useDefineForClassFields
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 34, 20))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 72, 20))
 
     caller: string; // ok
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 35, 26))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 73, 26))
+}
+
+class StaticCaller2 {
+>StaticCaller2 : Symbol(StaticCaller2, Decl(staticPropertyNameConflicts.ts, 75, 1))
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 77, 21))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 78, 50))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 class StaticCallerFn {
->StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 37, 1))
+>StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 80, 1))
 
     static caller() {} // error without useDefineForClassFields
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 39, 22))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 82, 22))
 
     caller() {} // ok
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 40, 22))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 83, 22))
+}
+
+class StaticCallerFn2 {
+>StaticCallerFn2 : Symbol(StaticCallerFn2, Decl(staticPropertyNameConflicts.ts, 85, 1))
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 87, 23))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 88, 46))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 // arguments
 class StaticArguments {
->StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 42, 1))
+>StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 90, 1))
 
     static arguments: number; // error without useDefineForClassFields
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 45, 23))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 93, 23))
 
     arguments: string; // ok
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 46, 29))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 94, 29))
+}
+
+class StaticArguments2 {
+>StaticArguments2 : Symbol(StaticArguments2, Decl(staticPropertyNameConflicts.ts, 96, 1))
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 98, 24))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 99, 53))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 class StaticArgumentsFn {
->StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 48, 1))
+>StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 101, 1))
 
     static arguments() {} // error without useDefineForClassFields
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 50, 25))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 103, 25))
 
     arguments() {} // ok
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 51, 25))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 104, 25))
 }
 
+class StaticArgumentsFn2 {
+>StaticArgumentsFn2 : Symbol(StaticArgumentsFn2, Decl(staticPropertyNameConflicts.ts, 106, 1))
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 108, 26))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 109, 49))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+}
 
 
 // === Static properties on anonymous classes ===
 
 // name
 var StaticName_Anonymous = class {
->StaticName_Anonymous : Symbol(StaticName_Anonymous, Decl(staticPropertyNameConflicts.ts, 60, 3))
+>StaticName_Anonymous : Symbol(StaticName_Anonymous, Decl(staticPropertyNameConflicts.ts, 117, 3))
 
     static name: number; // error without useDefineForClassFields
->name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 60, 34))
+>name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 117, 34))
 
     name: string; // ok
->name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 61, 24))
+>name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 118, 24))
+}
+
+var StaticName_Anonymous2 = class {
+>StaticName_Anonymous2 : Symbol(StaticName_Anonymous2, Decl(staticPropertyNameConflicts.ts, 122, 3))
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticName_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 122, 35))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : Symbol(StaticName_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 123, 48))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 var StaticNameFn_Anonymous = class {
->StaticNameFn_Anonymous : Symbol(StaticNameFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 65, 3))
+>StaticNameFn_Anonymous : Symbol(StaticNameFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 127, 3))
 
     static name() {} // error without useDefineForClassFields
->name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 65, 36))
+>name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 127, 36))
 
     name() {} // ok
->name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 66, 20))
+>name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 128, 20))
+}
+
+var StaticNameFn_Anonymous2 = class {
+>StaticNameFn_Anonymous2 : Symbol(StaticNameFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 132, 3))
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 132, 37))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 133, 44))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 // length
 var StaticLength_Anonymous = class {
->StaticLength_Anonymous : Symbol(StaticLength_Anonymous, Decl(staticPropertyNameConflicts.ts, 71, 3))
+>StaticLength_Anonymous : Symbol(StaticLength_Anonymous, Decl(staticPropertyNameConflicts.ts, 138, 3))
 
     static length: number; // error without useDefineForClassFields
->length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 71, 36))
+>length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 138, 36))
 
     length: string; // ok
->length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 72, 26))
+>length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 139, 26))
+}
+
+var StaticLength_Anonymous2 = class {
+>StaticLength_Anonymous2 : Symbol(StaticLength_Anonymous2, Decl(staticPropertyNameConflicts.ts, 143, 3))
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLength_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 143, 37))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLength_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 144, 50))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 var StaticLengthFn_Anonymous = class {
->StaticLengthFn_Anonymous : Symbol(StaticLengthFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 76, 3))
+>StaticLengthFn_Anonymous : Symbol(StaticLengthFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 148, 3))
 
     static length() {} // error without useDefineForClassFields
->length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 76, 38))
+>length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 148, 38))
 
     length() {} // ok
->length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 77, 22))
+>length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 149, 22))
+}
+
+var StaticLengthFn_Anonymous2 = class {
+>StaticLengthFn_Anonymous2 : Symbol(StaticLengthFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 153, 3))
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 153, 39))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 154, 46))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 // prototype
 var StaticPrototype_Anonymous = class {
->StaticPrototype_Anonymous : Symbol(StaticPrototype_Anonymous, Decl(staticPropertyNameConflicts.ts, 82, 3))
+>StaticPrototype_Anonymous : Symbol(StaticPrototype_Anonymous, Decl(staticPropertyNameConflicts.ts, 159, 3))
 
     static prototype: number; // always an error
->prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 82, 39))
+>prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 159, 39))
 
     prototype: string; // ok
->prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 83, 29))
+>prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 160, 29))
+}
+
+var StaticPrototype_Anonymous2 = class {
+>StaticPrototype_Anonymous2 : Symbol(StaticPrototype_Anonymous2, Decl(staticPropertyNameConflicts.ts, 164, 3))
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 164, 40))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 165, 53))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 var StaticPrototypeFn_Anonymous = class {
->StaticPrototypeFn_Anonymous : Symbol(StaticPrototypeFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 87, 3))
+>StaticPrototypeFn_Anonymous : Symbol(StaticPrototypeFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 169, 3))
 
     static prototype() {} // always an error
->prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 87, 41))
+>prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 169, 41))
 
     prototype() {} // ok
->prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 88, 25))
+>prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 170, 25))
+}
+
+var StaticPrototypeFn_Anonymous2 = class {
+>StaticPrototypeFn_Anonymous2 : Symbol(StaticPrototypeFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 174, 3))
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 174, 42))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 175, 49))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 // caller
 var StaticCaller_Anonymous = class {
->StaticCaller_Anonymous : Symbol(StaticCaller_Anonymous, Decl(staticPropertyNameConflicts.ts, 93, 3))
+>StaticCaller_Anonymous : Symbol(StaticCaller_Anonymous, Decl(staticPropertyNameConflicts.ts, 180, 3))
 
     static caller: number; // error without useDefineForClassFields
->caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 93, 36))
+>caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 180, 36))
 
     caller: string; // ok
->caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 94, 26))
+>caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 181, 26))
+}
+
+var StaticCaller_Anonymous2 = class {
+>StaticCaller_Anonymous2 : Symbol(StaticCaller_Anonymous2, Decl(staticPropertyNameConflicts.ts, 185, 3))
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 185, 37))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 186, 50))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 var StaticCallerFn_Anonymous = class {
->StaticCallerFn_Anonymous : Symbol(StaticCallerFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 98, 3))
+>StaticCallerFn_Anonymous : Symbol(StaticCallerFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 190, 3))
 
     static caller() {} // error without useDefineForClassFields
->caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 98, 38))
+>caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 190, 38))
 
     caller() {} // ok
->caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 99, 22))
+>caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 191, 22))
+}
+
+var StaticCallerFn_Anonymous2 = class {
+>StaticCallerFn_Anonymous2 : Symbol(StaticCallerFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 195, 3))
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 195, 39))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 196, 46))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 // arguments
 var StaticArguments_Anonymous = class {
->StaticArguments_Anonymous : Symbol(StaticArguments_Anonymous, Decl(staticPropertyNameConflicts.ts, 104, 3))
+>StaticArguments_Anonymous : Symbol(StaticArguments_Anonymous, Decl(staticPropertyNameConflicts.ts, 201, 3))
 
     static arguments: number; // error without useDefineForClassFields
->arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 104, 39))
+>arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 201, 39))
 
     arguments: string; // ok
->arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 105, 29))
+>arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 202, 29))
+}
+
+var StaticArguments_Anonymous2 = class {
+>StaticArguments_Anonymous2 : Symbol(StaticArguments_Anonymous2, Decl(staticPropertyNameConflicts.ts, 206, 3))
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 206, 40))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 207, 53))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 var StaticArgumentsFn_Anonymous = class {
->StaticArgumentsFn_Anonymous : Symbol(StaticArgumentsFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 109, 3))
+>StaticArgumentsFn_Anonymous : Symbol(StaticArgumentsFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 211, 3))
 
     static arguments() {} // error without useDefineForClassFields
->arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 109, 41))
+>arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 211, 41))
 
     arguments() {} // ok
->arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 110, 25))
+>arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 212, 25))
+}
+
+var StaticArgumentsFn_Anonymous2 = class {
+>StaticArgumentsFn_Anonymous2 : Symbol(StaticArgumentsFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 216, 3))
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 216, 42))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 217, 49))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 
@@ -220,146 +560,305 @@ var StaticArgumentsFn_Anonymous = class {
 
 // name
 module TestOnDefaultExportedClass_1 {
->TestOnDefaultExportedClass_1 : Symbol(TestOnDefaultExportedClass_1, Decl(staticPropertyNameConflicts.ts, 112, 1))
+>TestOnDefaultExportedClass_1 : Symbol(TestOnDefaultExportedClass_1, Decl(staticPropertyNameConflicts.ts, 219, 1))
 
     class StaticName {
->StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 118, 37))
+>StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 225, 37))
 
         static name: number; // error without useDefineForClassFields
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 119, 22))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 226, 22))
 
         name: string; // ok
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 120, 28))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 227, 28))
     }
 }
 
+export class ExportedStaticName {
+>ExportedStaticName : Symbol(ExportedStaticName, Decl(staticPropertyNameConflicts.ts, 230, 1))
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticName[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 232, 33))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticName[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 233, 48))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+}
+
 module TestOnDefaultExportedClass_2 {
->TestOnDefaultExportedClass_2 : Symbol(TestOnDefaultExportedClass_2, Decl(staticPropertyNameConflicts.ts, 123, 1))
+>TestOnDefaultExportedClass_2 : Symbol(TestOnDefaultExportedClass_2, Decl(staticPropertyNameConflicts.ts, 235, 1))
 
     class StaticNameFn {
->StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 125, 37))
+>StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 237, 37))
 
         static name() {} // error without useDefineForClassFields
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 126, 24))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 238, 24))
 
         name() {} // ok
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 127, 24))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 239, 24))
     }
+}
+
+export class ExportedStaticNameFn {
+>ExportedStaticNameFn : Symbol(ExportedStaticNameFn, Decl(staticPropertyNameConflicts.ts, 242, 1))
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticNameFn[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 244, 35))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticNameFn[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 245, 44))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 // length
 module TestOnDefaultExportedClass_3 {
->TestOnDefaultExportedClass_3 : Symbol(TestOnDefaultExportedClass_3, Decl(staticPropertyNameConflicts.ts, 130, 1))
+>TestOnDefaultExportedClass_3 : Symbol(TestOnDefaultExportedClass_3, Decl(staticPropertyNameConflicts.ts, 247, 1))
 
     export default class StaticLength {
->StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 133, 37))
+>StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 250, 37))
 
         static length: number; // error without useDefineForClassFields
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 134, 39))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 251, 39))
 
         length: string; // ok
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 135, 30))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 252, 30))
     }
 }
 
+export class ExportedStaticLength {
+>ExportedStaticLength : Symbol(ExportedStaticLength, Decl(staticPropertyNameConflicts.ts, 255, 1))
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLength[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 257, 35))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLength[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 258, 50))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+}
+
 module TestOnDefaultExportedClass_4 {
->TestOnDefaultExportedClass_4 : Symbol(TestOnDefaultExportedClass_4, Decl(staticPropertyNameConflicts.ts, 138, 1))
+>TestOnDefaultExportedClass_4 : Symbol(TestOnDefaultExportedClass_4, Decl(staticPropertyNameConflicts.ts, 260, 1))
 
     export default class StaticLengthFn {
->StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 140, 37))
+>StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 262, 37))
 
         static length() {} // error without useDefineForClassFields
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 141, 41))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 263, 41))
 
         length() {} // ok
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 142, 26))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 264, 26))
     }
+}
+
+export class ExportedStaticLengthFn {
+>ExportedStaticLengthFn : Symbol(ExportedStaticLengthFn, Decl(staticPropertyNameConflicts.ts, 267, 1))
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLengthFn[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 269, 37))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLengthFn[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 270, 46))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 // prototype
 module TestOnDefaultExportedClass_5 {
->TestOnDefaultExportedClass_5 : Symbol(TestOnDefaultExportedClass_5, Decl(staticPropertyNameConflicts.ts, 145, 1))
+>TestOnDefaultExportedClass_5 : Symbol(TestOnDefaultExportedClass_5, Decl(staticPropertyNameConflicts.ts, 272, 1))
 
     export default class StaticPrototype {
->StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 148, 37))
+>StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 275, 37))
 
         static prototype: number; // always an error
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 149, 42))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 276, 42))
 
         prototype: string; // ok
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 150, 33))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 277, 33))
     }
 }
 
+export class ExportedStaticPrototype {
+>ExportedStaticPrototype : Symbol(ExportedStaticPrototype, Decl(staticPropertyNameConflicts.ts, 280, 1))
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototype[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 282, 38))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototype[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 283, 53))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+}
+
 module TestOnDefaultExportedClass_6 {
->TestOnDefaultExportedClass_6 : Symbol(TestOnDefaultExportedClass_6, Decl(staticPropertyNameConflicts.ts, 153, 1))
+>TestOnDefaultExportedClass_6 : Symbol(TestOnDefaultExportedClass_6, Decl(staticPropertyNameConflicts.ts, 285, 1))
 
     export default class StaticPrototypeFn {
->StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 155, 37))
+>StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 287, 37))
 
         static prototype() {} // always an error
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 156, 44))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 288, 44))
 
         prototype() {} // ok
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 157, 29))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 289, 29))
     }
+}
+
+export class ExportedStaticPrototypeFn {
+>ExportedStaticPrototypeFn : Symbol(ExportedStaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 292, 1))
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototypeFn[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 294, 40))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototypeFn[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 295, 49))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 // caller
 module TestOnDefaultExportedClass_7 {
->TestOnDefaultExportedClass_7 : Symbol(TestOnDefaultExportedClass_7, Decl(staticPropertyNameConflicts.ts, 160, 1))
+>TestOnDefaultExportedClass_7 : Symbol(TestOnDefaultExportedClass_7, Decl(staticPropertyNameConflicts.ts, 297, 1))
 
     export default class StaticCaller {
->StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 163, 37))
+>StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 300, 37))
 
         static caller: number; // error without useDefineForClassFields
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 164, 39))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 301, 39))
 
         caller: string; // ok
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 165, 30))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 302, 30))
     }
 }
 
+export class ExportedStaticCaller {
+>ExportedStaticCaller : Symbol(ExportedStaticCaller, Decl(staticPropertyNameConflicts.ts, 305, 1))
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCaller[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 307, 35))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCaller[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 308, 50))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+}
+
 module TestOnDefaultExportedClass_8 {
->TestOnDefaultExportedClass_8 : Symbol(TestOnDefaultExportedClass_8, Decl(staticPropertyNameConflicts.ts, 168, 1))
+>TestOnDefaultExportedClass_8 : Symbol(TestOnDefaultExportedClass_8, Decl(staticPropertyNameConflicts.ts, 310, 1))
 
     export default class StaticCallerFn {
->StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 170, 37))
+>StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 312, 37))
 
         static caller() {} // error without useDefineForClassFields
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 171, 41))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 313, 41))
 
         caller() {} // ok
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 172, 26))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 314, 26))
     }
+}
+
+export class ExportedStaticCallerFn {
+>ExportedStaticCallerFn : Symbol(ExportedStaticCallerFn, Decl(staticPropertyNameConflicts.ts, 317, 1))
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCallerFn[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 319, 37))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCallerFn[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 320, 46))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 // arguments
 module TestOnDefaultExportedClass_9 {
->TestOnDefaultExportedClass_9 : Symbol(TestOnDefaultExportedClass_9, Decl(staticPropertyNameConflicts.ts, 175, 1))
+>TestOnDefaultExportedClass_9 : Symbol(TestOnDefaultExportedClass_9, Decl(staticPropertyNameConflicts.ts, 322, 1))
 
     export default class StaticArguments {
->StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 178, 37))
+>StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 325, 37))
 
         static arguments: number; // error without useDefineForClassFields
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 179, 42))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 326, 42))
 
         arguments: string; // ok
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 180, 33))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 327, 33))
     }
+}
+
+export class ExportedStaticArguments {
+>ExportedStaticArguments : Symbol(ExportedStaticArguments, Decl(staticPropertyNameConflicts.ts, 330, 1))
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArguments[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 332, 38))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArguments[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 333, 53))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 module TestOnDefaultExportedClass_10 {
->TestOnDefaultExportedClass_10 : Symbol(TestOnDefaultExportedClass_10, Decl(staticPropertyNameConflicts.ts, 183, 1))
+>TestOnDefaultExportedClass_10 : Symbol(TestOnDefaultExportedClass_10, Decl(staticPropertyNameConflicts.ts, 335, 1))
 
     export default class StaticArgumentsFn {
->StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 185, 38))
+>StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 337, 38))
 
         static arguments() {} // error without useDefineForClassFields
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 186, 44))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 338, 44))
 
         arguments() {} // ok
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 187, 29))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 339, 29))
     }
 }
 
+export class ExportedStaticArgumentsFn {
+>ExportedStaticArgumentsFn : Symbol(ExportedStaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 342, 1))
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArgumentsFn[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 344, 40))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArgumentsFn[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 345, 49))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+}

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).types
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=false).types
@@ -1,6 +1,33 @@
 //// [tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts] ////
 
 === staticPropertyNameConflicts.ts ===
+const FunctionPropertyNames = {
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>{    name: 'name',    length: 'length',    prototype: 'prototype',    caller: 'caller',    arguments: 'arguments',} as const : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>{    name: 'name',    length: 'length',    prototype: 'prototype',    caller: 'caller',    arguments: 'arguments',} : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+
+    name: 'name',
+>name : "name"
+>'name' : "name"
+
+    length: 'length',
+>length : "length"
+>'length' : "length"
+
+    prototype: 'prototype',
+>prototype : "prototype"
+>'prototype' : "prototype"
+
+    caller: 'caller',
+>caller : "caller"
+>'caller' : "caller"
+
+    arguments: 'arguments',
+>arguments : "arguments"
+>'arguments' : "arguments"
+
+} as const;
+
 // name
 class StaticName {
 >StaticName : StaticName
@@ -12,6 +39,22 @@ class StaticName {
 >name : string
 }
 
+class StaticName2 {
+>StaticName2 : StaticName2
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]: number; // ok
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+}
+
 class StaticNameFn {
 >StaticNameFn : StaticNameFn
 
@@ -20,6 +63,22 @@ class StaticNameFn {
 
     name() {} // ok
 >name : () => void
+}
+
+class StaticNameFn2 {
+>StaticNameFn2 : StaticNameFn2
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
 }
 
 // length
@@ -33,6 +92,22 @@ class StaticLength {
 >length : string
 }
 
+class StaticLength2 {
+>StaticLength2 : StaticLength2
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]: number; // ok
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+}
+
 class StaticLengthFn {
 >StaticLengthFn : StaticLengthFn
 
@@ -41,6 +116,22 @@ class StaticLengthFn {
 
     length() {} // ok
 >length : () => void
+}
+
+class StaticLengthFn2 {
+>StaticLengthFn2 : StaticLengthFn2
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
 }
 
 // prototype
@@ -54,6 +145,22 @@ class StaticPrototype {
 >prototype : string
 }
 
+class StaticPrototype2 {
+>StaticPrototype2 : StaticPrototype2
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : StaticPrototype2
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : string
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+}
+
 class StaticPrototypeFn {
 >StaticPrototypeFn : StaticPrototypeFn
 
@@ -62,6 +169,22 @@ class StaticPrototypeFn {
 
     prototype() {} // ok
 >prototype : () => void
+}
+
+class StaticPrototypeFn2 {
+>StaticPrototypeFn2 : StaticPrototypeFn2
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
 }
 
 // caller
@@ -75,6 +198,22 @@ class StaticCaller {
 >caller : string
 }
 
+class StaticCaller2 {
+>StaticCaller2 : StaticCaller2
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : number
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : string
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+}
+
 class StaticCallerFn {
 >StaticCallerFn : StaticCallerFn
 
@@ -83,6 +222,22 @@ class StaticCallerFn {
 
     caller() {} // ok
 >caller : () => void
+}
+
+class StaticCallerFn2 {
+>StaticCallerFn2 : StaticCallerFn2
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
 }
 
 // arguments
@@ -96,6 +251,22 @@ class StaticArguments {
 >arguments : string
 }
 
+class StaticArguments2 {
+>StaticArguments2 : StaticArguments2
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : number
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : string
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
+
 class StaticArgumentsFn {
 >StaticArgumentsFn : StaticArgumentsFn
 
@@ -106,6 +277,21 @@ class StaticArgumentsFn {
 >arguments : () => void
 }
 
+class StaticArgumentsFn2 {
+>StaticArgumentsFn2 : StaticArgumentsFn2
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
 
 
 // === Static properties on anonymous classes ===
@@ -122,6 +308,23 @@ var StaticName_Anonymous = class {
 >name : string
 }
 
+var StaticName_Anonymous2 = class {
+>StaticName_Anonymous2 : typeof StaticName_Anonymous2
+>class {    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields    [FunctionPropertyNames.name]: string; // ok} : typeof StaticName_Anonymous2
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : string
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+}
+
 var StaticNameFn_Anonymous = class {
 >StaticNameFn_Anonymous : typeof StaticNameFn_Anonymous
 >class {    static name() {} // error without useDefineForClassFields    name() {} // ok} : typeof StaticNameFn_Anonymous
@@ -131,6 +334,23 @@ var StaticNameFn_Anonymous = class {
 
     name() {} // ok
 >name : () => void
+}
+
+var StaticNameFn_Anonymous2 = class {
+>StaticNameFn_Anonymous2 : typeof StaticNameFn_Anonymous2
+>class {    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields    [FunctionPropertyNames.name]() {} // ok} : typeof StaticNameFn_Anonymous2
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
 }
 
 // length
@@ -145,6 +365,23 @@ var StaticLength_Anonymous = class {
 >length : string
 }
 
+var StaticLength_Anonymous2 = class {
+>StaticLength_Anonymous2 : typeof StaticLength_Anonymous2
+>class {    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields    [FunctionPropertyNames.length]: string; // ok} : typeof StaticLength_Anonymous2
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : string
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+}
+
 var StaticLengthFn_Anonymous = class {
 >StaticLengthFn_Anonymous : typeof StaticLengthFn_Anonymous
 >class {    static length() {} // error without useDefineForClassFields    length() {} // ok} : typeof StaticLengthFn_Anonymous
@@ -154,6 +391,23 @@ var StaticLengthFn_Anonymous = class {
 
     length() {} // ok
 >length : () => void
+}
+
+var StaticLengthFn_Anonymous2 = class {
+>StaticLengthFn_Anonymous2 : typeof StaticLengthFn_Anonymous2
+>class {    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields    [FunctionPropertyNames.length]() {} // ok} : typeof StaticLengthFn_Anonymous2
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
 }
 
 // prototype
@@ -168,6 +422,23 @@ var StaticPrototype_Anonymous = class {
 >prototype : string
 }
 
+var StaticPrototype_Anonymous2 = class {
+>StaticPrototype_Anonymous2 : typeof StaticPrototype_Anonymous2
+>class {    static [FunctionPropertyNames.prototype]: number; // always an error    [FunctionPropertyNames.prototype]: string; // ok} : typeof StaticPrototype_Anonymous2
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : StaticPrototype_Anonymous2
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : string
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+}
+
 var StaticPrototypeFn_Anonymous = class {
 >StaticPrototypeFn_Anonymous : typeof StaticPrototypeFn_Anonymous
 >class {    static prototype() {} // always an error    prototype() {} // ok} : typeof StaticPrototypeFn_Anonymous
@@ -177,6 +448,23 @@ var StaticPrototypeFn_Anonymous = class {
 
     prototype() {} // ok
 >prototype : () => void
+}
+
+var StaticPrototypeFn_Anonymous2 = class {
+>StaticPrototypeFn_Anonymous2 : typeof StaticPrototypeFn_Anonymous2
+>class {    static [FunctionPropertyNames.prototype]() {} // always an error    [FunctionPropertyNames.prototype]() {} // ok} : typeof StaticPrototypeFn_Anonymous2
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
 }
 
 // caller
@@ -191,6 +479,23 @@ var StaticCaller_Anonymous = class {
 >caller : string
 }
 
+var StaticCaller_Anonymous2 = class {
+>StaticCaller_Anonymous2 : typeof StaticCaller_Anonymous2
+>class {    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields    [FunctionPropertyNames.caller]: string; // ok} : typeof StaticCaller_Anonymous2
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : number
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : string
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+}
+
 var StaticCallerFn_Anonymous = class {
 >StaticCallerFn_Anonymous : typeof StaticCallerFn_Anonymous
 >class {    static caller() {} // error without useDefineForClassFields    caller() {} // ok} : typeof StaticCallerFn_Anonymous
@@ -200,6 +505,23 @@ var StaticCallerFn_Anonymous = class {
 
     caller() {} // ok
 >caller : () => void
+}
+
+var StaticCallerFn_Anonymous2 = class {
+>StaticCallerFn_Anonymous2 : typeof StaticCallerFn_Anonymous2
+>class {    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields    [FunctionPropertyNames.caller]() {} // ok} : typeof StaticCallerFn_Anonymous2
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
 }
 
 // arguments
@@ -214,6 +536,23 @@ var StaticArguments_Anonymous = class {
 >arguments : string
 }
 
+var StaticArguments_Anonymous2 = class {
+>StaticArguments_Anonymous2 : typeof StaticArguments_Anonymous2
+>class {    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields    [FunctionPropertyNames.arguments]: string; // ok} : typeof StaticArguments_Anonymous2
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : number
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : string
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
+
 var StaticArgumentsFn_Anonymous = class {
 >StaticArgumentsFn_Anonymous : typeof StaticArgumentsFn_Anonymous
 >class {    static arguments() {} // error without useDefineForClassFields    arguments() {} // ok} : typeof StaticArgumentsFn_Anonymous
@@ -223,6 +562,23 @@ var StaticArgumentsFn_Anonymous = class {
 
     arguments() {} // ok
 >arguments : () => void
+}
+
+var StaticArgumentsFn_Anonymous2 = class {
+>StaticArgumentsFn_Anonymous2 : typeof StaticArgumentsFn_Anonymous2
+>class {    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields    [FunctionPropertyNames.arguments]() {} // ok} : typeof StaticArgumentsFn_Anonymous2
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
 }
 
 
@@ -243,6 +599,22 @@ module TestOnDefaultExportedClass_1 {
     }
 }
 
+export class ExportedStaticName {
+>ExportedStaticName : ExportedStaticName
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : string
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+}
+
 module TestOnDefaultExportedClass_2 {
 >TestOnDefaultExportedClass_2 : typeof TestOnDefaultExportedClass_2
 
@@ -255,6 +627,22 @@ module TestOnDefaultExportedClass_2 {
         name() {} // ok
 >name : () => void
     }
+}
+
+export class ExportedStaticNameFn {
+>ExportedStaticNameFn : ExportedStaticNameFn
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
 }
 
 // length
@@ -272,6 +660,22 @@ module TestOnDefaultExportedClass_3 {
     }
 }
 
+export class ExportedStaticLength {
+>ExportedStaticLength : ExportedStaticLength
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : string
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+}
+
 module TestOnDefaultExportedClass_4 {
 >TestOnDefaultExportedClass_4 : typeof TestOnDefaultExportedClass_4
 
@@ -284,6 +688,22 @@ module TestOnDefaultExportedClass_4 {
         length() {} // ok
 >length : () => void
     }
+}
+
+export class ExportedStaticLengthFn {
+>ExportedStaticLengthFn : ExportedStaticLengthFn
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
 }
 
 // prototype
@@ -301,6 +721,22 @@ module TestOnDefaultExportedClass_5 {
     }
 }
 
+export class ExportedStaticPrototype {
+>ExportedStaticPrototype : ExportedStaticPrototype
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : ExportedStaticPrototype
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : string
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+}
+
 module TestOnDefaultExportedClass_6 {
 >TestOnDefaultExportedClass_6 : typeof TestOnDefaultExportedClass_6
 
@@ -313,6 +749,22 @@ module TestOnDefaultExportedClass_6 {
         prototype() {} // ok
 >prototype : () => void
     }
+}
+
+export class ExportedStaticPrototypeFn {
+>ExportedStaticPrototypeFn : ExportedStaticPrototypeFn
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
 }
 
 // caller
@@ -330,6 +782,22 @@ module TestOnDefaultExportedClass_7 {
     }
 }
 
+export class ExportedStaticCaller {
+>ExportedStaticCaller : ExportedStaticCaller
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : number
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : string
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+}
+
 module TestOnDefaultExportedClass_8 {
 >TestOnDefaultExportedClass_8 : typeof TestOnDefaultExportedClass_8
 
@@ -342,6 +810,22 @@ module TestOnDefaultExportedClass_8 {
         caller() {} // ok
 >caller : () => void
     }
+}
+
+export class ExportedStaticCallerFn {
+>ExportedStaticCallerFn : ExportedStaticCallerFn
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
 }
 
 // arguments
@@ -359,6 +843,22 @@ module TestOnDefaultExportedClass_9 {
     }
 }
 
+export class ExportedStaticArguments {
+>ExportedStaticArguments : ExportedStaticArguments
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : number
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : string
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
+
 module TestOnDefaultExportedClass_10 {
 >TestOnDefaultExportedClass_10 : typeof TestOnDefaultExportedClass_10
 
@@ -373,3 +873,18 @@ module TestOnDefaultExportedClass_10 {
     }
 }
 
+export class ExportedStaticArgumentsFn {
+>ExportedStaticArgumentsFn : ExportedStaticArgumentsFn
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).errors.txt
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).errors.txt
@@ -1,32 +1,59 @@
-staticPropertyNameConflicts.ts(25,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
-staticPropertyNameConflicts.ts(30,12): error TS2300: Duplicate identifier 'prototype'.
-staticPropertyNameConflicts.ts(30,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
-staticPropertyNameConflicts.ts(84,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous'.
-staticPropertyNameConflicts.ts(89,12): error TS2300: Duplicate identifier 'prototype'.
-staticPropertyNameConflicts.ts(89,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous'.
-staticPropertyNameConflicts.ts(135,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(142,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(150,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(151,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
-staticPropertyNameConflicts.ts(157,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(158,16): error TS2300: Duplicate identifier 'prototype'.
-staticPropertyNameConflicts.ts(158,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
-staticPropertyNameConflicts.ts(165,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(172,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(180,12): error TS1319: A default export can only be used in an ECMAScript-style module.
-staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(53,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
+staticPropertyNameConflicts.ts(58,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype2'.
+staticPropertyNameConflicts.ts(63,12): error TS2300: Duplicate identifier 'prototype'.
+staticPropertyNameConflicts.ts(63,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
+staticPropertyNameConflicts.ts(68,12): error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+staticPropertyNameConflicts.ts(68,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn2'.
+staticPropertyNameConflicts.ts(161,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous'.
+staticPropertyNameConflicts.ts(166,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous2'.
+staticPropertyNameConflicts.ts(171,12): error TS2300: Duplicate identifier 'prototype'.
+staticPropertyNameConflicts.ts(171,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous'.
+staticPropertyNameConflicts.ts(176,12): error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+staticPropertyNameConflicts.ts(176,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous2'.
+staticPropertyNameConflicts.ts(252,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(264,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(277,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(278,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
+staticPropertyNameConflicts.ts(284,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototype'.
+staticPropertyNameConflicts.ts(289,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(290,16): error TS2300: Duplicate identifier 'prototype'.
+staticPropertyNameConflicts.ts(290,16): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn'.
+staticPropertyNameConflicts.ts(296,12): error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+staticPropertyNameConflicts.ts(296,12): error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototypeFn'.
+staticPropertyNameConflicts.ts(302,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(314,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(327,12): error TS1319: A default export can only be used in an ECMAScript-style module.
+staticPropertyNameConflicts.ts(339,12): error TS1319: A default export can only be used in an ECMAScript-style module.
 
 
-==== staticPropertyNameConflicts.ts (17 errors) ====
+==== staticPropertyNameConflicts.ts (26 errors) ====
+    const FunctionPropertyNames = {
+        name: 'name',
+        length: 'length',
+        prototype: 'prototype',
+        caller: 'caller',
+        arguments: 'arguments',
+    } as const;
+    
     // name
     class StaticName {
         static name: number; // error without useDefineForClassFields
         name: string; // ok
     }
     
+    class StaticName2 {
+        static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.name]: number; // ok
+    }
+    
     class StaticNameFn {
         static name() {} // error without useDefineForClassFields
         name() {} // ok
+    }
+    
+    class StaticNameFn2 {
+        static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.name]() {} // ok
     }
     
     // length
@@ -35,9 +62,19 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         length: string; // ok
     }
     
+    class StaticLength2 {
+        static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.length]: number; // ok
+    }
+    
     class StaticLengthFn {
         static length() {} // error without useDefineForClassFields
         length() {} // ok
+    }
+    
+    class StaticLengthFn2 {
+        static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.length]() {} // ok
     }
     
     // prototype
@@ -46,6 +83,13 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
                ~~~~~~~~~
 !!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
         prototype: string; // ok
+    }
+    
+    class StaticPrototype2 {
+        static [FunctionPropertyNames.prototype]: number; // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype2'.
+        [FunctionPropertyNames.prototype]: string; // ok
     }
     
     class StaticPrototypeFn {
@@ -57,15 +101,34 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         prototype() {} // ok
     }
     
+    class StaticPrototypeFn2 {
+        static [FunctionPropertyNames.prototype]() {} // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn2'.
+        [FunctionPropertyNames.prototype]() {} // ok
+    }
+    
     // caller
     class StaticCaller {
         static caller: number; // error without useDefineForClassFields
         caller: string; // ok
     }
     
+    class StaticCaller2 {
+        static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.caller]: string; // ok
+    }
+    
     class StaticCallerFn {
         static caller() {} // error without useDefineForClassFields
         caller() {} // ok
+    }
+    
+    class StaticCallerFn2 {
+        static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.caller]() {} // ok
     }
     
     // arguments
@@ -74,11 +137,20 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         arguments: string; // ok
     }
     
+    class StaticArguments2 {
+        static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.arguments]: string; // ok
+    }
+    
     class StaticArgumentsFn {
         static arguments() {} // error without useDefineForClassFields
         arguments() {} // ok
     }
     
+    class StaticArgumentsFn2 {
+        static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.arguments]() {} // ok
+    }
     
     
     // === Static properties on anonymous classes ===
@@ -89,9 +161,19 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         name: string; // ok
     }
     
+    var StaticName_Anonymous2 = class {
+        static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.name]: string; // ok
+    }
+    
     var StaticNameFn_Anonymous = class {
         static name() {} // error without useDefineForClassFields
         name() {} // ok
+    }
+    
+    var StaticNameFn_Anonymous2 = class {
+        static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.name]() {} // ok
     }
     
     // length
@@ -100,9 +182,19 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         length: string; // ok
     }
     
+    var StaticLength_Anonymous2 = class {
+        static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.length]: string; // ok
+    }
+    
     var StaticLengthFn_Anonymous = class {
         static length() {} // error without useDefineForClassFields
         length() {} // ok
+    }
+    
+    var StaticLengthFn_Anonymous2 = class {
+        static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.length]() {} // ok
     }
     
     // prototype
@@ -111,6 +203,13 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
                ~~~~~~~~~
 !!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous'.
         prototype: string; // ok
+    }
+    
+    var StaticPrototype_Anonymous2 = class {
+        static [FunctionPropertyNames.prototype]: number; // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype_Anonymous2'.
+        [FunctionPropertyNames.prototype]: string; // ok
     }
     
     var StaticPrototypeFn_Anonymous = class {
@@ -122,15 +221,34 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         prototype() {} // ok
     }
     
+    var StaticPrototypeFn_Anonymous2 = class {
+        static [FunctionPropertyNames.prototype]() {} // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototypeFn_Anonymous2'.
+        [FunctionPropertyNames.prototype]() {} // ok
+    }
+    
     // caller
     var StaticCaller_Anonymous = class {
         static caller: number; // error without useDefineForClassFields
         caller: string; // ok
     }
     
+    var StaticCaller_Anonymous2 = class {
+        static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.caller]: string; // ok
+    }
+    
     var StaticCallerFn_Anonymous = class {
         static caller() {} // error without useDefineForClassFields
         caller() {} // ok
+    }
+    
+    var StaticCallerFn_Anonymous2 = class {
+        static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.caller]() {} // ok
     }
     
     // arguments
@@ -139,9 +257,19 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         arguments: string; // ok
     }
     
+    var StaticArguments_Anonymous2 = class {
+        static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.arguments]: string; // ok
+    }
+    
     var StaticArgumentsFn_Anonymous = class {
         static arguments() {} // error without useDefineForClassFields
         arguments() {} // ok
+    }
+    
+    var StaticArgumentsFn_Anonymous2 = class {
+        static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.arguments]() {} // ok
     }
     
     
@@ -155,11 +283,21 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         }
     }
     
+    export class ExportedStaticName {
+        static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.name]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_2 {
         class StaticNameFn {
             static name() {} // error without useDefineForClassFields
             name() {} // ok
         }
+    }
+    
+    export class ExportedStaticNameFn {
+        static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.name]() {} // ok
     }
     
     // length
@@ -172,6 +310,11 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         }
     }
     
+    export class ExportedStaticLength {
+        static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.length]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_4 {
         export default class StaticLengthFn {
                ~~~~~~~
@@ -179,6 +322,11 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
             static length() {} // error without useDefineForClassFields
             length() {} // ok
         }
+    }
+    
+    export class ExportedStaticLengthFn {
+        static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.length]() {} // ok
     }
     
     // prototype
@@ -191,6 +339,13 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
 !!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'StaticPrototype'.
             prototype: string; // ok
         }
+    }
+    
+    export class ExportedStaticPrototype {
+        static [FunctionPropertyNames.prototype]: number; // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototype'.
+        [FunctionPropertyNames.prototype]: string; // ok
     }
     
     module TestOnDefaultExportedClass_6 {
@@ -206,6 +361,15 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         }
     }
     
+    export class ExportedStaticPrototypeFn {
+        static [FunctionPropertyNames.prototype]() {} // always an error
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[FunctionPropertyNames.prototype]'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2699: Static property 'prototype' conflicts with built-in property 'Function.prototype' of constructor function 'ExportedStaticPrototypeFn'.
+        [FunctionPropertyNames.prototype]() {} // ok
+    }
+    
     // caller
     module TestOnDefaultExportedClass_7 {
         export default class StaticCaller {
@@ -216,6 +380,11 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         }
     }
     
+    export class ExportedStaticCaller {
+        static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.caller]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_8 {
         export default class StaticCallerFn {
                ~~~~~~~
@@ -223,6 +392,11 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
             static caller() {} // error without useDefineForClassFields
             caller() {} // ok
         }
+    }
+    
+    export class ExportedStaticCallerFn {
+        static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.caller]() {} // ok
     }
     
     // arguments
@@ -235,6 +409,11 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         }
     }
     
+    export class ExportedStaticArguments {
+        static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+        [FunctionPropertyNames.arguments]: string; // ok
+    }
+    
     module TestOnDefaultExportedClass_10 {
         export default class StaticArgumentsFn {
                ~~~~~~~
@@ -244,3 +423,7 @@ staticPropertyNameConflicts.ts(187,12): error TS1319: A default export can only 
         }
     }
     
+    export class ExportedStaticArgumentsFn {
+        static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+        [FunctionPropertyNames.arguments]() {} // ok
+    }

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).js
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).js
@@ -1,15 +1,33 @@
 //// [tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts] ////
 
 //// [staticPropertyNameConflicts.ts]
+const FunctionPropertyNames = {
+    name: 'name',
+    length: 'length',
+    prototype: 'prototype',
+    caller: 'caller',
+    arguments: 'arguments',
+} as const;
+
 // name
 class StaticName {
     static name: number; // error without useDefineForClassFields
     name: string; // ok
 }
 
+class StaticName2 {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: number; // ok
+}
+
 class StaticNameFn {
     static name() {} // error without useDefineForClassFields
     name() {} // ok
+}
+
+class StaticNameFn2 {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -18,9 +36,19 @@ class StaticLength {
     length: string; // ok
 }
 
+class StaticLength2 {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: number; // ok
+}
+
 class StaticLengthFn {
     static length() {} // error without useDefineForClassFields
     length() {} // ok
+}
+
+class StaticLengthFn2 {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -29,9 +57,19 @@ class StaticPrototype {
     prototype: string; // ok
 }
 
+class StaticPrototype2 {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 class StaticPrototypeFn {
     static prototype() {} // always an error
     prototype() {} // ok
+}
+
+class StaticPrototypeFn2 {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -40,9 +78,19 @@ class StaticCaller {
     caller: string; // ok
 }
 
+class StaticCaller2 {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 class StaticCallerFn {
     static caller() {} // error without useDefineForClassFields
     caller() {} // ok
+}
+
+class StaticCallerFn2 {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -51,11 +99,20 @@ class StaticArguments {
     arguments: string; // ok
 }
 
+class StaticArguments2 {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 class StaticArgumentsFn {
     static arguments() {} // error without useDefineForClassFields
     arguments() {} // ok
 }
 
+class StaticArgumentsFn2 {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
+}
 
 
 // === Static properties on anonymous classes ===
@@ -66,9 +123,19 @@ var StaticName_Anonymous = class {
     name: string; // ok
 }
 
+var StaticName_Anonymous2 = class {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: string; // ok
+}
+
 var StaticNameFn_Anonymous = class {
     static name() {} // error without useDefineForClassFields
     name() {} // ok
+}
+
+var StaticNameFn_Anonymous2 = class {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -77,9 +144,19 @@ var StaticLength_Anonymous = class {
     length: string; // ok
 }
 
+var StaticLength_Anonymous2 = class {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: string; // ok
+}
+
 var StaticLengthFn_Anonymous = class {
     static length() {} // error without useDefineForClassFields
     length() {} // ok
+}
+
+var StaticLengthFn_Anonymous2 = class {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -88,9 +165,19 @@ var StaticPrototype_Anonymous = class {
     prototype: string; // ok
 }
 
+var StaticPrototype_Anonymous2 = class {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 var StaticPrototypeFn_Anonymous = class {
     static prototype() {} // always an error
     prototype() {} // ok
+}
+
+var StaticPrototypeFn_Anonymous2 = class {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -99,9 +186,19 @@ var StaticCaller_Anonymous = class {
     caller: string; // ok
 }
 
+var StaticCaller_Anonymous2 = class {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 var StaticCallerFn_Anonymous = class {
     static caller() {} // error without useDefineForClassFields
     caller() {} // ok
+}
+
+var StaticCallerFn_Anonymous2 = class {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -110,9 +207,19 @@ var StaticArguments_Anonymous = class {
     arguments: string; // ok
 }
 
+var StaticArguments_Anonymous2 = class {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 var StaticArgumentsFn_Anonymous = class {
     static arguments() {} // error without useDefineForClassFields
     arguments() {} // ok
+}
+
+var StaticArgumentsFn_Anonymous2 = class {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
 }
 
 
@@ -126,11 +233,21 @@ module TestOnDefaultExportedClass_1 {
     }
 }
 
+export class ExportedStaticName {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: string; // ok
+}
+
 module TestOnDefaultExportedClass_2 {
     class StaticNameFn {
         static name() {} // error without useDefineForClassFields
         name() {} // ok
     }
+}
+
+export class ExportedStaticNameFn {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -141,11 +258,21 @@ module TestOnDefaultExportedClass_3 {
     }
 }
 
+export class ExportedStaticLength {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: string; // ok
+}
+
 module TestOnDefaultExportedClass_4 {
     export default class StaticLengthFn {
         static length() {} // error without useDefineForClassFields
         length() {} // ok
     }
+}
+
+export class ExportedStaticLengthFn {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -156,11 +283,21 @@ module TestOnDefaultExportedClass_5 {
     }
 }
 
+export class ExportedStaticPrototype {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 module TestOnDefaultExportedClass_6 {
     export default class StaticPrototypeFn {
         static prototype() {} // always an error
         prototype() {} // ok
     }
+}
+
+export class ExportedStaticPrototypeFn {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -171,11 +308,21 @@ module TestOnDefaultExportedClass_7 {
     }
 }
 
+export class ExportedStaticCaller {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 module TestOnDefaultExportedClass_8 {
     export default class StaticCallerFn {
         static caller() {} // error without useDefineForClassFields
         caller() {} // ok
     }
+}
+
+export class ExportedStaticCallerFn {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -186,6 +333,11 @@ module TestOnDefaultExportedClass_9 {
     }
 }
 
+export class ExportedStaticArguments {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 module TestOnDefaultExportedClass_10 {
     export default class StaticArgumentsFn {
         static arguments() {} // error without useDefineForClassFields
@@ -193,8 +345,23 @@ module TestOnDefaultExportedClass_10 {
     }
 }
 
+export class ExportedStaticArgumentsFn {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
+}
 
 //// [staticPropertyNameConflicts.js]
+"use strict";
+var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ExportedStaticArgumentsFn = exports.ExportedStaticArguments = exports.ExportedStaticCallerFn = exports.ExportedStaticCaller = exports.ExportedStaticPrototypeFn = exports.ExportedStaticPrototype = exports.ExportedStaticLengthFn = exports.ExportedStaticLength = exports.ExportedStaticNameFn = exports.ExportedStaticName = void 0;
+var FunctionPropertyNames = {
+    name: 'name',
+    length: 'length',
+    prototype: 'prototype',
+    caller: 'caller',
+    arguments: 'arguments',
+};
 // name
 var StaticName = /** @class */ (function () {
     function StaticName() {
@@ -207,6 +374,18 @@ var StaticName = /** @class */ (function () {
     }
     return StaticName;
 }());
+var StaticName2 = /** @class */ (function () {
+    function StaticName2() {
+        Object.defineProperty(this, _b, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return StaticName2;
+}());
+_a = FunctionPropertyNames.name, _b = FunctionPropertyNames.name;
 var StaticNameFn = /** @class */ (function () {
     function StaticNameFn() {
     }
@@ -224,6 +403,23 @@ var StaticNameFn = /** @class */ (function () {
     }); // ok
     return StaticNameFn;
 }());
+var StaticNameFn2 = /** @class */ (function () {
+    function StaticNameFn2() {
+    }
+    Object.defineProperty(StaticNameFn2, FunctionPropertyNames.name, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticNameFn2.prototype, FunctionPropertyNames.name, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticNameFn2;
+}());
 // length
 var StaticLength = /** @class */ (function () {
     function StaticLength() {
@@ -236,6 +432,18 @@ var StaticLength = /** @class */ (function () {
     }
     return StaticLength;
 }());
+var StaticLength2 = /** @class */ (function () {
+    function StaticLength2() {
+        Object.defineProperty(this, _d, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return StaticLength2;
+}());
+_c = FunctionPropertyNames.length, _d = FunctionPropertyNames.length;
 var StaticLengthFn = /** @class */ (function () {
     function StaticLengthFn() {
     }
@@ -253,6 +461,23 @@ var StaticLengthFn = /** @class */ (function () {
     }); // ok
     return StaticLengthFn;
 }());
+var StaticLengthFn2 = /** @class */ (function () {
+    function StaticLengthFn2() {
+    }
+    Object.defineProperty(StaticLengthFn2, FunctionPropertyNames.length, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticLengthFn2.prototype, FunctionPropertyNames.length, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticLengthFn2;
+}());
 // prototype
 var StaticPrototype = /** @class */ (function () {
     function StaticPrototype() {
@@ -265,6 +490,18 @@ var StaticPrototype = /** @class */ (function () {
     }
     return StaticPrototype;
 }());
+var StaticPrototype2 = /** @class */ (function () {
+    function StaticPrototype2() {
+        Object.defineProperty(this, _f, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return StaticPrototype2;
+}());
+_e = FunctionPropertyNames.prototype, _f = FunctionPropertyNames.prototype;
 var StaticPrototypeFn = /** @class */ (function () {
     function StaticPrototypeFn() {
     }
@@ -282,6 +519,23 @@ var StaticPrototypeFn = /** @class */ (function () {
     }); // ok
     return StaticPrototypeFn;
 }());
+var StaticPrototypeFn2 = /** @class */ (function () {
+    function StaticPrototypeFn2() {
+    }
+    Object.defineProperty(StaticPrototypeFn2, FunctionPropertyNames.prototype, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // always an error
+    Object.defineProperty(StaticPrototypeFn2.prototype, FunctionPropertyNames.prototype, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticPrototypeFn2;
+}());
 // caller
 var StaticCaller = /** @class */ (function () {
     function StaticCaller() {
@@ -294,6 +548,18 @@ var StaticCaller = /** @class */ (function () {
     }
     return StaticCaller;
 }());
+var StaticCaller2 = /** @class */ (function () {
+    function StaticCaller2() {
+        Object.defineProperty(this, _h, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return StaticCaller2;
+}());
+_g = FunctionPropertyNames.caller, _h = FunctionPropertyNames.caller;
 var StaticCallerFn = /** @class */ (function () {
     function StaticCallerFn() {
     }
@@ -311,6 +577,23 @@ var StaticCallerFn = /** @class */ (function () {
     }); // ok
     return StaticCallerFn;
 }());
+var StaticCallerFn2 = /** @class */ (function () {
+    function StaticCallerFn2() {
+    }
+    Object.defineProperty(StaticCallerFn2, FunctionPropertyNames.caller, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticCallerFn2.prototype, FunctionPropertyNames.caller, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticCallerFn2;
+}());
 // arguments
 var StaticArguments = /** @class */ (function () {
     function StaticArguments() {
@@ -323,6 +606,18 @@ var StaticArguments = /** @class */ (function () {
     }
     return StaticArguments;
 }());
+var StaticArguments2 = /** @class */ (function () {
+    function StaticArguments2() {
+        Object.defineProperty(this, _k, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return StaticArguments2;
+}());
+_j = FunctionPropertyNames.arguments, _k = FunctionPropertyNames.arguments;
 var StaticArgumentsFn = /** @class */ (function () {
     function StaticArgumentsFn() {
     }
@@ -340,6 +635,23 @@ var StaticArgumentsFn = /** @class */ (function () {
     }); // ok
     return StaticArgumentsFn;
 }());
+var StaticArgumentsFn2 = /** @class */ (function () {
+    function StaticArgumentsFn2() {
+    }
+    Object.defineProperty(StaticArgumentsFn2, FunctionPropertyNames.arguments, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticArgumentsFn2.prototype, FunctionPropertyNames.arguments, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticArgumentsFn2;
+}());
 // === Static properties on anonymous classes ===
 // name
 var StaticName_Anonymous = /** @class */ (function () {
@@ -353,6 +665,20 @@ var StaticName_Anonymous = /** @class */ (function () {
     }
     return class_1;
 }());
+var StaticName_Anonymous2 = (_o = /** @class */ (function () {
+        function class_2() {
+            Object.defineProperty(this, _m, {
+                enumerable: true,
+                configurable: true,
+                writable: true,
+                value: void 0
+            }); // ok
+        }
+        return class_2;
+    }()),
+    _l = FunctionPropertyNames.name,
+    _m = FunctionPropertyNames.name,
+    _o);
 var StaticNameFn_Anonymous = /** @class */ (function () {
     function StaticNameFn_Anonymous() {
     }
@@ -370,9 +696,26 @@ var StaticNameFn_Anonymous = /** @class */ (function () {
     }); // ok
     return StaticNameFn_Anonymous;
 }());
+var StaticNameFn_Anonymous2 = /** @class */ (function () {
+    function StaticNameFn_Anonymous2() {
+    }
+    Object.defineProperty(StaticNameFn_Anonymous2, FunctionPropertyNames.name, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticNameFn_Anonymous2.prototype, FunctionPropertyNames.name, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticNameFn_Anonymous2;
+}());
 // length
 var StaticLength_Anonymous = /** @class */ (function () {
-    function class_2() {
+    function class_3() {
         Object.defineProperty(this, "length", {
             enumerable: true,
             configurable: true,
@@ -380,8 +723,22 @@ var StaticLength_Anonymous = /** @class */ (function () {
             value: void 0
         }); // ok
     }
-    return class_2;
+    return class_3;
 }());
+var StaticLength_Anonymous2 = (_r = /** @class */ (function () {
+        function class_4() {
+            Object.defineProperty(this, _q, {
+                enumerable: true,
+                configurable: true,
+                writable: true,
+                value: void 0
+            }); // ok
+        }
+        return class_4;
+    }()),
+    _p = FunctionPropertyNames.length,
+    _q = FunctionPropertyNames.length,
+    _r);
 var StaticLengthFn_Anonymous = /** @class */ (function () {
     function StaticLengthFn_Anonymous() {
     }
@@ -399,9 +756,26 @@ var StaticLengthFn_Anonymous = /** @class */ (function () {
     }); // ok
     return StaticLengthFn_Anonymous;
 }());
+var StaticLengthFn_Anonymous2 = /** @class */ (function () {
+    function StaticLengthFn_Anonymous2() {
+    }
+    Object.defineProperty(StaticLengthFn_Anonymous2, FunctionPropertyNames.length, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticLengthFn_Anonymous2.prototype, FunctionPropertyNames.length, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticLengthFn_Anonymous2;
+}());
 // prototype
 var StaticPrototype_Anonymous = /** @class */ (function () {
-    function class_3() {
+    function class_5() {
         Object.defineProperty(this, "prototype", {
             enumerable: true,
             configurable: true,
@@ -409,8 +783,22 @@ var StaticPrototype_Anonymous = /** @class */ (function () {
             value: void 0
         }); // ok
     }
-    return class_3;
+    return class_5;
 }());
+var StaticPrototype_Anonymous2 = (_u = /** @class */ (function () {
+        function class_6() {
+            Object.defineProperty(this, _t, {
+                enumerable: true,
+                configurable: true,
+                writable: true,
+                value: void 0
+            }); // ok
+        }
+        return class_6;
+    }()),
+    _s = FunctionPropertyNames.prototype,
+    _t = FunctionPropertyNames.prototype,
+    _u);
 var StaticPrototypeFn_Anonymous = /** @class */ (function () {
     function StaticPrototypeFn_Anonymous() {
     }
@@ -428,9 +816,26 @@ var StaticPrototypeFn_Anonymous = /** @class */ (function () {
     }); // ok
     return StaticPrototypeFn_Anonymous;
 }());
+var StaticPrototypeFn_Anonymous2 = /** @class */ (function () {
+    function StaticPrototypeFn_Anonymous2() {
+    }
+    Object.defineProperty(StaticPrototypeFn_Anonymous2, FunctionPropertyNames.prototype, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // always an error
+    Object.defineProperty(StaticPrototypeFn_Anonymous2.prototype, FunctionPropertyNames.prototype, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticPrototypeFn_Anonymous2;
+}());
 // caller
 var StaticCaller_Anonymous = /** @class */ (function () {
-    function class_4() {
+    function class_7() {
         Object.defineProperty(this, "caller", {
             enumerable: true,
             configurable: true,
@@ -438,8 +843,22 @@ var StaticCaller_Anonymous = /** @class */ (function () {
             value: void 0
         }); // ok
     }
-    return class_4;
+    return class_7;
 }());
+var StaticCaller_Anonymous2 = (_x = /** @class */ (function () {
+        function class_8() {
+            Object.defineProperty(this, _w, {
+                enumerable: true,
+                configurable: true,
+                writable: true,
+                value: void 0
+            }); // ok
+        }
+        return class_8;
+    }()),
+    _v = FunctionPropertyNames.caller,
+    _w = FunctionPropertyNames.caller,
+    _x);
 var StaticCallerFn_Anonymous = /** @class */ (function () {
     function StaticCallerFn_Anonymous() {
     }
@@ -457,9 +876,26 @@ var StaticCallerFn_Anonymous = /** @class */ (function () {
     }); // ok
     return StaticCallerFn_Anonymous;
 }());
+var StaticCallerFn_Anonymous2 = /** @class */ (function () {
+    function StaticCallerFn_Anonymous2() {
+    }
+    Object.defineProperty(StaticCallerFn_Anonymous2, FunctionPropertyNames.caller, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticCallerFn_Anonymous2.prototype, FunctionPropertyNames.caller, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticCallerFn_Anonymous2;
+}());
 // arguments
 var StaticArguments_Anonymous = /** @class */ (function () {
-    function class_5() {
+    function class_9() {
         Object.defineProperty(this, "arguments", {
             enumerable: true,
             configurable: true,
@@ -467,8 +903,22 @@ var StaticArguments_Anonymous = /** @class */ (function () {
             value: void 0
         }); // ok
     }
-    return class_5;
+    return class_9;
 }());
+var StaticArguments_Anonymous2 = (_0 = /** @class */ (function () {
+        function class_10() {
+            Object.defineProperty(this, _z, {
+                enumerable: true,
+                configurable: true,
+                writable: true,
+                value: void 0
+            }); // ok
+        }
+        return class_10;
+    }()),
+    _y = FunctionPropertyNames.arguments,
+    _z = FunctionPropertyNames.arguments,
+    _0);
 var StaticArgumentsFn_Anonymous = /** @class */ (function () {
     function StaticArgumentsFn_Anonymous() {
     }
@@ -486,6 +936,23 @@ var StaticArgumentsFn_Anonymous = /** @class */ (function () {
     }); // ok
     return StaticArgumentsFn_Anonymous;
 }());
+var StaticArgumentsFn_Anonymous2 = /** @class */ (function () {
+    function StaticArgumentsFn_Anonymous2() {
+    }
+    Object.defineProperty(StaticArgumentsFn_Anonymous2, FunctionPropertyNames.arguments, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(StaticArgumentsFn_Anonymous2.prototype, FunctionPropertyNames.arguments, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return StaticArgumentsFn_Anonymous2;
+}());
 // === Static properties on default exported classes ===
 // name
 var TestOnDefaultExportedClass_1;
@@ -502,6 +969,19 @@ var TestOnDefaultExportedClass_1;
         return StaticName;
     }());
 })(TestOnDefaultExportedClass_1 || (TestOnDefaultExportedClass_1 = {}));
+var ExportedStaticName = /** @class */ (function () {
+    function ExportedStaticName() {
+        Object.defineProperty(this, _2, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return ExportedStaticName;
+}());
+exports.ExportedStaticName = ExportedStaticName;
+_1 = FunctionPropertyNames.name, _2 = FunctionPropertyNames.name;
 var TestOnDefaultExportedClass_2;
 (function (TestOnDefaultExportedClass_2) {
     var StaticNameFn = /** @class */ (function () {
@@ -522,6 +1002,24 @@ var TestOnDefaultExportedClass_2;
         return StaticNameFn;
     }());
 })(TestOnDefaultExportedClass_2 || (TestOnDefaultExportedClass_2 = {}));
+var ExportedStaticNameFn = /** @class */ (function () {
+    function ExportedStaticNameFn() {
+    }
+    Object.defineProperty(ExportedStaticNameFn, FunctionPropertyNames.name, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(ExportedStaticNameFn.prototype, FunctionPropertyNames.name, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return ExportedStaticNameFn;
+}());
+exports.ExportedStaticNameFn = ExportedStaticNameFn;
 // length
 var TestOnDefaultExportedClass_3;
 (function (TestOnDefaultExportedClass_3) {
@@ -538,6 +1036,19 @@ var TestOnDefaultExportedClass_3;
     }());
     TestOnDefaultExportedClass_3.StaticLength = StaticLength;
 })(TestOnDefaultExportedClass_3 || (TestOnDefaultExportedClass_3 = {}));
+var ExportedStaticLength = /** @class */ (function () {
+    function ExportedStaticLength() {
+        Object.defineProperty(this, _4, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return ExportedStaticLength;
+}());
+exports.ExportedStaticLength = ExportedStaticLength;
+_3 = FunctionPropertyNames.length, _4 = FunctionPropertyNames.length;
 var TestOnDefaultExportedClass_4;
 (function (TestOnDefaultExportedClass_4) {
     var StaticLengthFn = /** @class */ (function () {
@@ -559,6 +1070,24 @@ var TestOnDefaultExportedClass_4;
     }());
     TestOnDefaultExportedClass_4.StaticLengthFn = StaticLengthFn;
 })(TestOnDefaultExportedClass_4 || (TestOnDefaultExportedClass_4 = {}));
+var ExportedStaticLengthFn = /** @class */ (function () {
+    function ExportedStaticLengthFn() {
+    }
+    Object.defineProperty(ExportedStaticLengthFn, FunctionPropertyNames.length, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(ExportedStaticLengthFn.prototype, FunctionPropertyNames.length, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return ExportedStaticLengthFn;
+}());
+exports.ExportedStaticLengthFn = ExportedStaticLengthFn;
 // prototype
 var TestOnDefaultExportedClass_5;
 (function (TestOnDefaultExportedClass_5) {
@@ -575,6 +1104,19 @@ var TestOnDefaultExportedClass_5;
     }());
     TestOnDefaultExportedClass_5.StaticPrototype = StaticPrototype;
 })(TestOnDefaultExportedClass_5 || (TestOnDefaultExportedClass_5 = {}));
+var ExportedStaticPrototype = /** @class */ (function () {
+    function ExportedStaticPrototype() {
+        Object.defineProperty(this, _6, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return ExportedStaticPrototype;
+}());
+exports.ExportedStaticPrototype = ExportedStaticPrototype;
+_5 = FunctionPropertyNames.prototype, _6 = FunctionPropertyNames.prototype;
 var TestOnDefaultExportedClass_6;
 (function (TestOnDefaultExportedClass_6) {
     var StaticPrototypeFn = /** @class */ (function () {
@@ -596,6 +1138,24 @@ var TestOnDefaultExportedClass_6;
     }());
     TestOnDefaultExportedClass_6.StaticPrototypeFn = StaticPrototypeFn;
 })(TestOnDefaultExportedClass_6 || (TestOnDefaultExportedClass_6 = {}));
+var ExportedStaticPrototypeFn = /** @class */ (function () {
+    function ExportedStaticPrototypeFn() {
+    }
+    Object.defineProperty(ExportedStaticPrototypeFn, FunctionPropertyNames.prototype, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // always an error
+    Object.defineProperty(ExportedStaticPrototypeFn.prototype, FunctionPropertyNames.prototype, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return ExportedStaticPrototypeFn;
+}());
+exports.ExportedStaticPrototypeFn = ExportedStaticPrototypeFn;
 // caller
 var TestOnDefaultExportedClass_7;
 (function (TestOnDefaultExportedClass_7) {
@@ -612,6 +1172,19 @@ var TestOnDefaultExportedClass_7;
     }());
     TestOnDefaultExportedClass_7.StaticCaller = StaticCaller;
 })(TestOnDefaultExportedClass_7 || (TestOnDefaultExportedClass_7 = {}));
+var ExportedStaticCaller = /** @class */ (function () {
+    function ExportedStaticCaller() {
+        Object.defineProperty(this, _8, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return ExportedStaticCaller;
+}());
+exports.ExportedStaticCaller = ExportedStaticCaller;
+_7 = FunctionPropertyNames.caller, _8 = FunctionPropertyNames.caller;
 var TestOnDefaultExportedClass_8;
 (function (TestOnDefaultExportedClass_8) {
     var StaticCallerFn = /** @class */ (function () {
@@ -633,6 +1206,24 @@ var TestOnDefaultExportedClass_8;
     }());
     TestOnDefaultExportedClass_8.StaticCallerFn = StaticCallerFn;
 })(TestOnDefaultExportedClass_8 || (TestOnDefaultExportedClass_8 = {}));
+var ExportedStaticCallerFn = /** @class */ (function () {
+    function ExportedStaticCallerFn() {
+    }
+    Object.defineProperty(ExportedStaticCallerFn, FunctionPropertyNames.caller, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(ExportedStaticCallerFn.prototype, FunctionPropertyNames.caller, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return ExportedStaticCallerFn;
+}());
+exports.ExportedStaticCallerFn = ExportedStaticCallerFn;
 // arguments
 var TestOnDefaultExportedClass_9;
 (function (TestOnDefaultExportedClass_9) {
@@ -649,6 +1240,19 @@ var TestOnDefaultExportedClass_9;
     }());
     TestOnDefaultExportedClass_9.StaticArguments = StaticArguments;
 })(TestOnDefaultExportedClass_9 || (TestOnDefaultExportedClass_9 = {}));
+var ExportedStaticArguments = /** @class */ (function () {
+    function ExportedStaticArguments() {
+        Object.defineProperty(this, _10, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        }); // ok
+    }
+    return ExportedStaticArguments;
+}());
+exports.ExportedStaticArguments = ExportedStaticArguments;
+_9 = FunctionPropertyNames.arguments, _10 = FunctionPropertyNames.arguments;
 var TestOnDefaultExportedClass_10;
 (function (TestOnDefaultExportedClass_10) {
     var StaticArgumentsFn = /** @class */ (function () {
@@ -670,3 +1274,21 @@ var TestOnDefaultExportedClass_10;
     }());
     TestOnDefaultExportedClass_10.StaticArgumentsFn = StaticArgumentsFn;
 })(TestOnDefaultExportedClass_10 || (TestOnDefaultExportedClass_10 = {}));
+var ExportedStaticArgumentsFn = /** @class */ (function () {
+    function ExportedStaticArgumentsFn() {
+    }
+    Object.defineProperty(ExportedStaticArgumentsFn, FunctionPropertyNames.arguments, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // error without useDefineForClassFields
+    Object.defineProperty(ExportedStaticArgumentsFn.prototype, FunctionPropertyNames.arguments, {
+        enumerable: false,
+        configurable: true,
+        writable: true,
+        value: function () { }
+    }); // ok
+    return ExportedStaticArgumentsFn;
+}());
+exports.ExportedStaticArgumentsFn = ExportedStaticArgumentsFn;

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).symbols
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).symbols
@@ -1,218 +1,558 @@
 //// [tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts] ////
 
 === staticPropertyNameConflicts.ts ===
+const FunctionPropertyNames = {
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+
+    name: 'name',
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    length: 'length',
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    prototype: 'prototype',
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    caller: 'caller',
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    arguments: 'arguments',
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+} as const;
+>const : Symbol(const)
+
 // name
 class StaticName {
->StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 0, 0))
+>StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 6, 11))
 
     static name: number; // error without useDefineForClassFields
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 1, 18))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 9, 18))
 
     name: string; // ok
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 2, 24))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 10, 24))
+}
+
+class StaticName2 {
+>StaticName2 : Symbol(StaticName2, Decl(staticPropertyNameConflicts.ts, 12, 1))
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticName2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 14, 19))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]: number; // ok
+>[FunctionPropertyNames.name] : Symbol(StaticName2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 15, 48))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 class StaticNameFn {
->StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 4, 1))
+>StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 17, 1))
 
     static name() {} // error without useDefineForClassFields
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 6, 20))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 19, 20))
 
     name() {} // ok
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 7, 20))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 20, 20))
+}
+
+class StaticNameFn2 {
+>StaticNameFn2 : Symbol(StaticNameFn2, Decl(staticPropertyNameConflicts.ts, 22, 1))
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 24, 21))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 25, 44))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 // length
 class StaticLength {
->StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 9, 1))
+>StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 27, 1))
 
     static length: number; // error without useDefineForClassFields
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 12, 20))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 30, 20))
 
     length: string; // ok
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 13, 26))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 31, 26))
+}
+
+class StaticLength2 {
+>StaticLength2 : Symbol(StaticLength2, Decl(staticPropertyNameConflicts.ts, 33, 1))
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLength2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 35, 21))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]: number; // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLength2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 36, 50))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 class StaticLengthFn {
->StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 15, 1))
+>StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 38, 1))
 
     static length() {} // error without useDefineForClassFields
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 17, 22))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 40, 22))
 
     length() {} // ok
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 18, 22))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 41, 22))
+}
+
+class StaticLengthFn2 {
+>StaticLengthFn2 : Symbol(StaticLengthFn2, Decl(staticPropertyNameConflicts.ts, 43, 1))
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 45, 23))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 46, 46))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 // prototype
 class StaticPrototype {
->StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 20, 1))
+>StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 48, 1))
 
     static prototype: number; // always an error
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 23, 23))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 51, 23))
 
     prototype: string; // ok
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 24, 29))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 52, 29))
+}
+
+class StaticPrototype2 {
+>StaticPrototype2 : Symbol(StaticPrototype2, Decl(staticPropertyNameConflicts.ts, 54, 1))
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 56, 24))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 57, 53))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 class StaticPrototypeFn {
->StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 26, 1))
+>StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 59, 1))
 
     static prototype() {} // always an error
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 28, 25))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 61, 25))
 
     prototype() {} // ok
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 29, 25))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 62, 25))
+}
+
+class StaticPrototypeFn2 {
+>StaticPrototypeFn2 : Symbol(StaticPrototypeFn2, Decl(staticPropertyNameConflicts.ts, 64, 1))
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 66, 26))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 67, 49))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 // caller
 class StaticCaller {
->StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 31, 1))
+>StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 69, 1))
 
     static caller: number; // error without useDefineForClassFields
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 34, 20))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 72, 20))
 
     caller: string; // ok
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 35, 26))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 73, 26))
+}
+
+class StaticCaller2 {
+>StaticCaller2 : Symbol(StaticCaller2, Decl(staticPropertyNameConflicts.ts, 75, 1))
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 77, 21))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 78, 50))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 class StaticCallerFn {
->StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 37, 1))
+>StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 80, 1))
 
     static caller() {} // error without useDefineForClassFields
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 39, 22))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 82, 22))
 
     caller() {} // ok
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 40, 22))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 83, 22))
+}
+
+class StaticCallerFn2 {
+>StaticCallerFn2 : Symbol(StaticCallerFn2, Decl(staticPropertyNameConflicts.ts, 85, 1))
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 87, 23))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 88, 46))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 // arguments
 class StaticArguments {
->StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 42, 1))
+>StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 90, 1))
 
     static arguments: number; // error without useDefineForClassFields
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 45, 23))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 93, 23))
 
     arguments: string; // ok
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 46, 29))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 94, 29))
+}
+
+class StaticArguments2 {
+>StaticArguments2 : Symbol(StaticArguments2, Decl(staticPropertyNameConflicts.ts, 96, 1))
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 98, 24))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 99, 53))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 class StaticArgumentsFn {
->StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 48, 1))
+>StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 101, 1))
 
     static arguments() {} // error without useDefineForClassFields
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 50, 25))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 103, 25))
 
     arguments() {} // ok
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 51, 25))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 104, 25))
 }
 
+class StaticArgumentsFn2 {
+>StaticArgumentsFn2 : Symbol(StaticArgumentsFn2, Decl(staticPropertyNameConflicts.ts, 106, 1))
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 108, 26))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 109, 49))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+}
 
 
 // === Static properties on anonymous classes ===
 
 // name
 var StaticName_Anonymous = class {
->StaticName_Anonymous : Symbol(StaticName_Anonymous, Decl(staticPropertyNameConflicts.ts, 60, 3))
+>StaticName_Anonymous : Symbol(StaticName_Anonymous, Decl(staticPropertyNameConflicts.ts, 117, 3))
 
     static name: number; // error without useDefineForClassFields
->name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 60, 34))
+>name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 117, 34))
 
     name: string; // ok
->name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 61, 24))
+>name : Symbol(StaticName_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 118, 24))
+}
+
+var StaticName_Anonymous2 = class {
+>StaticName_Anonymous2 : Symbol(StaticName_Anonymous2, Decl(staticPropertyNameConflicts.ts, 122, 3))
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticName_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 122, 35))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : Symbol(StaticName_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 123, 48))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 var StaticNameFn_Anonymous = class {
->StaticNameFn_Anonymous : Symbol(StaticNameFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 65, 3))
+>StaticNameFn_Anonymous : Symbol(StaticNameFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 127, 3))
 
     static name() {} // error without useDefineForClassFields
->name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 65, 36))
+>name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 127, 36))
 
     name() {} // ok
->name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 66, 20))
+>name : Symbol(StaticNameFn_Anonymous.name, Decl(staticPropertyNameConflicts.ts, 128, 20))
+}
+
+var StaticNameFn_Anonymous2 = class {
+>StaticNameFn_Anonymous2 : Symbol(StaticNameFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 132, 3))
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 132, 37))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : Symbol(StaticNameFn_Anonymous2[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 133, 44))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 // length
 var StaticLength_Anonymous = class {
->StaticLength_Anonymous : Symbol(StaticLength_Anonymous, Decl(staticPropertyNameConflicts.ts, 71, 3))
+>StaticLength_Anonymous : Symbol(StaticLength_Anonymous, Decl(staticPropertyNameConflicts.ts, 138, 3))
 
     static length: number; // error without useDefineForClassFields
->length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 71, 36))
+>length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 138, 36))
 
     length: string; // ok
->length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 72, 26))
+>length : Symbol(StaticLength_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 139, 26))
+}
+
+var StaticLength_Anonymous2 = class {
+>StaticLength_Anonymous2 : Symbol(StaticLength_Anonymous2, Decl(staticPropertyNameConflicts.ts, 143, 3))
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLength_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 143, 37))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLength_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 144, 50))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 var StaticLengthFn_Anonymous = class {
->StaticLengthFn_Anonymous : Symbol(StaticLengthFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 76, 3))
+>StaticLengthFn_Anonymous : Symbol(StaticLengthFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 148, 3))
 
     static length() {} // error without useDefineForClassFields
->length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 76, 38))
+>length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 148, 38))
 
     length() {} // ok
->length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 77, 22))
+>length : Symbol(StaticLengthFn_Anonymous.length, Decl(staticPropertyNameConflicts.ts, 149, 22))
+}
+
+var StaticLengthFn_Anonymous2 = class {
+>StaticLengthFn_Anonymous2 : Symbol(StaticLengthFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 153, 3))
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 153, 39))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : Symbol(StaticLengthFn_Anonymous2[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 154, 46))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 // prototype
 var StaticPrototype_Anonymous = class {
->StaticPrototype_Anonymous : Symbol(StaticPrototype_Anonymous, Decl(staticPropertyNameConflicts.ts, 82, 3))
+>StaticPrototype_Anonymous : Symbol(StaticPrototype_Anonymous, Decl(staticPropertyNameConflicts.ts, 159, 3))
 
     static prototype: number; // always an error
->prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 82, 39))
+>prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 159, 39))
 
     prototype: string; // ok
->prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 83, 29))
+>prototype : Symbol(StaticPrototype_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 160, 29))
+}
+
+var StaticPrototype_Anonymous2 = class {
+>StaticPrototype_Anonymous2 : Symbol(StaticPrototype_Anonymous2, Decl(staticPropertyNameConflicts.ts, 164, 3))
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 164, 40))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototype_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 165, 53))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 var StaticPrototypeFn_Anonymous = class {
->StaticPrototypeFn_Anonymous : Symbol(StaticPrototypeFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 87, 3))
+>StaticPrototypeFn_Anonymous : Symbol(StaticPrototypeFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 169, 3))
 
     static prototype() {} // always an error
->prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 87, 41))
+>prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 169, 41))
 
     prototype() {} // ok
->prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 88, 25))
+>prototype : Symbol(StaticPrototypeFn_Anonymous.prototype, Decl(staticPropertyNameConflicts.ts, 170, 25))
+}
+
+var StaticPrototypeFn_Anonymous2 = class {
+>StaticPrototypeFn_Anonymous2 : Symbol(StaticPrototypeFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 174, 3))
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 174, 42))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : Symbol(StaticPrototypeFn_Anonymous2[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 175, 49))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 // caller
 var StaticCaller_Anonymous = class {
->StaticCaller_Anonymous : Symbol(StaticCaller_Anonymous, Decl(staticPropertyNameConflicts.ts, 93, 3))
+>StaticCaller_Anonymous : Symbol(StaticCaller_Anonymous, Decl(staticPropertyNameConflicts.ts, 180, 3))
 
     static caller: number; // error without useDefineForClassFields
->caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 93, 36))
+>caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 180, 36))
 
     caller: string; // ok
->caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 94, 26))
+>caller : Symbol(StaticCaller_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 181, 26))
+}
+
+var StaticCaller_Anonymous2 = class {
+>StaticCaller_Anonymous2 : Symbol(StaticCaller_Anonymous2, Decl(staticPropertyNameConflicts.ts, 185, 3))
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 185, 37))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCaller_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 186, 50))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 var StaticCallerFn_Anonymous = class {
->StaticCallerFn_Anonymous : Symbol(StaticCallerFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 98, 3))
+>StaticCallerFn_Anonymous : Symbol(StaticCallerFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 190, 3))
 
     static caller() {} // error without useDefineForClassFields
->caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 98, 38))
+>caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 190, 38))
 
     caller() {} // ok
->caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 99, 22))
+>caller : Symbol(StaticCallerFn_Anonymous.caller, Decl(staticPropertyNameConflicts.ts, 191, 22))
+}
+
+var StaticCallerFn_Anonymous2 = class {
+>StaticCallerFn_Anonymous2 : Symbol(StaticCallerFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 195, 3))
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 195, 39))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : Symbol(StaticCallerFn_Anonymous2[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 196, 46))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 // arguments
 var StaticArguments_Anonymous = class {
->StaticArguments_Anonymous : Symbol(StaticArguments_Anonymous, Decl(staticPropertyNameConflicts.ts, 104, 3))
+>StaticArguments_Anonymous : Symbol(StaticArguments_Anonymous, Decl(staticPropertyNameConflicts.ts, 201, 3))
 
     static arguments: number; // error without useDefineForClassFields
->arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 104, 39))
+>arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 201, 39))
 
     arguments: string; // ok
->arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 105, 29))
+>arguments : Symbol(StaticArguments_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 202, 29))
+}
+
+var StaticArguments_Anonymous2 = class {
+>StaticArguments_Anonymous2 : Symbol(StaticArguments_Anonymous2, Decl(staticPropertyNameConflicts.ts, 206, 3))
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 206, 40))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArguments_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 207, 53))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 var StaticArgumentsFn_Anonymous = class {
->StaticArgumentsFn_Anonymous : Symbol(StaticArgumentsFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 109, 3))
+>StaticArgumentsFn_Anonymous : Symbol(StaticArgumentsFn_Anonymous, Decl(staticPropertyNameConflicts.ts, 211, 3))
 
     static arguments() {} // error without useDefineForClassFields
->arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 109, 41))
+>arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 211, 41))
 
     arguments() {} // ok
->arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 110, 25))
+>arguments : Symbol(StaticArgumentsFn_Anonymous.arguments, Decl(staticPropertyNameConflicts.ts, 212, 25))
+}
+
+var StaticArgumentsFn_Anonymous2 = class {
+>StaticArgumentsFn_Anonymous2 : Symbol(StaticArgumentsFn_Anonymous2, Decl(staticPropertyNameConflicts.ts, 216, 3))
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 216, 42))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : Symbol(StaticArgumentsFn_Anonymous2[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 217, 49))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 
@@ -220,146 +560,305 @@ var StaticArgumentsFn_Anonymous = class {
 
 // name
 module TestOnDefaultExportedClass_1 {
->TestOnDefaultExportedClass_1 : Symbol(TestOnDefaultExportedClass_1, Decl(staticPropertyNameConflicts.ts, 112, 1))
+>TestOnDefaultExportedClass_1 : Symbol(TestOnDefaultExportedClass_1, Decl(staticPropertyNameConflicts.ts, 219, 1))
 
     class StaticName {
->StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 118, 37))
+>StaticName : Symbol(StaticName, Decl(staticPropertyNameConflicts.ts, 225, 37))
 
         static name: number; // error without useDefineForClassFields
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 119, 22))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 226, 22))
 
         name: string; // ok
->name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 120, 28))
+>name : Symbol(StaticName.name, Decl(staticPropertyNameConflicts.ts, 227, 28))
     }
 }
 
+export class ExportedStaticName {
+>ExportedStaticName : Symbol(ExportedStaticName, Decl(staticPropertyNameConflicts.ts, 230, 1))
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticName[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 232, 33))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticName[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 233, 48))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+}
+
 module TestOnDefaultExportedClass_2 {
->TestOnDefaultExportedClass_2 : Symbol(TestOnDefaultExportedClass_2, Decl(staticPropertyNameConflicts.ts, 123, 1))
+>TestOnDefaultExportedClass_2 : Symbol(TestOnDefaultExportedClass_2, Decl(staticPropertyNameConflicts.ts, 235, 1))
 
     class StaticNameFn {
->StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 125, 37))
+>StaticNameFn : Symbol(StaticNameFn, Decl(staticPropertyNameConflicts.ts, 237, 37))
 
         static name() {} // error without useDefineForClassFields
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 126, 24))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 238, 24))
 
         name() {} // ok
->name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 127, 24))
+>name : Symbol(StaticNameFn.name, Decl(staticPropertyNameConflicts.ts, 239, 24))
     }
+}
+
+export class ExportedStaticNameFn {
+>ExportedStaticNameFn : Symbol(ExportedStaticNameFn, Decl(staticPropertyNameConflicts.ts, 242, 1))
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticNameFn[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 244, 35))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : Symbol(ExportedStaticNameFn[FunctionPropertyNames.name], Decl(staticPropertyNameConflicts.ts, 245, 44))
+>FunctionPropertyNames.name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>name : Symbol(name, Decl(staticPropertyNameConflicts.ts, 0, 31))
 }
 
 // length
 module TestOnDefaultExportedClass_3 {
->TestOnDefaultExportedClass_3 : Symbol(TestOnDefaultExportedClass_3, Decl(staticPropertyNameConflicts.ts, 130, 1))
+>TestOnDefaultExportedClass_3 : Symbol(TestOnDefaultExportedClass_3, Decl(staticPropertyNameConflicts.ts, 247, 1))
 
     export default class StaticLength {
->StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 133, 37))
+>StaticLength : Symbol(StaticLength, Decl(staticPropertyNameConflicts.ts, 250, 37))
 
         static length: number; // error without useDefineForClassFields
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 134, 39))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 251, 39))
 
         length: string; // ok
->length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 135, 30))
+>length : Symbol(StaticLength.length, Decl(staticPropertyNameConflicts.ts, 252, 30))
     }
 }
 
+export class ExportedStaticLength {
+>ExportedStaticLength : Symbol(ExportedStaticLength, Decl(staticPropertyNameConflicts.ts, 255, 1))
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLength[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 257, 35))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLength[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 258, 50))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+}
+
 module TestOnDefaultExportedClass_4 {
->TestOnDefaultExportedClass_4 : Symbol(TestOnDefaultExportedClass_4, Decl(staticPropertyNameConflicts.ts, 138, 1))
+>TestOnDefaultExportedClass_4 : Symbol(TestOnDefaultExportedClass_4, Decl(staticPropertyNameConflicts.ts, 260, 1))
 
     export default class StaticLengthFn {
->StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 140, 37))
+>StaticLengthFn : Symbol(StaticLengthFn, Decl(staticPropertyNameConflicts.ts, 262, 37))
 
         static length() {} // error without useDefineForClassFields
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 141, 41))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 263, 41))
 
         length() {} // ok
->length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 142, 26))
+>length : Symbol(StaticLengthFn.length, Decl(staticPropertyNameConflicts.ts, 264, 26))
     }
+}
+
+export class ExportedStaticLengthFn {
+>ExportedStaticLengthFn : Symbol(ExportedStaticLengthFn, Decl(staticPropertyNameConflicts.ts, 267, 1))
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLengthFn[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 269, 37))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : Symbol(ExportedStaticLengthFn[FunctionPropertyNames.length], Decl(staticPropertyNameConflicts.ts, 270, 46))
+>FunctionPropertyNames.length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>length : Symbol(length, Decl(staticPropertyNameConflicts.ts, 1, 17))
 }
 
 // prototype
 module TestOnDefaultExportedClass_5 {
->TestOnDefaultExportedClass_5 : Symbol(TestOnDefaultExportedClass_5, Decl(staticPropertyNameConflicts.ts, 145, 1))
+>TestOnDefaultExportedClass_5 : Symbol(TestOnDefaultExportedClass_5, Decl(staticPropertyNameConflicts.ts, 272, 1))
 
     export default class StaticPrototype {
->StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 148, 37))
+>StaticPrototype : Symbol(StaticPrototype, Decl(staticPropertyNameConflicts.ts, 275, 37))
 
         static prototype: number; // always an error
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 149, 42))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 276, 42))
 
         prototype: string; // ok
->prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 150, 33))
+>prototype : Symbol(StaticPrototype.prototype, Decl(staticPropertyNameConflicts.ts, 277, 33))
     }
 }
 
+export class ExportedStaticPrototype {
+>ExportedStaticPrototype : Symbol(ExportedStaticPrototype, Decl(staticPropertyNameConflicts.ts, 280, 1))
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototype[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 282, 38))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototype[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 283, 53))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+}
+
 module TestOnDefaultExportedClass_6 {
->TestOnDefaultExportedClass_6 : Symbol(TestOnDefaultExportedClass_6, Decl(staticPropertyNameConflicts.ts, 153, 1))
+>TestOnDefaultExportedClass_6 : Symbol(TestOnDefaultExportedClass_6, Decl(staticPropertyNameConflicts.ts, 285, 1))
 
     export default class StaticPrototypeFn {
->StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 155, 37))
+>StaticPrototypeFn : Symbol(StaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 287, 37))
 
         static prototype() {} // always an error
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 156, 44))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 288, 44))
 
         prototype() {} // ok
->prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 157, 29))
+>prototype : Symbol(StaticPrototypeFn.prototype, Decl(staticPropertyNameConflicts.ts, 289, 29))
     }
+}
+
+export class ExportedStaticPrototypeFn {
+>ExportedStaticPrototypeFn : Symbol(ExportedStaticPrototypeFn, Decl(staticPropertyNameConflicts.ts, 292, 1))
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototypeFn[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 294, 40))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : Symbol(ExportedStaticPrototypeFn[FunctionPropertyNames.prototype], Decl(staticPropertyNameConflicts.ts, 295, 49))
+>FunctionPropertyNames.prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>prototype : Symbol(prototype, Decl(staticPropertyNameConflicts.ts, 2, 21))
 }
 
 // caller
 module TestOnDefaultExportedClass_7 {
->TestOnDefaultExportedClass_7 : Symbol(TestOnDefaultExportedClass_7, Decl(staticPropertyNameConflicts.ts, 160, 1))
+>TestOnDefaultExportedClass_7 : Symbol(TestOnDefaultExportedClass_7, Decl(staticPropertyNameConflicts.ts, 297, 1))
 
     export default class StaticCaller {
->StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 163, 37))
+>StaticCaller : Symbol(StaticCaller, Decl(staticPropertyNameConflicts.ts, 300, 37))
 
         static caller: number; // error without useDefineForClassFields
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 164, 39))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 301, 39))
 
         caller: string; // ok
->caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 165, 30))
+>caller : Symbol(StaticCaller.caller, Decl(staticPropertyNameConflicts.ts, 302, 30))
     }
 }
 
+export class ExportedStaticCaller {
+>ExportedStaticCaller : Symbol(ExportedStaticCaller, Decl(staticPropertyNameConflicts.ts, 305, 1))
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCaller[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 307, 35))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCaller[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 308, 50))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+}
+
 module TestOnDefaultExportedClass_8 {
->TestOnDefaultExportedClass_8 : Symbol(TestOnDefaultExportedClass_8, Decl(staticPropertyNameConflicts.ts, 168, 1))
+>TestOnDefaultExportedClass_8 : Symbol(TestOnDefaultExportedClass_8, Decl(staticPropertyNameConflicts.ts, 310, 1))
 
     export default class StaticCallerFn {
->StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 170, 37))
+>StaticCallerFn : Symbol(StaticCallerFn, Decl(staticPropertyNameConflicts.ts, 312, 37))
 
         static caller() {} // error without useDefineForClassFields
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 171, 41))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 313, 41))
 
         caller() {} // ok
->caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 172, 26))
+>caller : Symbol(StaticCallerFn.caller, Decl(staticPropertyNameConflicts.ts, 314, 26))
     }
+}
+
+export class ExportedStaticCallerFn {
+>ExportedStaticCallerFn : Symbol(ExportedStaticCallerFn, Decl(staticPropertyNameConflicts.ts, 317, 1))
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCallerFn[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 319, 37))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : Symbol(ExportedStaticCallerFn[FunctionPropertyNames.caller], Decl(staticPropertyNameConflicts.ts, 320, 46))
+>FunctionPropertyNames.caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>caller : Symbol(caller, Decl(staticPropertyNameConflicts.ts, 3, 27))
 }
 
 // arguments
 module TestOnDefaultExportedClass_9 {
->TestOnDefaultExportedClass_9 : Symbol(TestOnDefaultExportedClass_9, Decl(staticPropertyNameConflicts.ts, 175, 1))
+>TestOnDefaultExportedClass_9 : Symbol(TestOnDefaultExportedClass_9, Decl(staticPropertyNameConflicts.ts, 322, 1))
 
     export default class StaticArguments {
->StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 178, 37))
+>StaticArguments : Symbol(StaticArguments, Decl(staticPropertyNameConflicts.ts, 325, 37))
 
         static arguments: number; // error without useDefineForClassFields
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 179, 42))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 326, 42))
 
         arguments: string; // ok
->arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 180, 33))
+>arguments : Symbol(StaticArguments.arguments, Decl(staticPropertyNameConflicts.ts, 327, 33))
     }
+}
+
+export class ExportedStaticArguments {
+>ExportedStaticArguments : Symbol(ExportedStaticArguments, Decl(staticPropertyNameConflicts.ts, 330, 1))
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArguments[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 332, 38))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArguments[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 333, 53))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
 }
 
 module TestOnDefaultExportedClass_10 {
->TestOnDefaultExportedClass_10 : Symbol(TestOnDefaultExportedClass_10, Decl(staticPropertyNameConflicts.ts, 183, 1))
+>TestOnDefaultExportedClass_10 : Symbol(TestOnDefaultExportedClass_10, Decl(staticPropertyNameConflicts.ts, 335, 1))
 
     export default class StaticArgumentsFn {
->StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 185, 38))
+>StaticArgumentsFn : Symbol(StaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 337, 38))
 
         static arguments() {} // error without useDefineForClassFields
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 186, 44))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 338, 44))
 
         arguments() {} // ok
->arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 187, 29))
+>arguments : Symbol(StaticArgumentsFn.arguments, Decl(staticPropertyNameConflicts.ts, 339, 29))
     }
 }
 
+export class ExportedStaticArgumentsFn {
+>ExportedStaticArgumentsFn : Symbol(ExportedStaticArgumentsFn, Decl(staticPropertyNameConflicts.ts, 342, 1))
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArgumentsFn[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 344, 40))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : Symbol(ExportedStaticArgumentsFn[FunctionPropertyNames.arguments], Decl(staticPropertyNameConflicts.ts, 345, 49))
+>FunctionPropertyNames.arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+>FunctionPropertyNames : Symbol(FunctionPropertyNames, Decl(staticPropertyNameConflicts.ts, 0, 5))
+>arguments : Symbol(arguments, Decl(staticPropertyNameConflicts.ts, 4, 21))
+}

--- a/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).types
+++ b/tests/baselines/reference/staticPropertyNameConflicts(usedefineforclassfields=true).types
@@ -1,6 +1,33 @@
 //// [tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts] ////
 
 === staticPropertyNameConflicts.ts ===
+const FunctionPropertyNames = {
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>{    name: 'name',    length: 'length',    prototype: 'prototype',    caller: 'caller',    arguments: 'arguments',} as const : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>{    name: 'name',    length: 'length',    prototype: 'prototype',    caller: 'caller',    arguments: 'arguments',} : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+
+    name: 'name',
+>name : "name"
+>'name' : "name"
+
+    length: 'length',
+>length : "length"
+>'length' : "length"
+
+    prototype: 'prototype',
+>prototype : "prototype"
+>'prototype' : "prototype"
+
+    caller: 'caller',
+>caller : "caller"
+>'caller' : "caller"
+
+    arguments: 'arguments',
+>arguments : "arguments"
+>'arguments' : "arguments"
+
+} as const;
+
 // name
 class StaticName {
 >StaticName : StaticName
@@ -12,6 +39,22 @@ class StaticName {
 >name : string
 }
 
+class StaticName2 {
+>StaticName2 : StaticName2
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]: number; // ok
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+}
+
 class StaticNameFn {
 >StaticNameFn : StaticNameFn
 
@@ -20,6 +63,22 @@ class StaticNameFn {
 
     name() {} // ok
 >name : () => void
+}
+
+class StaticNameFn2 {
+>StaticNameFn2 : StaticNameFn2
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
 }
 
 // length
@@ -33,6 +92,22 @@ class StaticLength {
 >length : string
 }
 
+class StaticLength2 {
+>StaticLength2 : StaticLength2
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]: number; // ok
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+}
+
 class StaticLengthFn {
 >StaticLengthFn : StaticLengthFn
 
@@ -41,6 +116,22 @@ class StaticLengthFn {
 
     length() {} // ok
 >length : () => void
+}
+
+class StaticLengthFn2 {
+>StaticLengthFn2 : StaticLengthFn2
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
 }
 
 // prototype
@@ -54,6 +145,22 @@ class StaticPrototype {
 >prototype : string
 }
 
+class StaticPrototype2 {
+>StaticPrototype2 : StaticPrototype2
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : StaticPrototype2
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : string
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+}
+
 class StaticPrototypeFn {
 >StaticPrototypeFn : StaticPrototypeFn
 
@@ -62,6 +169,22 @@ class StaticPrototypeFn {
 
     prototype() {} // ok
 >prototype : () => void
+}
+
+class StaticPrototypeFn2 {
+>StaticPrototypeFn2 : StaticPrototypeFn2
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
 }
 
 // caller
@@ -75,6 +198,22 @@ class StaticCaller {
 >caller : string
 }
 
+class StaticCaller2 {
+>StaticCaller2 : StaticCaller2
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : number
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : string
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+}
+
 class StaticCallerFn {
 >StaticCallerFn : StaticCallerFn
 
@@ -83,6 +222,22 @@ class StaticCallerFn {
 
     caller() {} // ok
 >caller : () => void
+}
+
+class StaticCallerFn2 {
+>StaticCallerFn2 : StaticCallerFn2
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
 }
 
 // arguments
@@ -96,6 +251,22 @@ class StaticArguments {
 >arguments : string
 }
 
+class StaticArguments2 {
+>StaticArguments2 : StaticArguments2
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : number
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : string
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
+
 class StaticArgumentsFn {
 >StaticArgumentsFn : StaticArgumentsFn
 
@@ -106,6 +277,21 @@ class StaticArgumentsFn {
 >arguments : () => void
 }
 
+class StaticArgumentsFn2 {
+>StaticArgumentsFn2 : StaticArgumentsFn2
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
 
 
 // === Static properties on anonymous classes ===
@@ -122,6 +308,23 @@ var StaticName_Anonymous = class {
 >name : string
 }
 
+var StaticName_Anonymous2 = class {
+>StaticName_Anonymous2 : typeof StaticName_Anonymous2
+>class {    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields    [FunctionPropertyNames.name]: string; // ok} : typeof StaticName_Anonymous2
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : string
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+}
+
 var StaticNameFn_Anonymous = class {
 >StaticNameFn_Anonymous : typeof StaticNameFn_Anonymous
 >class {    static name() {} // error without useDefineForClassFields    name() {} // ok} : typeof StaticNameFn_Anonymous
@@ -131,6 +334,23 @@ var StaticNameFn_Anonymous = class {
 
     name() {} // ok
 >name : () => void
+}
+
+var StaticNameFn_Anonymous2 = class {
+>StaticNameFn_Anonymous2 : typeof StaticNameFn_Anonymous2
+>class {    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields    [FunctionPropertyNames.name]() {} // ok} : typeof StaticNameFn_Anonymous2
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
 }
 
 // length
@@ -145,6 +365,23 @@ var StaticLength_Anonymous = class {
 >length : string
 }
 
+var StaticLength_Anonymous2 = class {
+>StaticLength_Anonymous2 : typeof StaticLength_Anonymous2
+>class {    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields    [FunctionPropertyNames.length]: string; // ok} : typeof StaticLength_Anonymous2
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : string
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+}
+
 var StaticLengthFn_Anonymous = class {
 >StaticLengthFn_Anonymous : typeof StaticLengthFn_Anonymous
 >class {    static length() {} // error without useDefineForClassFields    length() {} // ok} : typeof StaticLengthFn_Anonymous
@@ -154,6 +391,23 @@ var StaticLengthFn_Anonymous = class {
 
     length() {} // ok
 >length : () => void
+}
+
+var StaticLengthFn_Anonymous2 = class {
+>StaticLengthFn_Anonymous2 : typeof StaticLengthFn_Anonymous2
+>class {    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields    [FunctionPropertyNames.length]() {} // ok} : typeof StaticLengthFn_Anonymous2
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
 }
 
 // prototype
@@ -168,6 +422,23 @@ var StaticPrototype_Anonymous = class {
 >prototype : string
 }
 
+var StaticPrototype_Anonymous2 = class {
+>StaticPrototype_Anonymous2 : typeof StaticPrototype_Anonymous2
+>class {    static [FunctionPropertyNames.prototype]: number; // always an error    [FunctionPropertyNames.prototype]: string; // ok} : typeof StaticPrototype_Anonymous2
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : StaticPrototype_Anonymous2
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : string
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+}
+
 var StaticPrototypeFn_Anonymous = class {
 >StaticPrototypeFn_Anonymous : typeof StaticPrototypeFn_Anonymous
 >class {    static prototype() {} // always an error    prototype() {} // ok} : typeof StaticPrototypeFn_Anonymous
@@ -177,6 +448,23 @@ var StaticPrototypeFn_Anonymous = class {
 
     prototype() {} // ok
 >prototype : () => void
+}
+
+var StaticPrototypeFn_Anonymous2 = class {
+>StaticPrototypeFn_Anonymous2 : typeof StaticPrototypeFn_Anonymous2
+>class {    static [FunctionPropertyNames.prototype]() {} // always an error    [FunctionPropertyNames.prototype]() {} // ok} : typeof StaticPrototypeFn_Anonymous2
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
 }
 
 // caller
@@ -191,6 +479,23 @@ var StaticCaller_Anonymous = class {
 >caller : string
 }
 
+var StaticCaller_Anonymous2 = class {
+>StaticCaller_Anonymous2 : typeof StaticCaller_Anonymous2
+>class {    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields    [FunctionPropertyNames.caller]: string; // ok} : typeof StaticCaller_Anonymous2
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : number
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : string
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+}
+
 var StaticCallerFn_Anonymous = class {
 >StaticCallerFn_Anonymous : typeof StaticCallerFn_Anonymous
 >class {    static caller() {} // error without useDefineForClassFields    caller() {} // ok} : typeof StaticCallerFn_Anonymous
@@ -200,6 +505,23 @@ var StaticCallerFn_Anonymous = class {
 
     caller() {} // ok
 >caller : () => void
+}
+
+var StaticCallerFn_Anonymous2 = class {
+>StaticCallerFn_Anonymous2 : typeof StaticCallerFn_Anonymous2
+>class {    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields    [FunctionPropertyNames.caller]() {} // ok} : typeof StaticCallerFn_Anonymous2
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
 }
 
 // arguments
@@ -214,6 +536,23 @@ var StaticArguments_Anonymous = class {
 >arguments : string
 }
 
+var StaticArguments_Anonymous2 = class {
+>StaticArguments_Anonymous2 : typeof StaticArguments_Anonymous2
+>class {    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields    [FunctionPropertyNames.arguments]: string; // ok} : typeof StaticArguments_Anonymous2
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : number
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : string
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
+
 var StaticArgumentsFn_Anonymous = class {
 >StaticArgumentsFn_Anonymous : typeof StaticArgumentsFn_Anonymous
 >class {    static arguments() {} // error without useDefineForClassFields    arguments() {} // ok} : typeof StaticArgumentsFn_Anonymous
@@ -223,6 +562,23 @@ var StaticArgumentsFn_Anonymous = class {
 
     arguments() {} // ok
 >arguments : () => void
+}
+
+var StaticArgumentsFn_Anonymous2 = class {
+>StaticArgumentsFn_Anonymous2 : typeof StaticArgumentsFn_Anonymous2
+>class {    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields    [FunctionPropertyNames.arguments]() {} // ok} : typeof StaticArgumentsFn_Anonymous2
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
 }
 
 
@@ -243,6 +599,22 @@ module TestOnDefaultExportedClass_1 {
     }
 }
 
+export class ExportedStaticName {
+>ExportedStaticName : ExportedStaticName
+
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : number
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]: string; // ok
+>[FunctionPropertyNames.name] : string
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+}
+
 module TestOnDefaultExportedClass_2 {
 >TestOnDefaultExportedClass_2 : typeof TestOnDefaultExportedClass_2
 
@@ -255,6 +627,22 @@ module TestOnDefaultExportedClass_2 {
         name() {} // ok
 >name : () => void
     }
+}
+
+export class ExportedStaticNameFn {
+>ExportedStaticNameFn : ExportedStaticNameFn
+
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
+
+    [FunctionPropertyNames.name]() {} // ok
+>[FunctionPropertyNames.name] : () => void
+>FunctionPropertyNames.name : "name"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>name : "name"
 }
 
 // length
@@ -272,6 +660,22 @@ module TestOnDefaultExportedClass_3 {
     }
 }
 
+export class ExportedStaticLength {
+>ExportedStaticLength : ExportedStaticLength
+
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : number
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]: string; // ok
+>[FunctionPropertyNames.length] : string
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+}
+
 module TestOnDefaultExportedClass_4 {
 >TestOnDefaultExportedClass_4 : typeof TestOnDefaultExportedClass_4
 
@@ -284,6 +688,22 @@ module TestOnDefaultExportedClass_4 {
         length() {} // ok
 >length : () => void
     }
+}
+
+export class ExportedStaticLengthFn {
+>ExportedStaticLengthFn : ExportedStaticLengthFn
+
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
+
+    [FunctionPropertyNames.length]() {} // ok
+>[FunctionPropertyNames.length] : () => void
+>FunctionPropertyNames.length : "length"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>length : "length"
 }
 
 // prototype
@@ -301,6 +721,22 @@ module TestOnDefaultExportedClass_5 {
     }
 }
 
+export class ExportedStaticPrototype {
+>ExportedStaticPrototype : ExportedStaticPrototype
+
+    static [FunctionPropertyNames.prototype]: number; // always an error
+>[FunctionPropertyNames.prototype] : ExportedStaticPrototype
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]: string; // ok
+>[FunctionPropertyNames.prototype] : string
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+}
+
 module TestOnDefaultExportedClass_6 {
 >TestOnDefaultExportedClass_6 : typeof TestOnDefaultExportedClass_6
 
@@ -313,6 +749,22 @@ module TestOnDefaultExportedClass_6 {
         prototype() {} // ok
 >prototype : () => void
     }
+}
+
+export class ExportedStaticPrototypeFn {
+>ExportedStaticPrototypeFn : ExportedStaticPrototypeFn
+
+    static [FunctionPropertyNames.prototype]() {} // always an error
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
+
+    [FunctionPropertyNames.prototype]() {} // ok
+>[FunctionPropertyNames.prototype] : () => void
+>FunctionPropertyNames.prototype : "prototype"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>prototype : "prototype"
 }
 
 // caller
@@ -330,6 +782,22 @@ module TestOnDefaultExportedClass_7 {
     }
 }
 
+export class ExportedStaticCaller {
+>ExportedStaticCaller : ExportedStaticCaller
+
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : number
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]: string; // ok
+>[FunctionPropertyNames.caller] : string
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+}
+
 module TestOnDefaultExportedClass_8 {
 >TestOnDefaultExportedClass_8 : typeof TestOnDefaultExportedClass_8
 
@@ -342,6 +810,22 @@ module TestOnDefaultExportedClass_8 {
         caller() {} // ok
 >caller : () => void
     }
+}
+
+export class ExportedStaticCallerFn {
+>ExportedStaticCallerFn : ExportedStaticCallerFn
+
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
+
+    [FunctionPropertyNames.caller]() {} // ok
+>[FunctionPropertyNames.caller] : () => void
+>FunctionPropertyNames.caller : "caller"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>caller : "caller"
 }
 
 // arguments
@@ -359,6 +843,22 @@ module TestOnDefaultExportedClass_9 {
     }
 }
 
+export class ExportedStaticArguments {
+>ExportedStaticArguments : ExportedStaticArguments
+
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : number
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]: string; // ok
+>[FunctionPropertyNames.arguments] : string
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}
+
 module TestOnDefaultExportedClass_10 {
 >TestOnDefaultExportedClass_10 : typeof TestOnDefaultExportedClass_10
 
@@ -373,3 +873,18 @@ module TestOnDefaultExportedClass_10 {
     }
 }
 
+export class ExportedStaticArgumentsFn {
+>ExportedStaticArgumentsFn : ExportedStaticArgumentsFn
+
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+
+    [FunctionPropertyNames.arguments]() {} // ok
+>[FunctionPropertyNames.arguments] : () => void
+>FunctionPropertyNames.arguments : "arguments"
+>FunctionPropertyNames : { readonly name: "name"; readonly length: "length"; readonly prototype: "prototype"; readonly caller: "caller"; readonly arguments: "arguments"; }
+>arguments : "arguments"
+}

--- a/tests/baselines/reference/symbolDeclarationEmit12.errors.txt
+++ b/tests/baselines/reference/symbolDeclarationEmit12.errors.txt
@@ -1,24 +1,21 @@
-symbolDeclarationEmit12.ts(5,9): error TS2733: Property '[Symbol.toPrimitive]' was also declared here.
-symbolDeclarationEmit12.ts(9,13): error TS2718: Duplicate property '[Symbol.toPrimitive]'.
-symbolDeclarationEmit12.ts(10,13): error TS2718: Duplicate property '[Symbol.toPrimitive]'.
+symbolDeclarationEmit12.ts(9,13): error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
+symbolDeclarationEmit12.ts(10,13): error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
 
 
-==== symbolDeclarationEmit12.ts (3 errors) ====
+==== symbolDeclarationEmit12.ts (2 errors) ====
     module M {
         interface I { }
         export class C {
             [Symbol.iterator]: I;
             [Symbol.toPrimitive](x: I) { }
-            ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2733: Property '[Symbol.toPrimitive]' was also declared here.
             [Symbol.isConcatSpreadable](): I {
                 return undefined
             }
             get [Symbol.toPrimitive]() { return undefined; }
                 ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2718: Duplicate property '[Symbol.toPrimitive]'.
+!!! error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
             set [Symbol.toPrimitive](x: I) { }
                 ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2718: Duplicate property '[Symbol.toPrimitive]'.
+!!! error TS2300: Duplicate identifier '[Symbol.toPrimitive]'.
         }
     }

--- a/tests/baselines/reference/symbolDeclarationEmit12.js
+++ b/tests/baselines/reference/symbolDeclarationEmit12.js
@@ -35,9 +35,8 @@ declare namespace M {
     }
     export class C {
         [Symbol.iterator]: I;
-        [Symbol.toPrimitive](x: I): void;
         [Symbol.isConcatSpreadable](): I;
-        get [Symbol.toPrimitive](): any;
+        get [Symbol.toPrimitive](): I;
         set [Symbol.toPrimitive](x: I);
     }
     export {};

--- a/tests/baselines/reference/symbolDeclarationEmit12.symbols
+++ b/tests/baselines/reference/symbolDeclarationEmit12.symbols
@@ -18,7 +18,7 @@ module M {
 >I : Symbol(I, Decl(symbolDeclarationEmit12.ts, 0, 10))
 
         [Symbol.toPrimitive](x: I) { }
->[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 3, 29))
+>[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 3, 29), Decl(symbolDeclarationEmit12.ts, 7, 9), Decl(symbolDeclarationEmit12.ts, 8, 56))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
@@ -36,14 +36,14 @@ module M {
 >undefined : Symbol(undefined)
         }
         get [Symbol.toPrimitive]() { return undefined; }
->[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 7, 9))
+>[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 3, 29), Decl(symbolDeclarationEmit12.ts, 7, 9), Decl(symbolDeclarationEmit12.ts, 8, 56))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >undefined : Symbol(undefined)
 
         set [Symbol.toPrimitive](x: I) { }
->[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 8, 56))
+>[Symbol.toPrimitive] : Symbol(C[Symbol.toPrimitive], Decl(symbolDeclarationEmit12.ts, 3, 29), Decl(symbolDeclarationEmit12.ts, 7, 9), Decl(symbolDeclarationEmit12.ts, 8, 56))
 >Symbol.toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >toPrimitive : Symbol(SymbolConstructor.toPrimitive, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))

--- a/tests/baselines/reference/symbolDeclarationEmit12.types
+++ b/tests/baselines/reference/symbolDeclarationEmit12.types
@@ -15,7 +15,7 @@ module M {
 >iterator : unique symbol
 
         [Symbol.toPrimitive](x: I) { }
->[Symbol.toPrimitive] : (x: I) => void
+>[Symbol.toPrimitive] : I
 >Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
 >toPrimitive : unique symbol
@@ -31,7 +31,7 @@ module M {
 >undefined : undefined
         }
         get [Symbol.toPrimitive]() { return undefined; }
->[Symbol.toPrimitive] : any
+>[Symbol.toPrimitive] : I
 >Symbol.toPrimitive : unique symbol
 >Symbol : SymbolConstructor
 >toPrimitive : unique symbol

--- a/tests/baselines/reference/symbolProperty44.errors.txt
+++ b/tests/baselines/reference/symbolProperty44.errors.txt
@@ -1,17 +1,14 @@
-symbolProperty44.ts(2,9): error TS2733: Property '[Symbol.hasInstance]' was also declared here.
-symbolProperty44.ts(5,9): error TS2718: Duplicate property '[Symbol.hasInstance]'.
+symbolProperty44.ts(5,9): error TS2300: Duplicate identifier '[Symbol.hasInstance]'.
 
 
-==== symbolProperty44.ts (2 errors) ====
+==== symbolProperty44.ts (1 errors) ====
     class C {
         get [Symbol.hasInstance]() {
-            ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2733: Property '[Symbol.hasInstance]' was also declared here.
             return "";
         }
         get [Symbol.hasInstance]() {
             ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2718: Duplicate property '[Symbol.hasInstance]'.
+!!! error TS2300: Duplicate identifier '[Symbol.hasInstance]'.
             return "";
         }
     }

--- a/tests/baselines/reference/symbolProperty44.symbols
+++ b/tests/baselines/reference/symbolProperty44.symbols
@@ -5,7 +5,7 @@ class C {
 >C : Symbol(C, Decl(symbolProperty44.ts, 0, 0))
 
     get [Symbol.hasInstance]() {
->[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty44.ts, 0, 9))
+>[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty44.ts, 0, 9), Decl(symbolProperty44.ts, 3, 5))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
@@ -13,7 +13,7 @@ class C {
         return "";
     }
     get [Symbol.hasInstance]() {
->[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty44.ts, 3, 5))
+>[Symbol.hasInstance] : Symbol(C[Symbol.hasInstance], Decl(symbolProperty44.ts, 0, 9), Decl(symbolProperty44.ts, 3, 5))
 >Symbol.hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >hasInstance : Symbol(SymbolConstructor.hasInstance, Decl(lib.es2015.symbol.wellknown.d.ts, --, --))

--- a/tests/baselines/reference/uniqueSymbolsPropertyNames.errors.txt
+++ b/tests/baselines/reference/uniqueSymbolsPropertyNames.errors.txt
@@ -4,9 +4,18 @@ uniqueSymbolsPropertyNames.ts(33,3): error TS1117: An object literal cannot have
 uniqueSymbolsPropertyNames.ts(38,3): error TS1117: An object literal cannot have multiple properties with the same name.
 uniqueSymbolsPropertyNames.ts(43,3): error TS1117: An object literal cannot have multiple properties with the same name.
 uniqueSymbolsPropertyNames.ts(45,3): error TS1117: An object literal cannot have multiple properties with the same name.
+uniqueSymbolsPropertyNames.ts(50,3): error TS2300: Duplicate identifier '[uniqueSymbol0]'.
+uniqueSymbolsPropertyNames.ts(52,3): error TS2300: Duplicate identifier '[uniqueSymbol1]'.
+uniqueSymbolsPropertyNames.ts(57,3): error TS2300: Duplicate identifier '[OpNamespace.equal]'.
+uniqueSymbolsPropertyNames.ts(61,3): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+uniqueSymbolsPropertyNames.ts(62,3): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+uniqueSymbolsPropertyNames.ts(62,3): error TS2300: Duplicate identifier '[getUniqueSymbol0()]'.
+uniqueSymbolsPropertyNames.ts(63,3): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+uniqueSymbolsPropertyNames.ts(64,3): error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+uniqueSymbolsPropertyNames.ts(64,3): error TS2300: Duplicate identifier '[getUniqueSymbol1()]'.
 
 
-==== uniqueSymbolsPropertyNames.ts (6 errors) ====
+==== uniqueSymbolsPropertyNames.ts (15 errors) ====
     interface OpTypes {
       readonly equal: unique symbol;
     }
@@ -66,3 +75,39 @@ uniqueSymbolsPropertyNames.ts(45,3): error TS1117: An object literal cannot have
 !!! error TS1117: An object literal cannot have multiple properties with the same name.
     };
     
+    class Cls1 {
+      [uniqueSymbol0] = "first";
+      [uniqueSymbol0] = "last";
+      ~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[uniqueSymbol0]'.
+      [uniqueSymbol1] = "first";
+      [uniqueSymbol1] = "last";
+      ~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[uniqueSymbol1]'.
+    }
+    
+    class Cls2 {
+      [OpNamespace.equal] = "first";
+      [OpNamespace.equal] = "last";
+      ~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[OpNamespace.equal]'.
+    }
+    
+    class Cls3 {
+      [getUniqueSymbol0()] = "first";
+      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+      [getUniqueSymbol0()] = "last";
+      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[getUniqueSymbol0()]'.
+      [getUniqueSymbol1()] = "first";
+      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+      [getUniqueSymbol1()] = "last";
+      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS1166: A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.
+      ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2300: Duplicate identifier '[getUniqueSymbol1()]'.
+    }

--- a/tests/baselines/reference/uniqueSymbolsPropertyNames.js
+++ b/tests/baselines/reference/uniqueSymbolsPropertyNames.js
@@ -48,6 +48,24 @@ const t3 = {
   [getUniqueSymbol1()]: "last",
 };
 
+class Cls1 {
+  [uniqueSymbol0] = "first";
+  [uniqueSymbol0] = "last";
+  [uniqueSymbol1] = "first";
+  [uniqueSymbol1] = "last";
+}
+
+class Cls2 {
+  [OpNamespace.equal] = "first";
+  [OpNamespace.equal] = "last";
+}
+
+class Cls3 {
+  [getUniqueSymbol0()] = "first";
+  [getUniqueSymbol0()] = "last";
+  [getUniqueSymbol1()] = "first";
+  [getUniqueSymbol1()] = "last";
+}
 
 //// [uniqueSymbolsPropertyNames.js]
 var OpNamespace;
@@ -83,3 +101,19 @@ const t3 = {
     [getUniqueSymbol1()]: "first",
     [getUniqueSymbol1()]: "last",
 };
+class Cls1 {
+    [uniqueSymbol0] = "first";
+    [uniqueSymbol0] = "last";
+    [uniqueSymbol1] = "first";
+    [uniqueSymbol1] = "last";
+}
+class Cls2 {
+    [OpNamespace.equal] = "first";
+    [OpNamespace.equal] = "last";
+}
+class Cls3 {
+    [getUniqueSymbol0()] = "first";
+    [getUniqueSymbol0()] = "last";
+    [getUniqueSymbol1()] = "first";
+    [getUniqueSymbol1()] = "last";
+}

--- a/tests/baselines/reference/uniqueSymbolsPropertyNames.symbols
+++ b/tests/baselines/reference/uniqueSymbolsPropertyNames.symbols
@@ -127,3 +127,58 @@ const t3 = {
 
 };
 
+class Cls1 {
+>Cls1 : Symbol(Cls1, Decl(uniqueSymbolsPropertyNames.ts, 45, 2))
+
+  [uniqueSymbol0] = "first";
+>[uniqueSymbol0] : Symbol(Cls1[uniqueSymbol0], Decl(uniqueSymbolsPropertyNames.ts, 47, 12), Decl(uniqueSymbolsPropertyNames.ts, 48, 28))
+>uniqueSymbol0 : Symbol(uniqueSymbol0, Decl(uniqueSymbolsPropertyNames.ts, 8, 5))
+
+  [uniqueSymbol0] = "last";
+>[uniqueSymbol0] : Symbol(Cls1[uniqueSymbol0], Decl(uniqueSymbolsPropertyNames.ts, 47, 12), Decl(uniqueSymbolsPropertyNames.ts, 48, 28))
+>uniqueSymbol0 : Symbol(uniqueSymbol0, Decl(uniqueSymbolsPropertyNames.ts, 8, 5))
+
+  [uniqueSymbol1] = "first";
+>[uniqueSymbol1] : Symbol(Cls1[uniqueSymbol1], Decl(uniqueSymbolsPropertyNames.ts, 49, 27), Decl(uniqueSymbolsPropertyNames.ts, 50, 28))
+>uniqueSymbol1 : Symbol(uniqueSymbol1, Decl(uniqueSymbolsPropertyNames.ts, 9, 5))
+
+  [uniqueSymbol1] = "last";
+>[uniqueSymbol1] : Symbol(Cls1[uniqueSymbol1], Decl(uniqueSymbolsPropertyNames.ts, 49, 27), Decl(uniqueSymbolsPropertyNames.ts, 50, 28))
+>uniqueSymbol1 : Symbol(uniqueSymbol1, Decl(uniqueSymbolsPropertyNames.ts, 9, 5))
+}
+
+class Cls2 {
+>Cls2 : Symbol(Cls2, Decl(uniqueSymbolsPropertyNames.ts, 52, 1))
+
+  [OpNamespace.equal] = "first";
+>[OpNamespace.equal] : Symbol(Cls2[OpNamespace.equal], Decl(uniqueSymbolsPropertyNames.ts, 54, 12), Decl(uniqueSymbolsPropertyNames.ts, 55, 32))
+>OpNamespace.equal : Symbol(OpNamespace.equal, Decl(uniqueSymbolsPropertyNames.ts, 5, 22))
+>OpNamespace : Symbol(OpNamespace, Decl(uniqueSymbolsPropertyNames.ts, 2, 1))
+>equal : Symbol(OpNamespace.equal, Decl(uniqueSymbolsPropertyNames.ts, 5, 22))
+
+  [OpNamespace.equal] = "last";
+>[OpNamespace.equal] : Symbol(Cls2[OpNamespace.equal], Decl(uniqueSymbolsPropertyNames.ts, 54, 12), Decl(uniqueSymbolsPropertyNames.ts, 55, 32))
+>OpNamespace.equal : Symbol(OpNamespace.equal, Decl(uniqueSymbolsPropertyNames.ts, 5, 22))
+>OpNamespace : Symbol(OpNamespace, Decl(uniqueSymbolsPropertyNames.ts, 2, 1))
+>equal : Symbol(OpNamespace.equal, Decl(uniqueSymbolsPropertyNames.ts, 5, 22))
+}
+
+class Cls3 {
+>Cls3 : Symbol(Cls3, Decl(uniqueSymbolsPropertyNames.ts, 57, 1))
+
+  [getUniqueSymbol0()] = "first";
+>[getUniqueSymbol0()] : Symbol(Cls3[getUniqueSymbol0()], Decl(uniqueSymbolsPropertyNames.ts, 59, 12))
+>getUniqueSymbol0 : Symbol(getUniqueSymbol0, Decl(uniqueSymbolsPropertyNames.ts, 9, 37))
+
+  [getUniqueSymbol0()] = "last";
+>[getUniqueSymbol0()] : Symbol(Cls3[getUniqueSymbol0()], Decl(uniqueSymbolsPropertyNames.ts, 60, 33))
+>getUniqueSymbol0 : Symbol(getUniqueSymbol0, Decl(uniqueSymbolsPropertyNames.ts, 9, 37))
+
+  [getUniqueSymbol1()] = "first";
+>[getUniqueSymbol1()] : Symbol(Cls3[getUniqueSymbol1()], Decl(uniqueSymbolsPropertyNames.ts, 61, 32))
+>getUniqueSymbol1 : Symbol(getUniqueSymbol1, Decl(uniqueSymbolsPropertyNames.ts, 14, 1))
+
+  [getUniqueSymbol1()] = "last";
+>[getUniqueSymbol1()] : Symbol(Cls3[getUniqueSymbol1()], Decl(uniqueSymbolsPropertyNames.ts, 62, 33))
+>getUniqueSymbol1 : Symbol(getUniqueSymbol1, Decl(uniqueSymbolsPropertyNames.ts, 14, 1))
+}

--- a/tests/baselines/reference/uniqueSymbolsPropertyNames.types
+++ b/tests/baselines/reference/uniqueSymbolsPropertyNames.types
@@ -150,3 +150,72 @@ const t3 = {
 
 };
 
+class Cls1 {
+>Cls1 : Cls1
+
+  [uniqueSymbol0] = "first";
+>[uniqueSymbol0] : string
+>uniqueSymbol0 : unique symbol
+>"first" : "first"
+
+  [uniqueSymbol0] = "last";
+>[uniqueSymbol0] : string
+>uniqueSymbol0 : unique symbol
+>"last" : "last"
+
+  [uniqueSymbol1] = "first";
+>[uniqueSymbol1] : string
+>uniqueSymbol1 : unique symbol
+>"first" : "first"
+
+  [uniqueSymbol1] = "last";
+>[uniqueSymbol1] : string
+>uniqueSymbol1 : unique symbol
+>"last" : "last"
+}
+
+class Cls2 {
+>Cls2 : Cls2
+
+  [OpNamespace.equal] = "first";
+>[OpNamespace.equal] : string
+>OpNamespace.equal : unique symbol
+>OpNamespace : typeof OpNamespace
+>equal : unique symbol
+>"first" : "first"
+
+  [OpNamespace.equal] = "last";
+>[OpNamespace.equal] : string
+>OpNamespace.equal : unique symbol
+>OpNamespace : typeof OpNamespace
+>equal : unique symbol
+>"last" : "last"
+}
+
+class Cls3 {
+>Cls3 : Cls3
+
+  [getUniqueSymbol0()] = "first";
+>[getUniqueSymbol0()] : string
+>getUniqueSymbol0() : unique symbol
+>getUniqueSymbol0 : () => unique symbol
+>"first" : "first"
+
+  [getUniqueSymbol0()] = "last";
+>[getUniqueSymbol0()] : string
+>getUniqueSymbol0() : unique symbol
+>getUniqueSymbol0 : () => unique symbol
+>"last" : "last"
+
+  [getUniqueSymbol1()] = "first";
+>[getUniqueSymbol1()] : string
+>getUniqueSymbol1() : unique symbol
+>getUniqueSymbol1 : () => unique symbol
+>"first" : "first"
+
+  [getUniqueSymbol1()] = "last";
+>[getUniqueSymbol1()] : string
+>getUniqueSymbol1() : unique symbol
+>getUniqueSymbol1 : () => unique symbol
+>"last" : "last"
+}

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
@@ -1,15 +1,33 @@
 // @target: es5
 // @useDefineForClassFields: true,false
 
+const FunctionPropertyNames = {
+    name: 'name',
+    length: 'length',
+    prototype: 'prototype',
+    caller: 'caller',
+    arguments: 'arguments',
+} as const;
+
 // name
 class StaticName {
     static name: number; // error without useDefineForClassFields
     name: string; // ok
 }
 
+class StaticName2 {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: number; // ok
+}
+
 class StaticNameFn {
     static name() {} // error without useDefineForClassFields
     name() {} // ok
+}
+
+class StaticNameFn2 {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -18,9 +36,19 @@ class StaticLength {
     length: string; // ok
 }
 
+class StaticLength2 {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: number; // ok
+}
+
 class StaticLengthFn {
     static length() {} // error without useDefineForClassFields
     length() {} // ok
+}
+
+class StaticLengthFn2 {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -29,9 +57,19 @@ class StaticPrototype {
     prototype: string; // ok
 }
 
+class StaticPrototype2 {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 class StaticPrototypeFn {
     static prototype() {} // always an error
     prototype() {} // ok
+}
+
+class StaticPrototypeFn2 {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -40,9 +78,19 @@ class StaticCaller {
     caller: string; // ok
 }
 
+class StaticCaller2 {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 class StaticCallerFn {
     static caller() {} // error without useDefineForClassFields
     caller() {} // ok
+}
+
+class StaticCallerFn2 {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -51,11 +99,20 @@ class StaticArguments {
     arguments: string; // ok
 }
 
+class StaticArguments2 {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 class StaticArgumentsFn {
     static arguments() {} // error without useDefineForClassFields
     arguments() {} // ok
 }
 
+class StaticArgumentsFn2 {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
+}
 
 
 // === Static properties on anonymous classes ===
@@ -66,9 +123,19 @@ var StaticName_Anonymous = class {
     name: string; // ok
 }
 
+var StaticName_Anonymous2 = class {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: string; // ok
+}
+
 var StaticNameFn_Anonymous = class {
     static name() {} // error without useDefineForClassFields
     name() {} // ok
+}
+
+var StaticNameFn_Anonymous2 = class {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -77,9 +144,19 @@ var StaticLength_Anonymous = class {
     length: string; // ok
 }
 
+var StaticLength_Anonymous2 = class {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: string; // ok
+}
+
 var StaticLengthFn_Anonymous = class {
     static length() {} // error without useDefineForClassFields
     length() {} // ok
+}
+
+var StaticLengthFn_Anonymous2 = class {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -88,9 +165,19 @@ var StaticPrototype_Anonymous = class {
     prototype: string; // ok
 }
 
+var StaticPrototype_Anonymous2 = class {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 var StaticPrototypeFn_Anonymous = class {
     static prototype() {} // always an error
     prototype() {} // ok
+}
+
+var StaticPrototypeFn_Anonymous2 = class {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -99,9 +186,19 @@ var StaticCaller_Anonymous = class {
     caller: string; // ok
 }
 
+var StaticCaller_Anonymous2 = class {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 var StaticCallerFn_Anonymous = class {
     static caller() {} // error without useDefineForClassFields
     caller() {} // ok
+}
+
+var StaticCallerFn_Anonymous2 = class {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -110,9 +207,19 @@ var StaticArguments_Anonymous = class {
     arguments: string; // ok
 }
 
+var StaticArguments_Anonymous2 = class {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 var StaticArgumentsFn_Anonymous = class {
     static arguments() {} // error without useDefineForClassFields
     arguments() {} // ok
+}
+
+var StaticArgumentsFn_Anonymous2 = class {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
 }
 
 
@@ -126,11 +233,21 @@ module TestOnDefaultExportedClass_1 {
     }
 }
 
+export class ExportedStaticName {
+    static [FunctionPropertyNames.name]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.name]: string; // ok
+}
+
 module TestOnDefaultExportedClass_2 {
     class StaticNameFn {
         static name() {} // error without useDefineForClassFields
         name() {} // ok
     }
+}
+
+export class ExportedStaticNameFn {
+    static [FunctionPropertyNames.name]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.name]() {} // ok
 }
 
 // length
@@ -141,11 +258,21 @@ module TestOnDefaultExportedClass_3 {
     }
 }
 
+export class ExportedStaticLength {
+    static [FunctionPropertyNames.length]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.length]: string; // ok
+}
+
 module TestOnDefaultExportedClass_4 {
     export default class StaticLengthFn {
         static length() {} // error without useDefineForClassFields
         length() {} // ok
     }
+}
+
+export class ExportedStaticLengthFn {
+    static [FunctionPropertyNames.length]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.length]() {} // ok
 }
 
 // prototype
@@ -156,11 +283,21 @@ module TestOnDefaultExportedClass_5 {
     }
 }
 
+export class ExportedStaticPrototype {
+    static [FunctionPropertyNames.prototype]: number; // always an error
+    [FunctionPropertyNames.prototype]: string; // ok
+}
+
 module TestOnDefaultExportedClass_6 {
     export default class StaticPrototypeFn {
         static prototype() {} // always an error
         prototype() {} // ok
     }
+}
+
+export class ExportedStaticPrototypeFn {
+    static [FunctionPropertyNames.prototype]() {} // always an error
+    [FunctionPropertyNames.prototype]() {} // ok
 }
 
 // caller
@@ -171,11 +308,21 @@ module TestOnDefaultExportedClass_7 {
     }
 }
 
+export class ExportedStaticCaller {
+    static [FunctionPropertyNames.caller]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]: string; // ok
+}
+
 module TestOnDefaultExportedClass_8 {
     export default class StaticCallerFn {
         static caller() {} // error without useDefineForClassFields
         caller() {} // ok
     }
+}
+
+export class ExportedStaticCallerFn {
+    static [FunctionPropertyNames.caller]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.caller]() {} // ok
 }
 
 // arguments
@@ -186,9 +333,19 @@ module TestOnDefaultExportedClass_9 {
     }
 }
 
+export class ExportedStaticArguments {
+    static [FunctionPropertyNames.arguments]: number; // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]: string; // ok
+}
+
 module TestOnDefaultExportedClass_10 {
     export default class StaticArgumentsFn {
         static arguments() {} // error without useDefineForClassFields
         arguments() {} // ok
     }
+}
+
+export class ExportedStaticArgumentsFn {
+    static [FunctionPropertyNames.arguments]() {} // error without useDefineForClassFields
+    [FunctionPropertyNames.arguments]() {} // ok
 }

--- a/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsPropertyNames.ts
+++ b/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsPropertyNames.ts
@@ -46,3 +46,22 @@ const t3 = {
   [getUniqueSymbol1()]: "first",
   [getUniqueSymbol1()]: "last",
 };
+
+class Cls1 {
+  [uniqueSymbol0] = "first";
+  [uniqueSymbol0] = "last";
+  [uniqueSymbol1] = "first";
+  [uniqueSymbol1] = "last";
+}
+
+class Cls2 {
+  [OpNamespace.equal] = "first";
+  [OpNamespace.equal] = "last";
+}
+
+class Cls3 {
+  [getUniqueSymbol0()] = "first";
+  [getUniqueSymbol0()] = "last";
+  [getUniqueSymbol1()] = "first";
+  [getUniqueSymbol1()] = "last";
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #55163
This is a follow-up of #55193. I was testing whether `getEffectivePropertyNameForPropertyNameNode` should be used more, and it turns out that the answer is yes. It helps identify more duplicate symbol properties.

[playground](https://www.typescriptlang.org/play?jsx=1&ts=5.3.0-dev.20230818#code/MYewdgzgLgBArmAlgRzgUwMoE8C2AjEAGwAYYBeGbfIgOgDMQAnACgCJWBKAbgChRJYCFOioFCARnKVcY+kzadefQgEMIEGAGFCESQG8eMGAG0hqTDKLEAulNZ1EjaK15HTSc6Ku2KrVc64jAHogmAgACxA4QgATGDRGRiZDEzMRSwkfGHtHAJT3YQtqTLt-KBdg0Iio2PjE5IBfHiA)

```ts
const uniqueSymbol0 = Symbol.for("");
const uniqueSymbol1 = Symbol.for("");

class Cls1 {
  [uniqueSymbol0] = "first";
  [uniqueSymbol0] = "last";  // should error
  [uniqueSymbol1] = "first";
  [uniqueSymbol1] = "last";  // should error
}
```