### PR TITLE
Fixed JSDoc get-only accessors to be serialized as `const`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9675,11 +9675,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         serializeAsFunctionNamespaceMerge(typeToSerialize, symbol, varName, isExportAssignmentCompatibleSymbolName ? ModifierFlags.None : ModifierFlags.Export);
                     }
                     else {
+                        const flags = context.enclosingDeclaration?.kind === SyntaxKind.ModuleDeclaration && (!(symbol.flags & SymbolFlags.Accessor) || symbol.flags & SymbolFlags.SetAccessor) ? NodeFlags.Let : NodeFlags.Const;
                         const statement = factory.createVariableStatement(
                             /*modifiers*/ undefined,
                             factory.createVariableDeclarationList([
                                 factory.createVariableDeclaration(varName, /*exclamationToken*/ undefined, serializeTypeForDeclaration(context, typeToSerialize, symbol, enclosingDeclaration, includePrivateSymbol, bundled)),
-                            ], context.enclosingDeclaration?.kind === SyntaxKind.ModuleDeclaration ? NodeFlags.Let : NodeFlags.Const),
+                            ], flags),
                         );
                         // Inlined JSON types exported with [module.]exports= will already emit an export=, so should use `declare`.
                         // Otherwise, the type itself should be exported.

--- a/tests/baselines/reference/accessorDeclarationEmitJs.js
+++ b/tests/baselines/reference/accessorDeclarationEmitJs.js
@@ -27,7 +27,7 @@ export const t3 = {
 //// [a.d.ts]
 export namespace t1 {
     let p: string;
-    let getter: string;
+    const getter: string;
 }
 export namespace t2 {
     let v: string;


### PR DESCRIPTION
The same is serialized as a `readonly` property in TS so I think that `const` is fitting here.