### PR TITLE
Fix typo in getScriptTargetFeatures map

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1350,7 +1350,7 @@ export const getScriptTargetFeatures = /* @__PURE__ */ memoize((): ScriptTargetF
                 "defineProperty",
                 "deleteProperty",
                 "get",
-                " getOwnPropertyDescriptor",
+                "getOwnPropertyDescriptor",
                 "getPrototypeOf",
                 "has",
                 "isExtensible",


### PR DESCRIPTION
Noticed this while reviewing the PR to memoize this object.	Doesn't seem to have any affect on tests.