### PR TITLE
Discriminate types with divergent read/write property types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14389,7 +14389,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (writeTypes || writeType !== type) {
                 writeTypes = append(!writeTypes ? propTypes.slice() : writeTypes, writeType);
             }
-            else if (type !== firstType) {
+            if (type !== firstType) {
                 checkFlags |= CheckFlags.HasNonUniformType;
             }
             if (isLiteralType(type) || isPatternLiteralType(type)) {

--- a/tests/baselines/reference/discriminateWithDivergentAccessors1.symbols
+++ b/tests/baselines/reference/discriminateWithDivergentAccessors1.symbols
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/discriminateWithDivergentAccessors1.ts] ////
+
+=== discriminateWithDivergentAccessors1.ts ===
+type WeirdoBox<T> =
+>WeirdoBox : Symbol(WeirdoBox, Decl(discriminateWithDivergentAccessors1.ts, 0, 0))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 0, 15))
+
+  | { get done(): false; set done(v: T | null) }
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 1, 5), Decl(discriminateWithDivergentAccessors1.ts, 1, 24))
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 1, 5), Decl(discriminateWithDivergentAccessors1.ts, 1, 24))
+>v : Symbol(v, Decl(discriminateWithDivergentAccessors1.ts, 1, 34))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 0, 15))
+
+  | { get done(): true; set done(v: T | null); value: T };
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 2, 5), Decl(discriminateWithDivergentAccessors1.ts, 2, 23))
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 2, 5), Decl(discriminateWithDivergentAccessors1.ts, 2, 23))
+>v : Symbol(v, Decl(discriminateWithDivergentAccessors1.ts, 2, 33))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 0, 15))
+>value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 2, 46))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 0, 15))
+
+declare const weirdoBox: WeirdoBox<number>;
+>weirdoBox : Symbol(weirdoBox, Decl(discriminateWithDivergentAccessors1.ts, 4, 13))
+>WeirdoBox : Symbol(WeirdoBox, Decl(discriminateWithDivergentAccessors1.ts, 0, 0))
+
+if (weirdoBox.done) {
+>weirdoBox.done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 1, 5), Decl(discriminateWithDivergentAccessors1.ts, 1, 24), Decl(discriminateWithDivergentAccessors1.ts, 2, 5), Decl(discriminateWithDivergentAccessors1.ts, 2, 23))
+>weirdoBox : Symbol(weirdoBox, Decl(discriminateWithDivergentAccessors1.ts, 4, 13))
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 1, 5), Decl(discriminateWithDivergentAccessors1.ts, 1, 24), Decl(discriminateWithDivergentAccessors1.ts, 2, 5), Decl(discriminateWithDivergentAccessors1.ts, 2, 23))
+
+  weirdoBox.value;
+>weirdoBox.value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 2, 46))
+>weirdoBox : Symbol(weirdoBox, Decl(discriminateWithDivergentAccessors1.ts, 4, 13))
+>value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 2, 46))
+}
+

--- a/tests/baselines/reference/discriminateWithDivergentAccessors1.symbols
+++ b/tests/baselines/reference/discriminateWithDivergentAccessors1.symbols
@@ -34,3 +34,43 @@ if (weirdoBox.done) {
 >value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 2, 46))
 }
 
+type WeirdoBox2<T> =
+>WeirdoBox2 : Symbol(WeirdoBox2, Decl(discriminateWithDivergentAccessors1.ts, 8, 1))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 10, 16))
+
+  | { get done(): false; set done(v: T | null) }
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 11, 5), Decl(discriminateWithDivergentAccessors1.ts, 11, 24))
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 11, 5), Decl(discriminateWithDivergentAccessors1.ts, 11, 24))
+>v : Symbol(v, Decl(discriminateWithDivergentAccessors1.ts, 11, 34))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 10, 16))
+
+  | { get done(): true; set done(v: T | null); value: T }
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 12, 5), Decl(discriminateWithDivergentAccessors1.ts, 12, 23))
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 12, 5), Decl(discriminateWithDivergentAccessors1.ts, 12, 23))
+>v : Symbol(v, Decl(discriminateWithDivergentAccessors1.ts, 12, 33))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 10, 16))
+>value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 12, 46))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 10, 16))
+
+  | { get done(): true; set done(v: T | null | undefined); value: number };
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 13, 5), Decl(discriminateWithDivergentAccessors1.ts, 13, 23))
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 13, 5), Decl(discriminateWithDivergentAccessors1.ts, 13, 23))
+>v : Symbol(v, Decl(discriminateWithDivergentAccessors1.ts, 13, 33))
+>T : Symbol(T, Decl(discriminateWithDivergentAccessors1.ts, 10, 16))
+>value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 13, 58))
+
+declare const weirdoBox2: WeirdoBox2<string>;
+>weirdoBox2 : Symbol(weirdoBox2, Decl(discriminateWithDivergentAccessors1.ts, 15, 13))
+>WeirdoBox2 : Symbol(WeirdoBox2, Decl(discriminateWithDivergentAccessors1.ts, 8, 1))
+
+if (weirdoBox2.done) {
+>weirdoBox2.done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 11, 5), Decl(discriminateWithDivergentAccessors1.ts, 11, 24), Decl(discriminateWithDivergentAccessors1.ts, 12, 5), Decl(discriminateWithDivergentAccessors1.ts, 12, 23), Decl(discriminateWithDivergentAccessors1.ts, 13, 5) ... and 1 more)
+>weirdoBox2 : Symbol(weirdoBox2, Decl(discriminateWithDivergentAccessors1.ts, 15, 13))
+>done : Symbol(done, Decl(discriminateWithDivergentAccessors1.ts, 11, 5), Decl(discriminateWithDivergentAccessors1.ts, 11, 24), Decl(discriminateWithDivergentAccessors1.ts, 12, 5), Decl(discriminateWithDivergentAccessors1.ts, 12, 23), Decl(discriminateWithDivergentAccessors1.ts, 13, 5) ... and 1 more)
+
+  weirdoBox2.value;
+>weirdoBox2.value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 12, 46), Decl(discriminateWithDivergentAccessors1.ts, 13, 58))
+>weirdoBox2 : Symbol(weirdoBox2, Decl(discriminateWithDivergentAccessors1.ts, 15, 13))
+>value : Symbol(value, Decl(discriminateWithDivergentAccessors1.ts, 12, 46), Decl(discriminateWithDivergentAccessors1.ts, 13, 58))
+}
+

--- a/tests/baselines/reference/discriminateWithDivergentAccessors1.types
+++ b/tests/baselines/reference/discriminateWithDivergentAccessors1.types
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/discriminateWithDivergentAccessors1.ts] ////
+
+=== discriminateWithDivergentAccessors1.ts ===
+type WeirdoBox<T> =
+>WeirdoBox : WeirdoBox<T>
+
+  | { get done(): false; set done(v: T | null) }
+>done : false
+>false : false
+>done : false
+>v : T | null
+
+  | { get done(): true; set done(v: T | null); value: T };
+>done : true
+>true : true
+>done : true
+>v : T | null
+>value : T
+
+declare const weirdoBox: WeirdoBox<number>;
+>weirdoBox : WeirdoBox<number>
+
+if (weirdoBox.done) {
+>weirdoBox.done : boolean
+>weirdoBox : WeirdoBox<number>
+>done : boolean
+
+  weirdoBox.value;
+>weirdoBox.value : number
+>weirdoBox : { done: true; value: number; }
+>value : number
+}
+

--- a/tests/baselines/reference/discriminateWithDivergentAccessors1.types
+++ b/tests/baselines/reference/discriminateWithDivergentAccessors1.types
@@ -31,3 +31,40 @@ if (weirdoBox.done) {
 >value : number
 }
 
+type WeirdoBox2<T> =
+>WeirdoBox2 : WeirdoBox2<T>
+
+  | { get done(): false; set done(v: T | null) }
+>done : false
+>false : false
+>done : false
+>v : T | null
+
+  | { get done(): true; set done(v: T | null); value: T }
+>done : true
+>true : true
+>done : true
+>v : T | null
+>value : T
+
+  | { get done(): true; set done(v: T | null | undefined); value: number };
+>done : true
+>true : true
+>done : true
+>v : T | null | undefined
+>value : number
+
+declare const weirdoBox2: WeirdoBox2<string>;
+>weirdoBox2 : WeirdoBox2<string>
+
+if (weirdoBox2.done) {
+>weirdoBox2.done : boolean
+>weirdoBox2 : WeirdoBox2<string>
+>done : boolean
+
+  weirdoBox2.value;
+>weirdoBox2.value : string | number
+>weirdoBox2 : { done: true; value: string; } | { done: true; value: number; }
+>value : string | number
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty1.ts] ////
+
+=== discriminateWithOptionalProperty1.ts ===
+type Box<T> = { done?: false } | { done: true; value: T };
+>Box : Symbol(Box, Decl(discriminateWithOptionalProperty1.ts, 0, 0))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty1.ts, 0, 9))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 15))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 34))
+>value : Symbol(value, Decl(discriminateWithOptionalProperty1.ts, 0, 46))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty1.ts, 0, 9))
+
+declare const box: Box<number>;
+>box : Symbol(box, Decl(discriminateWithOptionalProperty1.ts, 2, 13))
+>Box : Symbol(Box, Decl(discriminateWithOptionalProperty1.ts, 0, 0))
+
+if (box.done) {
+>box.done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 15), Decl(discriminateWithOptionalProperty1.ts, 0, 34))
+>box : Symbol(box, Decl(discriminateWithOptionalProperty1.ts, 2, 13))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 15), Decl(discriminateWithOptionalProperty1.ts, 0, 34))
+
+  box.value;
+>box.value : Symbol(value, Decl(discriminateWithOptionalProperty1.ts, 0, 46))
+>box : Symbol(box, Decl(discriminateWithOptionalProperty1.ts, 2, 13))
+>value : Symbol(value, Decl(discriminateWithOptionalProperty1.ts, 0, 46))
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=false).types
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty1.ts] ////
+
+=== discriminateWithOptionalProperty1.ts ===
+type Box<T> = { done?: false } | { done: true; value: T };
+>Box : Box<T>
+>done : false | undefined
+>false : false
+>done : true
+>true : true
+>value : T
+
+declare const box: Box<number>;
+>box : Box<number>
+
+if (box.done) {
+>box.done : boolean | undefined
+>box : Box<number>
+>done : boolean | undefined
+
+  box.value;
+>box.value : number
+>box : { done: true; value: number; }
+>value : number
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty1.ts] ////
+
+=== discriminateWithOptionalProperty1.ts ===
+type Box<T> = { done?: false } | { done: true; value: T };
+>Box : Symbol(Box, Decl(discriminateWithOptionalProperty1.ts, 0, 0))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty1.ts, 0, 9))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 15))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 34))
+>value : Symbol(value, Decl(discriminateWithOptionalProperty1.ts, 0, 46))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty1.ts, 0, 9))
+
+declare const box: Box<number>;
+>box : Symbol(box, Decl(discriminateWithOptionalProperty1.ts, 2, 13))
+>Box : Symbol(Box, Decl(discriminateWithOptionalProperty1.ts, 0, 0))
+
+if (box.done) {
+>box.done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 15), Decl(discriminateWithOptionalProperty1.ts, 0, 34))
+>box : Symbol(box, Decl(discriminateWithOptionalProperty1.ts, 2, 13))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty1.ts, 0, 15), Decl(discriminateWithOptionalProperty1.ts, 0, 34))
+
+  box.value;
+>box.value : Symbol(value, Decl(discriminateWithOptionalProperty1.ts, 0, 46))
+>box : Symbol(box, Decl(discriminateWithOptionalProperty1.ts, 2, 13))
+>value : Symbol(value, Decl(discriminateWithOptionalProperty1.ts, 0, 46))
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty1(exactoptionalpropertytypes=true).types
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty1.ts] ////
+
+=== discriminateWithOptionalProperty1.ts ===
+type Box<T> = { done?: false } | { done: true; value: T };
+>Box : Box<T>
+>done : false | undefined
+>false : false
+>done : true
+>true : true
+>value : T
+
+declare const box: Box<number>;
+>box : Box<number>
+
+if (box.done) {
+>box.done : boolean | undefined
+>box : Box<number>
+>done : boolean | undefined
+
+  box.value;
+>box.value : number
+>box : { done: true; value: number; }
+>value : number
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,222 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty2.ts] ////
+
+=== discriminateWithOptionalProperty2.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type PromiseOrValue<T> = Promise<T> | T;
+>PromiseOrValue : Symbol(PromiseOrValue, Decl(discriminateWithOptionalProperty2.ts, 0, 0))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 2, 20))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 2, 20))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 2, 20))
+
+function mapAsyncIterable<T, U, R = undefined>(
+>mapAsyncIterable : Symbol(mapAsyncIterable, Decl(discriminateWithOptionalProperty2.ts, 2, 40))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+  iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 4, 47))
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+
+  callback: (value: T) => PromiseOrValue<U>,
+>callback : Symbol(callback, Decl(discriminateWithOptionalProperty2.ts, 5, 58))
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 6, 13))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>PromiseOrValue : Symbol(PromiseOrValue, Decl(discriminateWithOptionalProperty2.ts, 0, 0))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+
+): AsyncGenerator<U, R, void> {
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+  const iterator = iterable[Symbol.asyncIterator]();
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 4, 47))
+>Symbol.asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+  async function mapResult(
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+
+    result: IteratorResult<T, R>,
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+>IteratorResult : Symbol(IteratorResult, Decl(lib.es2015.iterable.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+  ): Promise<IteratorResult<U, R>> {
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>IteratorResult : Symbol(IteratorResult, Decl(lib.es2015.iterable.d.ts, --, --))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+    if (result.done) {
+>result.done : Symbol(done, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+>done : Symbol(done, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+
+      return result;
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+    }
+
+    try {
+      return { value: await callback(result.value), done: false };
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 18, 14))
+>callback : Symbol(callback, Decl(discriminateWithOptionalProperty2.ts, 5, 58))
+>result.value : Symbol(IteratorYieldResult.value, Decl(lib.es2015.iterable.d.ts, --, --))
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+>value : Symbol(IteratorYieldResult.value, Decl(lib.es2015.iterable.d.ts, --, --))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty2.ts, 18, 51))
+
+    } catch (error) {
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 19, 13))
+
+      if (typeof iterator.return === "function") {
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        try {
+          await iterator.return();
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        } catch (_e) {}
+>_e : Symbol(_e, Decl(discriminateWithOptionalProperty2.ts, 23, 17))
+      }
+      throw error;
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 19, 13))
+    }
+  }
+
+  return {
+    async next() {
+>next : Symbol(next, Decl(discriminateWithOptionalProperty2.ts, 29, 10))
+
+      return mapResult(await iterator.next());
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+>iterator.next : Symbol(AsyncIterator.next, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>next : Symbol(AsyncIterator.next, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+    },
+    async return(): Promise<IteratorResult<U, R>> {
+>return : Symbol(return, Decl(discriminateWithOptionalProperty2.ts, 32, 6))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>IteratorResult : Symbol(IteratorResult, Decl(lib.es2015.iterable.d.ts, --, --))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+      return typeof iterator.return === "function"
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        ? mapResult(await iterator.return())
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        : { value: undefined as any, done: true };
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 36, 11))
+>undefined : Symbol(undefined)
+>done : Symbol(done, Decl(discriminateWithOptionalProperty2.ts, 36, 36))
+
+    },
+    async throw(error?: unknown) {
+>throw : Symbol(throw, Decl(discriminateWithOptionalProperty2.ts, 37, 6))
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 38, 16))
+
+      if (typeof iterator.throw === "function") {
+>iterator.throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        return mapResult(await iterator.throw(error));
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+>iterator.throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 38, 16))
+      }
+      throw error;
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 38, 16))
+
+    },
+    [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : Symbol([Symbol.asyncIterator], Decl(discriminateWithOptionalProperty2.ts, 43, 6))
+>Symbol.asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+      return this;
+>this : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+
+    },
+  };
+}
+
+const items = [1, 2, 3];
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+
+const iterable = {
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 52, 5))
+
+  [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : Symbol([Symbol.asyncIterator], Decl(discriminateWithOptionalProperty2.ts, 52, 18))
+>Symbol.asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+    return this;
+>this : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 52, 16))
+
+  },
+  next() {
+>next : Symbol(next, Decl(discriminateWithOptionalProperty2.ts, 55, 4))
+
+    const value = items[0];
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 57, 9))
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+
+    items.shift();
+>items.shift : Symbol(Array.shift, Decl(lib.es5.d.ts, --, --))
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+>shift : Symbol(Array.shift, Decl(lib.es5.d.ts, --, --))
+
+    return Promise.resolve({
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+      done: items.length === 0,
+>done : Symbol(done, Decl(discriminateWithOptionalProperty2.ts, 59, 28))
+>items.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+      value,
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 60, 31))
+
+    });
+  },
+};
+
+const doubles = mapAsyncIterable(iterable, (x) => x + x);
+>doubles : Symbol(doubles, Decl(discriminateWithOptionalProperty2.ts, 66, 5))
+>mapAsyncIterable : Symbol(mapAsyncIterable, Decl(discriminateWithOptionalProperty2.ts, 2, 40))
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 52, 5))
+>x : Symbol(x, Decl(discriminateWithOptionalProperty2.ts, 66, 44))
+>x : Symbol(x, Decl(discriminateWithOptionalProperty2.ts, 66, 44))
+>x : Symbol(x, Decl(discriminateWithOptionalProperty2.ts, 66, 44))
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=false).types
@@ -1,0 +1,238 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty2.ts] ////
+
+=== discriminateWithOptionalProperty2.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type PromiseOrValue<T> = Promise<T> | T;
+>PromiseOrValue : PromiseOrValue<T>
+
+function mapAsyncIterable<T, U, R = undefined>(
+>mapAsyncIterable : <T, U, R = undefined>(iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>, callback: (value: T) => PromiseOrValue<U>) => AsyncGenerator<U, R, void>
+
+  iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
+>iterable : AsyncGenerator<T, R, void> | AsyncIterable<T>
+
+  callback: (value: T) => PromiseOrValue<U>,
+>callback : (value: T) => PromiseOrValue<U>
+>value : T
+
+): AsyncGenerator<U, R, void> {
+  const iterator = iterable[Symbol.asyncIterator]();
+>iterator : AsyncIterator<T, any, undefined>
+>iterable[Symbol.asyncIterator]() : AsyncIterator<T, any, undefined>
+>iterable[Symbol.asyncIterator] : (() => AsyncGenerator<T, R, void>) | (() => AsyncIterator<T, any, undefined>)
+>iterable : AsyncGenerator<T, R, void> | AsyncIterable<T>
+>Symbol.asyncIterator : unique symbol
+>Symbol : SymbolConstructor
+>asyncIterator : unique symbol
+
+  async function mapResult(
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+
+    result: IteratorResult<T, R>,
+>result : IteratorResult<T, R>
+
+  ): Promise<IteratorResult<U, R>> {
+    if (result.done) {
+>result.done : boolean | undefined
+>result : IteratorResult<T, R>
+>done : boolean | undefined
+
+      return result;
+>result : IteratorReturnResult<R>
+    }
+
+    try {
+      return { value: await callback(result.value), done: false };
+>{ value: await callback(result.value), done: false } : { value: Awaited<U>; done: false; }
+>value : Awaited<U>
+>await callback(result.value) : Awaited<U>
+>callback(result.value) : PromiseOrValue<U>
+>callback : (value: T) => PromiseOrValue<U>
+>result.value : T
+>result : IteratorYieldResult<T>
+>value : T
+>done : false
+>false : false
+
+    } catch (error) {
+>error : unknown
+
+      if (typeof iterator.return === "function") {
+>typeof iterator.return === "function" : boolean
+>typeof iterator.return : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>iterator.return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>iterator : AsyncIterator<T, any, undefined>
+>return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>"function" : "function"
+
+        try {
+          await iterator.return();
+>await iterator.return() : IteratorResult<T, any>
+>iterator.return() : Promise<IteratorResult<T, any>>
+>iterator.return : (value?: any) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>return : (value?: any) => Promise<IteratorResult<T, any>>
+
+        } catch (_e) {}
+>_e : unknown
+      }
+      throw error;
+>error : unknown
+    }
+  }
+
+  return {
+>{    async next() {      return mapResult(await iterator.next());    },    async return(): Promise<IteratorResult<U, R>> {      return typeof iterator.return === "function"        ? mapResult(await iterator.return())        : { value: undefined as any, done: true };    },    async throw(error?: unknown) {      if (typeof iterator.throw === "function") {        return mapResult(await iterator.throw(error));      }      throw error;    },    [Symbol.asyncIterator]() {      return this;    },  } : { next(): Promise<IteratorResult<U, R>>; return(): Promise<IteratorResult<U, R>>; throw(error?: unknown): Promise<IteratorResult<U, R>>; [Symbol.asyncIterator](): AsyncGenerator<U, R, void>; }
+
+    async next() {
+>next : () => Promise<IteratorResult<U, R>>
+
+      return mapResult(await iterator.next());
+>mapResult(await iterator.next()) : Promise<IteratorResult<U, R>>
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+>await iterator.next() : IteratorResult<T, any>
+>iterator.next() : Promise<IteratorResult<T, any>>
+>iterator.next : (...args: [] | [undefined]) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>next : (...args: [] | [undefined]) => Promise<IteratorResult<T, any>>
+
+    },
+    async return(): Promise<IteratorResult<U, R>> {
+>return : () => Promise<IteratorResult<U, R>>
+
+      return typeof iterator.return === "function"
+>typeof iterator.return === "function"        ? mapResult(await iterator.return())        : { value: undefined as any, done: true } : Promise<IteratorResult<U, R>> | { value: any; done: true; }
+>typeof iterator.return === "function" : boolean
+>typeof iterator.return : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>iterator.return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>iterator : AsyncIterator<T, any, undefined>
+>return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>"function" : "function"
+
+        ? mapResult(await iterator.return())
+>mapResult(await iterator.return()) : Promise<IteratorResult<U, R>>
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+>await iterator.return() : IteratorResult<T, any>
+>iterator.return() : Promise<IteratorResult<T, any>>
+>iterator.return : (value?: any) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>return : (value?: any) => Promise<IteratorResult<T, any>>
+
+        : { value: undefined as any, done: true };
+>{ value: undefined as any, done: true } : { value: any; done: true; }
+>value : any
+>undefined as any : any
+>undefined : undefined
+>done : true
+>true : true
+
+    },
+    async throw(error?: unknown) {
+>throw : (error?: unknown) => Promise<IteratorResult<U, R>>
+>error : unknown
+
+      if (typeof iterator.throw === "function") {
+>typeof iterator.throw === "function" : boolean
+>typeof iterator.throw : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>iterator.throw : ((e?: any) => Promise<IteratorResult<T, any>>) | undefined
+>iterator : AsyncIterator<T, any, undefined>
+>throw : ((e?: any) => Promise<IteratorResult<T, any>>) | undefined
+>"function" : "function"
+
+        return mapResult(await iterator.throw(error));
+>mapResult(await iterator.throw(error)) : Promise<IteratorResult<U, R>>
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+>await iterator.throw(error) : IteratorResult<T, any>
+>iterator.throw(error) : Promise<IteratorResult<T, any>>
+>iterator.throw : (e?: any) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>throw : (e?: any) => Promise<IteratorResult<T, any>>
+>error : unknown
+      }
+      throw error;
+>error : unknown
+
+    },
+    [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : () => AsyncGenerator<U, R, void>
+>Symbol.asyncIterator : unique symbol
+>Symbol : SymbolConstructor
+>asyncIterator : unique symbol
+
+      return this;
+>this : AsyncGenerator<U, R, void>
+
+    },
+  };
+}
+
+const items = [1, 2, 3];
+>items : number[]
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+
+const iterable = {
+>iterable : { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+>{  [Symbol.asyncIterator]() {    return this;  },  next() {    const value = items[0];    items.shift();    return Promise.resolve({      done: items.length === 0,      value,    });  },} : { [Symbol.asyncIterator](): { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }; next(): Promise<{ done: boolean; value: number; }>; }
+
+  [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : () => { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+>Symbol.asyncIterator : unique symbol
+>Symbol : SymbolConstructor
+>asyncIterator : unique symbol
+
+    return this;
+>this : { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+
+  },
+  next() {
+>next : () => Promise<{ done: boolean; value: number; }>
+
+    const value = items[0];
+>value : number
+>items[0] : number
+>items : number[]
+>0 : 0
+
+    items.shift();
+>items.shift() : number | undefined
+>items.shift : () => number | undefined
+>items : number[]
+>shift : () => number | undefined
+
+    return Promise.resolve({
+>Promise.resolve({      done: items.length === 0,      value,    }) : Promise<{ done: boolean; value: number; }>
+>Promise.resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>Promise : PromiseConstructor
+>resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>{      done: items.length === 0,      value,    } : { done: boolean; value: number; }
+
+      done: items.length === 0,
+>done : boolean
+>items.length === 0 : boolean
+>items.length : number
+>items : number[]
+>length : number
+>0 : 0
+
+      value,
+>value : number
+
+    });
+  },
+};
+
+const doubles = mapAsyncIterable(iterable, (x) => x + x);
+>doubles : AsyncGenerator<number, number, void>
+>mapAsyncIterable(iterable, (x) => x + x) : AsyncGenerator<number, number, void>
+>mapAsyncIterable : <T, U, R = undefined>(iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>, callback: (value: T) => PromiseOrValue<U>) => AsyncGenerator<U, R, void>
+>iterable : { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+>(x) => x + x : (x: number) => number
+>x : number
+>x + x : number
+>x : number
+>x : number
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,222 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty2.ts] ////
+
+=== discriminateWithOptionalProperty2.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type PromiseOrValue<T> = Promise<T> | T;
+>PromiseOrValue : Symbol(PromiseOrValue, Decl(discriminateWithOptionalProperty2.ts, 0, 0))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 2, 20))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 2, 20))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 2, 20))
+
+function mapAsyncIterable<T, U, R = undefined>(
+>mapAsyncIterable : Symbol(mapAsyncIterable, Decl(discriminateWithOptionalProperty2.ts, 2, 40))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+  iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 4, 47))
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+
+  callback: (value: T) => PromiseOrValue<U>,
+>callback : Symbol(callback, Decl(discriminateWithOptionalProperty2.ts, 5, 58))
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 6, 13))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>PromiseOrValue : Symbol(PromiseOrValue, Decl(discriminateWithOptionalProperty2.ts, 0, 0))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+
+): AsyncGenerator<U, R, void> {
+>AsyncGenerator : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+  const iterator = iterable[Symbol.asyncIterator]();
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 4, 47))
+>Symbol.asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+  async function mapResult(
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+
+    result: IteratorResult<T, R>,
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+>IteratorResult : Symbol(IteratorResult, Decl(lib.es2015.iterable.d.ts, --, --))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty2.ts, 4, 26))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+  ): Promise<IteratorResult<U, R>> {
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>IteratorResult : Symbol(IteratorResult, Decl(lib.es2015.iterable.d.ts, --, --))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+    if (result.done) {
+>result.done : Symbol(done, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+>done : Symbol(done, Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+
+      return result;
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+    }
+
+    try {
+      return { value: await callback(result.value), done: false };
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 18, 14))
+>callback : Symbol(callback, Decl(discriminateWithOptionalProperty2.ts, 5, 58))
+>result.value : Symbol(IteratorYieldResult.value, Decl(lib.es2015.iterable.d.ts, --, --))
+>result : Symbol(result, Decl(discriminateWithOptionalProperty2.ts, 10, 27))
+>value : Symbol(IteratorYieldResult.value, Decl(lib.es2015.iterable.d.ts, --, --))
+>done : Symbol(done, Decl(discriminateWithOptionalProperty2.ts, 18, 51))
+
+    } catch (error) {
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 19, 13))
+
+      if (typeof iterator.return === "function") {
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        try {
+          await iterator.return();
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        } catch (_e) {}
+>_e : Symbol(_e, Decl(discriminateWithOptionalProperty2.ts, 23, 17))
+      }
+      throw error;
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 19, 13))
+    }
+  }
+
+  return {
+    async next() {
+>next : Symbol(next, Decl(discriminateWithOptionalProperty2.ts, 29, 10))
+
+      return mapResult(await iterator.next());
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+>iterator.next : Symbol(AsyncIterator.next, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>next : Symbol(AsyncIterator.next, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+    },
+    async return(): Promise<IteratorResult<U, R>> {
+>return : Symbol(return, Decl(discriminateWithOptionalProperty2.ts, 32, 6))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>IteratorResult : Symbol(IteratorResult, Decl(lib.es2015.iterable.d.ts, --, --))
+>U : Symbol(U, Decl(discriminateWithOptionalProperty2.ts, 4, 28))
+>R : Symbol(R, Decl(discriminateWithOptionalProperty2.ts, 4, 31))
+
+      return typeof iterator.return === "function"
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        ? mapResult(await iterator.return())
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+>iterator.return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>return : Symbol(AsyncIterator.return, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        : { value: undefined as any, done: true };
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 36, 11))
+>undefined : Symbol(undefined)
+>done : Symbol(done, Decl(discriminateWithOptionalProperty2.ts, 36, 36))
+
+    },
+    async throw(error?: unknown) {
+>throw : Symbol(throw, Decl(discriminateWithOptionalProperty2.ts, 37, 6))
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 38, 16))
+
+      if (typeof iterator.throw === "function") {
+>iterator.throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+        return mapResult(await iterator.throw(error));
+>mapResult : Symbol(mapResult, Decl(discriminateWithOptionalProperty2.ts, 8, 52))
+>iterator.throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>iterator : Symbol(iterator, Decl(discriminateWithOptionalProperty2.ts, 8, 7))
+>throw : Symbol(AsyncIterator.throw, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 38, 16))
+      }
+      throw error;
+>error : Symbol(error, Decl(discriminateWithOptionalProperty2.ts, 38, 16))
+
+    },
+    [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : Symbol([Symbol.asyncIterator], Decl(discriminateWithOptionalProperty2.ts, 43, 6))
+>Symbol.asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+      return this;
+>this : Symbol(AsyncGenerator, Decl(lib.es2018.asyncgenerator.d.ts, --, --))
+
+    },
+  };
+}
+
+const items = [1, 2, 3];
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+
+const iterable = {
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 52, 5))
+
+  [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : Symbol([Symbol.asyncIterator], Decl(discriminateWithOptionalProperty2.ts, 52, 18))
+>Symbol.asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>asyncIterator : Symbol(SymbolConstructor.asyncIterator, Decl(lib.es2018.asynciterable.d.ts, --, --))
+
+    return this;
+>this : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 52, 16))
+
+  },
+  next() {
+>next : Symbol(next, Decl(discriminateWithOptionalProperty2.ts, 55, 4))
+
+    const value = items[0];
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 57, 9))
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+
+    items.shift();
+>items.shift : Symbol(Array.shift, Decl(lib.es5.d.ts, --, --))
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+>shift : Symbol(Array.shift, Decl(lib.es5.d.ts, --, --))
+
+    return Promise.resolve({
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+      done: items.length === 0,
+>done : Symbol(done, Decl(discriminateWithOptionalProperty2.ts, 59, 28))
+>items.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>items : Symbol(items, Decl(discriminateWithOptionalProperty2.ts, 50, 5))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+      value,
+>value : Symbol(value, Decl(discriminateWithOptionalProperty2.ts, 60, 31))
+
+    });
+  },
+};
+
+const doubles = mapAsyncIterable(iterable, (x) => x + x);
+>doubles : Symbol(doubles, Decl(discriminateWithOptionalProperty2.ts, 66, 5))
+>mapAsyncIterable : Symbol(mapAsyncIterable, Decl(discriminateWithOptionalProperty2.ts, 2, 40))
+>iterable : Symbol(iterable, Decl(discriminateWithOptionalProperty2.ts, 52, 5))
+>x : Symbol(x, Decl(discriminateWithOptionalProperty2.ts, 66, 44))
+>x : Symbol(x, Decl(discriminateWithOptionalProperty2.ts, 66, 44))
+>x : Symbol(x, Decl(discriminateWithOptionalProperty2.ts, 66, 44))
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty2(exactoptionalpropertytypes=true).types
@@ -1,0 +1,238 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty2.ts] ////
+
+=== discriminateWithOptionalProperty2.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type PromiseOrValue<T> = Promise<T> | T;
+>PromiseOrValue : PromiseOrValue<T>
+
+function mapAsyncIterable<T, U, R = undefined>(
+>mapAsyncIterable : <T, U, R = undefined>(iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>, callback: (value: T) => PromiseOrValue<U>) => AsyncGenerator<U, R, void>
+
+  iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
+>iterable : AsyncGenerator<T, R, void> | AsyncIterable<T>
+
+  callback: (value: T) => PromiseOrValue<U>,
+>callback : (value: T) => PromiseOrValue<U>
+>value : T
+
+): AsyncGenerator<U, R, void> {
+  const iterator = iterable[Symbol.asyncIterator]();
+>iterator : AsyncIterator<T, any, undefined>
+>iterable[Symbol.asyncIterator]() : AsyncIterator<T, any, undefined>
+>iterable[Symbol.asyncIterator] : (() => AsyncGenerator<T, R, void>) | (() => AsyncIterator<T, any, undefined>)
+>iterable : AsyncGenerator<T, R, void> | AsyncIterable<T>
+>Symbol.asyncIterator : unique symbol
+>Symbol : SymbolConstructor
+>asyncIterator : unique symbol
+
+  async function mapResult(
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+
+    result: IteratorResult<T, R>,
+>result : IteratorResult<T, R>
+
+  ): Promise<IteratorResult<U, R>> {
+    if (result.done) {
+>result.done : boolean | undefined
+>result : IteratorResult<T, R>
+>done : boolean | undefined
+
+      return result;
+>result : IteratorReturnResult<R>
+    }
+
+    try {
+      return { value: await callback(result.value), done: false };
+>{ value: await callback(result.value), done: false } : { value: Awaited<U>; done: false; }
+>value : Awaited<U>
+>await callback(result.value) : Awaited<U>
+>callback(result.value) : PromiseOrValue<U>
+>callback : (value: T) => PromiseOrValue<U>
+>result.value : T
+>result : IteratorYieldResult<T>
+>value : T
+>done : false
+>false : false
+
+    } catch (error) {
+>error : unknown
+
+      if (typeof iterator.return === "function") {
+>typeof iterator.return === "function" : boolean
+>typeof iterator.return : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>iterator.return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>iterator : AsyncIterator<T, any, undefined>
+>return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>"function" : "function"
+
+        try {
+          await iterator.return();
+>await iterator.return() : IteratorResult<T, any>
+>iterator.return() : Promise<IteratorResult<T, any>>
+>iterator.return : (value?: any) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>return : (value?: any) => Promise<IteratorResult<T, any>>
+
+        } catch (_e) {}
+>_e : unknown
+      }
+      throw error;
+>error : unknown
+    }
+  }
+
+  return {
+>{    async next() {      return mapResult(await iterator.next());    },    async return(): Promise<IteratorResult<U, R>> {      return typeof iterator.return === "function"        ? mapResult(await iterator.return())        : { value: undefined as any, done: true };    },    async throw(error?: unknown) {      if (typeof iterator.throw === "function") {        return mapResult(await iterator.throw(error));      }      throw error;    },    [Symbol.asyncIterator]() {      return this;    },  } : { next(): Promise<IteratorResult<U, R>>; return(): Promise<IteratorResult<U, R>>; throw(error?: unknown): Promise<IteratorResult<U, R>>; [Symbol.asyncIterator](): AsyncGenerator<U, R, void>; }
+
+    async next() {
+>next : () => Promise<IteratorResult<U, R>>
+
+      return mapResult(await iterator.next());
+>mapResult(await iterator.next()) : Promise<IteratorResult<U, R>>
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+>await iterator.next() : IteratorResult<T, any>
+>iterator.next() : Promise<IteratorResult<T, any>>
+>iterator.next : (...args: [] | [undefined]) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>next : (...args: [] | [undefined]) => Promise<IteratorResult<T, any>>
+
+    },
+    async return(): Promise<IteratorResult<U, R>> {
+>return : () => Promise<IteratorResult<U, R>>
+
+      return typeof iterator.return === "function"
+>typeof iterator.return === "function"        ? mapResult(await iterator.return())        : { value: undefined as any, done: true } : Promise<IteratorResult<U, R>> | { value: any; done: true; }
+>typeof iterator.return === "function" : boolean
+>typeof iterator.return : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>iterator.return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>iterator : AsyncIterator<T, any, undefined>
+>return : ((value?: any) => Promise<IteratorResult<T, any>>) | undefined
+>"function" : "function"
+
+        ? mapResult(await iterator.return())
+>mapResult(await iterator.return()) : Promise<IteratorResult<U, R>>
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+>await iterator.return() : IteratorResult<T, any>
+>iterator.return() : Promise<IteratorResult<T, any>>
+>iterator.return : (value?: any) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>return : (value?: any) => Promise<IteratorResult<T, any>>
+
+        : { value: undefined as any, done: true };
+>{ value: undefined as any, done: true } : { value: any; done: true; }
+>value : any
+>undefined as any : any
+>undefined : undefined
+>done : true
+>true : true
+
+    },
+    async throw(error?: unknown) {
+>throw : (error?: unknown) => Promise<IteratorResult<U, R>>
+>error : unknown
+
+      if (typeof iterator.throw === "function") {
+>typeof iterator.throw === "function" : boolean
+>typeof iterator.throw : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>iterator.throw : ((e?: any) => Promise<IteratorResult<T, any>>) | undefined
+>iterator : AsyncIterator<T, any, undefined>
+>throw : ((e?: any) => Promise<IteratorResult<T, any>>) | undefined
+>"function" : "function"
+
+        return mapResult(await iterator.throw(error));
+>mapResult(await iterator.throw(error)) : Promise<IteratorResult<U, R>>
+>mapResult : (result: IteratorResult<T, R>) => Promise<IteratorResult<U, R>>
+>await iterator.throw(error) : IteratorResult<T, any>
+>iterator.throw(error) : Promise<IteratorResult<T, any>>
+>iterator.throw : (e?: any) => Promise<IteratorResult<T, any>>
+>iterator : AsyncIterator<T, any, undefined>
+>throw : (e?: any) => Promise<IteratorResult<T, any>>
+>error : unknown
+      }
+      throw error;
+>error : unknown
+
+    },
+    [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : () => AsyncGenerator<U, R, void>
+>Symbol.asyncIterator : unique symbol
+>Symbol : SymbolConstructor
+>asyncIterator : unique symbol
+
+      return this;
+>this : AsyncGenerator<U, R, void>
+
+    },
+  };
+}
+
+const items = [1, 2, 3];
+>items : number[]
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+
+const iterable = {
+>iterable : { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+>{  [Symbol.asyncIterator]() {    return this;  },  next() {    const value = items[0];    items.shift();    return Promise.resolve({      done: items.length === 0,      value,    });  },} : { [Symbol.asyncIterator](): { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }; next(): Promise<{ done: boolean; value: number; }>; }
+
+  [Symbol.asyncIterator]() {
+>[Symbol.asyncIterator] : () => { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+>Symbol.asyncIterator : unique symbol
+>Symbol : SymbolConstructor
+>asyncIterator : unique symbol
+
+    return this;
+>this : { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+
+  },
+  next() {
+>next : () => Promise<{ done: boolean; value: number; }>
+
+    const value = items[0];
+>value : number
+>items[0] : number
+>items : number[]
+>0 : 0
+
+    items.shift();
+>items.shift() : number | undefined
+>items.shift : () => number | undefined
+>items : number[]
+>shift : () => number | undefined
+
+    return Promise.resolve({
+>Promise.resolve({      done: items.length === 0,      value,    }) : Promise<{ done: boolean; value: number; }>
+>Promise.resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>Promise : PromiseConstructor
+>resolve : { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: T | PromiseLike<T>): Promise<Awaited<T>>; }
+>{      done: items.length === 0,      value,    } : { done: boolean; value: number; }
+
+      done: items.length === 0,
+>done : boolean
+>items.length === 0 : boolean
+>items.length : number
+>items : number[]
+>length : number
+>0 : 0
+
+      value,
+>value : number
+
+    });
+  },
+};
+
+const doubles = mapAsyncIterable(iterable, (x) => x + x);
+>doubles : AsyncGenerator<number, number, void>
+>mapAsyncIterable(iterable, (x) => x + x) : AsyncGenerator<number, number, void>
+>mapAsyncIterable : <T, U, R = undefined>(iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>, callback: (value: T) => PromiseOrValue<U>) => AsyncGenerator<U, R, void>
+>iterable : { [Symbol.asyncIterator](): any; next(): Promise<{ done: boolean; value: number; }>; }
+>(x) => x + x : (x: number) => number
+>x : number
+>x + x : number
+>x : number
+>x : number
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,103 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty3.ts] ////
+
+=== discriminateWithOptionalProperty3.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type Maybe<T> = null | undefined | T;
+>Maybe : Symbol(Maybe, Decl(discriminateWithOptionalProperty3.ts, 0, 0))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty3.ts, 2, 11))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty3.ts, 2, 11))
+
+declare class GraphQLError extends Error {
+>GraphQLError : Symbol(GraphQLError, Decl(discriminateWithOptionalProperty3.ts, 2, 37))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+  originalError: Error;
+>originalError : Symbol(GraphQLError.originalError, Decl(discriminateWithOptionalProperty3.ts, 4, 42))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+}
+
+interface ExecutionArgs {
+>ExecutionArgs : Symbol(ExecutionArgs, Decl(discriminateWithOptionalProperty3.ts, 6, 1))
+
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
+>variableValues : Symbol(ExecutionArgs.variableValues, Decl(discriminateWithOptionalProperty3.ts, 8, 25))
+>Maybe : Symbol(Maybe, Decl(discriminateWithOptionalProperty3.ts, 0, 0))
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 9, 37))
+}
+
+interface ExecutionContext {
+>ExecutionContext : Symbol(ExecutionContext, Decl(discriminateWithOptionalProperty3.ts, 10, 1))
+
+  variableValues: { [variable: string]: unknown };
+>variableValues : Symbol(ExecutionContext.variableValues, Decl(discriminateWithOptionalProperty3.ts, 12, 28))
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 13, 21))
+}
+
+type CoercedVariableValues =
+>CoercedVariableValues : Symbol(CoercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 14, 1))
+
+  | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2016.array.include.d.ts, --, --) ... and 3 more)
+>GraphQLError : Symbol(GraphQLError, Decl(discriminateWithOptionalProperty3.ts, 2, 37))
+>coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 17, 42))
+
+  | { coerced: { [variable: string]: unknown }; errors?: never };
+>coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 18, 5))
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 18, 18))
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 18, 47))
+
+declare function getVariableValues(inputs: {
+>getVariableValues : Symbol(getVariableValues, Decl(discriminateWithOptionalProperty3.ts, 18, 65))
+>inputs : Symbol(inputs, Decl(discriminateWithOptionalProperty3.ts, 20, 35))
+
+  readonly [variable: string]: unknown;
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 21, 12))
+
+}): CoercedVariableValues;
+>CoercedVariableValues : Symbol(CoercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 14, 1))
+
+export function buildExecutionContext(
+>buildExecutionContext : Symbol(buildExecutionContext, Decl(discriminateWithOptionalProperty3.ts, 22, 26))
+
+  args: ExecutionArgs,
+>args : Symbol(args, Decl(discriminateWithOptionalProperty3.ts, 24, 38))
+>ExecutionArgs : Symbol(ExecutionArgs, Decl(discriminateWithOptionalProperty3.ts, 6, 1))
+
+): ReadonlyArray<GraphQLError> | ExecutionContext {
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2016.array.include.d.ts, --, --) ... and 3 more)
+>GraphQLError : Symbol(GraphQLError, Decl(discriminateWithOptionalProperty3.ts, 2, 37))
+>ExecutionContext : Symbol(ExecutionContext, Decl(discriminateWithOptionalProperty3.ts, 10, 1))
+
+  const { variableValues: rawVariableValues } = args;
+>variableValues : Symbol(ExecutionArgs.variableValues, Decl(discriminateWithOptionalProperty3.ts, 8, 25))
+>rawVariableValues : Symbol(rawVariableValues, Decl(discriminateWithOptionalProperty3.ts, 27, 9))
+>args : Symbol(args, Decl(discriminateWithOptionalProperty3.ts, 24, 38))
+
+  const coercedVariableValues = getVariableValues(rawVariableValues ?? {});
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>getVariableValues : Symbol(getVariableValues, Decl(discriminateWithOptionalProperty3.ts, 18, 65))
+>rawVariableValues : Symbol(rawVariableValues, Decl(discriminateWithOptionalProperty3.ts, 27, 9))
+
+  if (coercedVariableValues.errors) {
+>coercedVariableValues.errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5), Decl(discriminateWithOptionalProperty3.ts, 18, 47))
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5), Decl(discriminateWithOptionalProperty3.ts, 18, 47))
+
+    return coercedVariableValues.errors;
+>coercedVariableValues.errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5))
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5))
+  }
+
+  return {
+    variableValues: coercedVariableValues.coerced,
+>variableValues : Symbol(variableValues, Decl(discriminateWithOptionalProperty3.ts, 35, 10))
+>coercedVariableValues.coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 18, 5))
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 18, 5))
+
+  };
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=false).types
@@ -1,0 +1,92 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty3.ts] ////
+
+=== discriminateWithOptionalProperty3.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type Maybe<T> = null | undefined | T;
+>Maybe : Maybe<T>
+
+declare class GraphQLError extends Error {
+>GraphQLError : GraphQLError
+>Error : Error
+
+  originalError: Error;
+>originalError : Error
+}
+
+interface ExecutionArgs {
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
+>variableValues : Maybe<{ readonly [variable: string]: unknown; }>
+>variable : string
+}
+
+interface ExecutionContext {
+  variableValues: { [variable: string]: unknown };
+>variableValues : { [variable: string]: unknown; }
+>variable : string
+}
+
+type CoercedVariableValues =
+>CoercedVariableValues : { errors: ReadonlyArray<GraphQLError>; coerced?: undefined; } | { coerced: { [variable: string]: unknown; }; errors?: undefined; }
+
+  | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
+>errors : readonly GraphQLError[]
+>coerced : undefined
+
+  | { coerced: { [variable: string]: unknown }; errors?: never };
+>coerced : { [variable: string]: unknown; }
+>variable : string
+>errors : undefined
+
+declare function getVariableValues(inputs: {
+>getVariableValues : (inputs: { readonly [variable: string]: unknown; }) => CoercedVariableValues
+>inputs : { readonly [variable: string]: unknown; }
+
+  readonly [variable: string]: unknown;
+>variable : string
+
+}): CoercedVariableValues;
+
+export function buildExecutionContext(
+>buildExecutionContext : (args: ExecutionArgs) => ReadonlyArray<GraphQLError> | ExecutionContext
+
+  args: ExecutionArgs,
+>args : ExecutionArgs
+
+): ReadonlyArray<GraphQLError> | ExecutionContext {
+  const { variableValues: rawVariableValues } = args;
+>variableValues : any
+>rawVariableValues : Maybe<{ readonly [variable: string]: unknown; }>
+>args : ExecutionArgs
+
+  const coercedVariableValues = getVariableValues(rawVariableValues ?? {});
+>coercedVariableValues : CoercedVariableValues
+>getVariableValues(rawVariableValues ?? {}) : CoercedVariableValues
+>getVariableValues : (inputs: { readonly [variable: string]: unknown; }) => CoercedVariableValues
+>rawVariableValues ?? {} : { readonly [variable: string]: unknown; }
+>rawVariableValues : Maybe<{ readonly [variable: string]: unknown; }>
+>{} : {}
+
+  if (coercedVariableValues.errors) {
+>coercedVariableValues.errors : readonly GraphQLError[] | undefined
+>coercedVariableValues : CoercedVariableValues
+>errors : readonly GraphQLError[] | undefined
+
+    return coercedVariableValues.errors;
+>coercedVariableValues.errors : readonly GraphQLError[]
+>coercedVariableValues : { errors: readonly GraphQLError[]; coerced?: undefined; }
+>errors : readonly GraphQLError[]
+  }
+
+  return {
+>{    variableValues: coercedVariableValues.coerced,  } : { variableValues: { [variable: string]: unknown; }; }
+
+    variableValues: coercedVariableValues.coerced,
+>variableValues : { [variable: string]: unknown; }
+>coercedVariableValues.coerced : { [variable: string]: unknown; }
+>coercedVariableValues : { coerced: { [variable: string]: unknown; }; errors?: undefined; }
+>coerced : { [variable: string]: unknown; }
+
+  };
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,103 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty3.ts] ////
+
+=== discriminateWithOptionalProperty3.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type Maybe<T> = null | undefined | T;
+>Maybe : Symbol(Maybe, Decl(discriminateWithOptionalProperty3.ts, 0, 0))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty3.ts, 2, 11))
+>T : Symbol(T, Decl(discriminateWithOptionalProperty3.ts, 2, 11))
+
+declare class GraphQLError extends Error {
+>GraphQLError : Symbol(GraphQLError, Decl(discriminateWithOptionalProperty3.ts, 2, 37))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+
+  originalError: Error;
+>originalError : Symbol(GraphQLError.originalError, Decl(discriminateWithOptionalProperty3.ts, 4, 42))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2022.error.d.ts, --, --))
+}
+
+interface ExecutionArgs {
+>ExecutionArgs : Symbol(ExecutionArgs, Decl(discriminateWithOptionalProperty3.ts, 6, 1))
+
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
+>variableValues : Symbol(ExecutionArgs.variableValues, Decl(discriminateWithOptionalProperty3.ts, 8, 25))
+>Maybe : Symbol(Maybe, Decl(discriminateWithOptionalProperty3.ts, 0, 0))
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 9, 37))
+}
+
+interface ExecutionContext {
+>ExecutionContext : Symbol(ExecutionContext, Decl(discriminateWithOptionalProperty3.ts, 10, 1))
+
+  variableValues: { [variable: string]: unknown };
+>variableValues : Symbol(ExecutionContext.variableValues, Decl(discriminateWithOptionalProperty3.ts, 12, 28))
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 13, 21))
+}
+
+type CoercedVariableValues =
+>CoercedVariableValues : Symbol(CoercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 14, 1))
+
+  | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2016.array.include.d.ts, --, --) ... and 3 more)
+>GraphQLError : Symbol(GraphQLError, Decl(discriminateWithOptionalProperty3.ts, 2, 37))
+>coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 17, 42))
+
+  | { coerced: { [variable: string]: unknown }; errors?: never };
+>coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 18, 5))
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 18, 18))
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 18, 47))
+
+declare function getVariableValues(inputs: {
+>getVariableValues : Symbol(getVariableValues, Decl(discriminateWithOptionalProperty3.ts, 18, 65))
+>inputs : Symbol(inputs, Decl(discriminateWithOptionalProperty3.ts, 20, 35))
+
+  readonly [variable: string]: unknown;
+>variable : Symbol(variable, Decl(discriminateWithOptionalProperty3.ts, 21, 12))
+
+}): CoercedVariableValues;
+>CoercedVariableValues : Symbol(CoercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 14, 1))
+
+export function buildExecutionContext(
+>buildExecutionContext : Symbol(buildExecutionContext, Decl(discriminateWithOptionalProperty3.ts, 22, 26))
+
+  args: ExecutionArgs,
+>args : Symbol(args, Decl(discriminateWithOptionalProperty3.ts, 24, 38))
+>ExecutionArgs : Symbol(ExecutionArgs, Decl(discriminateWithOptionalProperty3.ts, 6, 1))
+
+): ReadonlyArray<GraphQLError> | ExecutionContext {
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2016.array.include.d.ts, --, --) ... and 3 more)
+>GraphQLError : Symbol(GraphQLError, Decl(discriminateWithOptionalProperty3.ts, 2, 37))
+>ExecutionContext : Symbol(ExecutionContext, Decl(discriminateWithOptionalProperty3.ts, 10, 1))
+
+  const { variableValues: rawVariableValues } = args;
+>variableValues : Symbol(ExecutionArgs.variableValues, Decl(discriminateWithOptionalProperty3.ts, 8, 25))
+>rawVariableValues : Symbol(rawVariableValues, Decl(discriminateWithOptionalProperty3.ts, 27, 9))
+>args : Symbol(args, Decl(discriminateWithOptionalProperty3.ts, 24, 38))
+
+  const coercedVariableValues = getVariableValues(rawVariableValues ?? {});
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>getVariableValues : Symbol(getVariableValues, Decl(discriminateWithOptionalProperty3.ts, 18, 65))
+>rawVariableValues : Symbol(rawVariableValues, Decl(discriminateWithOptionalProperty3.ts, 27, 9))
+
+  if (coercedVariableValues.errors) {
+>coercedVariableValues.errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5), Decl(discriminateWithOptionalProperty3.ts, 18, 47))
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5), Decl(discriminateWithOptionalProperty3.ts, 18, 47))
+
+    return coercedVariableValues.errors;
+>coercedVariableValues.errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5))
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>errors : Symbol(errors, Decl(discriminateWithOptionalProperty3.ts, 17, 5))
+  }
+
+  return {
+    variableValues: coercedVariableValues.coerced,
+>variableValues : Symbol(variableValues, Decl(discriminateWithOptionalProperty3.ts, 35, 10))
+>coercedVariableValues.coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 18, 5))
+>coercedVariableValues : Symbol(coercedVariableValues, Decl(discriminateWithOptionalProperty3.ts, 29, 7))
+>coerced : Symbol(coerced, Decl(discriminateWithOptionalProperty3.ts, 18, 5))
+
+  };
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty3(exactoptionalpropertytypes=true).types
@@ -1,0 +1,92 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty3.ts] ////
+
+=== discriminateWithOptionalProperty3.ts ===
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type Maybe<T> = null | undefined | T;
+>Maybe : Maybe<T>
+
+declare class GraphQLError extends Error {
+>GraphQLError : GraphQLError
+>Error : Error
+
+  originalError: Error;
+>originalError : Error
+}
+
+interface ExecutionArgs {
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
+>variableValues : Maybe<{ readonly [variable: string]: unknown; }>
+>variable : string
+}
+
+interface ExecutionContext {
+  variableValues: { [variable: string]: unknown };
+>variableValues : { [variable: string]: unknown; }
+>variable : string
+}
+
+type CoercedVariableValues =
+>CoercedVariableValues : { errors: ReadonlyArray<GraphQLError>; coerced?: never; } | { coerced: { [variable: string]: unknown; }; errors?: never; }
+
+  | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
+>errors : readonly GraphQLError[]
+>coerced : undefined
+
+  | { coerced: { [variable: string]: unknown }; errors?: never };
+>coerced : { [variable: string]: unknown; }
+>variable : string
+>errors : undefined
+
+declare function getVariableValues(inputs: {
+>getVariableValues : (inputs: { readonly [variable: string]: unknown; }) => CoercedVariableValues
+>inputs : { readonly [variable: string]: unknown; }
+
+  readonly [variable: string]: unknown;
+>variable : string
+
+}): CoercedVariableValues;
+
+export function buildExecutionContext(
+>buildExecutionContext : (args: ExecutionArgs) => ReadonlyArray<GraphQLError> | ExecutionContext
+
+  args: ExecutionArgs,
+>args : ExecutionArgs
+
+): ReadonlyArray<GraphQLError> | ExecutionContext {
+  const { variableValues: rawVariableValues } = args;
+>variableValues : any
+>rawVariableValues : Maybe<{ readonly [variable: string]: unknown; }>
+>args : ExecutionArgs
+
+  const coercedVariableValues = getVariableValues(rawVariableValues ?? {});
+>coercedVariableValues : CoercedVariableValues
+>getVariableValues(rawVariableValues ?? {}) : CoercedVariableValues
+>getVariableValues : (inputs: { readonly [variable: string]: unknown; }) => CoercedVariableValues
+>rawVariableValues ?? {} : { readonly [variable: string]: unknown; }
+>rawVariableValues : Maybe<{ readonly [variable: string]: unknown; }>
+>{} : {}
+
+  if (coercedVariableValues.errors) {
+>coercedVariableValues.errors : readonly GraphQLError[] | undefined
+>coercedVariableValues : CoercedVariableValues
+>errors : readonly GraphQLError[] | undefined
+
+    return coercedVariableValues.errors;
+>coercedVariableValues.errors : readonly GraphQLError[]
+>coercedVariableValues : { errors: readonly GraphQLError[]; coerced?: never; }
+>errors : readonly GraphQLError[]
+  }
+
+  return {
+>{    variableValues: coercedVariableValues.coerced,  } : { variableValues: { [variable: string]: unknown; }; }
+
+    variableValues: coercedVariableValues.coerced,
+>variableValues : { [variable: string]: unknown; }
+>coercedVariableValues.coerced : { [variable: string]: unknown; }
+>coercedVariableValues : { coerced: { [variable: string]: unknown; }; errors?: never; }
+>coerced : { [variable: string]: unknown; }
+
+  };
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=false).errors.txt
+++ b/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=false).errors.txt
@@ -1,0 +1,24 @@
+discriminateWithOptionalProperty4.ts(16,14): error TS18048: 'z.a' is possibly 'undefined'.
+
+
+==== discriminateWithOptionalProperty4.ts (1 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/55566
+    
+    export function main(a: string[] | undefined) {
+      const z = a ? { a } : { b: ["there"] };
+    
+      z.a //
+        ? z.a.toString()
+        : z.b.toString();
+    
+      const zWorkAround:
+        | { a: string[]; b?: undefined }
+        | { b: string[]; a?: undefined } = z;
+    
+      zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString();
+    
+      "a" in z ? z.a.toString() : z.b.toString();
+                 ~~~
+!!! error TS18048: 'z.a' is possibly 'undefined'.
+    }
+    

--- a/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=false).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=false).symbols
@@ -1,0 +1,75 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty4.ts] ////
+
+=== discriminateWithOptionalProperty4.ts ===
+// https://github.com/microsoft/TypeScript/issues/55566
+
+export function main(a: string[] | undefined) {
+>main : Symbol(main, Decl(discriminateWithOptionalProperty4.ts, 0, 0))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 2, 21))
+
+  const z = a ? { a } : { b: ["there"] };
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 2, 21))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+
+  z.a //
+>z.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+
+    ? z.a.toString()
+>z.a.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+
+    : z.b.toString();
+>z.b.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+
+  const zWorkAround:
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+
+    | { a: string[]; b?: undefined }
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 10, 20))
+
+    | { b: string[]; a?: undefined } = z;
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 11, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 11, 20))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+
+  zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString();
+>zWorkAround.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7), Decl(discriminateWithOptionalProperty4.ts, 11, 20))
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7), Decl(discriminateWithOptionalProperty4.ts, 11, 20))
+>zWorkAround.a.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>zWorkAround.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7))
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>zWorkAround.b.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>zWorkAround.b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 11, 7))
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 11, 7))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+
+  "a" in z ? z.a.toString() : z.b.toString();
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>z.a.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.b.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=false).types
@@ -1,0 +1,91 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty4.ts] ////
+
+=== discriminateWithOptionalProperty4.ts ===
+// https://github.com/microsoft/TypeScript/issues/55566
+
+export function main(a: string[] | undefined) {
+>main : (a: string[] | undefined) => void
+>a : string[] | undefined
+
+  const z = a ? { a } : { b: ["there"] };
+>z : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+>a ? { a } : { b: ["there"] } : { a: string[]; } | { b: string[]; }
+>a : string[] | undefined
+>{ a } : { a: string[]; }
+>a : string[]
+>{ b: ["there"] } : { b: string[]; }
+>b : string[]
+>["there"] : string[]
+>"there" : "there"
+
+  z.a //
+>z.a //    ? z.a.toString()    : z.b.toString() : string
+>z.a : string[] | undefined
+>z : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+>a : string[] | undefined
+
+    ? z.a.toString()
+>z.a.toString() : string
+>z.a.toString : () => string
+>z.a : string[]
+>z : { a: string[]; b?: undefined; }
+>a : string[]
+>toString : () => string
+
+    : z.b.toString();
+>z.b.toString() : string
+>z.b.toString : () => string
+>z.b : string[]
+>z : { b: string[]; a?: undefined; }
+>b : string[]
+>toString : () => string
+
+  const zWorkAround:
+>zWorkAround : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+
+    | { a: string[]; b?: undefined }
+>a : string[]
+>b : undefined
+
+    | { b: string[]; a?: undefined } = z;
+>b : string[]
+>a : undefined
+>z : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+
+  zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString();
+>zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString() : string
+>zWorkAround.a : string[] | undefined
+>zWorkAround : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+>a : string[] | undefined
+>zWorkAround.a.toString() : string
+>zWorkAround.a.toString : () => string
+>zWorkAround.a : string[]
+>zWorkAround : { a: string[]; b?: undefined; }
+>a : string[]
+>toString : () => string
+>zWorkAround.b.toString() : string
+>zWorkAround.b.toString : () => string
+>zWorkAround.b : string[]
+>zWorkAround : { b: string[]; a?: undefined; }
+>b : string[]
+>toString : () => string
+
+  "a" in z ? z.a.toString() : z.b.toString();
+>"a" in z ? z.a.toString() : z.b.toString() : string
+>"a" in z : boolean
+>"a" : "a"
+>z : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+>z.a.toString() : string
+>z.a.toString : () => string
+>z.a : string[] | undefined
+>z : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+>a : string[] | undefined
+>toString : () => string
+>z.b.toString() : string
+>z.b.toString : () => string
+>z.b : string[]
+>z : { b: string[]; a?: undefined; }
+>b : string[]
+>toString : () => string
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=true).symbols
+++ b/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=true).symbols
@@ -1,0 +1,75 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty4.ts] ////
+
+=== discriminateWithOptionalProperty4.ts ===
+// https://github.com/microsoft/TypeScript/issues/55566
+
+export function main(a: string[] | undefined) {
+>main : Symbol(main, Decl(discriminateWithOptionalProperty4.ts, 0, 0))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 2, 21))
+
+  const z = a ? { a } : { b: ["there"] };
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 2, 21))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+
+  z.a //
+>z.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+
+    ? z.a.toString()
+>z.a.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+
+    : z.b.toString();
+>z.b.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+
+  const zWorkAround:
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+
+    | { a: string[]; b?: undefined }
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 10, 20))
+
+    | { b: string[]; a?: undefined } = z;
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 11, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 11, 20))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+
+  zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString();
+>zWorkAround.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7), Decl(discriminateWithOptionalProperty4.ts, 11, 20))
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7), Decl(discriminateWithOptionalProperty4.ts, 11, 20))
+>zWorkAround.a.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>zWorkAround.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7))
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 10, 7))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>zWorkAround.b.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>zWorkAround.b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 11, 7))
+>zWorkAround : Symbol(zWorkAround, Decl(discriminateWithOptionalProperty4.ts, 9, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 11, 7))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+
+  "a" in z ? z.a.toString() : z.b.toString();
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>z.a.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>a : Symbol(a, Decl(discriminateWithOptionalProperty4.ts, 3, 17), Decl(discriminateWithOptionalProperty4.ts, 3, 17))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.b.toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+>z.b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>z : Symbol(z, Decl(discriminateWithOptionalProperty4.ts, 3, 7))
+>b : Symbol(b, Decl(discriminateWithOptionalProperty4.ts, 3, 25))
+>toString : Symbol(Array.toString, Decl(lib.es5.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/discriminateWithOptionalProperty4(exactoptionalpropertytypes=true).types
@@ -1,0 +1,91 @@
+//// [tests/cases/compiler/discriminateWithOptionalProperty4.ts] ////
+
+=== discriminateWithOptionalProperty4.ts ===
+// https://github.com/microsoft/TypeScript/issues/55566
+
+export function main(a: string[] | undefined) {
+>main : (a: string[] | undefined) => void
+>a : string[] | undefined
+
+  const z = a ? { a } : { b: ["there"] };
+>z : { a: string[]; b?: never; } | { b: string[]; a?: never; }
+>a ? { a } : { b: ["there"] } : { a: string[]; } | { b: string[]; }
+>a : string[] | undefined
+>{ a } : { a: string[]; }
+>a : string[]
+>{ b: ["there"] } : { b: string[]; }
+>b : string[]
+>["there"] : string[]
+>"there" : "there"
+
+  z.a //
+>z.a //    ? z.a.toString()    : z.b.toString() : string
+>z.a : string[] | undefined
+>z : { a: string[]; b?: never; } | { b: string[]; a?: never; }
+>a : string[] | undefined
+
+    ? z.a.toString()
+>z.a.toString() : string
+>z.a.toString : () => string
+>z.a : string[]
+>z : { a: string[]; b?: never; }
+>a : string[]
+>toString : () => string
+
+    : z.b.toString();
+>z.b.toString() : string
+>z.b.toString : () => string
+>z.b : string[]
+>z : { b: string[]; a?: never; }
+>b : string[]
+>toString : () => string
+
+  const zWorkAround:
+>zWorkAround : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+
+    | { a: string[]; b?: undefined }
+>a : string[]
+>b : undefined
+
+    | { b: string[]; a?: undefined } = z;
+>b : string[]
+>a : undefined
+>z : { a: string[]; b?: never; } | { b: string[]; a?: never; }
+
+  zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString();
+>zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString() : string
+>zWorkAround.a : string[] | undefined
+>zWorkAround : { a: string[]; b?: undefined; } | { b: string[]; a?: undefined; }
+>a : string[] | undefined
+>zWorkAround.a.toString() : string
+>zWorkAround.a.toString : () => string
+>zWorkAround.a : string[]
+>zWorkAround : { a: string[]; b?: undefined; }
+>a : string[]
+>toString : () => string
+>zWorkAround.b.toString() : string
+>zWorkAround.b.toString : () => string
+>zWorkAround.b : string[]
+>zWorkAround : { b: string[]; a?: undefined; }
+>b : string[]
+>toString : () => string
+
+  "a" in z ? z.a.toString() : z.b.toString();
+>"a" in z ? z.a.toString() : z.b.toString() : string
+>"a" in z : boolean
+>"a" : "a"
+>z : { a: string[]; b?: never; } | { b: string[]; a?: never; }
+>z.a.toString() : string
+>z.a.toString : () => string
+>z.a : string[]
+>z : { a: string[]; b?: never; } | { b: string[]; a?: never; }
+>a : string[]
+>toString : () => string
+>z.b.toString() : string
+>z.b.toString : () => string
+>z.b : string[]
+>z : { b: string[]; a?: never; }
+>b : string[]
+>toString : () => string
+}
+

--- a/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
+++ b/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
@@ -1,0 +1,12 @@
+// @strict: true
+// @noEmit: true
+
+type WeirdoBox<T> =
+  | { get done(): false; set done(v: T | null) }
+  | { get done(): true; set done(v: T | null); value: T };
+
+declare const weirdoBox: WeirdoBox<number>;
+
+if (weirdoBox.done) {
+  weirdoBox.value;
+}

--- a/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
+++ b/tests/cases/compiler/discriminateWithDivergentAccessors1.ts
@@ -10,3 +10,14 @@ declare const weirdoBox: WeirdoBox<number>;
 if (weirdoBox.done) {
   weirdoBox.value;
 }
+
+type WeirdoBox2<T> =
+  | { get done(): false; set done(v: T | null) }
+  | { get done(): true; set done(v: T | null); value: T }
+  | { get done(): true; set done(v: T | null | undefined); value: number };
+
+declare const weirdoBox2: WeirdoBox2<string>;
+
+if (weirdoBox2.done) {
+  weirdoBox2.value;
+}

--- a/tests/cases/compiler/discriminateWithOptionalProperty1.ts
+++ b/tests/cases/compiler/discriminateWithOptionalProperty1.ts
@@ -1,0 +1,11 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true, false
+// @noEmit: true
+
+type Box<T> = { done?: false } | { done: true; value: T };
+
+declare const box: Box<number>;
+
+if (box.done) {
+  box.value;
+}

--- a/tests/cases/compiler/discriminateWithOptionalProperty2.ts
+++ b/tests/cases/compiler/discriminateWithOptionalProperty2.ts
@@ -1,0 +1,72 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true, false
+// @lib: esnext
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type PromiseOrValue<T> = Promise<T> | T;
+
+function mapAsyncIterable<T, U, R = undefined>(
+  iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
+  callback: (value: T) => PromiseOrValue<U>,
+): AsyncGenerator<U, R, void> {
+  const iterator = iterable[Symbol.asyncIterator]();
+
+  async function mapResult(
+    result: IteratorResult<T, R>,
+  ): Promise<IteratorResult<U, R>> {
+    if (result.done) {
+      return result;
+    }
+
+    try {
+      return { value: await callback(result.value), done: false };
+    } catch (error) {
+      if (typeof iterator.return === "function") {
+        try {
+          await iterator.return();
+        } catch (_e) {}
+      }
+      throw error;
+    }
+  }
+
+  return {
+    async next() {
+      return mapResult(await iterator.next());
+    },
+    async return(): Promise<IteratorResult<U, R>> {
+      return typeof iterator.return === "function"
+        ? mapResult(await iterator.return())
+        : { value: undefined as any, done: true };
+    },
+    async throw(error?: unknown) {
+      if (typeof iterator.throw === "function") {
+        return mapResult(await iterator.throw(error));
+      }
+      throw error;
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}
+
+const items = [1, 2, 3];
+
+const iterable = {
+  [Symbol.asyncIterator]() {
+    return this;
+  },
+  next() {
+    const value = items[0];
+    items.shift();
+    return Promise.resolve({
+      done: items.length === 0,
+      value,
+    });
+  },
+};
+
+const doubles = mapAsyncIterable(iterable, (x) => x + x);

--- a/tests/cases/compiler/discriminateWithOptionalProperty3.ts
+++ b/tests/cases/compiler/discriminateWithOptionalProperty3.ts
@@ -1,0 +1,44 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true, false
+// @lib: esnext
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
+
+type Maybe<T> = null | undefined | T;
+
+declare class GraphQLError extends Error {
+  originalError: Error;
+}
+
+interface ExecutionArgs {
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
+}
+
+interface ExecutionContext {
+  variableValues: { [variable: string]: unknown };
+}
+
+type CoercedVariableValues =
+  | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
+  | { coerced: { [variable: string]: unknown }; errors?: never };
+
+declare function getVariableValues(inputs: {
+  readonly [variable: string]: unknown;
+}): CoercedVariableValues;
+
+export function buildExecutionContext(
+  args: ExecutionArgs,
+): ReadonlyArray<GraphQLError> | ExecutionContext {
+  const { variableValues: rawVariableValues } = args;
+
+  const coercedVariableValues = getVariableValues(rawVariableValues ?? {});
+
+  if (coercedVariableValues.errors) {
+    return coercedVariableValues.errors;
+  }
+
+  return {
+    variableValues: coercedVariableValues.coerced,
+  };
+}

--- a/tests/cases/compiler/discriminateWithOptionalProperty4.ts
+++ b/tests/cases/compiler/discriminateWithOptionalProperty4.ts
@@ -1,0 +1,21 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true, false
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/55566
+
+export function main(a: string[] | undefined) {
+  const z = a ? { a } : { b: ["there"] };
+
+  z.a //
+    ? z.a.toString()
+    : z.b.toString();
+
+  const zWorkAround:
+    | { a: string[]; b?: undefined }
+    | { b: string[]; a?: undefined } = z;
+
+  zWorkAround.a ? zWorkAround.a.toString() : zWorkAround.b.toString();
+
+  "a" in z ? z.a.toString() : z.b.toString();
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/55532#issuecomment-1694744665
fixes https://github.com/microsoft/TypeScript/issues/55566

The cases related to optional members and EOPT regressed from https://github.com/microsoft/TypeScript/pull/54777
The divergent accessors case has never worked but I feel like it should and this fixes it as well

cc @jakebailey 