### PR TITLE
Preserve partially typed tuple names in more places

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -33235,12 +33235,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (arg.kind === SyntaxKind.SyntheticExpression && (arg as SyntheticExpression).tupleNameSource) {
                 names.push((arg as SyntheticExpression).tupleNameSource!);
             }
-            // else {
-            //     names.push(undefined);
-            // }
-            // TODO(jakebailey): names? need test
+            else {
+                names.push(undefined);
+            }
         }
-        return createTupleType(types, flags, inConstContext && !someType(restType, isMutableArrayLikeType), length(names) === length(types) ? names : undefined);
+        return createTupleType(types, flags, inConstContext && !someType(restType, isMutableArrayLikeType), names);
     }
 
     function checkTypeArguments(signature: Signature, typeArgumentNodes: readonly TypeNode[], reportErrors: boolean, headMessage?: DiagnosticMessage): Type[] | undefined {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19362,7 +19362,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return instantiateMappedType(mappedType, prependTypeMapping(typeVariable, singleton, mapper));
         });
         const newReadonly = getModifiedReadonlyState(tupleType.target.readonly, getMappedTypeModifiers(mappedType));
-        return createTupleType(elementTypes, map(elementTypes, _ => ElementFlags.Variadic), newReadonly); // TODO(jakebailey): names?
+        return createTupleType(elementTypes, map(elementTypes, _ => ElementFlags.Variadic), newReadonly);
     }
 
     function instantiateMappedArrayType(arrayType: Type, mappedType: MappedType, mapper: TypeMapper) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19362,7 +19362,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return instantiateMappedType(mappedType, prependTypeMapping(typeVariable, singleton, mapper));
         });
         const newReadonly = getModifiedReadonlyState(tupleType.target.readonly, getMappedTypeModifiers(mappedType));
-        return createTupleType(elementTypes, map(elementTypes, _ => ElementFlags.Variadic), newReadonly);
+        return createTupleType(elementTypes, map(elementTypes, _ => ElementFlags.Variadic), newReadonly); // TODO(jakebailey): names?
     }
 
     function instantiateMappedArrayType(arrayType: Type, mappedType: MappedType, mapper: TypeMapper) {
@@ -30635,9 +30635,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         popContextualType();
         if (inDestructuringPattern) {
+            // TODO(jakebailey): names?
             return createTupleType(elementTypes, elementFlags);
         }
         if (forceTuple || inConstContext || inTupleContext) {
+            // TODO(jakebailey): names?
             return createArrayLiteralType(createTupleType(elementTypes, elementFlags, /*readonly*/ inConstContext && !(contextualType && someType(contextualType, isMutableArrayLikeType))));
         }
         return createArrayLiteralType(createArrayType(
@@ -33235,6 +33237,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (arg.kind === SyntaxKind.SyntheticExpression && (arg as SyntheticExpression).tupleNameSource) {
                 names.push((arg as SyntheticExpression).tupleNameSource!);
             }
+            // else {
+            //     names.push(undefined);
+            // }
+            // TODO(jakebailey): names? need test
         }
         return createTupleType(types, flags, inConstContext && !someType(restType, isMutableArrayLikeType), length(names) === length(types) ? names : undefined);
     }
@@ -35571,12 +35577,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 types.push(restType);
                 flags.push(ElementFlags.Variadic);
             }
-            const name = getNameableDeclarationAtPosition(source, i);
-            if (name) {
-                names.push(name);
-            }
+            names.push(getNameableDeclarationAtPosition(source, i));
         }
-        return createTupleType(types, flags, readonly, length(names) === length(types) ? names : undefined);
+        return createTupleType(types, flags, readonly, names);
     }
 
     // Return the number of parameters in a signature. The rest parameter, if present, counts as one
@@ -38220,7 +38223,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
         }
-        return createTupleType(elementTypes, elementFlags, type.target.readonly);
+        return createTupleType(elementTypes, elementFlags, type.target.readonly); // TODO(jakebailey): names?
     }
 
     function widenTypeInferredFromInitializer(declaration: HasExpressionInitializer, type: Type) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30635,11 +30635,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         popContextualType();
         if (inDestructuringPattern) {
-            // TODO(jakebailey): names?
             return createTupleType(elementTypes, elementFlags);
         }
         if (forceTuple || inConstContext || inTupleContext) {
-            // TODO(jakebailey): names?
             return createArrayLiteralType(createTupleType(elementTypes, elementFlags, /*readonly*/ inConstContext && !(contextualType && someType(contextualType, isMutableArrayLikeType))));
         }
         return createArrayLiteralType(createArrayType(
@@ -38223,7 +38221,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
             }
         }
-        return createTupleType(elementTypes, elementFlags, type.target.readonly); // TODO(jakebailey): names?
+        return createTupleType(elementTypes, elementFlags, type.target.readonly);
     }
 
     function widenTypeInferredFromInitializer(declaration: HasExpressionInitializer, type: Type) {

--- a/tests/baselines/reference/argumentsReferenceInFunction1_Js.errors.txt
+++ b/tests/baselines/reference/argumentsReferenceInFunction1_Js.errors.txt
@@ -1,5 +1,5 @@
 index.js(1,25): error TS7006: Parameter 'f' implicitly has an 'any' type.
-index.js(13,29): error TS2345: Argument of type 'IArguments' is not assignable to parameter of type '[any?, ...any[]]'.
+index.js(13,29): error TS2345: Argument of type 'IArguments' is not assignable to parameter of type '[f?: any, ...any[]]'.
 
 
 ==== index.js (2 errors) ====
@@ -19,6 +19,6 @@ index.js(13,29): error TS2345: Argument of type 'IArguments' is not assignable t
     const debuglog = function() {
       return format.apply(null, arguments);
                                 ~~~~~~~~~
-!!! error TS2345: Argument of type 'IArguments' is not assignable to parameter of type '[any?, ...any[]]'.
+!!! error TS2345: Argument of type 'IArguments' is not assignable to parameter of type '[f?: any, ...any[]]'.
     };
     

--- a/tests/baselines/reference/partiallyNamedTuples3.js
+++ b/tests/baselines/reference/partiallyNamedTuples3.js
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts] ////
+
+//// [partiallyNamedTuples3.ts]
+declare const tuple: [number, name: string, boolean, value: number, string];
+
+const output = ((...args) => args)(...tuple);
+
+
+//// [partiallyNamedTuples3.js]
+"use strict";
+var output = (function () {
+    var args = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        args[_i] = arguments[_i];
+    }
+    return args;
+}).apply(void 0, tuple);

--- a/tests/baselines/reference/partiallyNamedTuples3.symbols
+++ b/tests/baselines/reference/partiallyNamedTuples3.symbols
@@ -1,0 +1,12 @@
+//// [tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts] ////
+
+=== partiallyNamedTuples3.ts ===
+declare const tuple: [number, name: string, boolean, value: number, string];
+>tuple : Symbol(tuple, Decl(partiallyNamedTuples3.ts, 0, 13))
+
+const output = ((...args) => args)(...tuple);
+>output : Symbol(output, Decl(partiallyNamedTuples3.ts, 2, 5))
+>args : Symbol(args, Decl(partiallyNamedTuples3.ts, 2, 17))
+>args : Symbol(args, Decl(partiallyNamedTuples3.ts, 2, 17))
+>tuple : Symbol(tuple, Decl(partiallyNamedTuples3.ts, 0, 13))
+

--- a/tests/baselines/reference/partiallyNamedTuples3.types
+++ b/tests/baselines/reference/partiallyNamedTuples3.types
@@ -5,12 +5,12 @@ declare const tuple: [number, name: string, boolean, value: number, string];
 >tuple : [number, name: string, boolean, value: number, string]
 
 const output = ((...args) => args)(...tuple);
->output : [number, string, boolean, number, string]
->((...args) => args)(...tuple) : [number, string, boolean, number, string]
->((...args) => args) : (args_0: number, args_1: string, args_2: boolean, args_3: number, args_4: string) => [number, string, boolean, number, string]
->(...args) => args : (args_0: number, args_1: string, args_2: boolean, args_3: number, args_4: string) => [number, string, boolean, number, string]
->args : [number, string, boolean, number, string]
->args : [number, string, boolean, number, string]
+>output : [number, name: string, boolean, value: number, string]
+>((...args) => args)(...tuple) : [number, name: string, boolean, value: number, string]
+>((...args) => args) : (args_0: number, name: string, args_2: boolean, value: number, args_4: string) => [number, name: string, boolean, value: number, string]
+>(...args) => args : (args_0: number, name: string, args_2: boolean, value: number, args_4: string) => [number, name: string, boolean, value: number, string]
+>args : [number, name: string, boolean, value: number, string]
+>args : [number, name: string, boolean, value: number, string]
 >...tuple : string | number | boolean
 >tuple : [number, name: string, boolean, value: number, string]
 

--- a/tests/baselines/reference/partiallyNamedTuples3.types
+++ b/tests/baselines/reference/partiallyNamedTuples3.types
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts] ////
+
+=== partiallyNamedTuples3.ts ===
+declare const tuple: [number, name: string, boolean, value: number, string];
+>tuple : [number, name: string, boolean, value: number, string]
+
+const output = ((...args) => args)(...tuple);
+>output : [number, string, boolean, number, string]
+>((...args) => args)(...tuple) : [number, string, boolean, number, string]
+>((...args) => args) : (args_0: number, args_1: string, args_2: boolean, args_3: number, args_4: string) => [number, string, boolean, number, string]
+>(...args) => args : (args_0: number, args_1: string, args_2: boolean, args_3: number, args_4: string) => [number, string, boolean, number, string]
+>args : [number, string, boolean, number, string]
+>args : [number, string, boolean, number, string]
+>...tuple : string | number | boolean
+>tuple : [number, name: string, boolean, value: number, string]
+

--- a/tests/baselines/reference/restTuplesFromContextualTypes.types
+++ b/tests/baselines/reference/restTuplesFromContextualTypes.types
@@ -265,8 +265,8 @@ f3((a, b, c) => {})
 f3((...x) => {})
 >f3((...x) => {}) : void
 >f3 : (cb: (x: number, args_0: boolean, ...args_1: string[]) => void) => void
->(...x) => {} : (x_0: number, x_1: boolean, ...x_2: string[]) => void
->x : [number, boolean, ...string[]]
+>(...x) => {} : (x: number, x_1: boolean, ...x_2: string[]) => void
+>x : [x: number, boolean, ...string[]]
 
 f3((a, ...x) => {})
 >f3((a, ...x) => {}) : void

--- a/tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts
+++ b/tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts
@@ -1,0 +1,6 @@
+// @strict: true
+// @lib: esnext
+
+declare const tuple: [number, name: string, boolean, value: number, string];
+
+const output = ((...args) => args)(...tuple);


### PR DESCRIPTION
#53356 introduced the ability to have partially named tuples, but while working on another bug, I noticed that there were a few places that the PR missed that should also be preserving names. This fixes those cases, with tests.

There are still other calls to `createTupleType` which are missing names, but they all appear to be unable to generate them (anywhere that generates a tuple from a binding, or are "noramlizing" a tuple which can create more than one element for the same name).