### PR TITLE
Allow rest elements to follow other rest elements in tuple types

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -855,10 +855,6 @@
         "category": "Error",
         "code": 1264
     },
-    "A rest element cannot follow another rest element.": {
-        "category": "Error",
-        "code": 1265
-    },
     "An optional element cannot follow a rest element.": {
         "category": "Error",
         "code": 1266

--- a/tests/baselines/reference/variadicTuples2.errors.txt
+++ b/tests/baselines/reference/variadicTuples2.errors.txt
@@ -1,4 +1,3 @@
-variadicTuples2.ts(7,34): error TS1265: A rest element cannot follow another rest element.
 variadicTuples2.ts(8,34): error TS1266: An optional element cannot follow a rest element.
 variadicTuples2.ts(9,30): error TS1257: A required element cannot follow an optional element.
 variadicTuples2.ts(42,1): error TS2322: Type '[string, string, number, number]' is not assignable to type '[...string[], number]'.
@@ -65,20 +64,18 @@ variadicTuples2.ts(134,25): error TS2345: Argument of type '["blah2", 1, 2, 3]' 
     Type 'number' is not assignable to type 'string'.
 
 
-==== variadicTuples2.ts (29 errors) ====
+==== variadicTuples2.ts (28 errors) ====
     // Declarations
     
     type V00 = [number, ...string[]];
     type V01 = [...string[], number];
     type V03 = [number, ...string[], number];
+    type V04 = [number, ...string[], ...boolean[]];
     
-    type V10 = [number, ...string[], ...boolean[]];  // Error
-                                     ~~~~~~~~~~~~
-!!! error TS1265: A rest element cannot follow another rest element.
-    type V11 = [number, ...string[], boolean?];  // Error
+    type V10 = [number, ...string[], boolean?];  // Error
                                      ~~~~~~~~
 !!! error TS1266: An optional element cannot follow a rest element.
-    type V12 = [number, string?, boolean];  // Error
+    type V11 = [number, string?, boolean];  // Error
                                  ~~~~~~~
 !!! error TS1257: A required element cannot follow an optional element.
     

--- a/tests/baselines/reference/variadicTuples2.js
+++ b/tests/baselines/reference/variadicTuples2.js
@@ -6,10 +6,10 @@
 type V00 = [number, ...string[]];
 type V01 = [...string[], number];
 type V03 = [number, ...string[], number];
+type V04 = [number, ...string[], ...boolean[]];
 
-type V10 = [number, ...string[], ...boolean[]];  // Error
-type V11 = [number, ...string[], boolean?];  // Error
-type V12 = [number, string?, boolean];  // Error
+type V10 = [number, ...string[], boolean?];  // Error
+type V11 = [number, string?, boolean];  // Error
 
 // Normalization
 
@@ -239,9 +239,9 @@ var e1 = foo('blah1', 'blah2', 1, 2, 3); // Error
 type V00 = [number, ...string[]];
 type V01 = [...string[], number];
 type V03 = [number, ...string[], number];
-type V10 = [number, ...string[], ...boolean[]];
-type V11 = [number, ...string[], boolean?];
-type V12 = [number, string?, boolean];
+type V04 = [number, ...string[], ...boolean[]];
+type V10 = [number, ...string[], boolean?];
+type V11 = [number, string?, boolean];
 type Tup3<T extends unknown[], U extends unknown[], V extends unknown[]> = [...T, ...U, ...V];
 type V20 = Tup3<[number], string[], [number]>;
 type V21 = Tup3<[number], [string?], [boolean]>;

--- a/tests/baselines/reference/variadicTuples2.symbols
+++ b/tests/baselines/reference/variadicTuples2.symbols
@@ -12,14 +12,14 @@ type V01 = [...string[], number];
 type V03 = [number, ...string[], number];
 >V03 : Symbol(V03, Decl(variadicTuples2.ts, 3, 33))
 
-type V10 = [number, ...string[], ...boolean[]];  // Error
->V10 : Symbol(V10, Decl(variadicTuples2.ts, 4, 41))
+type V04 = [number, ...string[], ...boolean[]];
+>V04 : Symbol(V04, Decl(variadicTuples2.ts, 4, 41))
 
-type V11 = [number, ...string[], boolean?];  // Error
->V11 : Symbol(V11, Decl(variadicTuples2.ts, 6, 47))
+type V10 = [number, ...string[], boolean?];  // Error
+>V10 : Symbol(V10, Decl(variadicTuples2.ts, 5, 47))
 
-type V12 = [number, string?, boolean];  // Error
->V12 : Symbol(V12, Decl(variadicTuples2.ts, 7, 43))
+type V11 = [number, string?, boolean];  // Error
+>V11 : Symbol(V11, Decl(variadicTuples2.ts, 7, 43))
 
 // Normalization
 

--- a/tests/baselines/reference/variadicTuples2.types
+++ b/tests/baselines/reference/variadicTuples2.types
@@ -12,14 +12,14 @@ type V01 = [...string[], number];
 type V03 = [number, ...string[], number];
 >V03 : [number, ...string[], number]
 
-type V10 = [number, ...string[], ...boolean[]];  // Error
->V10 : [number, ...string[], ...boolean[]]
+type V04 = [number, ...string[], ...boolean[]];
+>V04 : [number, ...(string | boolean)[]]
 
-type V11 = [number, ...string[], boolean?];  // Error
->V11 : [number, ...string[], (boolean | undefined)?]
+type V10 = [number, ...string[], boolean?];  // Error
+>V10 : [number, ...string[], (boolean | undefined)?]
 
-type V12 = [number, string?, boolean];  // Error
->V12 : [number, (string | undefined)?, boolean]
+type V11 = [number, string?, boolean];  // Error
+>V11 : [number, (string | undefined)?, boolean]
 
 // Normalization
 

--- a/tests/cases/conformance/types/tuple/variadicTuples2.ts
+++ b/tests/cases/conformance/types/tuple/variadicTuples2.ts
@@ -6,10 +6,10 @@
 type V00 = [number, ...string[]];
 type V01 = [...string[], number];
 type V03 = [number, ...string[], number];
+type V04 = [number, ...string[], ...boolean[]];
 
-type V10 = [number, ...string[], ...boolean[]];  // Error
-type V11 = [number, ...string[], boolean?];  // Error
-type V12 = [number, string?, boolean];  // Error
+type V10 = [number, ...string[], boolean?];  // Error
+type V11 = [number, string?, boolean];  // Error
 
 // Normalization
 


### PR DESCRIPTION
I think that this restriction is somewhat artificial and doesn't bring a lot of value. Those are allowed and work OK:
```ts
type Ok1 = [...Array<number>, ...Array<string>]

type Alias = string[]
type Ok2 = [...number[], ...Alias]
```