### PR TITLE
Add a test case with a generic member call returning a closed over object

### DIFF
--- a/tests/baselines/reference/genericCallOnMemberReturningClosedOverObject.symbols
+++ b/tests/baselines/reference/genericCallOnMemberReturningClosedOverObject.symbols
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts] ////
+
+=== genericCallOnMemberReturningClosedOverObject.ts ===
+// https://github.com/microsoft/TypeScript/issues/11584
+
+function example<T1>() {
+>example : Symbol(example, Decl(genericCallOnMemberReturningClosedOverObject.ts, 0, 0))
+>T1 : Symbol(T1, Decl(genericCallOnMemberReturningClosedOverObject.ts, 2, 17))
+
+  let x = {
+>x : Symbol(x, Decl(genericCallOnMemberReturningClosedOverObject.ts, 3, 5))
+
+    foo: <T2>(t2: T2) => x,
+>foo : Symbol(foo, Decl(genericCallOnMemberReturningClosedOverObject.ts, 3, 11))
+>T2 : Symbol(T2, Decl(genericCallOnMemberReturningClosedOverObject.ts, 4, 10))
+>t2 : Symbol(t2, Decl(genericCallOnMemberReturningClosedOverObject.ts, 4, 14))
+>T2 : Symbol(T2, Decl(genericCallOnMemberReturningClosedOverObject.ts, 4, 10))
+>x : Symbol(x, Decl(genericCallOnMemberReturningClosedOverObject.ts, 3, 5))
+
+    bar: (t1: T1) => x,
+>bar : Symbol(bar, Decl(genericCallOnMemberReturningClosedOverObject.ts, 4, 27))
+>t1 : Symbol(t1, Decl(genericCallOnMemberReturningClosedOverObject.ts, 5, 10))
+>T1 : Symbol(T1, Decl(genericCallOnMemberReturningClosedOverObject.ts, 2, 17))
+>x : Symbol(x, Decl(genericCallOnMemberReturningClosedOverObject.ts, 3, 5))
+
+  };
+  return x;
+>x : Symbol(x, Decl(genericCallOnMemberReturningClosedOverObject.ts, 3, 5))
+}
+
+example<number>().foo("hello").bar(1);
+>example<number>().foo("hello").bar : Symbol(bar, Decl(genericCallOnMemberReturningClosedOverObject.ts, 4, 27))
+>example<number>().foo : Symbol(foo, Decl(genericCallOnMemberReturningClosedOverObject.ts, 3, 11))
+>example : Symbol(example, Decl(genericCallOnMemberReturningClosedOverObject.ts, 0, 0))
+>foo : Symbol(foo, Decl(genericCallOnMemberReturningClosedOverObject.ts, 3, 11))
+>bar : Symbol(bar, Decl(genericCallOnMemberReturningClosedOverObject.ts, 4, 27))
+

--- a/tests/baselines/reference/genericCallOnMemberReturningClosedOverObject.types
+++ b/tests/baselines/reference/genericCallOnMemberReturningClosedOverObject.types
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts] ////
+
+=== genericCallOnMemberReturningClosedOverObject.ts ===
+// https://github.com/microsoft/TypeScript/issues/11584
+
+function example<T1>() {
+>example : <T1>() => { foo: <T2>(t2: T2) => any; bar: (t1: T1) => any; }
+
+  let x = {
+>x : { foo: <T2>(t2: T2) => any; bar: (t1: T1) => any; }
+>{    foo: <T2>(t2: T2) => x,    bar: (t1: T1) => x,  } : { foo: <T2>(t2: T2) => any; bar: (t1: T1) => any; }
+
+    foo: <T2>(t2: T2) => x,
+>foo : <T2>(t2: T2) => { foo: any; bar: (t1: T1) => any; }
+><T2>(t2: T2) => x : <T2>(t2: T2) => { foo: any; bar: (t1: T1) => any; }
+>t2 : T2
+>x : { foo: <T2>(t2: T2) => any; bar: (t1: T1) => any; }
+
+    bar: (t1: T1) => x,
+>bar : (t1: T1) => { foo: <T2>(t2: T2) => any; bar: any; }
+>(t1: T1) => x : (t1: T1) => { foo: <T2>(t2: T2) => any; bar: any; }
+>t1 : T1
+>x : { foo: <T2>(t2: T2) => any; bar: (t1: T1) => any; }
+
+  };
+  return x;
+>x : { foo: <T2>(t2: T2) => any; bar: (t1: T1) => any; }
+}
+
+example<number>().foo("hello").bar(1);
+>example<number>().foo("hello").bar(1) : { foo: <T2>(t2: T2) => any; bar: (t1: number) => any; }
+>example<number>().foo("hello").bar : (t1: number) => { foo: <T2>(t2: T2) => any; bar: any; }
+>example<number>().foo("hello") : { foo: <T2>(t2: T2) => any; bar: (t1: number) => any; }
+>example<number>().foo : <T2>(t2: T2) => { foo: any; bar: (t1: number) => any; }
+>example<number>() : { foo: <T2>(t2: T2) => any; bar: (t1: number) => any; }
+>example : <T1>() => { foo: <T2>(t2: T2) => any; bar: (t1: T1) => any; }
+>foo : <T2>(t2: T2) => { foo: any; bar: (t1: number) => any; }
+>"hello" : "hello"
+>bar : (t1: number) => { foo: <T2>(t2: T2) => any; bar: any; }
+>1 : 1
+

--- a/tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts
+++ b/tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts
@@ -1,0 +1,14 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/11584
+
+function example<T1>() {
+  let x = {
+    foo: <T2>(t2: T2) => x,
+    bar: (t1: T1) => x,
+  };
+  return x;
+}
+
+example<number>().foo("hello").bar(1);


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/11584

@jakebailey [bisected the actual fix](https://github.com/microsoft/TypeScript/issues/11584#issuecomment-1693607862) to https://github.com/microsoft/TypeScript/pull/13356