### PR TITLE
Ensure parsing context is restored in jsdoc parser

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -8766,9 +8766,6 @@ namespace Parser {
         }
 
         function parseJSDocCommentWorker(start = 0, length: number | undefined): JSDoc | undefined {
-            const saveParsingContext = parsingContext;
-            parsingContext |= 1 << ParsingContext.JSDocComment;
-
             const content = sourceText;
             const end = length === undefined ? content.length : start + length;
             length = end - start;
@@ -8789,6 +8786,9 @@ namespace Parser {
             let commentsPos: number | undefined;
             let comments: string[] = [];
             const parts: JSDocComment[] = [];
+
+            const saveParsingContext = parsingContext;
+            parsingContext |= 1 << ParsingContext.JSDocComment;
 
             // + 3 for leading /**, - 5 in total for /** */
             const result = scanner.scanRange(start + 3, length - 5, doJSDocScan);


### PR DESCRIPTION
Noticed this while revisiting JSDoc stuff.

I put this code in the wrong place; we can return early with `undefined` before restoring the context, which is bad, though theoretically doesn't actually affect anything because this flag is not used for anything in particular besides making sure the context is non-empty when parsing lists (so, no test). These parsing contexts are very weird.

Still, not intentional at all.