### PR TITLE
Instantiable tuple labels

### DIFF
--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -326,6 +326,7 @@ import {
     NamedImportBindings,
     NamedImports,
     NamedTupleMember,
+    NamedTupleMemberName,
     NamespaceExport,
     NamespaceExportDeclaration,
     NamespaceImport,
@@ -2499,7 +2500,7 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     }
 
     // @api
-    function createNamedTupleMember(dotDotDotToken: DotDotDotToken | undefined, name: Identifier, questionToken: QuestionToken | undefined, type: TypeNode) {
+    function createNamedTupleMember(dotDotDotToken: DotDotDotToken | undefined, name: NamedTupleMemberName, questionToken: QuestionToken | undefined, type: TypeNode) {
         const node = createBaseDeclaration<NamedTupleMember>(SyntaxKind.NamedTupleMember);
         node.dotDotDotToken = dotDotDotToken;
         node.name = name;
@@ -2512,7 +2513,7 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
     }
 
     // @api
-    function updateNamedTupleMember(node: NamedTupleMember, dotDotDotToken: DotDotDotToken | undefined, name: Identifier, questionToken: QuestionToken | undefined, type: TypeNode) {
+    function updateNamedTupleMember(node: NamedTupleMember, dotDotDotToken: DotDotDotToken | undefined, name: NamedTupleMemberName, questionToken: QuestionToken | undefined, type: TypeNode) {
         return node.dotDotDotToken !== dotDotDotToken
                 || node.name !== name
                 || node.questionToken !== questionToken

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2222,10 +2222,12 @@ export interface TupleTypeNode extends TypeNode {
     readonly elements: NodeArray<TypeNode | NamedTupleMember>;
 }
 
+export type NamedTupleMemberName = Identifier | NoSubstitutionTemplateLiteral | TemplateLiteralTypeNode;
+
 export interface NamedTupleMember extends TypeNode, Declaration, JSDocContainer {
     readonly kind: SyntaxKind.NamedTupleMember;
     readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
-    readonly name: Identifier;
+    readonly name: NamedTupleMemberName;
     readonly questionToken?: Token<SyntaxKind.QuestionToken>;
     readonly type: TypeNode;
 }
@@ -8379,8 +8381,8 @@ export interface NodeFactory {
     updateArrayTypeNode(node: ArrayTypeNode, elementType: TypeNode): ArrayTypeNode;
     createTupleTypeNode(elements: readonly (TypeNode | NamedTupleMember)[]): TupleTypeNode;
     updateTupleTypeNode(node: TupleTypeNode, elements: readonly (TypeNode | NamedTupleMember)[]): TupleTypeNode;
-    createNamedTupleMember(dotDotDotToken: DotDotDotToken | undefined, name: Identifier, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
-    updateNamedTupleMember(node: NamedTupleMember, dotDotDotToken: DotDotDotToken | undefined, name: Identifier, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
+    createNamedTupleMember(dotDotDotToken: DotDotDotToken | undefined, name: NamedTupleMemberName, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
+    updateNamedTupleMember(node: NamedTupleMember, dotDotDotToken: DotDotDotToken | undefined, name: NamedTupleMemberName, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
     createOptionalTypeNode(type: TypeNode): OptionalTypeNode;
     updateOptionalTypeNode(node: OptionalTypeNode, type: TypeNode): OptionalTypeNode;
     createRestTypeNode(type: TypeNode): RestTypeNode;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -403,6 +403,7 @@ import {
     NamedExports,
     NamedImports,
     NamedImportsOrExports,
+    NamedTupleMemberName,
     NamespaceExport,
     NamespaceImport,
     NewExpression,
@@ -10433,4 +10434,9 @@ export function getPropertyNameFromType(type: StringLiteralType | NumberLiteralT
         return escapeLeadingUnderscores("" + (type as StringLiteralType | NumberLiteralType).value);
     }
     return Debug.fail();
+}
+
+/** @internal */
+export function isNamedTupleMemberName(node: Node): node is NamedTupleMemberName {
+    return node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.TemplateLiteralType || node.kind === SyntaxKind.NoSubstitutionTemplateLiteral;
 }

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -63,6 +63,7 @@ import {
     isModuleReference,
     isNamedExportBindings,
     isNamedImportBindings,
+    isNamedTupleMemberName,
     isObjectLiteralElementLike,
     isOptionalChain,
     isParameter,
@@ -913,7 +914,7 @@ const visitEachChildTable: VisitEachChildTable = {
         return context.factory.updateNamedTupleMember(
             node,
             tokenVisitor ? nodeVisitor(node.dotDotDotToken, tokenVisitor, isDotDotDotToken) : node.dotDotDotToken,
-            Debug.checkDefined(nodeVisitor(node.name, visitor, isIdentifier)),
+            Debug.checkDefined(nodeVisitor(node.name, visitor, isNamedTupleMemberName)),
             tokenVisitor ? nodeVisitor(node.questionToken, tokenVisitor, isQuestionToken) : node.questionToken,
             Debug.checkDefined(nodeVisitor(node.type, visitor, isTypeNode)),
         );

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5196,10 +5196,11 @@ declare namespace ts {
         readonly kind: SyntaxKind.TupleType;
         readonly elements: NodeArray<TypeNode | NamedTupleMember>;
     }
+    type NamedTupleMemberName = Identifier | NoSubstitutionTemplateLiteral | TemplateLiteralTypeNode;
     interface NamedTupleMember extends TypeNode, Declaration, JSDocContainer {
         readonly kind: SyntaxKind.NamedTupleMember;
         readonly dotDotDotToken?: Token<SyntaxKind.DotDotDotToken>;
-        readonly name: Identifier;
+        readonly name: NamedTupleMemberName;
         readonly questionToken?: Token<SyntaxKind.QuestionToken>;
         readonly type: TypeNode;
     }
@@ -7932,8 +7933,8 @@ declare namespace ts {
         updateArrayTypeNode(node: ArrayTypeNode, elementType: TypeNode): ArrayTypeNode;
         createTupleTypeNode(elements: readonly (TypeNode | NamedTupleMember)[]): TupleTypeNode;
         updateTupleTypeNode(node: TupleTypeNode, elements: readonly (TypeNode | NamedTupleMember)[]): TupleTypeNode;
-        createNamedTupleMember(dotDotDotToken: DotDotDotToken | undefined, name: Identifier, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
-        updateNamedTupleMember(node: NamedTupleMember, dotDotDotToken: DotDotDotToken | undefined, name: Identifier, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
+        createNamedTupleMember(dotDotDotToken: DotDotDotToken | undefined, name: NamedTupleMemberName, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
+        updateNamedTupleMember(node: NamedTupleMember, dotDotDotToken: DotDotDotToken | undefined, name: NamedTupleMemberName, questionToken: QuestionToken | undefined, type: TypeNode): NamedTupleMember;
         createOptionalTypeNode(type: TypeNode): OptionalTypeNode;
         updateOptionalTypeNode(node: OptionalTypeNode, type: TypeNode): OptionalTypeNode;
         createRestTypeNode(type: TypeNode): RestTypeNode;

--- a/tests/baselines/reference/instantiableTupleLabels1.errors.txt
+++ b/tests/baselines/reference/instantiableTupleLabels1.errors.txt
@@ -1,0 +1,40 @@
+instantiableTupleLabels1.ts(4,27): error TS5087: A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
+instantiableTupleLabels1.ts(15,24): error TS2322: Type 'unknown' is not assignable to type 'string | number | bigint | boolean | null | undefined'.
+instantiableTupleLabels1.ts(18,46): error TS2322: Type 'T1' is not assignable to type 'string | number | bigint | boolean | null | undefined'.
+instantiableTupleLabels1.ts(18,71): error TS2322: Type 'T2' is not assignable to type 'string | number | bigint | boolean | null | undefined'.
+
+
+==== instantiableTupleLabels1.ts (4 errors) ====
+    type T1 = [`wow`: boolean];
+    type T2 = [number, `wow`: boolean];
+    type T3 = [number, ...`wow`: boolean[]];
+    type T4 = [number, `wow`: ...boolean[]]; // error
+                              ~~~~~~~~~~~~
+!!! error TS5087: A labeled tuple element is declared as rest with a '...' before the name, rather than before the type.
+    
+    type Prefix = 'pre';
+    
+    type T5 = [`${Prefix}wow`: boolean];
+    type T6 = [number, `${Prefix}wow`: boolean];
+    type T7 = [number, ...`${Prefix}wow`: boolean[]];
+    
+    type T8 = [number, `${never}wontfly`: boolean]; // no label displayed
+    type T9 = [number, `${any}wontfly`: boolean]; // no label displayed
+    type T11 = [number, `${"a" | "b"}wontfly`: boolean]; // no label displayed
+    type T12 = [number, `${unknown}wontfly`: boolean]; // error
+                           ~~~~~~~
+!!! error TS2322: Type 'unknown' is not assignable to type 'string | number | bigint | boolean | null | undefined'.
+    
+    type MakeTuple1<T1 extends string, T2 extends string> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]];
+    type MakeTuple2<T1, T2> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]]; // error
+                                                 ~~
+!!! error TS2322: Type 'T1' is not assignable to type 'string | number | bigint | boolean | null | undefined'.
+!!! related TS2208 instantiableTupleLabels1.ts:18:17: This type parameter might need an `extends string | number | bigint | boolean | null | undefined` constraint.
+                                                                          ~~
+!!! error TS2322: Type 'T2' is not assignable to type 'string | number | bigint | boolean | null | undefined'.
+!!! related TS2208 instantiableTupleLabels1.ts:18:21: This type parameter might need an `extends string | number | bigint | boolean | null | undefined` constraint.
+    
+    type T13 = MakeTuple1<"awesome", "tail">;
+    type T14 = MakeTuple1<any, "tail">;
+    type T15 = MakeTuple1<"a" | "b", "tail">;
+    

--- a/tests/baselines/reference/instantiableTupleLabels1.js
+++ b/tests/baselines/reference/instantiableTupleLabels1.js
@@ -1,0 +1,49 @@
+//// [tests/cases/conformance/types/tuple/instantiableTupleLabels1.ts] ////
+
+//// [instantiableTupleLabels1.ts]
+type T1 = [`wow`: boolean];
+type T2 = [number, `wow`: boolean];
+type T3 = [number, ...`wow`: boolean[]];
+type T4 = [number, `wow`: ...boolean[]]; // error
+
+type Prefix = 'pre';
+
+type T5 = [`${Prefix}wow`: boolean];
+type T6 = [number, `${Prefix}wow`: boolean];
+type T7 = [number, ...`${Prefix}wow`: boolean[]];
+
+type T8 = [number, `${never}wontfly`: boolean]; // no label displayed
+type T9 = [number, `${any}wontfly`: boolean]; // no label displayed
+type T11 = [number, `${"a" | "b"}wontfly`: boolean]; // no label displayed
+type T12 = [number, `${unknown}wontfly`: boolean]; // error
+
+type MakeTuple1<T1 extends string, T2 extends string> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]];
+type MakeTuple2<T1, T2> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]]; // error
+
+type T13 = MakeTuple1<"awesome", "tail">;
+type T14 = MakeTuple1<any, "tail">;
+type T15 = MakeTuple1<"a" | "b", "tail">;
+
+
+//// [instantiableTupleLabels1.js]
+"use strict";
+
+
+//// [instantiableTupleLabels1.d.ts]
+type T1 = [`wow`: boolean];
+type T2 = [number, `wow`: boolean];
+type T3 = [number, ...`wow`: boolean[]];
+type T4 = [number, `wow`: ...boolean[]];
+type Prefix = 'pre';
+type T5 = [`${Prefix}wow`: boolean];
+type T6 = [number, `${Prefix}wow`: boolean];
+type T7 = [number, ...`${Prefix}wow`: boolean[]];
+type T8 = [number, `${never}wontfly`: boolean];
+type T9 = [number, `${any}wontfly`: boolean];
+type T11 = [number, `${"a" | "b"}wontfly`: boolean];
+type T12 = [number, `${unknown}wontfly`: boolean];
+type MakeTuple1<T1 extends string, T2 extends string> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]];
+type MakeTuple2<T1, T2> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]];
+type T13 = MakeTuple1<"awesome", "tail">;
+type T14 = MakeTuple1<any, "tail">;
+type T15 = MakeTuple1<"a" | "b", "tail">;

--- a/tests/baselines/reference/instantiableTupleLabels1.symbols
+++ b/tests/baselines/reference/instantiableTupleLabels1.symbols
@@ -1,0 +1,68 @@
+//// [tests/cases/conformance/types/tuple/instantiableTupleLabels1.ts] ////
+
+=== instantiableTupleLabels1.ts ===
+type T1 = [`wow`: boolean];
+>T1 : Symbol(T1, Decl(instantiableTupleLabels1.ts, 0, 0))
+
+type T2 = [number, `wow`: boolean];
+>T2 : Symbol(T2, Decl(instantiableTupleLabels1.ts, 0, 27))
+
+type T3 = [number, ...`wow`: boolean[]];
+>T3 : Symbol(T3, Decl(instantiableTupleLabels1.ts, 1, 35))
+
+type T4 = [number, `wow`: ...boolean[]]; // error
+>T4 : Symbol(T4, Decl(instantiableTupleLabels1.ts, 2, 40))
+
+type Prefix = 'pre';
+>Prefix : Symbol(Prefix, Decl(instantiableTupleLabels1.ts, 3, 40))
+
+type T5 = [`${Prefix}wow`: boolean];
+>T5 : Symbol(T5, Decl(instantiableTupleLabels1.ts, 5, 20))
+>Prefix : Symbol(Prefix, Decl(instantiableTupleLabels1.ts, 3, 40))
+
+type T6 = [number, `${Prefix}wow`: boolean];
+>T6 : Symbol(T6, Decl(instantiableTupleLabels1.ts, 7, 36))
+>Prefix : Symbol(Prefix, Decl(instantiableTupleLabels1.ts, 3, 40))
+
+type T7 = [number, ...`${Prefix}wow`: boolean[]];
+>T7 : Symbol(T7, Decl(instantiableTupleLabels1.ts, 8, 44))
+>Prefix : Symbol(Prefix, Decl(instantiableTupleLabels1.ts, 3, 40))
+
+type T8 = [number, `${never}wontfly`: boolean]; // no label displayed
+>T8 : Symbol(T8, Decl(instantiableTupleLabels1.ts, 9, 49))
+
+type T9 = [number, `${any}wontfly`: boolean]; // no label displayed
+>T9 : Symbol(T9, Decl(instantiableTupleLabels1.ts, 11, 47))
+
+type T11 = [number, `${"a" | "b"}wontfly`: boolean]; // no label displayed
+>T11 : Symbol(T11, Decl(instantiableTupleLabels1.ts, 12, 45))
+
+type T12 = [number, `${unknown}wontfly`: boolean]; // error
+>T12 : Symbol(T12, Decl(instantiableTupleLabels1.ts, 13, 52))
+
+type MakeTuple1<T1 extends string, T2 extends string> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]];
+>MakeTuple1 : Symbol(MakeTuple1, Decl(instantiableTupleLabels1.ts, 14, 50))
+>T1 : Symbol(T1, Decl(instantiableTupleLabels1.ts, 16, 16))
+>T2 : Symbol(T2, Decl(instantiableTupleLabels1.ts, 16, 34))
+>T1 : Symbol(T1, Decl(instantiableTupleLabels1.ts, 16, 16))
+>T2 : Symbol(T2, Decl(instantiableTupleLabels1.ts, 16, 34))
+
+type MakeTuple2<T1, T2> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]]; // error
+>MakeTuple2 : Symbol(MakeTuple2, Decl(instantiableTupleLabels1.ts, 16, 117))
+>T1 : Symbol(T1, Decl(instantiableTupleLabels1.ts, 17, 16))
+>T2 : Symbol(T2, Decl(instantiableTupleLabels1.ts, 17, 19))
+>T1 : Symbol(T1, Decl(instantiableTupleLabels1.ts, 17, 16))
+>T2 : Symbol(T2, Decl(instantiableTupleLabels1.ts, 17, 19))
+
+type T13 = MakeTuple1<"awesome", "tail">;
+>T13 : Symbol(T13, Decl(instantiableTupleLabels1.ts, 17, 87))
+>MakeTuple1 : Symbol(MakeTuple1, Decl(instantiableTupleLabels1.ts, 14, 50))
+
+type T14 = MakeTuple1<any, "tail">;
+>T14 : Symbol(T14, Decl(instantiableTupleLabels1.ts, 19, 41))
+>MakeTuple1 : Symbol(MakeTuple1, Decl(instantiableTupleLabels1.ts, 14, 50))
+
+type T15 = MakeTuple1<"a" | "b", "tail">;
+>T15 : Symbol(T15, Decl(instantiableTupleLabels1.ts, 20, 35))
+>MakeTuple1 : Symbol(MakeTuple1, Decl(instantiableTupleLabels1.ts, 14, 50))
+

--- a/tests/baselines/reference/instantiableTupleLabels1.types
+++ b/tests/baselines/reference/instantiableTupleLabels1.types
@@ -1,0 +1,54 @@
+//// [tests/cases/conformance/types/tuple/instantiableTupleLabels1.ts] ////
+
+=== instantiableTupleLabels1.ts ===
+type T1 = [`wow`: boolean];
+>T1 : [wow: boolean]
+
+type T2 = [number, `wow`: boolean];
+>T2 : [number, wow: boolean]
+
+type T3 = [number, ...`wow`: boolean[]];
+>T3 : [number, ...wow: boolean[]]
+
+type T4 = [number, `wow`: ...boolean[]]; // error
+>T4 : [number, wow: boolean]
+
+type Prefix = 'pre';
+>Prefix : "pre"
+
+type T5 = [`${Prefix}wow`: boolean];
+>T5 : [prewow: boolean]
+
+type T6 = [number, `${Prefix}wow`: boolean];
+>T6 : [number, prewow: boolean]
+
+type T7 = [number, ...`${Prefix}wow`: boolean[]];
+>T7 : [number, ...prewow: boolean[]]
+
+type T8 = [number, `${never}wontfly`: boolean]; // no label displayed
+>T8 : [number, boolean]
+
+type T9 = [number, `${any}wontfly`: boolean]; // no label displayed
+>T9 : [number, boolean]
+
+type T11 = [number, `${"a" | "b"}wontfly`: boolean]; // no label displayed
+>T11 : [number, boolean]
+
+type T12 = [number, `${unknown}wontfly`: boolean]; // error
+>T12 : [number, boolean]
+
+type MakeTuple1<T1 extends string, T2 extends string> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]];
+>MakeTuple1 : MakeTuple1<T1, T2>
+
+type MakeTuple2<T1, T2> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]]; // error
+>MakeTuple2 : MakeTuple2<T1, T2>
+
+type T13 = MakeTuple1<"awesome", "tail">;
+>T13 : [number, second-awesome: string, ...rest-tail: boolean[]]
+
+type T14 = MakeTuple1<any, "tail">;
+>T14 : [number, string, ...rest-tail: boolean[]]
+
+type T15 = MakeTuple1<"a" | "b", "tail">;
+>T15 : [number, string, ...rest-tail: boolean[]]
+

--- a/tests/cases/conformance/types/tuple/instantiableTupleLabels1.ts
+++ b/tests/cases/conformance/types/tuple/instantiableTupleLabels1.ts
@@ -1,0 +1,25 @@
+// @strict: true
+// @declaration: true
+
+type T1 = [`wow`: boolean];
+type T2 = [number, `wow`: boolean];
+type T3 = [number, ...`wow`: boolean[]];
+type T4 = [number, `wow`: ...boolean[]]; // error
+
+type Prefix = 'pre';
+
+type T5 = [`${Prefix}wow`: boolean];
+type T6 = [number, `${Prefix}wow`: boolean];
+type T7 = [number, ...`${Prefix}wow`: boolean[]];
+
+type T8 = [number, `${never}wontfly`: boolean]; // no label displayed
+type T9 = [number, `${any}wontfly`: boolean]; // no label displayed
+type T11 = [number, `${"a" | "b"}wontfly`: boolean]; // no label displayed
+type T12 = [number, `${unknown}wontfly`: boolean]; // error
+
+type MakeTuple1<T1 extends string, T2 extends string> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]];
+type MakeTuple2<T1, T2> = [number, `second-${T1}`: string, ...`rest-${T2}`: boolean[]]; // error
+
+type T13 = MakeTuple1<"awesome", "tail">;
+type T14 = MakeTuple1<any, "tail">;
+type T15 = MakeTuple1<"a" | "b", "tail">;


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/44939

A somewhat big drawback of this feature is that an instantiated label is only usable if it instantiates to a string literal type. This means that instantiations that end up being template literal types and even unions of strings are just discarded. I'm open to discussing other possible designs.

I think it's a reasonable tradeoff since this feature is primarily an editor experience improvement. Labels don't have any effect on type checking itself. 

