### PR TITLE
Always error on an attempt to use `await` as an identifier in modules

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -167,7 +167,6 @@ import {
     isIdentifier,
     isIdentifierName,
     isInJSFile,
-    isInTopLevelContext,
     isJSDocConstructSignature,
     isJSDocEnumTag,
     isJSDocTemplateTag,
@@ -2457,13 +2456,8 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
             ) {
                 file.bindDiagnostics.push(createDiagnosticForNode(node, getStrictModeIdentifierMessage(node), declarationNameToString(node)));
             }
-            else if (originalKeywordKind === SyntaxKind.AwaitKeyword) {
-                if (isExternalModule(file) && isInTopLevelContext(node)) {
-                    file.bindDiagnostics.push(createDiagnosticForNode(node, Diagnostics.Identifier_expected_0_is_a_reserved_word_at_the_top_level_of_a_module, declarationNameToString(node)));
-                }
-                else if (node.flags & NodeFlags.AwaitContext) {
-                    file.bindDiagnostics.push(createDiagnosticForNode(node, Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here, declarationNameToString(node)));
-                }
+            else if (originalKeywordKind === SyntaxKind.AwaitKeyword && (node.flags & NodeFlags.AwaitContext || isExternalModule(file))) {
+                file.bindDiagnostics.push(createDiagnosticForNode(node, Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here, declarationNameToString(node)));
             }
             else if (originalKeywordKind === SyntaxKind.YieldKeyword && node.flags & NodeFlags.YieldContext) {
                 file.bindDiagnostics.push(createDiagnosticForNode(node, Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here, declarationNameToString(node)));

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -843,10 +843,6 @@
         "category": "Error",
         "code": 1261
     },
-    "Identifier expected. '{0}' is a reserved word at the top-level of a module.": {
-        "category": "Error",
-        "code": 1262
-    },
     "Declarations with initializers cannot also have definite assignment assertions.": {
         "category": "Error",
         "code": 1263

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1346,7 +1346,6 @@ export const plainJSErrors = new Set<number>([
     Diagnostics.A_module_cannot_have_multiple_default_exports.code,
     Diagnostics.Another_export_default_is_here.code,
     Diagnostics.The_first_export_default_is_here.code,
-    Diagnostics.Identifier_expected_0_is_a_reserved_word_at_the_top_level_of_a_module.code,
     Diagnostics.Identifier_expected_0_is_a_reserved_word_in_strict_mode_Modules_are_automatically_in_strict_mode.code,
     Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here.code,
     Diagnostics.constructor_is_a_reserved_word.code,

--- a/tests/baselines/reference/exportDefaultAsyncFunction2.errors.txt
+++ b/tests/baselines/reference/exportDefaultAsyncFunction2.errors.txt
@@ -1,21 +1,24 @@
-a.ts(1,17): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
-asyncawait.ts(2,17): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
-c.ts(1,17): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
-d.ts(1,17): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
-e.ts(1,17): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+a.ts(1,17): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+a.ts(2,28): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+asyncawait.ts(2,17): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+c.ts(1,17): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+d.ts(1,17): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
+e.ts(1,17): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== asyncawait.ts (1 errors) ====
     export function async<T>(...args: any[]): any { }
     export function await(...args: any[]): any { }
                     ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
-==== a.ts (1 errors) ====
+==== a.ts (2 errors) ====
     import { async, await } from 'asyncawait';
                     ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     export default async(() => await(Promise.resolve(1)));
+                               ~~~~~
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== b.ts (0 errors) ====
     export default async () => { return 0; };
@@ -23,20 +26,20 @@ e.ts(1,17): error TS1262: Identifier expected. 'await' is a reserved word at the
 ==== c.ts (1 errors) ====
     import { async, await } from 'asyncawait';
                     ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     export default async<number>();
     
 ==== d.ts (1 errors) ====
     import { async, await } from 'asyncawait';
                     ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
     export default async;
     
 ==== e.ts (1 errors) ====
     import { async, await } from 'asyncawait';
                     ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
     export default async
     

--- a/tests/baselines/reference/plainJSBinderErrors.errors.txt
+++ b/tests/baselines/reference/plainJSBinderErrors.errors.txt
@@ -1,6 +1,6 @@
 plainJSBinderErrors.js(1,1): error TS2528: A module cannot have multiple default exports.
 plainJSBinderErrors.js(2,1): error TS2528: A module cannot have multiple default exports.
-plainJSBinderErrors.js(3,7): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+plainJSBinderErrors.js(3,7): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 plainJSBinderErrors.js(4,7): error TS1214: Identifier expected. 'yield' is a reserved word in strict mode. Modules are automatically in strict mode.
 plainJSBinderErrors.js(6,11): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 plainJSBinderErrors.js(9,11): error TS1214: Identifier expected. 'yield' is a reserved word in strict mode. Modules are automatically in strict mode.
@@ -28,7 +28,7 @@ plainJSBinderErrors.js(40,7): error TS1215: Invalid use of 'arguments'. Modules 
 !!! related TS2752 plainJSBinderErrors.js:1:1: The first export default is here.
     const await = 1
           ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     const yield = 2
           ~~~~~
 !!! error TS1214: Identifier expected. 'yield' is a reserved word in strict mode. Modules are automatically in strict mode.

--- a/tests/baselines/reference/topLevelAwaitErrors.10(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.10(module=es2022).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,19): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,19): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in alias of named import
     import { await as await } from "./other";
                       ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.10(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.10(module=esnext).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,19): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,19): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in alias of named import
     import { await as await } from "./other";
                       ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.11.errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.11.errors.txt
@@ -1,4 +1,4 @@
-index.ts(3,8): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(3,8): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
@@ -6,7 +6,7 @@ index.ts(3,8): error TS1262: Identifier expected. 'await' is a reserved word at 
     declare var require: any;
     import await = require("./other");
            ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.12(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.12(module=es2022).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.12.ts(5,8): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.12.ts(5,8): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.12.ts (1 errors) ====
@@ -8,5 +8,5 @@ topLevelAwaitErrors.12.ts(5,8): error TS1262: Identifier expected. 'await' is a 
     // await disallowed in import=namespace when in a module
     import await = foo.await;
            ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.12(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.12(module=esnext).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.12.ts(5,8): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.12.ts(5,8): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.12.ts (1 errors) ====
@@ -8,5 +8,5 @@ topLevelAwaitErrors.12.ts(5,8): error TS1262: Identifier expected. 'await' is a 
     // await disallowed in import=namespace when in a module
     import await = foo.await;
            ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.2(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.2(module=es2022).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.2.ts(4,5): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.2.ts(4,5): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.2.ts (1 errors) ====
@@ -7,5 +7,5 @@ topLevelAwaitErrors.2.ts(4,5): error TS1262: Identifier expected. 'await' is a r
     // reparse variable name as await should fail
     var await = 1;
         ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.2(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.2(module=esnext).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.2.ts(4,5): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.2.ts(4,5): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.2.ts (1 errors) ====
@@ -7,5 +7,5 @@ topLevelAwaitErrors.2.ts(4,5): error TS1262: Identifier expected. 'await' is a r
     // reparse variable name as await should fail
     var await = 1;
         ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.3(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.3(module=es2022).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.3.ts(4,6): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.3.ts(4,6): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.3.ts (1 errors) ====
@@ -7,5 +7,5 @@ topLevelAwaitErrors.3.ts(4,6): error TS1262: Identifier expected. 'await' is a r
     // reparse binding pattern as await should fail
     var {await} = {await:1};
          ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.3(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.3(module=esnext).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.3.ts(4,6): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.3.ts(4,6): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.3.ts (1 errors) ====
@@ -7,5 +7,5 @@ topLevelAwaitErrors.3.ts(4,6): error TS1262: Identifier expected. 'await' is a r
     // reparse binding pattern as await should fail
     var {await} = {await:1};
          ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.4(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.4(module=es2022).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.4.ts(4,6): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.4.ts(4,6): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.4.ts (1 errors) ====
@@ -7,5 +7,5 @@ topLevelAwaitErrors.4.ts(4,6): error TS1262: Identifier expected. 'await' is a r
     // reparse binding pattern as await should fail
     var [await] = [1];
          ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.4(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.4(module=esnext).errors.txt
@@ -1,4 +1,4 @@
-topLevelAwaitErrors.4.ts(4,6): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.4.ts(4,6): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.4.ts (1 errors) ====
@@ -7,5 +7,5 @@ topLevelAwaitErrors.4.ts(4,6): error TS1262: Identifier expected. 'await' is a r
     // reparse binding pattern as await should fail
     var [await] = [1];
          ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     

--- a/tests/baselines/reference/topLevelAwaitErrors.5(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.5(module=es2022).errors.txt
@@ -1,10 +1,10 @@
-topLevelAwaitErrors.5.ts(2,14): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.5.ts(2,14): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.5.ts (1 errors) ====
     // await in exported class name should fail
     export class await {
                  ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
     

--- a/tests/baselines/reference/topLevelAwaitErrors.5(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.5(module=esnext).errors.txt
@@ -1,10 +1,10 @@
-topLevelAwaitErrors.5.ts(2,14): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.5.ts(2,14): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.5.ts (1 errors) ====
     // await in exported class name should fail
     export class await {
                  ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
     

--- a/tests/baselines/reference/topLevelAwaitErrors.6(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.6(module=es2022).errors.txt
@@ -1,10 +1,10 @@
-topLevelAwaitErrors.6.ts(2,17): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.6.ts(2,17): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.6.ts (1 errors) ====
     // await in exported function name should fail
     export function await() {
                     ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
     

--- a/tests/baselines/reference/topLevelAwaitErrors.6(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.6(module=esnext).errors.txt
@@ -1,10 +1,10 @@
-topLevelAwaitErrors.6.ts(2,17): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+topLevelAwaitErrors.6.ts(2,17): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== topLevelAwaitErrors.6.ts (1 errors) ====
     // await in exported function name should fail
     export function await() {
                     ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     }
     

--- a/tests/baselines/reference/topLevelAwaitErrors.7(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.7(module=es2022).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,13): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,13): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in namespace import
     import * as await from "./other";
                 ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.7(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.7(module=esnext).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,13): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,13): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in namespace import
     import * as await from "./other";
                 ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.8(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.8(module=es2022).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,8): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,8): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in default import
     import await from "./other";
            ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.8(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.8(module=esnext).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,8): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,8): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in default import
     import await from "./other";
            ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.9(module=es2022).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.9(module=es2022).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,10): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,10): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in un-alised named import
     import { await } from "./other";
              ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;

--- a/tests/baselines/reference/topLevelAwaitErrors.9(module=esnext).errors.txt
+++ b/tests/baselines/reference/topLevelAwaitErrors.9(module=esnext).errors.txt
@@ -1,11 +1,11 @@
-index.ts(2,10): error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+index.ts(2,10): error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
 
 
 ==== index.ts (1 errors) ====
     // await disallowed in un-alised named import
     import { await } from "./other";
              ~~~~~
-!!! error TS1262: Identifier expected. 'await' is a reserved word at the top-level of a module.
+!!! error TS1359: Identifier expected. 'await' is a reserved word that cannot be used here.
     
 ==== other.ts (0 errors) ====
     declare const _await: any;


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/8559