### PR TITLE
Disallow comparisons between identical unit types.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37695,7 +37695,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         error(errorNode, Diagnostics.This_condition_will_always_return_0_since_JavaScript_compares_objects_by_reference_not_value, eqType ? "false" : "true");
                     }
                     checkNaNEquality(errorNode, operator, left, right);
-                    reportOperatorErrorUnless((left, right) => isTypeEqualityComparableTo(left, right) || isTypeEqualityComparableTo(right, left));
+                    if (isUnitType(leftType) && isUnitType(rightType) && isTypeIdenticalTo(leftType, rightType)) {
+                        error(errorNode, Diagnostics.This_condition_will_always_return_0, operator === SyntaxKind.EqualsEqualsEqualsToken || operator === SyntaxKind.EqualsEqualsToken ? "true" : "false");
+                    }
+                    else {
+                        reportOperatorErrorUnless((left, right) => isTypeEqualityComparableTo(left, right) || isTypeEqualityComparableTo(right, left));
+                    }
                 }
                 return booleanType;
             case SyntaxKind.InstanceOfKeyword:

--- a/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithDiscriminatedUnion.errors.txt
@@ -8,9 +8,10 @@ assignmentCompatWithDiscriminatedUnion.ts(58,5): error TS2322: Type 'S' is not a
   Type 'S' is not assignable to type '{ a: 0; b: 4 | 1; } | { a: 2; b: 4 | 3; c: string; }'.
     Property 'c' is missing in type 'S' but required in type '{ a: 2; b: 4 | 3; c: string; }'.
 assignmentCompatWithDiscriminatedUnion.ts(82,5): error TS2322: Type 'S' is not assignable to type 'T'.
+assignmentCompatWithDiscriminatedUnion.ts(132,13): error TS2845: This condition will always return 'true'.
 
 
-==== assignmentCompatWithDiscriminatedUnion.ts (3 errors) ====
+==== assignmentCompatWithDiscriminatedUnion.ts (4 errors) ====
     // see 'typeRelatedToDiscriminatedType' in checker.ts:
     
     // IteratorResult
@@ -157,6 +158,8 @@ assignmentCompatWithDiscriminatedUnion.ts(82,5): error TS2322: Type 'S' is not a
     
         function getAxisType(): IAxisType {
             if (1 == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return "categorical";
             } else {
                 return "linear";

--- a/tests/baselines/reference/capturedLetConstInLoop1.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop1.errors.txt
@@ -1,0 +1,165 @@
+capturedLetConstInLoop1.ts(19,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1.ts(29,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1.ts(42,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1.ts(52,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1.ts(89,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1.ts(99,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1.ts(112,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1.ts(122,10): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop1.ts (8 errors) ====
+    declare function use(x: any): any;
+    
+    //==== let
+    for (let x in {}) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (let x of []) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (let x = 0; x < 1; ++x) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x;
+        (function() { return x});
+        (() => x);
+    }
+    
+    do {
+        let x;
+        (function() { return x});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (let x = 0, y = 1; x < 1; ++x) {
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x, y;
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    do {
+        let x, y;
+        (function() { return x + y});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    for (let y = (use(() => y), 0); y < 1; ++y) {
+    }
+    
+    for (let y = 0; use(() => y), y < 1; ++y) {
+    }
+    
+    for (let y = 0; y < 1; use(() => y), ++y) {
+    }
+    
+    for (let y = (use(() => y), 0); use(() => y), y < 1; use(() => y), ++y) {
+        use(() => y);
+    }
+    
+    //=========const
+    for (const x in {}) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (const x of []) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (const x = 0; x < 1;) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x = 1;
+        (function() { return x});
+        (() => x);
+    }
+    
+    do {
+        const x = 1;
+        (function() { return x});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (const x = 0, y = 1; x < 1;) {
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x = 1, y = 1;
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    do {
+        const x = 1, y = 1;
+        (function() { return x + y});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    // https://github.com/Microsoft/TypeScript/issues/20594
+    declare const sobj: { [x: string]: any };
+    for (let sx in sobj) {
+        (() => sobj[sx]);
+    }
+    declare const iobj: { [x: number]: any };
+    for (let ix in iobj) {
+        (() => iobj[ix]);
+    }

--- a/tests/baselines/reference/capturedLetConstInLoop1_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop1_ES6.errors.txt
@@ -1,0 +1,140 @@
+capturedLetConstInLoop1_ES6.ts(17,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1_ES6.ts(27,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1_ES6.ts(40,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1_ES6.ts(50,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1_ES6.ts(74,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1_ES6.ts(84,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1_ES6.ts(97,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop1_ES6.ts(107,10): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop1_ES6.ts (8 errors) ====
+    //==== let
+    for (let x in {}) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (let x of []) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (let x = 0; x < 1; ++x) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x;
+        (function() { return x});
+        (() => x);
+    }
+    
+    do {
+        let x;
+        (function() { return x});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (let x = 0, y = 1; x < 1; ++x) {
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x, y;
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    do {
+        let x, y;
+        (function() { return x + y});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    //=========const
+    for (const x in {}) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (const x of []) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (const x = 0; x < 1;) {
+        (function() { return x});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x = 1;
+        (function() { return x});
+        (() => x);
+    }
+    
+    do {
+        const x = 1;
+        (function() { return x});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        (function() { return x});
+        (() => x);
+    }
+    
+    for (const x = 0, y = 1; x < 1;) {
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x = 1, y = 1;
+        (function() { return x + y});
+        (() => x + y);
+    }
+    
+    do {
+        const x = 1, y = 1;
+        (function() { return x + y});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        (function() { return x + y});
+        (() => x + y);
+    }

--- a/tests/baselines/reference/capturedLetConstInLoop2.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop2.errors.txt
@@ -1,0 +1,201 @@
+capturedLetConstInLoop2.ts(27,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2.ts(40,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2.ts(62,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2.ts(76,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2.ts(114,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2.ts(127,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2.ts(149,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2.ts(163,14): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop2.ts (8 errors) ====
+    // ========let
+    function foo0(x) {
+        for (let x of []) {
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo0_1(x) {
+        for (let x in []) {
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo1(x) {
+        for (let x = 0; x < 1; ++x) {
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo2(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo3(x) {
+        do {
+            let x;
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    function foo4(x) {
+        for (let y = 0; y < 1; ++y) {
+            let a = arguments.length;
+            let x = 1;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo5(x) {
+        for (let x = 0, y = 1; x < 1; ++x) {
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    
+    function foo6(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            let x, y;
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    function foo7(x) {
+        do {
+            let x, y;
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    
+    function foo8(x) {
+        for (let y = 0; y < 1; ++y) {
+            let x = 1;
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    ///=======const
+    function foo0_c(x) {
+        for (const x of []) {
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo0_1_c(x) {
+        for (const x in []) {
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo1_c(x) {
+        for (const x = 0; x < 1;) {
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo2_c(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo3_c(x) {
+        do {
+            const x = 1;
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    function foo4_c(x) {
+        for (const y = 0; y < 1;) {
+            const a = arguments.length;
+            const x = 1;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo5_c(x) {
+        for (const x = 0, y = 1; x < 1;) {
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    
+    function foo6_c(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            const x = 1, y =1 ;
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    function foo7_c(x) {
+        do {
+            const x = 1, y = 1;
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    
+    function foo8_c(x) {
+        for (const y = 0; y < 1;) {
+            const x = 1;
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }

--- a/tests/baselines/reference/capturedLetConstInLoop2_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop2_ES6.errors.txt
@@ -1,0 +1,201 @@
+capturedLetConstInLoop2_ES6.ts(27,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2_ES6.ts(40,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2_ES6.ts(62,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2_ES6.ts(76,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2_ES6.ts(114,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2_ES6.ts(127,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2_ES6.ts(149,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop2_ES6.ts(163,14): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop2_ES6.ts (8 errors) ====
+    // ========let
+    function foo0(x) {
+        for (let x of []) {
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo0_1(x) {
+        for (let x in []) {
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo1(x) {
+        for (let x = 0; x < 1; ++x) {
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo2(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo3(x) {
+        do {
+            let x;
+            let a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    function foo4(x) {
+        for (let y = 0; y < 1; ++y) {
+            let a = arguments.length;
+            let x = 1;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo5(x) {
+        for (let x = 0, y = 1; x < 1; ++x) {
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    
+    function foo6(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            let x, y;
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    function foo7(x) {
+        do {
+            let x, y;
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    
+    function foo8(x) {
+        for (let y = 0; y < 1; ++y) {
+            let x = 1;
+            let a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    ///=======const
+    function foo0_c(x) {
+        for (const x of []) {
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo0_1_c(x) {
+        for (const x in []) {
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo1_c(x) {
+        for (const x = 0; x < 1;) {
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo2_c(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo3_c(x) {
+        do {
+            const x = 1;
+            const a = arguments.length;
+            (function() { return x + a });
+            (() => x + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    function foo4_c(x) {
+        for (const y = 0; y < 1;) {
+            const a = arguments.length;
+            const x = 1;
+            (function() { return x + a });
+            (() => x + a);
+        }
+    }
+    
+    function foo5_c(x) {
+        for (const x = 0, y = 1; x < 1;) {
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    
+    function foo6_c(x) {
+        while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            const x = 1, y =1 ;
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }
+    
+    function foo7_c(x) {
+        do {
+            const x = 1, y = 1;
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    
+    
+    function foo8_c(x) {
+        for (const y = 0; y < 1;) {
+            const x = 1;
+            const a = arguments.length;
+            (function() { return x + y + a });
+            (() => x + y + a);
+        }
+    }

--- a/tests/baselines/reference/capturedLetConstInLoop3.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop3.errors.txt
@@ -1,45 +1,31 @@
-capturedLetConstInLoop5.ts(44,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(66,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(100,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(122,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(174,13): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-capturedLetConstInLoop5.ts(183,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(188,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(202,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(205,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(229,13): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-capturedLetConstInLoop5.ts(239,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(244,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(258,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(261,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(34,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(50,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(78,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(94,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(142,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(158,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(186,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3.ts(202,14): error TS2845: This condition will always return 'true'.
 
 
-==== capturedLetConstInLoop5.ts (15 errors) ====
+==== capturedLetConstInLoop3.ts (8 errors) ====
+    ///=========let
     declare function use(a: any);
-    
-    //====let
     function foo0(x) {
         for (let x of []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
     
         use(v);
     }
     
-    function foo00(x) {
+    function foo0_1(x) {
         for (let x in []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == "1") {
-                return;
-            }
         }
     
         use(v);
@@ -50,9 +36,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
     
         use(v);
@@ -66,9 +49,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -80,10 +60,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
-        } while (1 === 1)
+        } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
         
@@ -96,9 +73,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             let x = 1;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -109,9 +83,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -126,10 +97,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
-        };
+        }
         
         use(v)
     }
@@ -140,9 +108,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
         } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
@@ -157,36 +122,26 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
     }
-    
-    //====const
+    //===const
     function foo0_c(x) {
         for (const x of []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
     
         use(v);
     }
     
-    function foo00_c(x) {
+    function foo0_1_c(x) {
         for (const x in []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == "1") {
-                return;
-            }
         }
     
         use(v);
@@ -197,11 +152,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-                return;
-            }
         }
     
         use(v);
@@ -215,11 +165,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
         }
         
         use(v);
@@ -231,12 +176,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
-        } while (1 === 1)
+        } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
         
@@ -246,12 +186,9 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
     function foo4_c(x) {
         for (const y = 0; y < 1;) {
             var v = y;
-            let x = 1;
+            const x = 1;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -262,11 +199,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-                return;
-            }
         }
         
         use(v);
@@ -281,11 +213,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
         }
         
         use(v)
@@ -297,12 +224,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
-        } while (1 === 1)
+        } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
         
@@ -316,11 +238,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
         }
         
         use(v);

--- a/tests/baselines/reference/capturedLetConstInLoop3_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop3_ES6.errors.txt
@@ -1,45 +1,31 @@
-capturedLetConstInLoop5.ts(44,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(66,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(100,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(122,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(174,13): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-capturedLetConstInLoop5.ts(183,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(188,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(202,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(205,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(229,13): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-capturedLetConstInLoop5.ts(239,12): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(244,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(258,13): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(261,14): error TS2845: This condition will always return 'true'.
-capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(34,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(50,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(78,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(94,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(142,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(158,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(186,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop3_ES6.ts(202,14): error TS2845: This condition will always return 'true'.
 
 
-==== capturedLetConstInLoop5.ts (15 errors) ====
+==== capturedLetConstInLoop3_ES6.ts (8 errors) ====
+    ///=========let
     declare function use(a: any);
-    
-    //====let
     function foo0(x) {
         for (let x of []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
     
         use(v);
     }
     
-    function foo00(x) {
+    function foo0_1(x) {
         for (let x in []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == "1") {
-                return;
-            }
         }
     
         use(v);
@@ -50,9 +36,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
     
         use(v);
@@ -66,9 +49,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -80,10 +60,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
-        } while (1 === 1)
+        } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
         
@@ -96,9 +73,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             let x = 1;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -109,9 +83,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -126,10 +97,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
-        };
+        }
         
         use(v)
     }
@@ -140,9 +108,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
         } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
@@ -157,36 +122,26 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
     }
-    
-    //====const
+    //===const
     function foo0_c(x) {
         for (const x of []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
     
         use(v);
     }
     
-    function foo00_c(x) {
+    function foo0_1_c(x) {
         for (const x in []) {
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == "1") {
-                return;
-            }
         }
     
         use(v);
@@ -197,11 +152,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-                return;
-            }
         }
     
         use(v);
@@ -215,11 +165,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
         }
         
         use(v);
@@ -231,12 +176,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
-        } while (1 === 1)
+        } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
         
@@ -246,12 +186,9 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
     function foo4_c(x) {
         for (const y = 0; y < 1;) {
             var v = y;
-            let x = 1;
+            const x = 1;
             (function() { return x + v });
             (() => x + v);
-            if (x == 1) {
-                return;
-            }
         }
         
         use(v);
@@ -262,11 +199,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
-                return;
-            }
         }
         
         use(v);
@@ -281,11 +213,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
         }
         
         use(v)
@@ -297,12 +224,7 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
-        } while (1 === 1)
+        } while (1 === 1);
                  ~~~~~~~
 !!! error TS2845: This condition will always return 'true'.
         
@@ -316,11 +238,6 @@ capturedLetConstInLoop5.ts(273,13): error TS2845: This condition will always ret
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
-            if (x == 1) {
-                ~~~~~~
-!!! error TS2845: This condition will always return 'true'.
-                return;
-            }
         }
         
         use(v);

--- a/tests/baselines/reference/capturedLetConstInLoop4.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop4.errors.txt
@@ -1,0 +1,169 @@
+capturedLetConstInLoop4.ts(24,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4.ts(36,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4.ts(51,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4.ts(63,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4.ts(95,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4.ts(107,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4.ts(122,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4.ts(134,10): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop4.ts (8 errors) ====
+    //======let
+    export function exportedFoo() {
+        return v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8;
+    }
+    
+    for (let x of []) {
+        var v0 = x;
+        (function() { return x + v0});
+        (() => x);    
+    }
+    
+    for (let x in []) {
+        var v00 = x;
+        (function() { return x + v00});
+        (() => x);    
+    }
+    
+    for (let x = 0; x < 1; ++x) {
+        var v1 = x;
+        (function() { return x + v1});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x;
+        var v2 = x;
+        (function() { return x + v2});
+        (() => x);
+    }
+    
+    do {
+        let x;
+        var v3 = x;
+        (function() { return x + v3});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        var v4 = x;
+        (function() { return x + v4});
+        (() => x);
+    }
+    
+    for (let x = 0, y = 1; x < 1; ++x) {
+        var v5 = x;
+        (function() { return x + y + v5});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x, y;
+        var v6 = x;
+        (function() { return x + y + v6});
+        (() => x + y);
+    }
+    
+    do {
+        let x, y;
+        var v7 = x;
+        (function() { return x + y + v7});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        var v8 = x;
+        (function() { return x + y + v8});
+        (() => x + y);
+    }
+    
+    //======const
+    export function exportedFoo2() {
+        return v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c;
+    }
+    
+    for (const x of []) {
+        var v0_c = x;
+        (function() { return x + v0_c});
+        (() => x);    
+    }
+    
+    for (const x in []) {
+        var v00_c = x;
+        (function() { return x + v00});
+        (() => x);    
+    }
+    
+    for (const x = 0; x < 1;) {
+        var v1_c = x;
+        (function() { return x + v1_c});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x =1;
+        var v2_c = x;
+        (function() { return x + v2_c});
+        (() => x);
+    }
+    
+    do {
+        const x = 1;
+        var v3_c = x;
+        (function() { return x + v3_c});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        var v4_c = x;
+        (function() { return x + v4_c});
+        (() => x);
+    }
+    
+    for (const x = 0, y = 1; x < 1;) {
+        var v5_c = x;
+        (function() { return x + y + v5_c});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x = 1, y = 1;
+        var v6_c = x;
+        (function() { return x + y + v6_c});
+        (() => x + y);
+    }
+    
+    do {
+        const x = 1, y = 1;
+        var v7_c = x;
+        (function() { return x + y + v7_c});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        var v8_c = x;
+        (function() { return x + y + v8_c});
+        (() => x + y);
+    }
+    

--- a/tests/baselines/reference/capturedLetConstInLoop4_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop4_ES6.errors.txt
@@ -1,0 +1,169 @@
+capturedLetConstInLoop4_ES6.ts(24,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4_ES6.ts(36,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4_ES6.ts(51,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4_ES6.ts(63,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4_ES6.ts(95,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4_ES6.ts(107,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4_ES6.ts(122,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop4_ES6.ts(134,10): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop4_ES6.ts (8 errors) ====
+    //======let
+    export function exportedFoo() {
+        return v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8;
+    }
+    
+    for (let x of []) {
+        var v0 = x;
+        (function() { return x + v0});
+        (() => x);    
+    }
+    
+    for (let x in []) {
+        var v00 = x;
+        (function() { return x + v00});
+        (() => x);    
+    }
+    
+    for (let x = 0; x < 1; ++x) {
+        var v1 = x;
+        (function() { return x + v1});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x;
+        var v2 = x;
+        (function() { return x + v2});
+        (() => x);
+    }
+    
+    do {
+        let x;
+        var v3 = x;
+        (function() { return x + v3});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        var v4 = x;
+        (function() { return x + v4});
+        (() => x);
+    }
+    
+    for (let x = 0, y = 1; x < 1; ++x) {
+        var v5 = x;
+        (function() { return x + y + v5});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        let x, y;
+        var v6 = x;
+        (function() { return x + y + v6});
+        (() => x + y);
+    }
+    
+    do {
+        let x, y;
+        var v7 = x;
+        (function() { return x + y + v7});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (let y = 0; y < 1; ++y) {
+        let x = 1;
+        var v8 = x;
+        (function() { return x + y + v8});
+        (() => x + y);
+    }
+    
+    //======const
+    export function exportedFoo2() {
+        return v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c;
+    }
+    
+    for (const x of []) {
+        var v0_c = x;
+        (function() { return x + v0_c});
+        (() => x);    
+    }
+    
+    for (const x in []) {
+        var v00_c = x;
+        (function() { return x + v00});
+        (() => x);    
+    }
+    
+    for (const x = 0; x < 1;) {
+        var v1_c = x;
+        (function() { return x + v1_c});
+        (() => x);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x =1;
+        var v2_c = x;
+        (function() { return x + v2_c});
+        (() => x);
+    }
+    
+    do {
+        const x = 1;
+        var v3_c = x;
+        (function() { return x + v3_c});
+        (() => x);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        var v4_c = x;
+        (function() { return x + v4_c});
+        (() => x);
+    }
+    
+    for (const x = 0, y = 1; x < 1;) {
+        var v5_c = x;
+        (function() { return x + y + v5_c});
+        (() => x + y);
+    }
+    
+    while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        const x = 1, y = 1;
+        var v6_c = x;
+        (function() { return x + y + v6_c});
+        (() => x + y);
+    }
+    
+    do {
+        const x = 1, y = 1;
+        var v7_c = x;
+        (function() { return x + y + v7_c});
+        (() => x + y);
+    } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    for (const y = 0; y < 1;) {
+        const x = 1;
+        var v8_c = x;
+        (function() { return x + y + v8_c});
+        (() => x + y);
+    }
+    

--- a/tests/baselines/reference/capturedLetConstInLoop5_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop5_ES6.errors.txt
@@ -1,8 +1,21 @@
+capturedLetConstInLoop5_ES6.ts(44,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(66,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(100,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(122,14): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop5_ES6.ts(174,13): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
+capturedLetConstInLoop5_ES6.ts(183,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(188,13): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(202,13): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(205,14): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
+capturedLetConstInLoop5_ES6.ts(239,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(244,13): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(258,13): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(261,14): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop5_ES6.ts(273,13): error TS2845: This condition will always return 'true'.
 
 
-==== capturedLetConstInLoop5_ES6.ts (2 errors) ====
+==== capturedLetConstInLoop5_ES6.ts (15 errors) ====
     declare function use(a: any);
     
     //====let
@@ -47,6 +60,8 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
     
     function foo2(x) {
         while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             let x = 1;
             var v = x;
             (function() { return x + v });
@@ -69,6 +84,8 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
                 return;
             }
         } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         
         use(v);
     }
@@ -103,6 +120,8 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
     
     function foo6(x) {
         while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             let x, y;
             var v = x;
             (function() { return x + y + v });
@@ -125,6 +144,8 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
                 return;
             }
         } while (1 === 1);
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         
         use(v);
     }
@@ -188,11 +209,15 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
     
     function foo2_c(x) {
         while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             const x = 1;
             var v = x;
             (function() { return x + v });
             (() => x + v);
             if (x == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return;
             }
         }
@@ -207,9 +232,13 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
             (function() { return x + v });
             (() => x + v);
             if (x == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return;
             }
         } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         
         use(v);
     }
@@ -246,11 +275,15 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
     
     function foo6_c(x) {
         while (1 === 1) {
+               ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             const x = 1, y = 1;
             var v = x;
             (function() { return x + y + v });
             (() => x + y + v);
             if (x == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return;
             }
         }
@@ -265,9 +298,13 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
             (function() { return x + y + v });
             (() => x + y + v);
             if (x == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return;
             }
         } while (1 === 1)
+                 ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         
         use(v);
     }
@@ -280,6 +317,8 @@ capturedLetConstInLoop5_ES6.ts(229,13): error TS2367: This comparison appears to
             (function() { return x + y + v });
             (() => x + y + v);
             if (x == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return;
             }
         }

--- a/tests/baselines/reference/capturedLetConstInLoop6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop6.errors.txt
@@ -1,10 +1,24 @@
+capturedLetConstInLoop6.ts(36,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(58,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(83,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(105,10): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop6.ts(147,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop6.ts(150,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop6.ts(155,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(159,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(171,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(177,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(183,9): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop6.ts(194,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop6.ts(202,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(206,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(218,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(224,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6.ts(230,9): error TS2845: This condition will always return 'true'.
 
 
-==== capturedLetConstInLoop6.ts (4 errors) ====
+==== capturedLetConstInLoop6.ts (18 errors) ====
     // ====let
     for (let x of []) {
         (function() { return x});
@@ -41,6 +55,8 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x;
         (function() { return x});
         (() => x);
@@ -63,6 +79,8 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (let y = 0; y < 1; ++y) {
         let x = 1;
@@ -88,6 +106,8 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x, y;
         (function() { return x + y});
         (() => x + y);
@@ -110,6 +130,8 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (let y = 0; y < 1; ++y) {
         let x = 1;
@@ -164,10 +186,14 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1;
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
@@ -180,18 +206,24 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (const y = 0; y < 1;) {
         const x = 1;
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
@@ -215,10 +247,14 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1, y = 1;
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
@@ -231,18 +267,24 @@ capturedLetConstInLoop6.ts(197,9): error TS2367: This comparison appears to be u
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (const y = 0; y < 1;) {
         const x = 1;
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {

--- a/tests/baselines/reference/capturedLetConstInLoop6_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop6_ES6.errors.txt
@@ -1,10 +1,24 @@
+capturedLetConstInLoop6_ES6.ts(36,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(58,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(83,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(105,10): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop6_ES6.ts(147,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop6_ES6.ts(150,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop6_ES6.ts(155,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(159,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(171,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(177,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(183,9): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop6_ES6.ts(194,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop6_ES6.ts(202,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(206,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(218,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(224,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop6_ES6.ts(230,9): error TS2845: This condition will always return 'true'.
 
 
-==== capturedLetConstInLoop6_ES6.ts (4 errors) ====
+==== capturedLetConstInLoop6_ES6.ts (18 errors) ====
     // ====let
     for (let x of []) {
         (function() { return x});
@@ -41,6 +55,8 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x;
         (function() { return x});
         (() => x);
@@ -63,6 +79,8 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (let y = 0; y < 1; ++y) {
         let x = 1;
@@ -88,6 +106,8 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x, y;
         (function() { return x + y});
         (() => x + y);
@@ -110,6 +130,8 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (let y = 0; y < 1; ++y) {
         let x = 1;
@@ -164,10 +186,14 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1;
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
@@ -180,18 +206,24 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (const y = 0; y < 1;) {
         const x = 1;
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
@@ -215,10 +247,14 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
     }
     
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1, y = 1;
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
@@ -231,18 +267,24 @@ capturedLetConstInLoop6_ES6.ts(197,9): error TS2367: This comparison appears to 
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {
             continue;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     for (const y = 0; y < 1;) {
         const x = 1;
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 2) {

--- a/tests/baselines/reference/capturedLetConstInLoop7.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop7.errors.txt
@@ -1,14 +1,28 @@
+capturedLetConstInLoop7.ts(57,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(92,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(132,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(168,10): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop7.ts(230,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7.ts(233,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7.ts(236,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
 capturedLetConstInLoop7.ts(239,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop7.ts(245,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(249,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(268,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(280,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(287,9): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop7.ts(305,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7.ts(308,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7.ts(311,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
 capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop7.ts(320,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(324,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(344,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(356,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7.ts(363,9): error TS2845: This condition will always return 'true'.
 
 
-==== capturedLetConstInLoop7.ts (8 errors) ====
+==== capturedLetConstInLoop7.ts (22 errors) ====
     //===let
     l0:
     for (let x of []) {
@@ -66,6 +80,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
     
     l2:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x;
         (function() { return x});
         (() => x);
@@ -101,6 +117,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
             continue l3;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l4:
     for (let y = 0; y < 1; ++y) {
@@ -141,6 +159,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
     
     l6:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x, y;
         (function() { return x + y});
         (() => x + y);
@@ -177,6 +197,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
             continue l7;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l8:
     for (let y = 0; y < 1; ++y) {
@@ -262,10 +284,14 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
     
     l2_c:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1;
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -285,6 +311,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -297,6 +325,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
             continue l3_c;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l4_c:
     for (const y = 0; y < 1;) {
@@ -304,6 +334,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -345,10 +377,14 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
     
     l6_c:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1, y = 1;
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -369,6 +405,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -381,6 +419,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
             continue l7_c;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l8_c:
     for (const y = 0; y < 1;) {
@@ -388,6 +428,8 @@ capturedLetConstInLoop7.ts(314,9): error TS2367: This comparison appears to be u
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {

--- a/tests/baselines/reference/capturedLetConstInLoop7_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop7_ES6.errors.txt
@@ -1,14 +1,28 @@
+capturedLetConstInLoop7_ES6.ts(57,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(92,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(132,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(168,10): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop7_ES6.ts(230,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7_ES6.ts(233,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7_ES6.ts(236,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
 capturedLetConstInLoop7_ES6.ts(239,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop7_ES6.ts(245,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(249,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(268,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(280,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(287,9): error TS2845: This condition will always return 'true'.
 capturedLetConstInLoop7_ES6.ts(305,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7_ES6.ts(308,9): error TS2367: This comparison appears to be unintentional because the types '0' and '1' have no overlap.
 capturedLetConstInLoop7_ES6.ts(311,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
 capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to be unintentional because the types '0' and '2' have no overlap.
+capturedLetConstInLoop7_ES6.ts(320,8): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(324,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(344,9): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(356,10): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop7_ES6.ts(363,9): error TS2845: This condition will always return 'true'.
 
 
-==== capturedLetConstInLoop7_ES6.ts (8 errors) ====
+==== capturedLetConstInLoop7_ES6.ts (22 errors) ====
     //===let
     l0:
     for (let x of []) {
@@ -66,6 +80,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
     
     l2:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x;
         (function() { return x});
         (() => x);
@@ -101,6 +117,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
             continue l3;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l4:
     for (let y = 0; y < 1; ++y) {
@@ -141,6 +159,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
     
     l6:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         let x, y;
         (function() { return x + y});
         (() => x + y);
@@ -177,6 +197,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
             continue l7;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l8:
     for (let y = 0; y < 1; ++y) {
@@ -262,10 +284,14 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
     
     l2_c:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1;
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -285,6 +311,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -297,6 +325,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
             continue l3_c;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l4_c:
     for (const y = 0; y < 1;) {
@@ -304,6 +334,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
         (function() { return x});
         (() => x);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -345,10 +377,14 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
     
     l6_c:
     while (1 === 1) {
+           ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         const x = 1, y = 1;
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -369,6 +405,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {
@@ -381,6 +419,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
             continue l7_c;
         }
     } while (1 === 1)
+             ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     l8_c:
     for (const y = 0; y < 1;) {
@@ -388,6 +428,8 @@ capturedLetConstInLoop7_ES6.ts(314,9): error TS2367: This comparison appears to 
         (function() { return x + y});
         (() => x + y);
         if (x == 1) {
+            ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             break;
         }
         if (x == 1) {

--- a/tests/baselines/reference/capturedLetConstInLoop9.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop9.errors.txt
@@ -1,0 +1,147 @@
+capturedLetConstInLoop9.ts(22,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop9.ts(100,16): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop9.ts (2 errors) ====
+    for (let x = 0; x < 1; ++x) {
+        let x;
+        (function() { return x });
+        {
+            let x;
+            (function() { return x });
+        }
+    
+        try { }
+        catch (e) {
+            let x;
+            (function() { return x });
+        }
+    
+        switch (x) {
+            case 1:
+                let x;
+                (function() { return x });
+               break;
+        }
+        
+        while (1 == 1) {
+               ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            let x;
+            (function() { return x });
+        }
+        
+        class A {
+            m() {
+                return x + 1;
+            }
+        }
+    }
+    
+    declare function use(a: any);
+    
+    function foo() {
+        l0:
+        for (let a of []) {
+            
+            if (a === 1) {
+                break;
+            }
+            
+            if (a === 2) {
+                break l0;
+            }
+            
+            for (let b of []) {
+                var [{x, y:z}] = [{x:1, y:2}];
+                if (b === 1) {
+                    break;
+                }
+                
+                
+                if (b === 2) {
+                    break l0;
+                }
+                
+                l1:
+                if (b === 3) {
+                    break l1;
+                }
+                
+                return 50;
+            }
+    
+            for (let b of []) {
+                var [{x1, y:z1}] = [{x1:1, y:arguments.length}];
+                if (b === 1) {
+                    break;
+                }
+                
+                if (b === 2) {
+                    break l0;
+                }
+                
+                () => b
+                return 100;
+            }
+    
+            
+            () => a;
+        }
+        
+        use(x);
+        use(z);
+        use(x1);
+        use(z1);
+    }
+    
+    function foo2() {
+        for (let x of []) {
+            if (x === 1) {
+                break;
+            }
+            else if (x === 2) {
+                continue;
+            }
+            
+            while (1 === 1) {
+                   ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+                if (x) {
+                    break;
+                }
+                else {
+                    continue;
+                }
+            }
+            
+            switch(x) {
+                case 1: break;
+                case 2: continue;
+            }
+            
+            for (let y of []) {
+                switch(y) {
+                    case 1: break;
+                    case 2: continue;
+                }
+            }
+        }
+    }
+    
+    class C {
+        constructor(private N: number) { }
+        foo() {
+            for (let i = 0; i < 100; i++) {
+                let f = () => this.N * i;
+            }
+        }
+    }
+    
+    function foo3 () {
+        let x = arguments.length;
+        for (let y of []) {
+            let z = arguments.length;
+            (function() { return y + z + arguments.length; });
+        }
+    }

--- a/tests/baselines/reference/capturedLetConstInLoop9_ES6.errors.txt
+++ b/tests/baselines/reference/capturedLetConstInLoop9_ES6.errors.txt
@@ -1,0 +1,146 @@
+capturedLetConstInLoop9_ES6.ts(22,12): error TS2845: This condition will always return 'true'.
+capturedLetConstInLoop9_ES6.ts(99,16): error TS2845: This condition will always return 'true'.
+
+
+==== capturedLetConstInLoop9_ES6.ts (2 errors) ====
+    for (let x = 0; x < 1; ++x) {
+        let x;
+        (function() { return x });
+        {
+            let x;
+            (function() { return x });
+        }
+    
+        try { }
+        catch (e) {
+            let x;
+            (function() { return x });
+        }
+    
+        switch (x) {
+            case 1:
+                let x;
+                (function() { return x });
+               break;
+        }
+        
+        while (1 == 1) {
+               ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            let x;
+            (function() { return x });
+        }
+        
+        class A {
+            m() {
+                return x + 1;
+            }
+        }
+    }
+    
+    declare function use(a: any);
+    
+    function foo() {
+        l0:
+        for (let a of []) {
+            
+            if (a === 1) {
+                break;
+            }
+            
+            if (a === 2) {
+                break l0;
+            }
+            
+            for (let b of []) {
+                var [{x, y:z}] = [{x:1, y:2}];
+                if (b === 1) {
+                    break;
+                }
+                
+                
+                if (b === 2) {
+                    break l0;
+                }
+                
+                l1:
+                if (b === 3) {
+                    break l1;
+                }
+                
+                return 50;
+            }
+    
+            for (let b of []) {
+                var [{x1, y:z1}] = [{x1:1, y:arguments.length}];
+                if (b === 1) {
+                    break;
+                }
+                
+                if (b === 2) {
+                    break l0;
+                }
+                () => b
+                return 100;
+            }
+    
+            
+            () => a;
+        }
+        
+        use(x);
+        use(z);
+        use(x1);
+        use(z1);
+    }
+    
+    function foo2() {
+        for (let x of []) {
+            if (x === 1) {
+                break;
+            }
+            else if (x === 2) {
+                continue;
+            }
+            
+            while (1 === 1) {
+                   ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+                if (x) {
+                    break;
+                }
+                else {
+                    continue;
+                }
+            }
+            
+            switch(x) {
+                case 1: break;
+                case 2: continue;
+            }
+            
+            for (let y of []) {
+                switch(y) {
+                    case 1: break;
+                    case 2: continue;
+                }
+            }
+        }
+    }
+    
+    class C {
+        constructor(private N: number) { }
+        foo() {
+            for (let i = 0; i < 100; i++) {
+                let f = () => this.N * i;
+            }
+        }
+    }
+    
+    function foo3 () {
+        let x = arguments.length;
+        for (let y of []) {
+            let z = arguments.length;
+            (function() { return y + z + arguments.length; });
+        }
+    }

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
@@ -14,9 +14,17 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(42,11): error TS18050: The value
 comparisonOperatorWithIdenticalPrimitiveType.ts(42,19): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(43,11): error TS18050: The value 'undefined' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value 'undefined' cannot be used here.
+comparisonOperatorWithIdenticalPrimitiveType.ts(51,11): error TS2845: This condition will always return 'true'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(52,11): error TS2845: This condition will always return 'true'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(60,11): error TS2845: This condition will always return 'false'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(61,11): error TS2845: This condition will always return 'false'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(69,11): error TS2845: This condition will always return 'true'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(70,11): error TS2845: This condition will always return 'true'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(78,11): error TS2845: This condition will always return 'false'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(79,11): error TS2845: This condition will always return 'false'.
 
 
-==== comparisonOperatorWithIdenticalPrimitiveType.ts (16 errors) ====
+==== comparisonOperatorWithIdenticalPrimitiveType.ts (24 errors) ====
     enum E { a, b, c }
     
     var a: number;
@@ -100,7 +108,11 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     var re4 = d == d;
     var re5 = e == e;
     var re6 = null == null;
+              ~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     var re7 = undefined == undefined;
+              ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     // operator !=
     var rf1 = a != a;
@@ -109,7 +121,11 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     var rf4 = d != d;
     var rf5 = e != e;
     var rf6 = null != null;
+              ~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
     var rf7 = undefined != undefined;
+              ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
     
     // operator ===
     var rg1 = a === a;
@@ -118,7 +134,11 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     var rg4 = d === d;
     var rg5 = e === e;
     var rg6 = null === null;
+              ~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     var rg7 = undefined === undefined;
+              ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     // operator !==
     var rh1 = a !== a;
@@ -127,4 +147,8 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     var rh4 = d !== d;
     var rh5 = e !== e;
     var rh6 = null !== null;
+              ~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
     var rh7 = undefined !== undefined;
+              ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.

--- a/tests/baselines/reference/computedPropertyNames49_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames49_ES5.errors.txt
@@ -1,10 +1,12 @@
 computedPropertyNames49_ES5.ts(9,9): error TS1049: A 'set' accessor must have exactly one parameter.
 computedPropertyNames49_ES5.ts(13,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames49_ES5.ts(14,13): error TS2845: This condition will always return 'true'.
 computedPropertyNames49_ES5.ts(18,9): error TS1118: An object literal cannot have multiple get/set accessors with the same name.
 computedPropertyNames49_ES5.ts(18,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames49_ES5.ts(19,13): error TS2845: This condition will always return 'true'.
 
 
-==== computedPropertyNames49_ES5.ts (4 errors) ====
+==== computedPropertyNames49_ES5.ts (6 errors) ====
     var x = {
         p1: 10,
         get [1 + 1]() {
@@ -23,6 +25,8 @@ computedPropertyNames49_ES5.ts(18,9): error TS2300: Duplicate identifier 'foo'.
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (1 == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 10;
             }
         },
@@ -32,6 +36,8 @@ computedPropertyNames49_ES5.ts(18,9): error TS2300: Duplicate identifier 'foo'.
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (2 == 2) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 20;
             }
         },

--- a/tests/baselines/reference/computedPropertyNames49_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames49_ES6.errors.txt
@@ -1,10 +1,12 @@
 computedPropertyNames49_ES6.ts(9,9): error TS1049: A 'set' accessor must have exactly one parameter.
 computedPropertyNames49_ES6.ts(13,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames49_ES6.ts(14,13): error TS2845: This condition will always return 'true'.
 computedPropertyNames49_ES6.ts(18,9): error TS1118: An object literal cannot have multiple get/set accessors with the same name.
 computedPropertyNames49_ES6.ts(18,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames49_ES6.ts(19,13): error TS2845: This condition will always return 'true'.
 
 
-==== computedPropertyNames49_ES6.ts (4 errors) ====
+==== computedPropertyNames49_ES6.ts (6 errors) ====
     var x = {
         p1: 10,
         get [1 + 1]() {
@@ -23,6 +25,8 @@ computedPropertyNames49_ES6.ts(18,9): error TS2300: Duplicate identifier 'foo'.
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (1 == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 10;
             }
         },
@@ -32,6 +36,8 @@ computedPropertyNames49_ES6.ts(18,9): error TS2300: Duplicate identifier 'foo'.
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (2 == 2) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 20;
             }
         },

--- a/tests/baselines/reference/computedPropertyNames50_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames50_ES5.errors.txt
@@ -1,16 +1,20 @@
 computedPropertyNames50_ES5.ts(3,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames50_ES5.ts(4,13): error TS2845: This condition will always return 'true'.
 computedPropertyNames50_ES5.ts(11,9): error TS1049: A 'set' accessor must have exactly one parameter.
 computedPropertyNames50_ES5.ts(18,9): error TS1118: An object literal cannot have multiple get/set accessors with the same name.
 computedPropertyNames50_ES5.ts(18,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames50_ES5.ts(19,13): error TS2845: This condition will always return 'true'.
 
 
-==== computedPropertyNames50_ES5.ts (4 errors) ====
+==== computedPropertyNames50_ES5.ts (6 errors) ====
     var x = {
         p1: 10,
         get foo() {
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (1 == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 10;
             }
         },
@@ -32,6 +36,8 @@ computedPropertyNames50_ES5.ts(18,9): error TS2300: Duplicate identifier 'foo'.
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (2 == 2) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 20;
             }
         },

--- a/tests/baselines/reference/computedPropertyNames50_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames50_ES6.errors.txt
@@ -1,16 +1,20 @@
 computedPropertyNames50_ES6.ts(3,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames50_ES6.ts(4,13): error TS2845: This condition will always return 'true'.
 computedPropertyNames50_ES6.ts(11,9): error TS1049: A 'set' accessor must have exactly one parameter.
 computedPropertyNames50_ES6.ts(18,9): error TS1118: An object literal cannot have multiple get/set accessors with the same name.
 computedPropertyNames50_ES6.ts(18,9): error TS2300: Duplicate identifier 'foo'.
+computedPropertyNames50_ES6.ts(19,13): error TS2845: This condition will always return 'true'.
 
 
-==== computedPropertyNames50_ES6.ts (4 errors) ====
+==== computedPropertyNames50_ES6.ts (6 errors) ====
     var x = {
         p1: 10,
         get foo() {
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (1 == 1) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 10;
             }
         },
@@ -32,6 +36,8 @@ computedPropertyNames50_ES6.ts(18,9): error TS2300: Duplicate identifier 'foo'.
             ~~~
 !!! error TS2300: Duplicate identifier 'foo'.
             if (2 == 2) {
+                ~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                 return 20;
             }
         },

--- a/tests/baselines/reference/constEnums.errors.txt
+++ b/tests/baselines/reference/constEnums.errors.txt
@@ -1,0 +1,187 @@
+constEnums.ts(112,14): error TS2845: This condition will always return 'true'.
+constEnums.ts(119,14): error TS2845: This condition will always return 'true'.
+
+
+==== constEnums.ts (2 errors) ====
+    const enum Enum1 {
+       A0 = 100,
+    }
+    
+    const enum Enum1 {
+        // correct cases
+        A,
+        B,
+        C = 10,
+        D = A | B,
+        E = A | 1,
+        F = 1 | A,
+        G = (1 & 1),
+        H = ~(A | B),
+        I = A >>> 1,
+        J = 1 & A,
+        K = ~(1 | 5),
+        L = ~D,
+        M = E << B,
+        N = E << 1,
+        O = E >> B,
+        P = E >> 1,
+        PQ = E ** 2,
+        Q = -D,
+        R = C & 5,
+        S = 5 & C,
+        T = C | D,
+        U = C | 1,
+        V = 10 | D,
+        W = Enum1.V,
+    
+        // correct cases: reference to the enum member from different enum declaration
+        W1 = A0,
+        W2 = Enum1.A0,
+        W3 = Enum1["A0"],
+        W4 = Enum1["W"],
+        W5 = Enum1[`V`],
+    }
+    
+    const enum Comments {
+        "//",
+        "/*",
+        "*/",
+        "///",
+        "#",
+        "<!--",
+        "-->",
+    }
+    
+    module A {
+        export module B {
+            export module C {
+                export const enum E {
+                    V1 = 1,
+                    V2 = A.B.C.E.V1 | 100
+                }
+            }
+        }
+    }
+    
+    module A {
+        export module B {
+            export module C {
+                export const enum E {
+                    V3 = A.B.C.E["V2"] & 200,
+                    V4 = A.B.C.E[`V1`] << 1,
+                }
+            }
+        }
+    }
+    
+    module A1 {
+        export module B {
+            export module C {
+                export const enum E {
+                    V1 = 10,
+                    V2 = 110,
+                }
+            }
+        }
+    }
+    
+    module A2 {
+        export module B {
+            export module C {
+                export const enum E {
+                    V1 = 10,
+                    V2 = 110,
+                }
+            }
+            // module C will be classified as value
+            export module C {
+                var x = 1
+            }
+        }
+    }
+    
+    import I = A.B.C.E;
+    import I1 = A1.B;
+    import I2 = A2.B;
+    
+    function foo0(e: I): void {
+        if (e === I.V1) {
+        }
+        else if (e === I.V2) {
+        }
+    }
+    
+    function foo1(e: I1.C.E): void {
+        if (e === I1.C.E.V1) {
+        }
+        else if (e === I1.C.E.V2) {
+                 ~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        }
+    }
+    
+    function foo2(e: I2.C.E): void {
+        if (e === I2.C.E.V1) {
+        }
+        else if (e === I2.C.E.V2) {
+                 ~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        }
+    }
+    
+    
+    function foo(x: Enum1) {
+        switch (x) {
+            case Enum1.A:
+            case Enum1.B:
+            case Enum1.C:
+            case Enum1.D:
+            case Enum1.E:
+            case Enum1.F:
+            case Enum1.G:
+            case Enum1.H:
+            case Enum1.I:
+            case Enum1.J:
+            case Enum1.K:
+            case Enum1.L:
+            case Enum1.M:
+            case Enum1.N:
+            case Enum1.O:
+            case Enum1.P:
+            case Enum1.PQ:
+            case Enum1.Q:
+            case Enum1.R:
+            case Enum1.S:
+            case Enum1["T"]:
+            case Enum1[`U`]:
+            case Enum1.V:
+            case Enum1.W:
+            case Enum1.W1:
+            case Enum1.W2:
+            case Enum1.W3:
+            case Enum1.W4:
+                break;
+        }
+    }
+    
+    function bar(e: A.B.C.E): number {
+        switch (e) {
+            case A.B.C.E.V1: return 1;
+            case A.B.C.E.V2: return 1;
+            case A.B.C.E.V3: return 1;
+        }
+    }
+    
+    function baz(c: Comments) {
+        switch (c) {
+            case Comments["//"]:
+            case Comments["/*"]:
+            case Comments["*/"]:
+            case Comments["///"]:
+            case Comments["#"]:
+            case Comments["<!--"]:
+            case Comments["-->"]:
+            break;
+        }
+    }
+    

--- a/tests/baselines/reference/controlFlowManyConsecutiveConditionsNoTimeout.errors.txt
+++ b/tests/baselines/reference/controlFlowManyConsecutiveConditionsNoTimeout.errors.txt
@@ -1,0 +1,495 @@
+controlFlowManyConsecutiveConditionsNoTimeout.ts(9,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(10,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(11,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(12,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(13,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(14,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(15,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(16,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(17,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(18,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(19,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(20,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(21,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(22,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(23,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(24,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(25,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(26,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(27,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(28,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(29,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(30,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(31,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(32,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(33,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(34,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(35,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(36,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(37,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(38,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(39,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(40,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(41,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(42,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(43,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(44,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(45,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(46,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(47,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(48,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(49,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(50,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(51,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(52,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(53,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(54,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(55,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(56,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(57,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(58,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(59,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(60,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(61,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(62,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(63,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(64,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(65,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(66,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(67,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(68,5): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(71,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(72,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(73,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(74,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(75,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(76,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(77,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(78,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(79,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(80,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(81,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(82,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(83,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(84,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(85,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(86,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(87,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(88,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(89,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(90,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(91,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(92,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(93,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(94,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(95,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(96,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(97,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(98,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(99,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(100,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(101,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(102,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(103,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(104,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(105,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(106,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(107,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(108,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(109,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(110,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(111,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(112,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(113,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(114,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(115,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(116,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(117,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(118,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(119,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(120,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(121,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(122,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(123,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(124,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(125,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(126,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(127,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(128,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(129,9): error TS2845: This condition will always return 'true'.
+controlFlowManyConsecutiveConditionsNoTimeout.ts(130,9): error TS2845: This condition will always return 'true'.
+
+
+==== controlFlowManyConsecutiveConditionsNoTimeout.ts (120 errors) ====
+    export enum Choice {
+        One,
+        Two,
+    }
+    
+    const choice: Choice = Choice.One;
+    const choiceOne = Choice.One;
+    
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {}
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    if (choice === choiceOne) {} 
+        ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    
+    while (true) {
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {}
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+        if (choice === choiceOne) {} 
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+    }
+    

--- a/tests/baselines/reference/discriminantsAndTypePredicates.errors.txt
+++ b/tests/baselines/reference/discriminantsAndTypePredicates.errors.txt
@@ -1,0 +1,37 @@
+discriminantsAndTypePredicates.ts(27,9): error TS2845: This condition will always return 'true'.
+
+
+==== discriminantsAndTypePredicates.ts (1 errors) ====
+    // Repro from #10145
+    
+    interface A { type: 'A' }
+    interface B { type: 'B' }
+    
+    function isA(x: A | B): x is A { return x.type === 'A'; }
+    function isB(x: A | B): x is B { return x.type === 'B'; }
+    
+    function foo1(x: A | B): any {
+        x;  // A | B
+        if (isA(x)) {
+            return x;  // A
+        }
+        x;  // B
+        if (isB(x)) {
+            return x;  // B
+        }
+        x;  // never
+    }
+    
+    function foo2(x: A | B): any {
+        x;  // A | B
+        if (x.type === 'A') {
+            return x;  // A
+        }
+        x;  // B
+        if (x.type === 'B') {
+            ~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            return x;  // B
+        }
+        x;  // never
+    }

--- a/tests/baselines/reference/discriminatedUnionTypes1.errors.txt
+++ b/tests/baselines/reference/discriminatedUnionTypes1.errors.txt
@@ -1,7 +1,8 @@
+discriminatedUnionTypes1.ts(26,14): error TS2845: This condition will always return 'true'.
 discriminatedUnionTypes1.ts(89,9): error TS2367: This comparison appears to be unintentional because the types '"A" | "B" | "C" | "D"' and '"X"' have no overlap.
 
 
-==== discriminatedUnionTypes1.ts (1 errors) ====
+==== discriminatedUnionTypes1.ts (2 errors) ====
     interface Square {
         kind: "square";
         size: number;
@@ -28,6 +29,8 @@ discriminatedUnionTypes1.ts(89,9): error TS2367: This comparison appears to be u
             return Math.PI * s.radius * s.radius;
         }
         else if (s.kind === "rectangle") {
+                 ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             return s.width * s.height;
         }
         else {

--- a/tests/baselines/reference/discriminatedUnionTypes2.errors.txt
+++ b/tests/baselines/reference/discriminatedUnionTypes2.errors.txt
@@ -1,9 +1,10 @@
 discriminatedUnionTypes2.ts(27,30): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{ a: null; b: string; }'.
 discriminatedUnionTypes2.ts(32,11): error TS2339: Property 'b' does not exist on type '{ a: 0; b: string; } | { a: T; c: number; }'.
   Property 'b' does not exist on type '{ a: T; c: number; }'.
+discriminatedUnionTypes2.ts(128,9): error TS2845: This condition will always return 'true'.
 
 
-==== discriminatedUnionTypes2.ts (2 errors) ====
+==== discriminatedUnionTypes2.ts (3 errors) ====
     function f10(x : { kind: false, a: string } | { kind: true, b: string } | { kind: string, c: string }) {
         if (x.kind === false) {
             x.a;
@@ -137,6 +138,8 @@ discriminatedUnionTypes2.ts(32,11): error TS2339: Property 'b' does not exist on
     
     function foo1(x: RuntimeValue & { type: 'number' }) {
         if (x.type === 'number') {
+            ~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             x.value;  // number
         }
         else {

--- a/tests/baselines/reference/emptyThenWarning.errors.txt
+++ b/tests/baselines/reference/emptyThenWarning.errors.txt
@@ -1,14 +1,17 @@
 emptyThenWarning.ts(1,6): error TS1313: The body of an 'if' statement cannot be the empty statement.
+emptyThenWarning.ts(4,5): error TS2845: This condition will always return 'true'.
 emptyThenWarning.ts(4,19): error TS1313: The body of an 'if' statement cannot be the empty statement.
 
 
-==== emptyThenWarning.ts (2 errors) ====
+==== emptyThenWarning.ts (3 errors) ====
     if(1);
          ~
 !!! error TS1313: The body of an 'if' statement cannot be the empty statement.
     
     let x = 0;
     if (true === true); {  
+        ~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
                       ~
 !!! error TS1313: The body of an 'if' statement cannot be the empty statement.
         x = 1;

--- a/tests/baselines/reference/enumLiteralTypes3.errors.txt
+++ b/tests/baselines/reference/enumLiteralTypes3.errors.txt
@@ -10,14 +10,16 @@ enumLiteralTypes3.ts(37,5): error TS2322: Type 'Choice.Unknown' is not assignabl
 enumLiteralTypes3.ts(39,5): error TS2322: Type 'Choice.No' is not assignable to type 'Choice.Yes'.
 enumLiteralTypes3.ts(40,5): error TS2322: Type 'Choice.Unknown' is not assignable to type 'YesNo'.
 enumLiteralTypes3.ts(52,5): error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.Unknown' have no overlap.
+enumLiteralTypes3.ts(53,5): error TS2845: This condition will always return 'true'.
 enumLiteralTypes3.ts(54,5): error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.No' have no overlap.
 enumLiteralTypes3.ts(55,5): error TS2367: This comparison appears to be unintentional because the types 'YesNo' and 'Choice.Unknown' have no overlap.
+enumLiteralTypes3.ts(67,5): error TS2845: This condition will always return 'true'.
 enumLiteralTypes3.ts(87,14): error TS2678: Type 'Choice.Unknown' is not comparable to type 'Choice.Yes'.
 enumLiteralTypes3.ts(89,14): error TS2678: Type 'Choice.No' is not comparable to type 'Choice.Yes'.
 enumLiteralTypes3.ts(96,14): error TS2678: Type 'Choice.Unknown' is not comparable to type 'YesNo'.
 
 
-==== enumLiteralTypes3.ts (14 errors) ====
+==== enumLiteralTypes3.ts (16 errors) ====
     const enum Choice { Unknown, Yes, No };
     
     type Yes = Choice.Yes;
@@ -92,6 +94,8 @@ enumLiteralTypes3.ts(96,14): error TS2678: Type 'Choice.Unknown' is not comparab
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.Unknown' have no overlap.
         a === Choice.Yes;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         a === Choice.No;
         ~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.No' have no overlap.
@@ -110,6 +114,8 @@ enumLiteralTypes3.ts(96,14): error TS2678: Type 'Choice.Unknown' is not comparab
     
     function f7(a: Yes, b: YesNo, c: UnknownYesNo, d: Choice) {
         a === a;
+        ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         a === b;
         a === c;
         a === d;

--- a/tests/baselines/reference/equalityStrictNulls.errors.txt
+++ b/tests/baselines/reference/equalityStrictNulls.errors.txt
@@ -1,10 +1,12 @@
+equalityStrictNulls.ts(37,9): error TS2845: This condition will always return 'true'.
+equalityStrictNulls.ts(43,9): error TS2845: This condition will always return 'true'.
 equalityStrictNulls.ts(59,13): error TS18050: The value 'undefined' cannot be used here.
 equalityStrictNulls.ts(61,13): error TS18050: The value 'undefined' cannot be used here.
 equalityStrictNulls.ts(63,14): error TS18050: The value 'undefined' cannot be used here.
 equalityStrictNulls.ts(65,14): error TS18050: The value 'undefined' cannot be used here.
 
 
-==== equalityStrictNulls.ts (4 errors) ====
+==== equalityStrictNulls.ts (6 errors) ====
     function f1(x: string) {
         if (x == undefined) {
         }
@@ -42,12 +44,16 @@ equalityStrictNulls.ts(65,14): error TS18050: The value 'undefined' cannot be us
     
     function f2() {
         if (undefined == undefined) {
+            ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         }
         if (undefined == null) {
         }
         if (null == undefined) {
         }
         if (null == null) {
+            ~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         }
     }
     

--- a/tests/baselines/reference/narrowingByDiscriminantInLoop.errors.txt
+++ b/tests/baselines/reference/narrowingByDiscriminantInLoop.errors.txt
@@ -1,0 +1,94 @@
+narrowingByDiscriminantInLoop.ts(28,18): error TS2845: This condition will always return 'true'.
+narrowingByDiscriminantInLoop.ts(47,14): error TS2845: This condition will always return 'true'.
+
+
+==== narrowingByDiscriminantInLoop.ts (2 errors) ====
+    // Repro from #9977
+    
+    type IDLMemberTypes = OperationMemberType | ConstantMemberType;
+    
+    interface IDLTypeDescription {
+        origin: string;
+    }
+    
+    interface InterfaceType {
+        members: IDLMemberTypes[];
+    }
+    
+    interface OperationMemberType {
+        type: "operation";
+        idlType: IDLTypeDescription;
+    }
+    
+    interface ConstantMemberType {
+        type: "const";
+        idlType: string;
+    }
+    
+    function insertInterface(callbackType: InterfaceType) {
+        for (const memberType of callbackType.members) {
+            if (memberType.type === "const") {
+                memberType.idlType;  // string
+            }
+            else if (memberType.type === "operation") {
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+                memberType.idlType.origin;  // string
+                (memberType.idlType as IDLTypeDescription);
+            }
+        }
+    }
+    
+    function insertInterface2(callbackType: InterfaceType) {
+        for (const memberType of callbackType.members) {
+            if (memberType.type === "operation") {
+                memberType.idlType.origin;  // string
+            }
+        }
+    }
+    
+    function foo(memberType: IDLMemberTypes) {
+        if (memberType.type === "const") {
+            memberType.idlType;  // string
+        }
+        else if (memberType.type === "operation") {
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            memberType.idlType.origin;  // string
+        }
+    }
+    
+    // Repro for issue similar to #8383
+    
+    interface A {
+        kind: true;
+        prop: { a: string; };
+    }
+    
+    interface B {
+        kind: false;
+        prop: { b: string; }
+    }
+    
+    function f1(x: A | B) {
+        while (true) {
+            x.prop;
+            if (x.kind === true) {
+                x.prop.a;
+            }
+            if (x.kind === false) {
+                x.prop.b;
+            }
+        }
+    }
+    
+    function f2(x: A | B) {
+        while (true) {
+            if (x.kind) {
+                x.prop.a;
+            }
+            if (!x.kind) {
+                x.prop.b;
+            }
+        }
+    }

--- a/tests/baselines/reference/neverType.errors.txt
+++ b/tests/baselines/reference/neverType.errors.txt
@@ -1,0 +1,96 @@
+neverType.ts(42,9): error TS2845: This condition will always return 'true'.
+
+
+==== neverType.ts (1 errors) ====
+    function error(message: string): never {
+        throw new Error(message);
+    }
+    
+    function errorVoid(message: string) {
+        throw new Error(message);
+    }
+    
+    function fail() {
+        return error("Something failed");
+    }
+    
+    function failOrThrow(shouldFail: boolean) {
+        if (shouldFail) {
+            return fail();
+        }
+        throw new Error();
+    }
+    
+    function infiniteLoop1() {
+        while (true) {
+        }
+    }
+    
+    function infiniteLoop2(): never {
+        while (true) {
+        }
+    }
+    
+    function move1(direction: "up" | "down") {
+        switch (direction) {
+            case "up":
+                return 1;
+            case "down":
+                return -1; 
+        }
+        return error("Should never get here");
+    }
+    
+    function move2(direction: "up" | "down") {
+        return direction === "up" ? 1 :
+            direction === "down" ? -1 :
+            ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            error("Should never get here");
+    }
+    
+    function check<T>(x: T | undefined) {
+        return x || error("Undefined value");
+    }
+    
+    class C {
+        void1() {
+            throw new Error();
+        }
+        void2() {
+            while (true) {}
+        }
+        never1(): never {
+            throw new Error();
+        }
+        never2(): never {
+            while (true) {}
+        }
+    }
+    
+    function f1(x: string | number) {
+        if (typeof x === "boolean") {
+            x;  // never
+        }
+    }
+    
+    function f2(x: string | number) {
+        while (true) {
+            if (typeof x === "boolean") {
+                return x;  // never
+            }
+        }
+    }
+    
+    function test(cb: () => string) {
+        let s = cb();
+        return s;
+    }
+    
+    let errorCallback = () => error("Error callback");
+    
+    test(() => "hello");
+    test(() => fail());
+    test(() => { throw new Error(); })
+    test(errorCallback);
+    

--- a/tests/baselines/reference/numericLiteralTypes3.errors.txt
+++ b/tests/baselines/reference/numericLiteralTypes3.errors.txt
@@ -23,12 +23,14 @@ numericLiteralTypes3.ts(40,5): error TS2322: Type '1' is not assignable to type 
 numericLiteralTypes3.ts(43,5): error TS2322: Type '0' is not assignable to type 'C'.
 numericLiteralTypes3.ts(50,5): error TS2322: Type '3' is not assignable to type 'D'.
 numericLiteralTypes3.ts(54,5): error TS2367: This comparison appears to be unintentional because the types '1' and '0' have no overlap.
+numericLiteralTypes3.ts(55,5): error TS2845: This condition will always return 'true'.
 numericLiteralTypes3.ts(56,5): error TS2367: This comparison appears to be unintentional because the types '1' and '2' have no overlap.
 numericLiteralTypes3.ts(57,5): error TS2367: This comparison appears to be unintentional because the types '1' and '3' have no overlap.
 numericLiteralTypes3.ts(58,5): error TS2367: This comparison appears to be unintentional because the types 'B' and '0' have no overlap.
 numericLiteralTypes3.ts(59,5): error TS2367: This comparison appears to be unintentional because the types 'B' and '1' have no overlap.
 numericLiteralTypes3.ts(62,5): error TS2367: This comparison appears to be unintentional because the types 'C' and '0' have no overlap.
 numericLiteralTypes3.ts(69,5): error TS2367: This comparison appears to be unintentional because the types 'D' and '3' have no overlap.
+numericLiteralTypes3.ts(73,5): error TS2845: This condition will always return 'true'.
 numericLiteralTypes3.ts(74,5): error TS2367: This comparison appears to be unintentional because the types '1' and 'B' have no overlap.
 numericLiteralTypes3.ts(77,5): error TS2367: This comparison appears to be unintentional because the types 'B' and '1' have no overlap.
 numericLiteralTypes3.ts(94,14): error TS2678: Type '1' is not comparable to type '0 | 2 | 4'.
@@ -36,7 +38,7 @@ numericLiteralTypes3.ts(96,14): error TS2678: Type '3' is not comparable to type
 numericLiteralTypes3.ts(98,14): error TS2678: Type '5' is not comparable to type '0 | 2 | 4'.
 
 
-==== numericLiteralTypes3.ts (28 errors) ====
+==== numericLiteralTypes3.ts (30 errors) ====
     type A = 1;
     type B = 2 | 3;
     type C = 1 | 2 | 3;
@@ -134,6 +136,8 @@ numericLiteralTypes3.ts(98,14): error TS2678: Type '5' is not comparable to type
         ~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '1' and '0' have no overlap.
         a === 1;
+        ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         a === 2;
         ~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '1' and '2' have no overlap.
@@ -164,6 +168,8 @@ numericLiteralTypes3.ts(98,14): error TS2678: Type '5' is not comparable to type
     
     function f7(a: A, b: B, c: C, d: D) {
         a === a;
+        ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         a === b;
         ~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '1' and 'B' have no overlap.

--- a/tests/baselines/reference/objectFreeze.errors.txt
+++ b/tests/baselines/reference/objectFreeze.errors.txt
@@ -1,11 +1,14 @@
+objectFreeze.ts(2,1): error TS2845: This condition will always return 'true'.
 objectFreeze.ts(9,1): error TS2322: Type 'string' is not assignable to type 'number'.
 objectFreeze.ts(9,1): error TS2542: Index signature in type 'readonly number[]' only permits reading.
 objectFreeze.ts(12,3): error TS2540: Cannot assign to 'b' because it is a read-only property.
 
 
-==== objectFreeze.ts (3 errors) ====
+==== objectFreeze.ts (4 errors) ====
     const f = Object.freeze(function foo(a: number, b: string) { return false; });
     f(1, "") === false;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
     
     class C { constructor(a: number) { } }
     const c = Object.freeze(C);

--- a/tests/baselines/reference/stringEnumLiteralTypes3.errors.txt
+++ b/tests/baselines/reference/stringEnumLiteralTypes3.errors.txt
@@ -10,14 +10,16 @@ stringEnumLiteralTypes3.ts(37,5): error TS2322: Type 'Choice.Unknown' is not ass
 stringEnumLiteralTypes3.ts(39,5): error TS2322: Type 'Choice.No' is not assignable to type 'Choice.Yes'.
 stringEnumLiteralTypes3.ts(40,5): error TS2322: Type 'Choice.Unknown' is not assignable to type 'YesNo'.
 stringEnumLiteralTypes3.ts(52,5): error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.Unknown' have no overlap.
+stringEnumLiteralTypes3.ts(53,5): error TS2845: This condition will always return 'true'.
 stringEnumLiteralTypes3.ts(54,5): error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.No' have no overlap.
 stringEnumLiteralTypes3.ts(55,5): error TS2367: This comparison appears to be unintentional because the types 'YesNo' and 'Choice.Unknown' have no overlap.
+stringEnumLiteralTypes3.ts(67,5): error TS2845: This condition will always return 'true'.
 stringEnumLiteralTypes3.ts(87,14): error TS2678: Type 'Choice.Unknown' is not comparable to type 'Choice.Yes'.
 stringEnumLiteralTypes3.ts(89,14): error TS2678: Type 'Choice.No' is not comparable to type 'Choice.Yes'.
 stringEnumLiteralTypes3.ts(96,14): error TS2678: Type 'Choice.Unknown' is not comparable to type 'YesNo'.
 
 
-==== stringEnumLiteralTypes3.ts (14 errors) ====
+==== stringEnumLiteralTypes3.ts (16 errors) ====
     const enum Choice { Unknown = "", Yes = "yes", No = "no" };
     
     type Yes = Choice.Yes;
@@ -92,6 +94,8 @@ stringEnumLiteralTypes3.ts(96,14): error TS2678: Type 'Choice.Unknown' is not co
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.Unknown' have no overlap.
         a === Choice.Yes;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         a === Choice.No;
         ~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types 'Choice.Yes' and 'Choice.No' have no overlap.
@@ -110,6 +114,8 @@ stringEnumLiteralTypes3.ts(96,14): error TS2678: Type 'Choice.Unknown' is not co
     
     function f7(a: Yes, b: YesNo, c: UnknownYesNo, d: Choice) {
         a === a;
+        ~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
         a === b;
         a === c;
         a === d;

--- a/tests/baselines/reference/stringLiteralTypesAndTuples01.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesAndTuples01.errors.txt
@@ -1,0 +1,24 @@
+stringLiteralTypesAndTuples01.ts(13,9): error TS2845: This condition will always return 'true'.
+
+
+==== stringLiteralTypesAndTuples01.ts (1 errors) ====
+    // Should all be strings.
+    let [hello, brave, newish, world] = ["Hello", "Brave", "New", "World"];
+    
+    type RexOrRaptor = "t-rex" | "raptor"
+    let [im, a, dinosaur]: ["I'm", "a", RexOrRaptor] = ['I\'m', 'a', 't-rex'];
+    
+    rawr(dinosaur);
+    
+    function rawr(dino: RexOrRaptor) {
+        if (dino === "t-rex") {
+            return "ROAAAAR!";
+        }
+        if (dino === "raptor") {
+            ~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            return "yip yip!";
+        }
+    
+        throw "Unexpected " + dino;
+    }

--- a/tests/baselines/reference/stringLiteralTypesOverloads01.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesOverloads01.errors.txt
@@ -1,0 +1,58 @@
+stringLiteralTypesOverloads01.ts(17,9): error TS2845: This condition will always return 'true'.
+
+
+==== stringLiteralTypesOverloads01.ts (1 errors) ====
+    type PrimitiveName = 'string' | 'number' | 'boolean';
+    
+    function getFalsyPrimitive(x: "string"): string;
+    function getFalsyPrimitive(x: "number"): number;
+    function getFalsyPrimitive(x: "boolean"): boolean;
+    function getFalsyPrimitive(x: "boolean" | "string"): boolean | string;
+    function getFalsyPrimitive(x: "boolean" | "number"): boolean | number;
+    function getFalsyPrimitive(x: "number" | "string"): number | string;
+    function getFalsyPrimitive(x: "number" | "string" | "boolean"): number | string | boolean;
+    function getFalsyPrimitive(x: PrimitiveName): number | string | boolean {
+        if (x === "string") {
+            return "";
+        }
+        if (x === "number") {
+            return 0;
+        }
+        if (x === "boolean") {
+            ~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
+            return false;
+        }
+    
+        // Should be unreachable.
+        throw "Invalid value";
+    }
+    
+    namespace Consts1 {
+        const EMPTY_STRING = getFalsyPrimitive("string");
+        const ZERO = getFalsyPrimitive('number');
+        const FALSE = getFalsyPrimitive("boolean");
+    }
+    
+    const string: "string" = "string"
+    const number: "number" = "number"
+    const boolean: "boolean" = "boolean"
+    
+    const stringOrNumber = string || number;
+    const stringOrBoolean = string || boolean;
+    const booleanOrNumber = number || boolean;
+    const stringOrBooleanOrNumber = stringOrBoolean || number;
+    
+    namespace Consts2 {
+        const EMPTY_STRING = getFalsyPrimitive(string);
+        const ZERO = getFalsyPrimitive(number);
+        const FALSE = getFalsyPrimitive(boolean);
+    
+        const a = getFalsyPrimitive(stringOrNumber);
+        const b = getFalsyPrimitive(stringOrBoolean);
+        const c = getFalsyPrimitive(booleanOrNumber);
+        const d = getFalsyPrimitive(stringOrBooleanOrNumber);
+    }
+    
+    
+    

--- a/tests/baselines/reference/stringLiteralsAssertionsInEqualityComparisons02.errors.txt
+++ b/tests/baselines/reference/stringLiteralsAssertionsInEqualityComparisons02.errors.txt
@@ -1,15 +1,18 @@
 stringLiteralsAssertionsInEqualityComparisons02.ts(3,9): error TS2367: This comparison appears to be unintentional because the types '"foo"' and '"baz"' have no overlap.
+stringLiteralsAssertionsInEqualityComparisons02.ts(4,9): error TS2845: This condition will always return 'false'.
 stringLiteralsAssertionsInEqualityComparisons02.ts(5,9): error TS2367: This comparison appears to be unintentional because the types 'string' and 'number' have no overlap.
 stringLiteralsAssertionsInEqualityComparisons02.ts(5,19): error TS2352: Conversion of type 'string' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
-==== stringLiteralsAssertionsInEqualityComparisons02.ts (3 errors) ====
+==== stringLiteralsAssertionsInEqualityComparisons02.ts (4 errors) ====
     type EnhancedString = string & { enhancements: any };
     
     var a = "foo" === "bar" as "baz";
             ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '"foo"' and '"baz"' have no overlap.
     var b = "foo" !== ("bar" as "foo");
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
     var c = "foo" == (<number>"bar");
             ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types 'string' and 'number' have no overlap.

--- a/tests/baselines/reference/templateStringInEqualityChecks.errors.txt
+++ b/tests/baselines/reference/templateStringInEqualityChecks.errors.txt
@@ -1,8 +1,10 @@
 templateStringInEqualityChecks.ts(1,9): error TS2367: This comparison appears to be unintentional because the types '"abc0abc"' and '"abc"' have no overlap.
 templateStringInEqualityChecks.ts(2,9): error TS2367: This comparison appears to be unintentional because the types '"abc"' and '"abc0abc"' have no overlap.
+templateStringInEqualityChecks.ts(3,9): error TS2845: This condition will always return 'true'.
+templateStringInEqualityChecks.ts(4,9): error TS2845: This condition will always return 'false'.
 
 
-==== templateStringInEqualityChecks.ts (2 errors) ====
+==== templateStringInEqualityChecks.ts (4 errors) ====
     var x = `abc${0}abc` === `abc` ||
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '"abc0abc"' and '"abc"' have no overlap.
@@ -10,4 +12,8 @@ templateStringInEqualityChecks.ts(2,9): error TS2367: This comparison appears to
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '"abc"' and '"abc0abc"' have no overlap.
             `abc${0}abc` == "abc0abc" &&
+            ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             "abc0abc" !== `abc${0}abc`;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.

--- a/tests/baselines/reference/templateStringInEqualityChecksES6.errors.txt
+++ b/tests/baselines/reference/templateStringInEqualityChecksES6.errors.txt
@@ -1,8 +1,10 @@
 templateStringInEqualityChecksES6.ts(1,9): error TS2367: This comparison appears to be unintentional because the types '"abc0abc"' and '"abc"' have no overlap.
 templateStringInEqualityChecksES6.ts(2,9): error TS2367: This comparison appears to be unintentional because the types '"abc"' and '"abc0abc"' have no overlap.
+templateStringInEqualityChecksES6.ts(3,9): error TS2845: This condition will always return 'true'.
+templateStringInEqualityChecksES6.ts(4,9): error TS2845: This condition will always return 'false'.
 
 
-==== templateStringInEqualityChecksES6.ts (2 errors) ====
+==== templateStringInEqualityChecksES6.ts (4 errors) ====
     var x = `abc${0}abc` === `abc` ||
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '"abc0abc"' and '"abc"' have no overlap.
@@ -10,4 +12,8 @@ templateStringInEqualityChecksES6.ts(2,9): error TS2367: This comparison appears
             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This comparison appears to be unintentional because the types '"abc"' and '"abc0abc"' have no overlap.
             `abc${0}abc` == "abc0abc" &&
+            ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'true'.
             "abc0abc" !== `abc${0}abc`;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.

--- a/tests/baselines/reference/voidAsOperator.errors.txt
+++ b/tests/baselines/reference/voidAsOperator.errors.txt
@@ -1,0 +1,18 @@
+voidAsOperator.ts(1,5): error TS2845: This condition will always return 'false'.
+voidAsOperator.ts(6,5): error TS2845: This condition will always return 'false'.
+
+
+==== voidAsOperator.ts (2 errors) ====
+    if (!void 0 !== true) {
+        ~~~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
+     
+    }
+    
+    //CHECK#2
+    if (!null !== true) {
+        ~~~~~~~~~~~~~~
+!!! error TS2845: This condition will always return 'false'.
+     
+    }
+    


### PR DESCRIPTION
Just an experiment for now based on #55699.

This PR modifies our logic for comparison (in)equality operators by disallowing checks between two identical literal types. In the most trivial example, it will disallow the following:

```ts
if ("hello" === "hello") {
//  ~~~~~~~~~~~~~~~~~~~
//  error: This condition will always return 'true'.
}
```

Maybe more controversially, it will disallow the following:

```ts
function move2(direction: "up" | "down") {
    return direction === "up" ? 1 :
        direction === "down" ? -1 :
    //  ~~~~~~~~~~~~~~~~~~~~
    //  error: This condition will always return 'true'.
        error("Should never get here");
}
```
