### PR TITLE
[experiment] Don't smuggle deprecated out of parser, use jsdoc

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2413,7 +2413,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isDeprecatedDeclaration(declaration: Declaration) {
-        return !!(getCombinedNodeFlagsCached(declaration) & NodeFlags.Deprecated);
+        return !!getJSDocDeprecatedTag(declaration);
     }
 
     function addDeprecatedSuggestion(location: Node, declarations: Node[], deprecatedEntity: string) {
@@ -34941,7 +34941,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function checkDeprecatedSignature(signature: Signature, node: CallLikeExpression) {
         if (signature.flags & SignatureFlags.IsSignatureCandidateForOverloadFailure) return;
-        if (signature.declaration && signature.declaration.flags & NodeFlags.Deprecated) {
+        if (signature.declaration && !isExpression(signature.declaration) && isDeprecatedDeclaration(signature.declaration)) {
+            // Debug.assert(signature.declaration.flags & NodeFlags.Deprecated);
             const suggestionNode = getDeprecatedSuggestionNode(node);
             const name = tryGetPropertyAccessOrIdentifierToString(getInvokedExpression(node));
             addDeprecatedSuggestionWithSignature(suggestionNode, signature.declaration, name, signatureToString(signature));
@@ -39438,7 +39439,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
             const symbol = getNodeLinks(node).resolvedSymbol;
             if (symbol) {
-                if (some(symbol.declarations, d => isTypeDeclaration(d) && !!(d.flags & NodeFlags.Deprecated))) {
+                if (some(symbol.declarations, d => isTypeDeclaration(d) && isDeprecatedDeclaration(d))) {
                     addDeprecatedSuggestion(
                         getDeprecatedSuggestionNode(node),
                         symbol.declarations!,

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1804,7 +1804,6 @@ namespace Parser {
         }
     }
 
-    let hasDeprecatedTag = false;
     function withJSDoc<T extends HasJSDoc>(node: T, hasJSDoc: boolean): T {
         if (!hasJSDoc) {
             return node;
@@ -1813,10 +1812,6 @@ namespace Parser {
         Debug.assert(!node.jsDoc); // Should only be called once per node
         const jsDoc = mapDefined(getJSDocCommentRanges(node, sourceText), comment => JSDocParser.parseJSDocComment(node, comment.pos, comment.end - comment.pos));
         if (jsDoc.length) node.jsDoc = jsDoc;
-        if (hasDeprecatedTag) {
-            hasDeprecatedTag = false;
-            (node as Mutable<T>).flags |= NodeFlags.Deprecated;
-        }
         return node;
     }
 
@@ -9013,7 +9008,6 @@ namespace Parser {
                         tag = parseSimpleTag(start, factory.createJSDocOverrideTag, tagName, margin, indentText);
                         break;
                     case "deprecated":
-                        hasDeprecatedTag = true;
                         tag = parseSimpleTag(start, factory.createJSDocDeprecatedTag, tagName, margin, indentText);
                         break;
                     case "this":

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -822,7 +822,6 @@ export const enum NodeFlags {
     /** @internal */ InWithStatement               = 1 << 26, // If any ancestor of node was the `statement` of a WithStatement (not the `expression`)
     JsonFile                                       = 1 << 27, // If node was parsed in a Json
     /** @internal */ TypeCached                    = 1 << 28, // If a type was cached for node at any point
-    /** @internal */ Deprecated                    = 1 << 29, // If has '@deprecated' JSDoc tag
 
     BlockScoped = Let | Const | Using,
     Constant = Const | Using,


### PR DESCRIPTION
This is potentially part of #52921; this eager evaluation of `@deprecated` is the only reason that JSDoc parsing couldn't be lazy, but it's possible that this may be slow.