### PR TITLE
Source files not affected by all module resolution options

### DIFF
--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -238,8 +238,9 @@ export namespace BuilderState {
         }
 
         // Handle type reference directives
-        if (sourceFile.resolvedTypeReferenceDirectiveNames) {
-            sourceFile.resolvedTypeReferenceDirectiveNames.forEach(({ resolvedTypeReferenceDirective }) => {
+        const resolvedTypeReferenceDirectiveNames = program.resolvedTypeReferenceDirectiveNames?.get(sourceFile.path);
+        if (resolvedTypeReferenceDirectiveNames) {
+            resolvedTypeReferenceDirectiveNames.forEach(({ resolvedTypeReferenceDirective }) => {
                 if (!resolvedTypeReferenceDirective) {
                     return;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -342,7 +342,6 @@ import {
     getResolutionDiagnostic,
     getResolutionModeOverrideForClause,
     getResolvedExternalModuleName,
-    getResolvedModule,
     getResolveJsonModule,
     getRestParameterElementType,
     getRootDeclaration,
@@ -4960,7 +4959,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal;
         const mode = contextSpecifier && isStringLiteralLike(contextSpecifier) ? getModeForUsageLocation(currentSourceFile, contextSpecifier) : currentSourceFile.impliedNodeFormat;
         const moduleResolutionKind = getEmitModuleResolutionKind(compilerOptions);
-        const resolvedModule = getResolvedModule(currentSourceFile, moduleReference, mode);
+        const resolvedModule = host.resolvedModules?.get(currentSourceFile.path)?.get(moduleReference, mode)?.resolvedModule;
         const resolutionDiagnostic = resolvedModule && getResolutionDiagnostic(compilerOptions, resolvedModule, currentSourceFile);
         const sourceFile = resolvedModule
             && (!resolutionDiagnostic || resolutionDiagnostic === Diagnostics.Module_0_was_resolved_to_1_but_jsx_is_not_set)

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -553,6 +553,7 @@ export const moduleOptionDeclaration: CommandLineOptionOfCustomType = {
         node16: ModuleKind.Node16,
         nodenext: ModuleKind.NodeNext,
     })),
+    affectsSourceFile: true,
     affectsModuleResolution: true,
     affectsEmit: true,
     affectsBuildInfo: true,
@@ -994,6 +995,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
             bundler: ModuleResolutionKind.Bundler,
         })),
         deprecatedKeys: new Set(["node"]),
+        affectsSourceFile: true,
         affectsModuleResolution: true,
         paramType: Diagnostics.STRATEGY,
         category: Diagnostics.Modules,
@@ -1540,6 +1542,7 @@ const commandOptionsWithoutBuild: CommandLineOption[] = [
             legacy: ModuleDetectionKind.Legacy,
             force: ModuleDetectionKind.Force,
         })),
+        affectsSourceFile: true,
         affectsModuleResolution: true,
         description: Diagnostics.Control_what_method_is_used_to_detect_module_format_JS_files,
         category: Diagnostics.Language_and_Environment,
@@ -1571,7 +1574,7 @@ export const affectsDeclarationPathOptionDeclarations: readonly CommandLineOptio
 export const moduleResolutionOptionDeclarations: readonly CommandLineOption[] = optionDeclarations.filter(option => !!option.affectsModuleResolution);
 
 /** @internal */
-export const sourceFileAffectingCompilerOptions: readonly CommandLineOption[] = optionDeclarations.filter(option => !!option.affectsSourceFile || !!option.affectsModuleResolution || !!option.affectsBindDiagnostics);
+export const sourceFileAffectingCompilerOptions: readonly CommandLineOption[] = optionDeclarations.filter(option => !!option.affectsSourceFile || !!option.affectsBindDiagnostics);
 
 /** @internal */
 export const optionsAffectingProgramStructure: readonly CommandLineOption[] = optionDeclarations.filter(option => !!option.affectsProgramStructure);

--- a/src/compiler/factory/nodeFactory.ts
+++ b/src/compiler/factory/nodeFactory.ts
@@ -6026,7 +6026,6 @@ export function createNodeFactory(flags: NodeFactoryFlags, baseFactory: BaseNode
         node.imports = undefined!;
         node.moduleAugmentations = undefined!;
         node.ambientModuleNames = undefined!;
-        node.resolvedModules = undefined;
         node.classifiableNames = undefined;
         node.impliedNodeFormat = undefined;
         return node;

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -91,14 +91,12 @@ import {
     removeFileExtension,
     removePrefix,
     ResolutionMode,
-    ResolutionNameAndModeGetter,
     ResolvedModuleWithFailedLookupLocations,
     ResolvedProjectReference,
     ResolvedTypeReferenceDirective,
     ResolvedTypeReferenceDirectiveWithFailedLookupLocations,
     some,
     sort,
-    SourceFile,
     startsWith,
     supportedDeclarationExtensions,
     supportedJSExtensionsFlat,
@@ -1089,22 +1087,6 @@ export function createModeAwareCache<T>(): ModeAwareCache<T> {
         memoizedReverseKeys.set(result, [specifier, mode]);
         return result;
     }
-}
-
-/** @internal */
-export function zipToModeAwareCache<K, V>(
-    file: SourceFile,
-    keys: readonly K[],
-    values: readonly V[],
-    nameAndModeGetter: ResolutionNameAndModeGetter<K, SourceFile>,
-): ModeAwareCache<V> {
-    Debug.assert(keys.length === values.length);
-    const map = createModeAwareCache<V>();
-    for (let i = 0; i < keys.length; ++i) {
-        const entry = keys[i];
-        map.set(nameAndModeGetter.getName(entry), nameAndModeGetter.getMode(entry, file), values[i]);
-    }
-    return map;
 }
 
 function getOriginalOrResolvedModuleFileName(result: ResolvedModuleWithFailedLookupLocations) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -139,7 +139,6 @@ import {
     getPathFromPathComponents,
     getPositionOfLineAndCharacter,
     getPropertyArrayElementValue,
-    getResolvedModule,
     getResolveJsonModule,
     getRootLength,
     getSetExternalModuleIndicator,
@@ -272,6 +271,7 @@ import {
     removeSuffix,
     resolutionExtensionIsTSOrJson,
     ResolutionMode,
+    ResolutionWithFailedLookupLocations,
     resolveConfigFileProjectName,
     ResolvedConfigFileName,
     ResolvedModuleFull,
@@ -288,8 +288,6 @@ import {
     ScriptTarget,
     setParent,
     setParentRecursive,
-    setResolvedModule,
-    setResolvedTypeReferenceDirective,
     shouldResolveJsRequire,
     skipTrivia,
     skipTypeChecking,
@@ -1173,14 +1171,14 @@ export function isReferenceFileLocation(location: ReferenceFileLocation | Synthe
 }
 
 /** @internal */
-export function getReferencedFileLocation(getSourceFileByPath: (path: Path) => SourceFile | undefined, ref: ReferencedFile): ReferenceFileLocation | SyntheticReferenceFileLocation {
-    const file = Debug.checkDefined(getSourceFileByPath(ref.file));
+export function getReferencedFileLocation(program: Program, ref: ReferencedFile): ReferenceFileLocation | SyntheticReferenceFileLocation {
+    const file = Debug.checkDefined(program.getSourceFileByPath(ref.file));
     const { kind, index } = ref;
     let pos: number | undefined, end: number | undefined, packageId: PackageId | undefined, resolutionMode: FileReference["resolutionMode"] | undefined;
     switch (kind) {
         case FileIncludeKind.Import:
             const importLiteral = getModuleNameStringLiteralAt(file, index);
-            packageId = file.resolvedModules?.get(importLiteral.text, getModeForResolutionAtIndex(file, index))?.resolvedModule?.packageId;
+            packageId = program.resolvedModules?.get(file.path)?.get(importLiteral.text, getModeForResolutionAtIndex(file, index))?.resolvedModule?.packageId;
             if (importLiteral.pos === -1) return { file, packageId, text: importLiteral.text };
             pos = skipTrivia(file.text, importLiteral.pos);
             end = importLiteral.end;
@@ -1190,7 +1188,7 @@ export function getReferencedFileLocation(getSourceFileByPath: (path: Path) => S
             break;
         case FileIncludeKind.TypeReferenceDirective:
             ({ pos, end, resolutionMode } = file.typeReferenceDirectives[index]);
-            packageId = file.resolvedTypeReferenceDirectiveNames?.get(toFileNameLowerCase(file.typeReferenceDirectives[index].fileName), resolutionMode || file.impliedNodeFormat)?.resolvedTypeReferenceDirective?.packageId;
+            packageId = program.resolvedTypeReferenceDirectiveNames?.get(file.path)?.get(toFileNameLowerCase(file.typeReferenceDirectives[index].fileName), resolutionMode || file.impliedNodeFormat)?.resolvedTypeReferenceDirective?.packageId;
             break;
         case FileIncludeKind.LibReferenceDirective:
             ({ pos, end } = file.libReferenceDirectives[index]);
@@ -1514,6 +1512,11 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
     let resolvedLibReferences: Map<string, LibResolution> | undefined;
     let resolvedLibProcessing: Map<string, LibResolution> | undefined;
+
+    let resolvedModules: Map<Path, ModeAwareCache<ResolvedModuleWithFailedLookupLocations>> | undefined;
+    let resolvedModulesProcessing: Map<Path, ModeAwareCache<ResolvedModuleWithFailedLookupLocations>> | undefined;
+    let resolvedTypeReferenceDirectiveNames: Map<Path, ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>> | undefined;
+    let resolvedTypeReferenceDirectiveNamesProcessing: Map<Path, ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>> | undefined;
 
     let packageMap: Map<string, boolean> | undefined;
 
@@ -1840,6 +1843,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
     // unconditionally set oldProgram to undefined to prevent it from being captured in closure
     oldProgram = undefined;
     resolvedLibProcessing = undefined;
+    resolvedModulesProcessing = undefined;
+    resolvedTypeReferenceDirectiveNamesProcessing = undefined;
 
     const program: Program = {
         getRootFileNames: () => rootNames,
@@ -1881,6 +1886,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         sourceFileToPackageName,
         redirectTargetsMap,
         usesUriStyleNodeCoreModules,
+        resolvedModules,
+        resolvedTypeReferenceDirectiveNames,
         resolvedLibReferences,
         getCurrentPackagesMap: () => packageMap,
         typesPackageExists,
@@ -1915,7 +1922,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             case FilePreprocessingDiagnosticsKind.FilePreprocessingFileExplainingDiagnostic:
                 return programDiagnostics.add(createDiagnosticExplainingFile(diagnostic.file && getSourceFileByPath(diagnostic.file), diagnostic.fileProcessingReason, diagnostic.diagnostic, diagnostic.args || emptyArray));
             case FilePreprocessingDiagnosticsKind.FilePreprocessingReferencedDiagnostic:
-                const { file, pos, end } = getReferencedFileLocation(getSourceFileByPath, diagnostic.reason) as ReferenceFileLocation;
+                const { file, pos, end } = getReferencedFileLocation(program, diagnostic.reason) as ReferenceFileLocation;
                 return programDiagnostics.add(createFileDiagnostic(file, Debug.checkDefined(pos), Debug.checkDefined(end) - pos, diagnostic.diagnostic, ...diagnostic.args || emptyArray));
             case FilePreprocessingDiagnosticsKind.ResolutionDiagnostics:
                 return diagnostic.diagnostics.forEach(d => programDiagnostics.add(d));
@@ -1938,13 +1945,11 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         // This is useful as an approximation of whether a package bundles its own types.
         // Note: we only look at files already found by module resolution,
         // so there may be files we did not consider.
-        files.forEach(sf => {
-            if (!sf.resolvedModules) return;
-
-            sf.resolvedModules.forEach(({ resolvedModule }) => {
+        files.forEach(sf =>
+            resolvedModules?.get(sf.path)?.forEach(({ resolvedModule }) => {
                 if (resolvedModule?.packageId) packageMap!.set(resolvedModule.packageId.name, resolvedModule.extension === Extension.Dts || !!packageMap!.get(resolvedModule.packageId.name));
-            });
-        });
+            })
+        );
         return packageMap;
     }
 
@@ -2090,8 +2095,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             return resolveModuleNamesWorker(moduleNames, file, /*reusedNames*/ undefined);
         }
 
-        const oldSourceFile = oldProgram && oldProgram.getSourceFile(file.fileName);
-        if (oldSourceFile !== file && file.resolvedModules) {
+        const alreadyComputedResolutions = resolvedModulesProcessing?.get(file.path);
+        if (alreadyComputedResolutions) {
             // `file` was created for the new program.
             //
             // We only set `file.resolvedModules` via work from the current function,
@@ -2102,7 +2107,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             // it is safe to reuse resolutions from the earlier call.
             const result: ResolvedModuleWithFailedLookupLocations[] = [];
             for (const moduleName of moduleNames) {
-                const resolvedModule = file.resolvedModules.get(moduleName.text, getModeForUsageLocation(file, moduleName))!;
+                const resolvedModule = alreadyComputedResolutions.get(moduleName.text, getModeForUsageLocation(file, moduleName))!;
                 result.push(resolvedModule);
             }
             return result;
@@ -2127,13 +2132,14 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         let reusedNames: StringLiteralLike[] | undefined;
         /** A transient placeholder used to mark predicted resolution in the result list. */
         const predictedToResolveToAmbientModuleMarker: ResolvedModuleWithFailedLookupLocations = emptyResolution;
+        const oldSourceFile = oldProgram && oldProgram.getSourceFile(file.fileName);
 
         for (let i = 0; i < moduleNames.length; i++) {
             const moduleName = moduleNames[i];
             // If the source file is unchanged and doesnt have invalidated resolution, reuse the module resolutions
-            if (file === oldSourceFile && !hasInvalidatedResolutions(oldSourceFile.path)) {
+            if (file === oldSourceFile && !hasInvalidatedResolutions(file.path)) {
                 const mode = getModeForUsageLocation(file, moduleName);
-                const oldResolution = oldSourceFile.resolvedModules?.get(moduleName.text, mode);
+                const oldResolution = oldProgram?.resolvedModules?.get(file.path)?.get(moduleName.text, mode);
                 if (oldResolution?.resolvedModule) {
                     if (isTraceEnabled(options, host)) {
                         trace(
@@ -2201,7 +2207,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         // If we change our policy of rechecking failed lookups on each program create,
         // we should adjust the value returned here.
         function moduleNameResolvesToAmbientModuleInNonModifiedFile(moduleName: StringLiteralLike): boolean {
-            const resolutionToFile = getResolvedModule(oldSourceFile, moduleName.text, getModeForUsageLocation(file, moduleName));
+            const resolutionToFile = oldProgram?.resolvedModules?.get(file.path)?.get(moduleName.text, getModeForUsageLocation(file, moduleName))?.resolvedModule;
             const resolvedFile = resolutionToFile && oldProgram!.getSourceFile(resolutionToFile.resolvedFileName);
             if (resolutionToFile && resolvedFile) {
                 // In the old program, we resolved to an ambient module that was in the same
@@ -2236,7 +2242,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
         const oldSourceFile = !isString(containingFile) ? oldProgram && oldProgram.getSourceFile(containingFile.fileName) : undefined;
         if (!isString(containingFile)) {
-            if (oldSourceFile !== containingFile && containingFile.resolvedTypeReferenceDirectiveNames) {
+            const alreadyComputedResolutions = resolvedTypeReferenceDirectiveNamesProcessing?.get(containingFile.path);
+            if (alreadyComputedResolutions) {
                 // `file` was created for the new program.
                 //
                 // We only set `file.resolvedTypeReferenceDirectiveNames` via work from the current function,
@@ -2248,7 +2255,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 const result: ResolvedTypeReferenceDirectiveWithFailedLookupLocations[] = [];
                 for (const typeDirectiveName of typeDirectiveNames as readonly FileReference[]) {
                     // We lower-case all type references because npm automatically lowercases all packages. See GH#9824.
-                    const resolvedTypeReferenceDirective = containingFile.resolvedTypeReferenceDirectiveNames.get(getTypeReferenceResolutionName(typeDirectiveName), getModeForFileReference(typeDirectiveName, containingFile.impliedNodeFormat))!;
+                    const resolvedTypeReferenceDirective = alreadyComputedResolutions.get(getTypeReferenceResolutionName(typeDirectiveName), getModeForFileReference(typeDirectiveName, containingFile.impliedNodeFormat))!;
                     result.push(resolvedTypeReferenceDirective);
                 }
                 return result;
@@ -2261,14 +2268,14 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         let reusedNames: T[] | undefined;
         const containingSourceFile = !isString(containingFile) ? containingFile : undefined;
         const canReuseResolutions = !isString(containingFile) ?
-            containingFile === oldSourceFile && !hasInvalidatedResolutions(oldSourceFile.path) :
+            containingFile === oldSourceFile && !hasInvalidatedResolutions(containingFile.path) :
             !hasInvalidatedResolutions(toPath(containingFile));
         for (let i = 0; i < typeDirectiveNames.length; i++) {
             const entry = typeDirectiveNames[i];
             if (canReuseResolutions) {
                 const typeDirectiveName = getTypeReferenceResolutionName(entry);
                 const mode = getModeForFileReference(entry, containingSourceFile?.impliedNodeFormat);
-                const oldResolution = (!isString(containingFile) ? oldSourceFile?.resolvedTypeReferenceDirectiveNames : oldProgram?.getAutomaticTypeDirectiveResolutions())?.get(typeDirectiveName, mode);
+                const oldResolution = (!isString(containingFile) ? oldProgram?.resolvedTypeReferenceDirectiveNames?.get(containingFile.path) : oldProgram?.getAutomaticTypeDirectiveResolutions())?.get(typeDirectiveName, mode);
                 if (oldResolution?.resolvedTypeReferenceDirective) {
                     if (isTraceEnabled(options, host)) {
                         trace(
@@ -2509,28 +2516,30 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             }
         }
         // try to verify results of module resolution
-        for (const { oldFile: oldSourceFile, newFile: newSourceFile } of modifiedSourceFiles) {
+        for (const { newFile: newSourceFile } of modifiedSourceFiles) {
             const moduleNames = getModuleNames(newSourceFile);
             const resolutions = resolveModuleNamesReusingOldState(moduleNames, newSourceFile);
+            const oldResolutions = oldProgram.resolvedModules?.get(newSourceFile.path);
             // ensure that module resolution results are still correct
-            const resolutionsChanged = hasChangesInResolutions(moduleNames, newSourceFile, resolutions, oldSourceFile.resolvedModules, moduleResolutionIsEqualTo, moduleResolutionNameAndModeGetter);
+            const resolutionsChanged = hasChangesInResolutions(moduleNames, newSourceFile, resolutions, oldResolutions, moduleResolutionIsEqualTo, moduleResolutionNameAndModeGetter);
             if (resolutionsChanged) {
                 structureIsReused = StructureIsReused.SafeModules;
-                newSourceFile.resolvedModules = zipToModeAwareCache(newSourceFile, moduleNames, resolutions, moduleResolutionNameAndModeGetter);
+                (resolvedModulesProcessing ??= new Map()).set(newSourceFile.path, zipToModeAwareCache(newSourceFile, moduleNames, resolutions, moduleResolutionNameAndModeGetter));
             }
-            else {
-                newSourceFile.resolvedModules = oldSourceFile.resolvedModules;
+            else if (oldResolutions) {
+                (resolvedModulesProcessing ??= new Map()).set(newSourceFile.path, oldResolutions);
             }
             const typesReferenceDirectives = newSourceFile.typeReferenceDirectives;
             const typeReferenceResolutions = resolveTypeReferenceDirectiveNamesReusingOldState(typesReferenceDirectives, newSourceFile);
             // ensure that types resolutions are still correct
-            const typeReferenceResolutionsChanged = hasChangesInResolutions(typesReferenceDirectives, newSourceFile, typeReferenceResolutions, oldSourceFile.resolvedTypeReferenceDirectiveNames, typeDirectiveIsEqualTo, typeReferenceResolutionNameAndModeGetter);
+            const oldTypeResolutions = oldProgram.resolvedTypeReferenceDirectiveNames?.get(newSourceFile.path);
+            const typeReferenceResolutionsChanged = hasChangesInResolutions(typesReferenceDirectives, newSourceFile, typeReferenceResolutions, oldTypeResolutions, typeDirectiveIsEqualTo, typeReferenceResolutionNameAndModeGetter);
             if (typeReferenceResolutionsChanged) {
                 structureIsReused = StructureIsReused.SafeModules;
-                newSourceFile.resolvedTypeReferenceDirectiveNames = zipToModeAwareCache(newSourceFile, typesReferenceDirectives, typeReferenceResolutions, typeReferenceResolutionNameAndModeGetter);
+                (resolvedTypeReferenceDirectiveNamesProcessing ??= new Map()).set(newSourceFile.path, zipToModeAwareCache(newSourceFile, typesReferenceDirectives, typeReferenceResolutions, typeReferenceResolutionNameAndModeGetter));
             }
-            else {
-                newSourceFile.resolvedTypeReferenceDirectiveNames = oldSourceFile.resolvedTypeReferenceDirectiveNames;
+            else if (oldTypeResolutions) {
+                (resolvedTypeReferenceDirectiveNamesProcessing ??= new Map()).set(newSourceFile.path, oldTypeResolutions);
             }
         }
 
@@ -2589,6 +2598,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         sourceFileToPackageName = oldProgram.sourceFileToPackageName;
         redirectTargetsMap = oldProgram.redirectTargetsMap;
         usesUriStyleNodeCoreModules = oldProgram.usesUriStyleNodeCoreModules;
+        resolvedModules = oldProgram.resolvedModules;
+        resolvedTypeReferenceDirectiveNames = oldProgram.resolvedTypeReferenceDirectiveNames;
         resolvedLibReferences = oldProgram.resolvedLibReferences;
         packageMap = oldProgram.getCurrentPackagesMap();
 
@@ -3834,18 +3845,17 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
     function processTypeReferenceDirectives(file: SourceFile) {
         const typeDirectives = file.typeReferenceDirectives;
-        if (!typeDirectives.length) {
-            file.resolvedTypeReferenceDirectiveNames = undefined;
-            return;
-        }
+        if (!typeDirectives.length) return;
 
         const resolutions = resolveTypeReferenceDirectiveNamesReusingOldState(typeDirectives, file);
+        const resolutionsInFile = createModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>();
+        (resolvedTypeReferenceDirectiveNames ??= new Map()).set(file.path, resolutionsInFile);
         for (let index = 0; index < typeDirectives.length; index++) {
             const ref = file.typeReferenceDirectives[index];
             const resolvedTypeReferenceDirective = resolutions[index];
             // store resolved type directive on the file
             const fileName = toFileNameLowerCase(ref.fileName);
-            setResolvedTypeReferenceDirective(file, fileName, resolvedTypeReferenceDirective, getModeForFileReference(ref, file.impliedNodeFormat));
+            resolutionsInFile.set(fileName, getModeForFileReference(ref, file.impliedNodeFormat), resolvedTypeReferenceDirective);
             const mode = ref.resolutionMode || file.impliedNodeFormat;
             if (mode && getEmitModuleResolutionKind(options) !== ModuleResolutionKind.Node16 && getEmitModuleResolutionKind(options) !== ModuleResolutionKind.NodeNext) {
                 (fileProcessingDiagnostics ??= []).push({
@@ -4016,11 +4026,13 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             const resolutions = resolveModuleNamesReusingOldState(moduleNames, file);
             Debug.assert(resolutions.length === moduleNames.length);
             const optionsForFile = (useSourceOfProjectReferenceRedirect ? getRedirectReferenceForResolution(file)?.commandLine.options : undefined) || options;
+            const resolutionsInFile = createModeAwareCache<ResolutionWithFailedLookupLocations>();
+            (resolvedModules ??= new Map()).set(file.path, resolutionsInFile);
             for (let index = 0; index < moduleNames.length; index++) {
                 const resolution = resolutions[index].resolvedModule;
                 const moduleName = moduleNames[index].text;
                 const mode = getModeForUsageLocation(file, moduleNames[index]);
-                setResolvedModule(file, moduleName, resolutions[index], mode);
+                resolutionsInFile.set(moduleName, mode, resolutions[index]);
                 addResolutionDiagnosticsFromResolutionOrCache(file, moduleName, resolutions[index], mode);
 
                 if (!resolution) {
@@ -4069,10 +4081,6 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                     currentNodeModulesDepth--;
                 }
             }
-        }
-        else {
-            // no imports - drop cached module resolutions
-            file.resolvedModules = undefined;
         }
     }
 
@@ -4613,7 +4621,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         if (fileProcessingReason) processReason(fileProcessingReason);
         // If we have location and there is only one reason file is in which is the location, dont add details for file include
         if (locationReason && fileIncludeReasons?.length === 1) fileIncludeReasons = undefined;
-        const location = locationReason && getReferencedFileLocation(getSourceFileByPath, locationReason);
+        const location = locationReason && getReferencedFileLocation(program, locationReason);
         const fileIncludeReasonDetails = fileIncludeReasons && chainDiagnosticMessages(fileIncludeReasons, Diagnostics.The_file_is_in_the_program_because_Colon);
         const redirectInfo = file && explainIfFileIsRedirectAndImpliedFormat(file);
         const chain = chainDiagnosticMessages(redirectInfo ? fileIncludeReasonDetails ? [fileIncludeReasonDetails, ...redirectInfo] : redirectInfo : fileIncludeReasonDetails, diagnostic, ...args || emptyArray);
@@ -4651,7 +4659,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
     function fileIncludeReasonToRelatedInformation(reason: FileIncludeReason): DiagnosticWithLocation | undefined {
         if (isReferencedFile(reason)) {
-            const referenceLocation = getReferencedFileLocation(getSourceFileByPath, reason);
+            const referenceLocation = getReferencedFileLocation(program, reason);
             let message: DiagnosticMessage;
             switch (reason.kind) {
                 case FileIncludeKind.Import:
@@ -4969,8 +4977,8 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         if (!symlinks) {
             symlinks = createSymlinkCache(currentDirectory, getCanonicalFileName);
         }
-        if (files && automaticTypeDirectiveResolutions && !symlinks.hasProcessedResolutions()) {
-            symlinks.setSymlinksFromResolutions(files, automaticTypeDirectiveResolutions);
+        if (files && !symlinks.hasProcessedResolutions()) {
+            symlinks.setSymlinksFromResolutions(resolvedModules, resolvedTypeReferenceDirectiveNames, automaticTypeDirectiveResolutions);
         }
         return symlinks;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4277,11 +4277,6 @@ export interface SourceFile extends Declaration, LocalsContainer {
     /** @internal */ classifiableNames?: ReadonlySet<__String>;
     // Comments containing @ts-* directives, in order.
     /** @internal */ commentDirectives?: CommentDirective[];
-    // Stores a mapping 'external module reference text' -> 'resolved file name' | undefined
-    // It is used to resolve module names in the checker.
-    // Content of this field should never be used directly - use getResolvedModuleFileName/setResolvedModuleFileName functions instead
-    /** @internal */ resolvedModules?: ModeAwareCache<ResolvedModuleWithFailedLookupLocations>;
-    /** @internal */ resolvedTypeReferenceDirectiveNames?: ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>;
     /** @internal */ imports: readonly StringLiteralLike[];
     // Identifier only if `declare global`
     /** @internal */ moduleAugmentations: readonly (StringLiteral | Identifier)[];
@@ -4652,6 +4647,11 @@ export interface Program extends ScriptReferenceHost {
     /** @internal */
     getFilesByNameMap(): Map<string, SourceFile | false | undefined>;
 
+    /** @internal */
+    resolvedModules: Map<Path, ModeAwareCache<ResolvedModuleWithFailedLookupLocations>> | undefined;
+    /** @internal */
+    resolvedTypeReferenceDirectiveNames: Map<Path, ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>> | undefined;
+
     /**
      * Emits the JavaScript and declaration files.  If targetSourceFile is not specified, then
      * the JavaScript and declaration files will be produced for all the files in this program.
@@ -4867,6 +4867,8 @@ export interface TypeCheckerHost extends ModuleSpecifierResolutionHost {
     getResolvedTypeReferenceDirectives(): ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>;
     getProjectReferenceRedirect(fileName: string): string | undefined;
     isSourceOfProjectReferenceRedirect(fileName: string): boolean;
+
+    resolvedModules: Map<Path, ModeAwareCache<ResolvedModuleWithFailedLookupLocations>> | undefined;
 
     readonly redirectTargetsMap: RedirectTargetsMap;
 

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -442,7 +442,7 @@ export function getMatchedIncludeSpec(program: Program, fileName: string) {
 export function fileIncludeReasonToDiagnostics(program: Program, reason: FileIncludeReason, fileNameConvertor?: (fileName: string) => string): DiagnosticMessageChain {
     const options = program.getCompilerOptions();
     if (isReferencedFile(reason)) {
-        const referenceLocation = getReferencedFileLocation(path => program.getSourceFileByPath(path), reason);
+        const referenceLocation = getReferencedFileLocation(program, reason);
         const referenceText = isReferenceFileLocation(referenceLocation) ? referenceLocation.file.text.substring(referenceLocation.pos, referenceLocation.end) : `"${referenceLocation.text}"`;
         let message: DiagnosticMessage;
         Debug.assert(isReferenceFileLocation(referenceLocation) || reason.kind === FileIncludeKind.Import, "Only synthetic references are imports");

--- a/src/services/codefixes/fixImportNonExportedMember.ts
+++ b/src/services/codefixes/fixImportNonExportedMember.ts
@@ -10,7 +10,6 @@ import {
     findLast,
     firstOrUndefined,
     getIsolatedModules,
-    getResolvedModule,
     getTokenAtPosition,
     Identifier,
     isExportDeclaration,
@@ -120,7 +119,7 @@ function getInfo(sourceFile: SourceFile, pos: number, program: Program): Info | 
         const moduleSpecifier = isStringLiteral(importDeclaration.moduleSpecifier) ? importDeclaration.moduleSpecifier.text : undefined;
         if (moduleSpecifier === undefined) return undefined;
 
-        const resolvedModule = getResolvedModule(sourceFile, moduleSpecifier, /*mode*/ undefined);
+        const resolvedModule = program.resolvedModules?.get(sourceFile.path)?.get(moduleSpecifier, /*mode*/ undefined)?.resolvedModule;
         if (resolvedModule === undefined) return undefined;
 
         const moduleSourceFile = program.getSourceFile(resolvedModule.resolvedFileName);

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -8,7 +8,6 @@ import {
     getEmitScriptTarget,
     getMeaningFromLocation,
     getModeForUsageLocation,
-    getResolvedModule,
     getTextOfNode,
     getTokenAtPosition,
     hasSyntacticModifier,
@@ -183,7 +182,7 @@ function convertSemanticMeaningToSymbolFlags(meaning: SemanticMeaning): SymbolFl
 function getResolvedSourceFileFromImportDeclaration(sourceFile: SourceFile, context: CodeFixContextBase, importDeclaration: ImportDeclaration): SourceFile | undefined {
     if (!importDeclaration || !isStringLiteralLike(importDeclaration.moduleSpecifier)) return undefined;
 
-    const resolvedModule = getResolvedModule(sourceFile, importDeclaration.moduleSpecifier.text, getModeForUsageLocation(sourceFile, importDeclaration.moduleSpecifier));
+    const resolvedModule = context.program.resolvedModules?.get(sourceFile.path)?.get(importDeclaration.moduleSpecifier.text, getModeForUsageLocation(sourceFile, importDeclaration.moduleSpecifier))?.resolvedModule;
     if (!resolvedModule) return undefined;
 
     return context.program.getSourceFile(resolvedModule.resolvedFileName);

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1009,7 +1009,7 @@ export namespace Core {
             if (!options.implementations && isStringLiteralLike(node)) {
                 if (isModuleSpecifierLike(node)) {
                     const fileIncludeReasons = program.getFileIncludeReasons();
-                    const referencedFileName = node.getSourceFile().resolvedModules?.get(node.text, getModeForUsageLocation(node.getSourceFile(), node))?.resolvedModule?.resolvedFileName;
+                    const referencedFileName = program.resolvedModules?.get(node.getSourceFile().path)?.get(node.text, getModeForUsageLocation(node.getSourceFile(), node))?.resolvedModule?.resolvedFileName;
                     const referencedFile = referencedFileName ? program.getSourceFile(referencedFileName) : undefined;
                     if (referencedFile) {
                         return [{ definition: { type: DefinitionKind.String, node }, references: getReferencesForNonModule(referencedFile, fileIncludeReasons, program) || emptyArray }];
@@ -1066,7 +1066,7 @@ export namespace Core {
         for (const ref of references) {
             if (isReferencedFile(ref)) {
                 const referencingFile = program.getSourceFileByPath(ref.file)!;
-                const location = getReferencedFileLocation(program.getSourceFileByPath, ref);
+                const location = getReferencedFileLocation(program, ref);
                 if (isReferenceFileLocation(location)) {
                     entries = append(entries, {
                         kind: EntryKind.Span,

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -249,7 +249,7 @@ function getSourceFileToImport(
     else {
         const mode = getModeForUsageLocation(importingSourceFile, importLiteral);
         const resolved = host.resolveModuleNameLiterals || !host.resolveModuleNames ?
-            importingSourceFile.resolvedModules?.get(importLiteral.text, mode) :
+            program.resolvedModules?.get(importingSourceFile.path)?.get(importLiteral.text, mode) :
             host.getResolvedModuleWithFailedLookupLocationsFromCache && host.getResolvedModuleWithFailedLookupLocationsFromCache(importLiteral.text, importingSourceFile.fileName, mode);
         return getSourceFileToImportFromResolved(importLiteral, resolved, oldToNew, program.getSourceFiles());
     }

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -179,7 +179,7 @@ export function getDefinitionAtPosition(program: Program, sourceFile: SourceFile
     if (!symbol && isModuleSpecifierLike(fallbackNode)) {
         // We couldn't resolve the module specifier as an external module, but it could
         // be that module resolution succeeded but the target was not a module.
-        const ref = sourceFile.resolvedModules?.get(fallbackNode.text, getModeForUsageLocation(sourceFile, fallbackNode))?.resolvedModule;
+        const ref = program.resolvedModules?.get(sourceFile.path)?.get(fallbackNode.text, getModeForUsageLocation(sourceFile, fallbackNode))?.resolvedModule;
         if (ref) {
             return [{
                 name: fallbackNode.text,
@@ -332,10 +332,11 @@ export function getReferenceAtPosition(sourceFile: SourceFile, position: number,
         return file && { reference: libReferenceDirective, fileName: file.fileName, file, unverified: false };
     }
 
-    if (sourceFile.resolvedModules?.size()) {
+    const resolvedModules = program.resolvedModules?.get(sourceFile.path);
+    if (resolvedModules?.size()) {
         const node = getTouchingToken(sourceFile, position);
-        if (isModuleSpecifierLike(node) && isExternalModuleNameRelative(node.text) && sourceFile.resolvedModules.has(node.text, getModeForUsageLocation(sourceFile, node))) {
-            const verifiedFileName = sourceFile.resolvedModules.get(node.text, getModeForUsageLocation(sourceFile, node))?.resolvedModule?.resolvedFileName;
+        if (isModuleSpecifierLike(node) && isExternalModuleNameRelative(node.text) && resolvedModules.has(node.text, getModeForUsageLocation(sourceFile, node))) {
+            const verifiedFileName = resolvedModules.get(node.text, getModeForUsageLocation(sourceFile, node))?.resolvedModule?.resolvedFileName;
             const fileName = verifiedFileName || resolvePath(getDirectoryPath(sourceFile.fileName), node.text);
             return {
                 file: program.getSourceFile(fileName),

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -310,7 +310,7 @@ function getTargetFileImportsAndAddExportInOldFile(
             forEachImportInStatement(oldStatement, i => {
                 // Recomputing module specifier
                 const moduleSpecifier = moduleSpecifierFromImport(i);
-                const resolved = oldFile.resolvedModules?.get(moduleSpecifier.text, getModeForUsageLocation(oldFile, moduleSpecifier));
+                const resolved = program.resolvedModules?.get(oldFile.path)?.get(moduleSpecifier.text, getModeForUsageLocation(oldFile, moduleSpecifier));
                 const fileName = resolved?.resolvedModule?.resolvedFileName;
                 if (fileName && targetSourceFile) {
                     const newModuleSpecifier = getModuleSpecifier(program.getCompilerOptions(), targetSourceFile, targetSourceFile.path, fileName, createModuleSpecifierResolutionHost(program, host));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -212,7 +212,6 @@ import {
     mapOneOrMany,
     maybeBind,
     maybeSetLocalizedDiagnosticMessages,
-    ModeAwareCache,
     ModifierFlags,
     ModuleDeclaration,
     NavigateToItem,
@@ -256,9 +255,7 @@ import {
     RenameInfo,
     RenameInfoOptions,
     RenameLocation,
-    ResolvedModuleWithFailedLookupLocations,
     ResolvedProjectReference,
-    ResolvedTypeReferenceDirectiveWithFailedLookupLocations,
     returnFalse,
     scanner,
     ScriptElementKind,
@@ -1042,8 +1039,6 @@ class SourceFileObject extends NodeObject implements SourceFile {
     public languageVariant!: LanguageVariant;
     public identifiers!: Map<string, string>;
     public nameTable: Map<__String, number> | undefined;
-    public resolvedModules: ModeAwareCache<ResolvedModuleWithFailedLookupLocations> | undefined;
-    public resolvedTypeReferenceDirectiveNames!: ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>;
     public imports!: readonly StringLiteralLike[];
     public moduleAugmentations!: StringLiteral[];
     private namedDeclarations: Map<string, Declaration[]> | undefined;

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -24,7 +24,6 @@ import {
     getAssignmentDeclarationKind,
     getFunctionFlags,
     getModeForUsageLocation,
-    getResolvedModule,
     hasInitializer,
     hasPropertyAccessExpressionWithName,
     Identifier,
@@ -89,7 +88,7 @@ export function computeSuggestionDiagnostics(sourceFile: SourceFile, program: Pr
             const importNode = importFromModuleSpecifier(moduleSpecifier);
             const name = importNameForConvertToDefaultImport(importNode);
             if (!name) continue;
-            const module = getResolvedModule(sourceFile, moduleSpecifier.text, getModeForUsageLocation(sourceFile, moduleSpecifier));
+            const module = program.resolvedModules?.get(sourceFile.path)?.get(moduleSpecifier.text, getModeForUsageLocation(sourceFile, moduleSpecifier))?.resolvedModule;
             const resolvedFile = module && program.getSourceFile(module.resolvedFileName);
             if (resolvedFile && resolvedFile.externalModuleIndicator && resolvedFile.externalModuleIndicator !== true && isExportAssignment(resolvedFile.externalModuleIndicator) && resolvedFile.externalModuleIndicator.isExportEquals) {
                 diags.push(createDiagnosticForNode(name, Diagnostics.Import_may_be_converted_to_a_default_import));

--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -27,8 +27,8 @@ describe("unittests:: Reuse program structure:: General", () => {
         baselines.push(`Program Reused:: ${(ts as any).StructureIsReused[program.structureIsReused]}`);
         program.getSourceFiles().forEach(f => {
             baselines.push(`File: ${f.fileName}`, f.text);
-            baselineCache(baselines, "resolvedModules", f.resolvedModules);
-            baselineCache(baselines, "resolvedTypeReferenceDirectiveNames", f.resolvedTypeReferenceDirectiveNames);
+            baselineCache(baselines, "resolvedModules", program.resolvedModules?.get(f.path));
+            baselineCache(baselines, "resolvedTypeReferenceDirectiveNames", program.resolvedTypeReferenceDirectiveNames?.get(f.path));
             baselines.push("");
         });
         host ??= (program as ProgramWithSourceTexts).host;

--- a/src/testRunner/unittests/tsserver/symlinkCache.ts
+++ b/src/testRunner/unittests/tsserver/symlinkCache.ts
@@ -82,7 +82,7 @@ describe("unittests:: tsserver:: symlinkCache", () => {
                 resolvedFileName: "/one/two/foo",
             },
         });
-        cache.setSymlinksFromResolutions([], map);
+        cache.setSymlinksFromResolutions(/*resolvedModules*/ undefined, /*resolvedTypeReferenceDirectiveNames*/ undefined, map);
     });
 });
 

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -2312,7 +2312,9 @@ describe("unittests:: tsserver:: typingsInstaller:: recomputing resolutions of u
     const foooPath = "/a/b/node_modules/fooo/index.d.ts";
     function verifyResolvedModuleOfFooo(project: ts.server.Project) {
         ts.server.updateProjectIfDirty(project);
-        const foooResolution = project.getLanguageService().getProgram()!.getSourceFileByPath(appPath)!.resolvedModules!.get("fooo", /*mode*/ undefined)!.resolvedModule!;
+        const program = project.getLanguageService().getProgram()!;
+        const sourceFile = program.getSourceFileByPath(appPath)!;
+        const foooResolution = program.resolvedModules!.get(sourceFile.path)!.get("fooo", /*mode*/ undefined)!.resolvedModule!;
         assert.equal(foooResolution.resolvedFileName, foooPath);
         return foooResolution;
     }

--- a/tests/baselines/reference/nodeColonModuleResolution.trace.json
+++ b/tests/baselines/reference/nodeColonModuleResolution.trace.json
@@ -1,4 +1,5 @@
 [
+    "Module 'ph' was resolved as locally declared ambient module in file '/a/b/node_modules/@types/node/ph.d.ts'.",
     "======== Resolving module 'node:ph' from '/a/b/main.ts'. ========",
     "Explicitly specified module resolution kind: 'Node10'.",
     "Skipping module 'node:ph' that looks like an absolute URI, target file types: TypeScript, Declaration.",

--- a/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan,-and-orphan-script-info-changes.js
+++ b/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan,-and-orphan-script-info-changes.js
@@ -69,7 +69,7 @@ Info seq  [hh:mm:ss:mss] Open files:
 Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/myproject/index.ts ProjectRootPath: undefined
 Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/myproject/tsconfig.json
 DocumentRegistry::
-  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+  Key:: undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined
     /user/username/projects/myproject/index.ts: TS 1
     /user/username/projects/myproject/module1.d.ts: TS 1
     /a/lib/lib.d.ts: TS 1
@@ -88,7 +88,7 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 DocumentRegistry::
-  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+  Key:: undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined
     /user/username/projects/myproject/index.ts: TS 1
     /a/lib/lib.d.ts: TS 1
 Info seq  [hh:mm:ss:mss] FileWatcher:: Triggered with /user/username/projects/myproject/module1.d.ts 1:: WatchInfo: /user/username/projects/myproject/module1.d.ts 500 undefined WatchType: Closed Script info
@@ -111,7 +111,7 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 DocumentRegistry::
-  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+  Key:: undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined
     /user/username/projects/myproject/index.ts: TS 1
     /a/lib/lib.d.ts: TS 1
     /user/username/projects/myproject/module1.d.ts: TS 1

--- a/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan.js
+++ b/tests/baselines/reference/tsserver/documentRegistry/Caches-the-source-file-if-script-info-is-orphan.js
@@ -69,7 +69,7 @@ Info seq  [hh:mm:ss:mss] Open files:
 Info seq  [hh:mm:ss:mss] 	FileName: /user/username/projects/myproject/index.ts ProjectRootPath: undefined
 Info seq  [hh:mm:ss:mss] 		Projects: /user/username/projects/myproject/tsconfig.json
 DocumentRegistry::
-  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+  Key:: undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined
     /user/username/projects/myproject/index.ts: TS 1
     /user/username/projects/myproject/module1.d.ts: TS 1
     /a/lib/lib.d.ts: TS 1
@@ -88,7 +88,7 @@ Info seq  [hh:mm:ss:mss] 	Files (2)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 DocumentRegistry::
-  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+  Key:: undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined
     /user/username/projects/myproject/index.ts: TS 1
     /a/lib/lib.d.ts: TS 1
 Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /user/username/projects/myproject/tsconfig.json
@@ -109,7 +109,7 @@ Info seq  [hh:mm:ss:mss] 	Files (3)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 DocumentRegistry::
-  Key:: undefined|undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined|undefined
+  Key:: undefined|undefined|undefined|false|undefined|undefined|undefined|undefined|undefined|undefined
     /user/username/projects/myproject/index.ts: TS 1
     /a/lib/lib.d.ts: TS 1
     /user/username/projects/myproject/module1.d.ts: TS 1


### PR DESCRIPTION
Stops taking dependency on all module resolution options when sharing sourceFiles and instead moves `resolvedModules` and `resolvedTypeReferenceDirectiveNames` from `sourceFile` to `Program` so it is safe by program to copy the resolutions across.

This came up as part of testing with #54785 where `axion` and some more (which i dont recollect) didnt pass incremental resolution check. This is shown in ddaf1c7 specifically (https://github.com/microsoft/TypeScript/commit/ddaf1c77fc29e91cc8a8a5c45dc1cb002d0ee061#diff-215d7c39ab1082f80d4c3a4f1c8bd9dd1c9ccb1c6450192bbaf409b8e5376579R140) where the resolved module on sourceFile changes and results in issues program referencing other resolution.
The issue here lies in fact that "as type" resolution takes into account typeRoots and if config had it its good and used as a key for affecting resolution but if user didnt specify it depends on "config file location" if present otherwise "currentDirectory" . This is issue because you could include either by types or default types (matching in both projects) a type thats in parent directories `node_modules/@types` but then that type could include `types` directive of say `node` which in both projects will be resolved say from config location which is different and if those directories have their own `node_modules/@types/node` then the location which is picked will depend on which project is picked first
Investigated few options for this
- adding default type roots as key but that mean resolutions cannot be shared between two projects with config file in different directories which is very common.
- On top of above option adding only present `node_modules/@types`  in the key but that means on each `npm install` we would need to update module resolutions from scratch as its change in "key" and parse "sourceFiles" so that doesnt seem practical
-  The current change where decoupling sourceFiles and module resolution storage, This doesnt fix module resolution cache sharing across projects (which is only in tsbuild for now which doesnt share the caches between watch events and in future we will share in tsserver but that one will watch failed lookup locations so we could somehow use that so probably can be handled in some way without having to invalidate everything)