### PR TITLE
fix(chsTranslation): do not translate the word "rest" into Chinese

### DIFF
--- a/src/loc/lcl/chs/diagnosticMessages/diagnosticMessages.generated.json.lcl
+++ b/src/loc/lcl/chs/diagnosticMessages/diagnosticMessages.generated.json.lcl
@@ -685,7 +685,7 @@
         <Str Cat="Text">
           <Val><![CDATA[A rest element cannot have a property name.]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[其余元素不能具有属性名。]]></Val>
+            <Val><![CDATA[rest 元素不能具有属性名。]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />


### PR DESCRIPTION
The word "rest" should not be translated in the item `A_rest_element_cannot_have_a_property_name_2566`, otherwise it will be really confusing.

I have checked the other translations in the same file and the translation in [cht translation](https://github.com/microsoft/TypeScript/blob/main/src/loc/lcl/cht/diagnosticMessages/diagnosticMessages.generated.json.lcl#L688), they both did not translate the word "rest".