### PR TITLE
Don't debug assert on broken link in moduleNameResolver

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1896,7 +1896,6 @@ function realPath(path: string, host: ModuleResolutionHost, traceEnabled: boolea
     if (traceEnabled) {
         trace(host, Diagnostics.Resolving_real_path_for_0_result_1, path, real);
     }
-    Debug.assert(host.fileExists(real), `${path} linked to nonexistent file ${real}`);
     return real;
 }
 


### PR DESCRIPTION
Fixes #47372
Fixes #50973
Fixes #55084
Fixes #55085
Fixes #55590

This debug assert was added back in #20374. Unfortunately, I believe that it's causing more problems than it solves thanks to races.

Here's a potential flow:

- You open your editor, loading a `pnpm` installed project, which contains symlinks.
- You do some package operation, which starts mucking around in `node_modules`.
- The file watcher picks up on some of the changes, and kicks off some new program construction. `pnpm` is still working in the meantime, removing files and links.
- The new program construction observes a symlink and sees that it's valid so it's added to the program, but slightly later, `pnpm` removes what the link is pointing to.
- This broken symlink is observed later in a place that assumes that it won't be broken, debug asserting. Boom.

Could this be avoided if `pnpm` guaranteed to never cause a broken link by ensuring it removes things in the right order? Probably, but it clearly doesn't and that sounds challenging to get right and we really shouldn't crash like this.

In `sys`, `realpath` is implemented like:

```ts
function realpath(path: string): string {
    try {
        return fsRealpath(path);
    }
    catch {
        return path;
    }
}
```

To me, this implies that there's not much point in verifying that symlinks aren't broken, because we entirely ignore them everywhere else; if the link is broken we're going to get an error later. Or, more likely, the `pnpm install` will finish and the file watcher will say so.

Unfortunately I have not yet been able to produce a test case which causes this assert to fire; our compiler/fourslash tests don't really let you create broken symlinks. I think I can do it via `verifyTsc` so I'll try and do that.