### PR TITLE
Fix playright browser installs due to upstream breaking change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,6 @@ jobs:
           check-latest: true
       - run: npm ci
 
-      - name: Adding playwright
-        run: npm install --no-save --no-package-lock playwright
-
       - name: Installing browsers
         run: npx playwright install --with-deps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Adding playwright
         run: npm install --no-save --no-package-lock playwright
 
+      - name: Installing browsers
+        run: npx playwright install --with-deps
+
       - name: Validate the browser can import TypeScript
         run: npx hereby test-browser-integration
 

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -32,6 +32,8 @@ jobs:
           npm test
       - name: Adding playwright
         run: npm install --no-save --no-package-lock playwright
+      - name: Installing browsers
+        run: npx playwright install --with-deps
       - name: Validate the browser can import TypeScript
         run: npx hereby test-browser-integration
       - name: LKG, clean, and pack

--- a/.github/workflows/release-branch-artifact.yaml
+++ b/.github/workflows/release-branch-artifact.yaml
@@ -30,8 +30,6 @@ jobs:
         run: |
           npm ci
           npm test
-      - name: Adding playwright
-        run: npm install --no-save --no-package-lock playwright
       - name: Installing browsers
         run: npx playwright install --with-deps
       - name: Validate the browser can import TypeScript

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
                 "mocha-fivemat-progress-reporter": "^0.1.0",
                 "ms": "^2.1.3",
                 "node-fetch": "^3.2.10",
+                "playwright": "^1.38.0",
                 "source-map-support": "^0.5.21",
                 "tslib": "^2.5.0",
                 "typescript": "^5.0.2",
@@ -3144,6 +3145,50 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/playwright": {
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.0.tgz",
+            "integrity": "sha512-fJGw+HO0YY+fU/F1N57DMO+TmXHTrmr905J05zwAQE9xkuwP/QLDk63rVhmyxh03dYnEhnRbsdbH9B0UVVRB3A==",
+            "dev": true,
+            "dependencies": {
+                "playwright-core": "1.38.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.0.tgz",
+            "integrity": "sha512-f8z1y8J9zvmHoEhKgspmCvOExF2XdcxMW8jNRuX4vkQFrzV4MlZ55iwb5QeyiFQgOFCUolXiRHgpjSEnqvO48g==",
+            "dev": true,
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/plur": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -6007,6 +6052,31 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true
+        },
+        "playwright": {
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.0.tgz",
+            "integrity": "sha512-fJGw+HO0YY+fU/F1N57DMO+TmXHTrmr905J05zwAQE9xkuwP/QLDk63rVhmyxh03dYnEhnRbsdbH9B0UVVRB3A==",
+            "dev": true,
+            "requires": {
+                "fsevents": "2.3.2",
+                "playwright-core": "1.38.0"
+            },
+            "dependencies": {
+                "fsevents": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "playwright-core": {
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.0.tgz",
+            "integrity": "sha512-f8z1y8J9zvmHoEhKgspmCvOExF2XdcxMW8jNRuX4vkQFrzV4MlZ55iwb5QeyiFQgOFCUolXiRHgpjSEnqvO48g==",
             "dev": true
         },
         "plur": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "mocha-fivemat-progress-reporter": "^0.1.0",
         "ms": "^2.1.3",
         "node-fetch": "^3.2.10",
+        "playwright": "^1.38.0",
         "source-map-support": "^0.5.21",
         "tslib": "^2.5.0",
         "typescript": "^5.0.2",

--- a/scripts/browserIntegrationTest.mjs
+++ b/scripts/browserIntegrationTest.mjs
@@ -5,15 +5,7 @@ import {
 import {
     join,
 } from "path";
-
-let playwright;
-try {
-    // @ts-ignore-error
-    playwright = await import("playwright");
-}
-catch (error) {
-    throw new Error("Playwright is expected to be installed manually before running this script");
-}
+import playwright from "playwright";
 
 // Turning this on will leave the Chromium browser open, giving you the
 // chance to open up the web inspector.


### PR DESCRIPTION
See: https://github.com/microsoft/playwright/releases/tag/v1.38.0 and https://github.com/microsoft/TypeScript/actions/runs/6178823659/job/16773312341

The reason we didn't depend directly on `playwright` was because it'd automatically download multiple browsers. The latest version no longer does this, which breaks our workflow. But since that was the whole reason we didn't directly depend on it, we can just depend on it directly and get rid of the awkward CI scripts which needed to install it after the fact.