### PR TITLE
Ensure readJson in build throws when errors are present

### DIFF
--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -72,12 +72,18 @@ export class ExecError extends Error {
 }
 
 /**
- * Reads JSON data with optional comments using the LKG TypeScript compiler
+ * Reads JSON data with optional comments
  * @param {string} jsonPath
  */
 export function readJson(jsonPath) {
     const jsonText = fs.readFileSync(jsonPath, "utf8");
-    return JSONC.parse(jsonText);
+    /** @type {JSONC.ParseError[]} */
+    const errors = [];
+    const result = JSONC.parse(jsonText, errors);
+    if (errors.length) {
+        throw new Error(`Error parsing ${jsonPath}`);
+    }
+    return result;
 }
 
 /**


### PR DESCRIPTION
Back when I wrote this code, I apparently didn't read the docs enough to realize that `JSONC.parse` does not throw when a syntax error is present; it instead parses what it can and expects you to pass in an errors array to populate.