### PR TITLE
Avoid unnecessary resolution-mode assertion in declaration emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -47735,11 +47735,14 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         function addReferencedFilesToTypeDirective(file: SourceFile, key: string, mode: ResolutionMode) {
             if (fileToDirective.has(file.path)) return;
             fileToDirective.set(file.path, [key, mode]);
-            for (const { fileName, resolutionMode } of file.referencedFiles) {
+            for (const { fileName } of file.referencedFiles) {
                 const resolvedFile = resolveTripleslashReference(fileName, file.fileName);
                 const referencedFile = host.getSourceFile(resolvedFile);
                 if (referencedFile) {
-                    addReferencedFilesToTypeDirective(referencedFile, key, resolutionMode || file.impliedNodeFormat);
+                    // The resolution mode of the file reference doesn't actually matter here -
+                    // all we're recording is the fact that the file entered the compilation
+                    // transitively via a type reference directive of {key} with mode {mode}.
+                    addReferencedFilesToTypeDirective(referencedFile, key, mode || file.impliedNodeFormat);
                 }
             }
         }

--- a/tests/baselines/reference/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.js
+++ b/tests/baselines/reference/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts] ////
+
+//// [package.json]
+{
+  "name": "@types/node",
+  "version": "1.0.0",
+  "types": "index.d.ts"
+}
+
+//// [globals.d.ts]
+declare namespace NodeJS {
+  interface ReadableStream {}
+}
+
+//// [index.d.ts]
+/// <reference path="globals.d.ts" />
+
+//// [app.mts]
+/// <reference types="node" />
+export async function drainStream(stream: NodeJS.ReadableStream): Promise<void> {
+}
+
+
+
+
+//// [app.d.mts]
+/// <reference types="node" />
+export declare function drainStream(stream: NodeJS.ReadableStream): Promise<void>;

--- a/tests/baselines/reference/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.symbols
+++ b/tests/baselines/reference/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.symbols
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts] ////
+
+=== /app.mts ===
+/// <reference types="node" />
+export async function drainStream(stream: NodeJS.ReadableStream): Promise<void> {
+>drainStream : Symbol(drainStream, Decl(app.mts, 0, 0))
+>stream : Symbol(stream, Decl(app.mts, 1, 34))
+>NodeJS : Symbol(NodeJS, Decl(globals.d.ts, 0, 0))
+>ReadableStream : Symbol(NodeJS.ReadableStream, Decl(globals.d.ts, 0, 26))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+}
+
+=== /node_modules/@types/node/globals.d.ts ===
+declare namespace NodeJS {
+>NodeJS : Symbol(NodeJS, Decl(globals.d.ts, 0, 0))
+
+  interface ReadableStream {}
+>ReadableStream : Symbol(ReadableStream, Decl(globals.d.ts, 0, 26))
+}
+
+=== /node_modules/@types/node/index.d.ts ===
+
+/// <reference path="globals.d.ts" />
+

--- a/tests/baselines/reference/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.types
+++ b/tests/baselines/reference/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.types
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts] ////
+
+=== /app.mts ===
+/// <reference types="node" />
+export async function drainStream(stream: NodeJS.ReadableStream): Promise<void> {
+>drainStream : (stream: NodeJS.ReadableStream) => Promise<void>
+>stream : NodeJS.ReadableStream
+>NodeJS : any
+}
+
+=== /node_modules/@types/node/globals.d.ts ===
+
+declare namespace NodeJS {
+  interface ReadableStream {}
+}
+
+=== /node_modules/@types/node/index.d.ts ===
+
+/// <reference path="globals.d.ts" />
+

--- a/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
+++ b/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
@@ -1,0 +1,29 @@
+// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "types": [],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+  }
+}
+
+// @Filename: /node_modules/@types/node/package.json
+{
+  "name": "@types/node",
+  "version": "1.0.0",
+  "types": "index.d.ts"
+}
+
+// @Filename: /node_modules/@types/node/globals.d.ts
+declare namespace NodeJS {
+  interface ReadableStream {}
+}
+
+// @Filename: /node_modules/@types/node/index.d.ts
+/// <reference path="globals.d.ts" />
+
+// @Filename: /app.mts
+/// <reference types="node" />
+export async function drainStream(stream: NodeJS.ReadableStream): Promise<void> {
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes the bug part of #55579, where the manual triple-slash reference workaround doesn’t work for @types/node.

When a type reference directive is processed, we also record what additional files the resolved types bring in via `<reference path="..." />` directives. This way, when you reference a global declared in `node_modules/@types/node/globals.d.ts`, we can see that it actually came in via a `<reference types="node" />`. But instead of recording this entry with the resolution-mode that the _types_ reference had, we recorded it with the resolution-mode that the _file_ reference had, which is irrelevant (and could even lead to some totally incorrect results with some manufactured bizarre cases). All we need to know is _how did this file enter the program?_ which is the type reference directive with whatever mode it had.