### PR TITLE
Fix export path patterns with .d.ts target extensions in AutoImportProvider

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -2212,7 +2212,11 @@ function loadEntrypointsFromExportMap(
                     scope.packageDirectory,
                     extensionsToExtensionsArray(extensions),
                     /*excludes*/ undefined,
-                    [changeAnyExtension(target.replace("*", "**/*"), getDeclarationEmitExtensionForPath(target))],
+                    [
+                        isDeclarationFileName(target)
+                            ? target.replace("*", "**/*")
+                            : changeAnyExtension(target.replace("*", "**/*"), getDeclarationEmitExtensionForPath(target)),
+                    ],
                 ).forEach(entry => {
                     entrypoints = appendIfUnique(entrypoints, {
                         path: entry,

--- a/tests/cases/fourslash/server/autoImportProvider_wildcardExports2.ts
+++ b/tests/cases/fourslash/server/autoImportProvider_wildcardExports2.ts
@@ -1,0 +1,51 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /node_modules/pkg/package.json
+//// {
+////     "name": "pkg",
+////     "version": "1.0.0",
+////     "exports": {
+////         "./core/*": {
+////             "types": "./lib/core/*.d.ts",
+////             "default": "./lib/core/*.js"
+////         }
+////     }
+//// }
+
+// @Filename: /node_modules/pkg/lib/core/test.d.ts
+//// export function test(): void;
+
+// @Filename: /package.json
+//// {
+////     "type": "module",
+////     "dependencies": {
+////         "pkg": "1.0.0"
+////     }
+//// }
+
+// @Filename: /tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "module": "nodenext"
+////     }
+//// }
+
+// @Filename: /main.ts
+//// /**/
+
+verify.completions({
+  marker: "",
+  includes: [
+    {
+      name: "test",
+      source: "pkg/core/test",
+      sourceDisplay: "pkg/core/test",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions
+    },
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true
+  }
+});


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #53116 (a corner case of the 5.2 feature not working)
