### PR TITLE
Allow more things to be evaluated in enum members with template expression initializers

### DIFF
--- a/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.errors.txt
+++ b/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.errors.txt
@@ -51,3 +51,9 @@ enumConstantMemberWithTemplateLiterals.ts(28,15): error TS2363: The right-hand s
         c = "2" + `1`
     }
     
+    declare enum T8 {
+      X = `${1}`,
+      Y = `${true}`,
+      Z = `pre${!false}middle${"foo" + true}`,
+    }
+    

--- a/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.js
+++ b/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.js
@@ -45,6 +45,12 @@ declare enum T7 {
     c = "2" + `1`
 }
 
+declare enum T8 {
+  X = `${1}`,
+  Y = `${true}`,
+  Z = `pre${!false}middle${"foo" + true}`,
+}
+
 
 //// [enumConstantMemberWithTemplateLiterals.js]
 var T1;

--- a/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.symbols
+++ b/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.symbols
@@ -102,3 +102,16 @@ declare enum T7 {
 >c : Symbol(T7.c, Decl(enumConstantMemberWithTemplateLiterals.ts, 40, 18))
 }
 
+declare enum T8 {
+>T8 : Symbol(T8, Decl(enumConstantMemberWithTemplateLiterals.ts, 42, 1))
+
+  X = `${1}`,
+>X : Symbol(T8.X, Decl(enumConstantMemberWithTemplateLiterals.ts, 44, 17))
+
+  Y = `${true}`,
+>Y : Symbol(T8.Y, Decl(enumConstantMemberWithTemplateLiterals.ts, 45, 13))
+
+  Z = `pre${!false}middle${"foo" + true}`,
+>Z : Symbol(T8.Z, Decl(enumConstantMemberWithTemplateLiterals.ts, 46, 16))
+}
+

--- a/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.types
+++ b/tests/baselines/reference/enumConstantMemberWithTemplateLiterals.types
@@ -152,3 +152,26 @@ declare enum T7 {
 >`1` : "1"
 }
 
+declare enum T8 {
+>T8 : T8
+
+  X = `${1}`,
+>X : T8.X
+>`${1}` : "1"
+>1 : 1
+
+  Y = `${true}`,
+>Y : T8.Y
+>`${true}` : "true"
+>true : true
+
+  Z = `pre${!false}middle${"foo" + true}`,
+>Z : T8.Z
+>`pre${!false}middle${"foo" + true}` : "pretruemiddlefootrue"
+>!false : true
+>false : false
+>"foo" + true : string
+>"foo" : "foo"
+>true : true
+}
+

--- a/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiterals.ts
+++ b/tests/cases/conformance/enums/enumConstantMemberWithTemplateLiterals.ts
@@ -41,3 +41,9 @@ declare enum T7 {
     b = `1` + `1`,
     c = "2" + `1`
 }
+
+declare enum T8 {
+  X = `${1}`,
+  Y = `${true}`,
+  Z = `pre${!false}middle${"foo" + true}`,
+}


### PR DESCRIPTION
@dragomirtitian has noticed this inconsistency~ ([TS playground](https://www.typescriptlang.org/play?ts=5.2.2#code/MYewdgzgLgBAGjAvDABgEgN5QE4FcCmAvijAIYQyiRQDcAUPmLgLYwCCMGMdMv8SqTAEZiAGh58AmgPRY8RFOMJA)):
```ts
const X = `${true}` as const; // "true"
enum A { 
    X = `${1}`, // "1"
    Y = `${true}`, // Type 'string' is not assignable to type 'number' as required for computed enum member values.(18033)
}
```

Note that even with changes in this PR there will still be inconsistencies like:
```ts
const test1 = `${1 + 1}` as const; // `${number}`

export enum Test2 {
  A = `${1 + 1}`, // "2"
}
```

It's easy to fix this but I'm not sure if it's desirable so I left it out of this PR for now.