### PR TITLE
Bring back renamings in emitted d.ts files

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -116,8 +116,6 @@ import {
     isFunctionDeclaration,
     isFunctionLike,
     isGlobalScopeAugmentation,
-    isIdentifier,
-    isIdentifierANonContextualKeyword,
     isIdentifierText,
     isImportDeclaration,
     isImportEqualsDeclaration,
@@ -684,7 +682,7 @@ export function transformDeclarations(context: TransformationContext) {
         return ret;
     }
 
-    function filterBindingPatternInitializersAndRenamings(name: BindingName) {
+    function filterBindingPatternInitializers(name: BindingName) {
         if (name.kind === SyntaxKind.Identifier) {
             return name;
         }
@@ -705,21 +703,11 @@ export function transformDeclarations(context: TransformationContext) {
             if (elem.propertyName && isComputedPropertyName(elem.propertyName) && isEntityNameExpression(elem.propertyName.expression)) {
                 checkEntityNameVisibility(elem.propertyName.expression, enclosingDeclaration);
             }
-            if (elem.propertyName && isIdentifier(elem.propertyName) && isIdentifier(elem.name) && !elem.symbol.isReferenced && !isIdentifierANonContextualKeyword(elem.propertyName)) {
-                // Unnecessary property renaming is forbidden in types, so remove renaming
-                return factory.updateBindingElement(
-                    elem,
-                    elem.dotDotDotToken,
-                    /*propertyName*/ undefined,
-                    elem.propertyName,
-                    shouldPrintWithInitializer(elem) ? elem.initializer : undefined,
-                );
-            }
             return factory.updateBindingElement(
                 elem,
                 elem.dotDotDotToken,
                 elem.propertyName,
-                filterBindingPatternInitializersAndRenamings(elem.name),
+                filterBindingPatternInitializers(elem.name),
                 shouldPrintWithInitializer(elem) ? elem.initializer : undefined,
             );
         }
@@ -735,7 +723,7 @@ export function transformDeclarations(context: TransformationContext) {
             p,
             maskModifiers(factory, p, modifierMask),
             p.dotDotDotToken,
-            filterBindingPatternInitializersAndRenamings(p.name),
+            filterBindingPatternInitializers(p.name),
             resolver.isOptionalParameter(p) ? (p.questionToken || factory.createToken(SyntaxKind.QuestionToken)) : undefined,
             ensureType(p, type || p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
             ensureNoInitializer(p),

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.js
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.js
@@ -26,7 +26,7 @@ function shouldKeep({ name: alias }) {
 
 
 //// [declarationEmitBindingPatternsUnused.d.ts]
-declare function shouldNotKeep({ name }: {
+declare function shouldNotKeep({ name: alias }: {
     name: string;
 }): void;
 declare function shouldNotKeepButIsKept({ name: alias }: {

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.js
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.js
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/declarationEmitBindingPatternsUnused.ts] ////
+
+//// [declarationEmitBindingPatternsUnused.ts]
+function shouldNotKeep({ name: alias }: { name: string }) {
+
+}
+
+function shouldNotKeepButIsKept({ name: alias }: { name: string }) {
+    return alias;
+}
+
+function shouldKeep({ name: alias }: { name: string }): typeof alias {
+    return alias;
+}
+
+
+//// [declarationEmitBindingPatternsUnused.js]
+function shouldNotKeep({ name: alias }) {
+}
+function shouldNotKeepButIsKept({ name: alias }) {
+    return alias;
+}
+function shouldKeep({ name: alias }) {
+    return alias;
+}
+
+
+//// [declarationEmitBindingPatternsUnused.d.ts]
+declare function shouldNotKeep({ name }: {
+    name: string;
+}): void;
+declare function shouldNotKeepButIsKept({ name: alias }: {
+    name: string;
+}): string;
+declare function shouldKeep({ name: alias }: {
+    name: string;
+}): typeof alias;

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.symbols
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.symbols
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/declarationEmitBindingPatternsUnused.ts] ////
+
+=== declarationEmitBindingPatternsUnused.ts ===
+function shouldNotKeep({ name: alias }: { name: string }) {
+>shouldNotKeep : Symbol(shouldNotKeep, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 41))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 0, 24))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 41))
+
+}
+
+function shouldNotKeepButIsKept({ name: alias }: { name: string }) {
+>shouldNotKeepButIsKept : Symbol(shouldNotKeepButIsKept, Decl(declarationEmitBindingPatternsUnused.ts, 2, 1))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 4, 50))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 4, 33))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 4, 50))
+
+    return alias;
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 4, 33))
+}
+
+function shouldKeep({ name: alias }: { name: string }): typeof alias {
+>shouldKeep : Symbol(shouldKeep, Decl(declarationEmitBindingPatternsUnused.ts, 6, 1))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 8, 38))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 8, 21))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 8, 38))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 8, 21))
+
+    return alias;
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 8, 21))
+}
+

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.types
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.types
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/declarationEmitBindingPatternsUnused.ts] ////
+
+=== declarationEmitBindingPatternsUnused.ts ===
+function shouldNotKeep({ name: alias }: { name: string }) {
+>shouldNotKeep : ({ name: alias }: {    name: string;}) => void
+>name : any
+>alias : string
+>name : string
+
+}
+
+function shouldNotKeepButIsKept({ name: alias }: { name: string }) {
+>shouldNotKeepButIsKept : ({ name: alias }: {    name: string;}) => string
+>name : any
+>alias : string
+>name : string
+
+    return alias;
+>alias : string
+}
+
+function shouldKeep({ name: alias }: { name: string }): typeof alias {
+>shouldKeep : ({ name: alias }: {    name: string;}) => typeof alias
+>name : any
+>alias : string
+>name : string
+>alias : string
+
+    return alias;
+>alias : string
+}
+

--- a/tests/baselines/reference/declarationEmitKeywordDestructuring.js
+++ b/tests/baselines/reference/declarationEmitKeywordDestructuring.js
@@ -88,21 +88,21 @@ declare function f2({ function: _function, ...rest }: P): {
     await: boolean;
     one: boolean;
 };
-declare function f3({ abstract, ...rest }: P): {
+declare function f3({ abstract: _abstract, ...rest }: P): {
     enum: boolean;
     function: boolean;
     async: boolean;
     await: boolean;
     one: boolean;
 };
-declare function f4({ async, ...rest }: P): {
+declare function f4({ async: _async, ...rest }: P): {
     enum: boolean;
     function: boolean;
     abstract: boolean;
     await: boolean;
     one: boolean;
 };
-declare function f5({ await, ...rest }: P): {
+declare function f5({ await: _await, ...rest }: P): {
     enum: boolean;
     function: boolean;
     abstract: boolean;

--- a/tests/baselines/reference/destructuringInFunctionType.js
+++ b/tests/baselines/reference/destructuringInFunctionType.js
@@ -54,7 +54,7 @@ type T3 = ([{
 }, {
     b: a;
 }]);
-type F3 = ([{ a }, { b }]: [{
+type F3 = ([{ a: b }, { b: a }]: [{
     a: any;
 }, {
     b: any;

--- a/tests/baselines/reference/paramterDestrcuturingDeclaration.js
+++ b/tests/baselines/reference/paramterDestrcuturingDeclaration.js
@@ -12,10 +12,10 @@ interface C {
 
 //// [paramterDestrcuturingDeclaration.d.ts]
 interface C {
-    ({ p }: {
+    ({ p: name }: {
         p: any;
     }): any;
-    new ({ p }: {
+    new ({ p: boolean }: {
         p: any;
     }): any;
 }

--- a/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.js
+++ b/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.js
@@ -101,14 +101,14 @@ type O = {
     c: number;
 };
 type F1 = (arg: number) => any;
-type F2 = ({ a }: O) => any;
-type F3 = ({ a, b, c }: O) => any;
-type F4 = ({ a }: O) => any;
-type F5 = ({ a, b, c }: O) => any;
+type F2 = ({ a: string }: O) => any;
+type F3 = ({ a: string, b, c }: O) => any;
+type F4 = ({ a: string }: O) => any;
+type F5 = ({ a: string, b, c }: O) => any;
 type F6 = ({ a: string }: {
     a: any;
 }) => typeof string;
-type F7 = ({ a, b: number }: {
+type F7 = ({ a: string, b: number }: {
     a: any;
     b: any;
 }) => typeof number;
@@ -118,14 +118,14 @@ type F8 = ({ a, b: number }: {
 }) => typeof number;
 type F9 = ([a, b, c]: [any, any, any]) => void;
 type G1 = new (arg: number) => any;
-type G2 = new ({ a }: O) => any;
-type G3 = new ({ a, b, c }: O) => any;
-type G4 = new ({ a }: O) => any;
-type G5 = new ({ a, b, c }: O) => any;
+type G2 = new ({ a: string }: O) => any;
+type G3 = new ({ a: string, b, c }: O) => any;
+type G4 = new ({ a: string }: O) => any;
+type G5 = new ({ a: string, b, c }: O) => any;
 type G6 = new ({ a: string }: {
     a: any;
 }) => typeof string;
-type G7 = new ({ a, b: number }: {
+type G7 = new ({ a: string, b: number }: {
     a: any;
     b: any;
 }) => typeof number;
@@ -156,19 +156,19 @@ type G13 = new ({ [2]: string }: {
 }) => void;
 interface I {
     method1(arg: number): any;
-    method2({ a }: {
+    method2({ a: string }: {
         a: any;
     }): any;
     (arg: number): any;
-    ({ a }: {
+    ({ a: string }: {
         a: any;
     }): any;
     new (arg: number): any;
-    new ({ a }: {
+    new ({ a: string }: {
         a: any;
     }): any;
 }
-declare function f1({ a }: O): void;
+declare function f1({ a: string }: O): void;
 declare const f2: ({ a: string }: O) => void;
 declare const f3: ({ a: string, b, c }: O) => void;
 declare const f4: ({ a: string }: O) => string;
@@ -179,7 +179,7 @@ declare const obj1: {
 declare const obj2: {
     method({ a: string }: O): string;
 };
-declare function f6({ a }: O): void;
+declare function f6({ a: string }: O): void;
 declare const f7: ({ a: string, b, c }: O) => void;
 declare const f8: ({ "a": string }: O) => void;
 declare function f9({ 2: string }: {

--- a/tests/cases/compiler/declarationEmitBindingPatternsUnused.ts
+++ b/tests/cases/compiler/declarationEmitBindingPatternsUnused.ts
@@ -1,0 +1,15 @@
+// @declaration: true
+// @target: esnext
+// @skipLibCheck: false
+
+function shouldNotKeep({ name: alias }: { name: string }) {
+
+}
+
+function shouldNotKeepButIsKept({ name: alias }: { name: string }) {
+    return alias;
+}
+
+function shouldKeep({ name: alias }: { name: string }): typeof alias {
+    return alias;
+}


### PR DESCRIPTION
Fixes #55654 (with the unfortunate solution)

This isn't ideal. I think the direction we want to go is to not emit renamings if we don't have to, but the current implementation uses `isReferenced` which unfortunately considers references other than those that affect the signatures of the functions. So if you ever actually _use_ the parameter you've renamed, then it will be kept, even if that isn't required. In the real world, that'd of course be nearly _all_ instances, because there's usually no reason to destructure a parameter and then not use it. Of course our tests have a lot of this because we typically don't care about what's inside a function, or we don't have a body at all!

This with #50779 effectively reverts all of #41044 _except_ the new error. You'll notice that this PR's baseline changes don't contain any new errors, which is good. This is because the error only happens when the signature _doesn't_ have an annotation, e.g.:

```ts
declare function foo({ a: string }): void; // Error
declare function bar({ a: string }: { a: string }): void; // Okay!
```

The former can't happen in emitted `d.ts` files; we're always going to fully annotate the output.

Maybe there's a solution that would instead attempt to figure out if the name is ever actually used elsewhere, but I'm not sure how to do that. I feel like we probably have that logic somewhere for other reasons? In which case, I'm happy to redo the PR.