### PR TITLE
Add a fourslash completions test related to JSDoc `@template` on prototype method

### DIFF
--- a/tests/cases/fourslash/jsdocTemplatePrototypeCompletions.ts
+++ b/tests/cases/fourslash/jsdocTemplatePrototypeCompletions.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @checkJs: true
+// @filename: index.js
+
+//// https://github.com/microsoft/TypeScript/issues/11492
+
+//// /** @constructor */
+//// function Foo() {}
+//// /**
+////  * @template T
+////  * @param {T} bar
+////  * @returns {T}
+////  */
+//// Foo.prototype.foo = function (bar) {};
+//// new Foo().foo({ id: 1234 })./**/
+
+verify.completions({ marker: "", exact: ["id"] });


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/11492

@jakebailey [bisected the actual fix](https://github.com/microsoft/TypeScript/issues/11492#issuecomment-1693622571) to https://github.com/microsoft/TypeScript/pull/12335