### PR TITLE
fix(55775) - TS parameter inlay hints disconsiders used parameters when set to literals

### DIFF
--- a/tests/baselines/reference/inlayHintsParameterNames.baseline
+++ b/tests/baselines/reference/inlayHintsParameterNames.baseline
@@ -195,3 +195,21 @@ trace(``);
   "kind": "Parameter",
   "whitespaceAfter": true
 }
+
+    'foo',
+    ^
+{
+  "text": "param2:",
+  "position": 884,
+  "kind": "Parameter",
+  "whitespaceAfter": true
+}
+
+    true,
+    ^
+{
+  "text": "param3:",
+  "position": 895,
+  "kind": "Parameter",
+  "whitespaceAfter": true
+}

--- a/tests/cases/fourslash/inlayHintsParameterNames.ts
+++ b/tests/cases/fourslash/inlayHintsParameterNames.ts
@@ -49,4 +49,16 @@
 ////trace(`${1}`);
 ////trace(``);
 
+////function func(
+////    param1: number,
+////    param2: string,
+////    param3: boolean,
+////) {}
+////const param1 = 1;
+////func(
+////    param1,
+////    'foo',
+////    true,
+////)
+
 verify.baselineInlayHints(undefined, { includeInlayParameterNameHints: "literals" });


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/55775
