### PR TITLE
Infer `unknown` at value positions of objects inferred from `keyof T`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24526,7 +24526,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             isTypeParameterAtTopLevel(getReturnTypeOfSignature(signature), typeParameter);
     }
 
-    /** Create an object with properties named in the string literal type. Every property has type `any` */
+    /** Create an object with properties named in the string literal type. Every property has type `unknown` */
     function createEmptyObjectTypeFromStringLiteral(type: Type) {
         const members = createSymbolTable();
         forEachType(type, t => {
@@ -24535,7 +24535,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const name = escapeLeadingUnderscores((t as StringLiteralType).value);
             const literalProp = createSymbol(SymbolFlags.Property, name);
-            literalProp.links.type = anyType;
+            literalProp.links.type = unknownType;
             if (t.symbol) {
                 literalProp.declarations = t.symbol.declarations;
                 literalProp.valueDeclaration = t.symbol.valueDeclaration;

--- a/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.types
+++ b/tests/baselines/reference/inferObjectTypeFromStringLiteralToKeyof.types
@@ -14,8 +14,8 @@ declare var two: "a" | "d";
 >two : "a" | "d"
 
 const x = inference1(two);
->x : { a: any; d: any; }
->inference1(two) : { a: any; d: any; }
+>x : { a: unknown; d: unknown; }
+>inference1(two) : { a: unknown; d: unknown; }
 >inference1 : <T>(name: keyof T) => T
 >two : "a" | "d"
 

--- a/tests/baselines/reference/keyofInferenceIntersectsResults.types
+++ b/tests/baselines/reference/keyofInferenceIntersectsResults.types
@@ -27,15 +27,15 @@ const a = foo<X>('a', 'b'); // compiles cleanly
 >'b' : "b"
 
 const b = foo('a', 'b');    // also clean
->b : { a: any; } & { b: any; }
->foo('a', 'b') : { a: any; } & { b: any; }
+>b : { a: unknown; } & { b: unknown; }
+>foo('a', 'b') : { a: unknown; } & { b: unknown; }
 >foo : <T = X>(x: keyof T, y: keyof T) => T
 >'a' : "a"
 >'b' : "b"
 
 const c = bar('a', 'b');    // still clean
->c : { a: any; } & { b: any; }
->bar('a', 'b') : { a: any; } & { b: any; }
+>c : { a: unknown; } & { b: unknown; }
+>bar('a', 'b') : { a: unknown; } & { b: unknown; }
 >bar : <T>(x: keyof T, y: keyof T) => T
 >'a' : "a"
 >'b' : "b"


### PR DESCRIPTION
I noticed this when investigating a completion problem. Using `any` here might "accidentally leak" (which happens in the changed baselines) without the user noticing. I think it would be great to change this to `unknown` unless there is a strong reason why it should stay this way.

Note that this function was introduced by @sandersn in https://github.com/microsoft/TypeScript/pull/19227 . This was in pre(historic)-3.0 times when `unknown` wasn't even a thing in the language yet 😉 So back then `unknown` wasn't even an option.