### PR TITLE
Remove SuppressedErrorConstructor's extends clause

### DIFF
--- a/src/lib/esnext.disposable.d.ts
+++ b/src/lib/esnext.disposable.d.ts
@@ -25,7 +25,7 @@ interface SuppressedError extends Error {
     suppressed: any;
 }
 
-interface SuppressedErrorConstructor extends ErrorConstructor {
+interface SuppressedErrorConstructor {
     new (error: any, suppressed: any, message?: string): SuppressedError;
     (error: any, suppressed: any, message?: string): SuppressedError;
     readonly prototype: SuppressedError;


### PR DESCRIPTION
It should not inherit ErrorConstructor's signatures.

Fixes #55674
