### PR TITLE
Add a test for a property of reverse mapped type having a primitive type

### DIFF
--- a/tests/baselines/reference/reverseMappedTypePrimitiveConstraintProperty.symbols
+++ b/tests/baselines/reference/reverseMappedTypePrimitiveConstraintProperty.symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts] ////
+
+=== reverseMappedTypePrimitiveConstraintProperty.ts ===
+declare function test<
+>test : Symbol(test, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 0, 0))
+
+  T extends { prop: string; nested: { nestedProp: string } },
+>T : Symbol(T, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 0, 22))
+>prop : Symbol(prop, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 1, 13))
+>nested : Symbol(nested, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 1, 27))
+>nestedProp : Symbol(nestedProp, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 1, 37))
+
+>(obj: { [K in keyof T]: T[K] }): T;
+>obj : Symbol(obj, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 2, 2))
+>K : Symbol(K, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 2, 10))
+>T : Symbol(T, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 0, 22))
+>T : Symbol(T, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 0, 22))
+>K : Symbol(K, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 2, 10))
+>T : Symbol(T, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 0, 22))
+
+const result = test({
+>result : Symbol(result, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 4, 5))
+>test : Symbol(test, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 0, 0))
+
+  prop: "foo", // this one should not widen to string
+>prop : Symbol(prop, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 4, 21))
+
+  nested: {
+>nested : Symbol(nested, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 5, 14))
+
+    nestedProp: "bar",
+>nestedProp : Symbol(nestedProp, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 6, 11))
+
+  },
+  extra: "baz",
+>extra : Symbol(extra, Decl(reverseMappedTypePrimitiveConstraintProperty.ts, 8, 4))
+
+});
+

--- a/tests/baselines/reference/reverseMappedTypePrimitiveConstraintProperty.types
+++ b/tests/baselines/reference/reverseMappedTypePrimitiveConstraintProperty.types
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts] ////
+
+=== reverseMappedTypePrimitiveConstraintProperty.ts ===
+declare function test<
+>test : <T extends { prop: string; nested: {    nestedProp: string;}; }>(obj: { [K in keyof T]: T[K]; }) => T
+
+  T extends { prop: string; nested: { nestedProp: string } },
+>prop : string
+>nested : { nestedProp: string; }
+>nestedProp : string
+
+>(obj: { [K in keyof T]: T[K] }): T;
+>obj : { [K in keyof T]: T[K]; }
+
+const result = test({
+>result : { prop: "foo"; nested: { nestedProp: string; }; extra: string; }
+>test({  prop: "foo", // this one should not widen to string  nested: {    nestedProp: "bar",  },  extra: "baz",}) : { prop: "foo"; nested: { nestedProp: string; }; extra: string; }
+>test : <T extends { prop: string; nested: { nestedProp: string; }; }>(obj: { [K in keyof T]: T[K]; }) => T
+>{  prop: "foo", // this one should not widen to string  nested: {    nestedProp: "bar",  },  extra: "baz",} : { prop: "foo"; nested: { nestedProp: string; }; extra: string; }
+
+  prop: "foo", // this one should not widen to string
+>prop : "foo"
+>"foo" : "foo"
+
+  nested: {
+>nested : { nestedProp: string; }
+>{    nestedProp: "bar",  } : { nestedProp: string; }
+
+    nestedProp: "bar",
+>nestedProp : string
+>"bar" : "bar"
+
+  },
+  extra: "baz",
+>extra : string
+>"baz" : "baz"
+
+});
+

--- a/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts
+++ b/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts
@@ -1,0 +1,14 @@
+// @strict: true
+// @noEmit: true
+
+declare function test<
+  T extends { prop: string; nested: { nestedProp: string } },
+>(obj: { [K in keyof T]: T[K] }): T;
+
+const result = test({
+  prop: "foo", // this one should not widen to string
+  nested: {
+    nestedProp: "bar",
+  },
+  extra: "baz",
+});


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/55795

Please verify that this is actually the expected result. I think it is and explained why [here](https://github.com/microsoft/TypeScript/issues/55795#issuecomment-1727197771). 

I'm pretty sure that there is no test case like this in the codebase since I made an experiment to to obtain an apparent type of substituted mapped type property. Only 4 tests failed and none of them looked like this.