### PR TITLE
Add a test for finding all references of same-named imports from two missing modules

### DIFF
--- a/tests/baselines/reference/findAllRefsMissingModulesOverlappingSpecifiers.baseline.jsonc
+++ b/tests/baselines/reference/findAllRefsMissingModulesOverlappingSpecifiers.baseline.jsonc
@@ -1,0 +1,43 @@
+// === findAllReferences ===
+// === /tests/cases/fourslash/findAllRefsMissingModulesOverlappingSpecifiers.ts ===
+// // https://github.com/microsoft/TypeScript/issues/5551
+// import { resolve/*FIND ALL REFS*/ as resolveUrl } from "idontcare";
+// import { resolve } from "whatever";
+
+
+
+// === findAllReferences ===
+// === /tests/cases/fourslash/findAllRefsMissingModulesOverlappingSpecifiers.ts ===
+// // https://github.com/microsoft/TypeScript/issues/5551
+// import { resolve as resolveUrl } from "idontcare";
+// <|import { [|{| isWriteAccess: true, isDefinition: true |}resolve|]/*FIND ALL REFS*/ } from "whatever";|>
+
+  // === Definitions ===
+  // === /tests/cases/fourslash/findAllRefsMissingModulesOverlappingSpecifiers.ts ===
+  // // https://github.com/microsoft/TypeScript/issues/5551
+  // import { resolve as resolveUrl } from "idontcare";
+  // <|import { [|resolve|]/*FIND ALL REFS*/ } from "whatever";|>
+
+  // === Details ===
+  [
+   {
+    "containerKind": "",
+    "containerName": "",
+    "kind": "alias",
+    "name": "import resolve",
+    "displayParts": [
+     {
+      "text": "import",
+      "kind": "keyword"
+     },
+     {
+      "text": " ",
+      "kind": "space"
+     },
+     {
+      "text": "resolve",
+      "kind": "aliasName"
+     }
+    ]
+   }
+  ]

--- a/tests/cases/fourslash/findAllRefsMissingModulesOverlappingSpecifiers.ts
+++ b/tests/cases/fourslash/findAllRefsMissingModulesOverlappingSpecifiers.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+//// // https://github.com/microsoft/TypeScript/issues/5551
+//// import { resolve/*0*/ as resolveUrl } from "idontcare";
+//// import { resolve/*1*/ } from "whatever";
+
+verify.baselineFindAllReferences("0", "1");


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/5551

@jakebailey [bisected the actual fix](https://github.com/microsoft/TypeScript/issues/5551#issuecomment-1662690796) to https://github.com/microsoft/TypeScript/pull/13643