### PR TITLE
Add pre-commit dprint hook, fix post-checkout hook

### DIFF
--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,2 +1,2 @@
 #!/bin/sh
-npm run npx hereby -- generate-diagnostics
+npx hereby -- generate-diagnostics

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx dprint fmt

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,2 +1,3 @@
 #!/bin/sh
 git diff --name-only --cached --relative | xargs --no-run-if-empty npx dprint fmt
+git diff --name-only --cached --relative | xargs --no-run-if-empty git add

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-npx dprint fmt
+git diff --name-only --cached --relative | xargs --no-run-if-empty npx dprint fmt

--- a/scripts/link-hooks.mjs
+++ b/scripts/link-hooks.mjs
@@ -11,6 +11,7 @@ const __dirname = path.dirname(__filename);
 
 const hooks = [
     "post-checkout",
+    "pre-commit",
 ];
 
 hooks.forEach(hook => {


### PR DESCRIPTION
This adds a pre-commit hook that will format staged files before committing.

This also fixes the `post-checkout` hook, which I'm pretty sure has been broken this whole time (which to me means that it's not very useful).