### PR TITLE
Picking resolutions of module for sourceFile as method

### DIFF
--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -238,18 +238,15 @@ export namespace BuilderState {
         }
 
         // Handle type reference directives
-        const resolvedTypeReferenceDirectiveNames = program.resolvedTypeReferenceDirectiveNames?.get(sourceFile.path);
-        if (resolvedTypeReferenceDirectiveNames) {
-            resolvedTypeReferenceDirectiveNames.forEach(({ resolvedTypeReferenceDirective }) => {
-                if (!resolvedTypeReferenceDirective) {
-                    return;
-                }
+        program.forEachResolvedTypeReferenceDirective(({ resolvedTypeReferenceDirective }) => {
+            if (!resolvedTypeReferenceDirective) {
+                return;
+            }
 
-                const fileName = resolvedTypeReferenceDirective.resolvedFileName!; // TODO: GH#18217
-                const typeFilePath = getReferencedFileFromFileName(program, fileName, sourceFileDirectory, getCanonicalFileName);
-                addReferencedFile(typeFilePath);
-            });
-        }
+            const fileName = resolvedTypeReferenceDirective.resolvedFileName!; // TODO: GH#18217
+            const typeFilePath = getReferencedFileFromFileName(program, fileName, sourceFileDirectory, getCanonicalFileName);
+            addReferencedFile(typeFilePath);
+        }, sourceFile);
 
         // Add module augmentation as references
         if (sourceFile.moduleAugmentations.length) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4959,7 +4959,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 (isLiteralImportTypeNode(location) ? location : undefined)?.argument.literal;
         const mode = contextSpecifier && isStringLiteralLike(contextSpecifier) ? getModeForUsageLocation(currentSourceFile, contextSpecifier) : currentSourceFile.impliedNodeFormat;
         const moduleResolutionKind = getEmitModuleResolutionKind(compilerOptions);
-        const resolvedModule = host.resolvedModules?.get(currentSourceFile.path)?.get(moduleReference, mode)?.resolvedModule;
+        const resolvedModule = host.getResolvedModule(currentSourceFile, moduleReference, mode)?.resolvedModule;
         const resolutionDiagnostic = resolvedModule && getResolutionDiagnostic(compilerOptions, resolvedModule, currentSourceFile);
         const sourceFile = resolvedModule
             && (!resolutionDiagnostic || resolutionDiagnostic === Diagnostics.Module_0_was_resolved_to_1_but_jsx_is_not_set)

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1177,7 +1177,7 @@ export function getReferencedFileLocation(program: Program, ref: ReferencedFile)
     switch (kind) {
         case FileIncludeKind.Import:
             const importLiteral = getModuleNameStringLiteralAt(file, index);
-            packageId = program.resolvedModules?.get(file.path)?.get(importLiteral.text, getModeForResolutionAtIndex(file, index))?.resolvedModule?.packageId;
+            packageId = program.getResolvedModule(file, importLiteral.text, getModeForResolutionAtIndex(file, index))?.resolvedModule?.packageId;
             if (importLiteral.pos === -1) return { file, packageId, text: importLiteral.text };
             pos = skipTrivia(file.text, importLiteral.pos);
             end = importLiteral.end;
@@ -1187,7 +1187,7 @@ export function getReferencedFileLocation(program: Program, ref: ReferencedFile)
             break;
         case FileIncludeKind.TypeReferenceDirective:
             ({ pos, end, resolutionMode } = file.typeReferenceDirectives[index]);
-            packageId = program.resolvedTypeReferenceDirectiveNames?.get(file.path)?.get(toFileNameLowerCase(file.typeReferenceDirectives[index].fileName), resolutionMode || file.impliedNodeFormat)?.resolvedTypeReferenceDirective?.packageId;
+            packageId = program.getResolvedTypeReferenceDirective(file, toFileNameLowerCase(file.typeReferenceDirectives[index].fileName), resolutionMode || file.impliedNodeFormat)?.resolvedTypeReferenceDirective?.packageId;
             break;
         case FileIncludeKind.LibReferenceDirective:
             ({ pos, end } = file.libReferenceDirectives[index]);
@@ -1888,6 +1888,10 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         resolvedModules,
         resolvedTypeReferenceDirectiveNames,
         resolvedLibReferences,
+        getResolvedModule,
+        getResolvedTypeReferenceDirective,
+        forEachResolvedModule,
+        forEachResolvedTypeReferenceDirective,
         getCurrentPackagesMap: () => packageMap,
         typesPackageExists,
         packageBundlesTypes,
@@ -1937,6 +1941,37 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
 
     return program;
 
+    function getResolvedModule(file: SourceFile, moduleName: string, mode: ResolutionMode) {
+        return resolvedModules?.get(file.path)?.get(moduleName, mode);
+    }
+
+    function getResolvedTypeReferenceDirective(file: SourceFile, typeDirectiveName: string, mode: ResolutionMode) {
+        return resolvedTypeReferenceDirectiveNames?.get(file.path)?.get(typeDirectiveName, mode);
+    }
+
+    function forEachResolvedModule(
+        callback: (resolution: ResolvedModuleWithFailedLookupLocations, moduleName: string, mode: ResolutionMode, filePath: Path) => void,
+        file?: SourceFile,
+    ) {
+        forEachResolution(resolvedModules, callback, file);
+    }
+
+    function forEachResolvedTypeReferenceDirective(
+        callback: (resolution: ResolvedTypeReferenceDirectiveWithFailedLookupLocations, moduleName: string, mode: ResolutionMode, filePath: Path) => void,
+        file?: SourceFile,
+    ): void {
+        forEachResolution(resolvedTypeReferenceDirectiveNames, callback, file);
+    }
+
+    function forEachResolution<T>(
+        resolutionCache: Map<Path, ModeAwareCache<T>> | undefined,
+        callback: (resolution: T, moduleName: string, mode: ResolutionMode, filePath: Path) => void,
+        file: SourceFile | undefined,
+    ) {
+        if (file) resolutionCache?.get(file.path)?.forEach((resolution, name, mode) => callback(resolution, name, mode, file.path));
+        else resolutionCache?.forEach((resolutions, filePath) => resolutions.forEach((resolution, name, mode) => callback(resolution, name, mode, filePath)));
+    }
+
     function getPackagesMap() {
         if (packageMap) return packageMap;
         packageMap = new Map();
@@ -1944,11 +1979,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         // This is useful as an approximation of whether a package bundles its own types.
         // Note: we only look at files already found by module resolution,
         // so there may be files we did not consider.
-        files.forEach(sf =>
-            resolvedModules?.get(sf.path)?.forEach(({ resolvedModule }) => {
-                if (resolvedModule?.packageId) packageMap!.set(resolvedModule.packageId.name, resolvedModule.extension === Extension.Dts || !!packageMap!.get(resolvedModule.packageId.name));
-            })
-        );
+        forEachResolvedModule(({ resolvedModule }) => {
+            if (resolvedModule?.packageId) packageMap!.set(resolvedModule.packageId.name, resolvedModule.extension === Extension.Dts || !!packageMap!.get(resolvedModule.packageId.name));
+        });
         return packageMap;
     }
 
@@ -2121,7 +2154,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             // If the source file is unchanged and doesnt have invalidated resolution, reuse the module resolutions
             if (file === oldSourceFile && !hasInvalidatedResolutions(file.path)) {
                 const mode = getModeForUsageLocation(file, moduleName);
-                const oldResolution = oldProgram?.resolvedModules?.get(file.path)?.get(moduleName.text, mode);
+                const oldResolution = oldProgram?.getResolvedModule(file, moduleName.text, mode);
                 if (oldResolution?.resolvedModule) {
                     if (isTraceEnabled(options, host)) {
                         trace(
@@ -2189,7 +2222,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
         // If we change our policy of rechecking failed lookups on each program create,
         // we should adjust the value returned here.
         function moduleNameResolvesToAmbientModuleInNonModifiedFile(moduleName: StringLiteralLike): boolean {
-            const resolutionToFile = oldProgram?.resolvedModules?.get(file.path)?.get(moduleName.text, getModeForUsageLocation(file, moduleName))?.resolvedModule;
+            const resolutionToFile = oldProgram?.getResolvedModule(file, moduleName.text, getModeForUsageLocation(file, moduleName))?.resolvedModule;
             const resolvedFile = resolutionToFile && oldProgram!.getSourceFile(resolutionToFile.resolvedFileName);
             if (resolutionToFile && resolvedFile) {
                 // In the old program, we resolved to an ambient module that was in the same
@@ -2236,7 +2269,9 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             if (canReuseResolutions) {
                 const typeDirectiveName = getTypeReferenceResolutionName(entry);
                 const mode = getModeForFileReference(entry, containingSourceFile?.impliedNodeFormat);
-                const oldResolution = (!isString(containingFile) ? oldProgram?.resolvedTypeReferenceDirectiveNames?.get(containingFile.path) : oldProgram?.getAutomaticTypeDirectiveResolutions())?.get(typeDirectiveName, mode);
+                const oldResolution = !isString(containingFile) ?
+                    oldProgram?.getResolvedTypeReferenceDirective(containingFile, typeDirectiveName, mode) :
+                    oldProgram?.getAutomaticTypeDirectiveResolutions()?.get(typeDirectiveName, mode);
                 if (oldResolution?.resolvedTypeReferenceDirective) {
                     if (isTraceEnabled(options, host)) {
                         trace(
@@ -2478,22 +2513,29 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             const moduleNames = getModuleNames(newSourceFile);
             const resolutions = resolveModuleNamesReusingOldState(moduleNames, newSourceFile);
             (resolvedModulesProcessing ??= new Map()).set(newSourceFile.path, resolutions);
-            const oldResolutions = oldProgram.resolvedModules?.get(newSourceFile.path);
             // ensure that module resolution results are still correct
-            const resolutionsChanged = hasChangesInResolutions(moduleNames, newSourceFile, resolutions, oldResolutions, moduleResolutionIsEqualTo, moduleResolutionNameAndModeGetter);
+            const resolutionsChanged = hasChangesInResolutions(
+                moduleNames,
+                newSourceFile,
+                resolutions,
+                (name, mode) => oldProgram!.getResolvedModule(newSourceFile, name, mode),
+                moduleResolutionIsEqualTo,
+                moduleResolutionNameAndModeGetter,
+            );
             if (resolutionsChanged) structureIsReused = StructureIsReused.SafeModules;
             const typesReferenceDirectives = newSourceFile.typeReferenceDirectives;
             const typeReferenceResolutions = resolveTypeReferenceDirectiveNamesReusingOldState(typesReferenceDirectives, newSourceFile);
             (resolvedTypeReferenceDirectiveNamesProcessing ??= new Map()).set(newSourceFile.path, typeReferenceResolutions);
             // ensure that types resolutions are still correct
-            const oldTypeResolutions = oldProgram.resolvedTypeReferenceDirectiveNames?.get(newSourceFile.path);
-            const typeReferenceResolutionsChanged = hasChangesInResolutions(typesReferenceDirectives, newSourceFile, typeReferenceResolutions, oldTypeResolutions, typeDirectiveIsEqualTo, typeReferenceResolutionNameAndModeGetter);
-            if (typeReferenceResolutionsChanged) {
-                structureIsReused = StructureIsReused.SafeModules;
-            }
-            else if (oldTypeResolutions) {
-                (resolvedTypeReferenceDirectiveNamesProcessing ??= new Map()).set(newSourceFile.path, oldTypeResolutions);
-            }
+            const typeReferenceResolutionsChanged = hasChangesInResolutions(
+                typesReferenceDirectives,
+                newSourceFile,
+                typeReferenceResolutions,
+                (name, mode) => oldProgram?.getResolvedTypeReferenceDirective(newSourceFile, name, mode),
+                typeDirectiveIsEqualTo,
+                typeReferenceResolutionNameAndModeGetter,
+            );
+            if (typeReferenceResolutionsChanged) structureIsReused = StructureIsReused.SafeModules;
         }
 
         if (structureIsReused !== StructureIsReused.Completely) {
@@ -4933,7 +4975,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             symlinks = createSymlinkCache(currentDirectory, getCanonicalFileName);
         }
         if (files && !symlinks.hasProcessedResolutions()) {
-            symlinks.setSymlinksFromResolutions(resolvedModules, resolvedTypeReferenceDirectiveNames, automaticTypeDirectiveResolutions);
+            symlinks.setSymlinksFromResolutions(forEachResolvedModule, forEachResolvedTypeReferenceDirective, automaticTypeDirectiveResolutions);
         }
         return symlinks;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4651,6 +4651,20 @@ export interface Program extends ScriptReferenceHost {
     resolvedModules: Map<Path, ModeAwareCache<ResolvedModuleWithFailedLookupLocations>> | undefined;
     /** @internal */
     resolvedTypeReferenceDirectiveNames: Map<Path, ModeAwareCache<ResolvedTypeReferenceDirectiveWithFailedLookupLocations>> | undefined;
+    /** @internal */
+    getResolvedModule(f: SourceFile, moduleName: string, mode: ResolutionMode): ResolvedModuleWithFailedLookupLocations | undefined;
+    /** @internal */
+    getResolvedTypeReferenceDirective(f: SourceFile, typeDirectiveName: string, mode: ResolutionMode): ResolvedTypeReferenceDirectiveWithFailedLookupLocations | undefined;
+    /** @internal */
+    forEachResolvedModule(
+        callback: (resolution: ResolvedModuleWithFailedLookupLocations, moduleName: string, mode: ResolutionMode, filePath: Path) => void,
+        file?: SourceFile,
+    ): void;
+    /** @internal */
+    forEachResolvedTypeReferenceDirective(
+        callback: (resolution: ResolvedTypeReferenceDirectiveWithFailedLookupLocations, moduleName: string, mode: ResolutionMode, filePath: Path) => void,
+        file?: SourceFile,
+    ): void;
 
     /**
      * Emits the JavaScript and declaration files.  If targetSourceFile is not specified, then
@@ -4868,7 +4882,7 @@ export interface TypeCheckerHost extends ModuleSpecifierResolutionHost {
     getProjectReferenceRedirect(fileName: string): string | undefined;
     isSourceOfProjectReferenceRedirect(fileName: string): boolean;
 
-    resolvedModules: Map<Path, ModeAwareCache<ResolvedModuleWithFailedLookupLocations>> | undefined;
+    getResolvedModule(f: SourceFile, moduleName: string, mode: ResolutionMode): ResolvedModuleWithFailedLookupLocations | undefined;
 
     readonly redirectTargetsMap: RedirectTargetsMap;
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -603,8 +603,8 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
         }
         if (this.program && !this.symlinks.hasProcessedResolutions()) {
             this.symlinks.setSymlinksFromResolutions(
-                this.program.resolvedModules,
-                this.program.resolvedTypeReferenceDirectiveNames,
+                this.program.forEachResolvedModule,
+                this.program.forEachResolvedTypeReferenceDirective,
                 this.program.getAutomaticTypeDirectiveResolutions(),
             );
         }
@@ -2250,10 +2250,8 @@ function extractUnresolvedImportsFromSourceFile(
     cachedUnresolvedImportsPerFile: Map<Path, readonly string[]>,
 ): readonly string[] {
     return getOrUpdate(cachedUnresolvedImportsPerFile, file.path, () => {
-        const resolvedModules = program.resolvedModules?.get(file.path);
-        if (!resolvedModules) return emptyArray;
         let unresolvedImports: string[] | undefined;
-        resolvedModules.forEach(({ resolvedModule }, name) => {
+        program.forEachResolvedModule(({ resolvedModule }, name) => {
             // pick unresolved non-relative names
             if (
                 (!resolvedModule || !resolutionExtensionIsTSOrJson(resolvedModule.extension)) &&
@@ -2262,7 +2260,7 @@ function extractUnresolvedImportsFromSourceFile(
             ) {
                 unresolvedImports = append(unresolvedImports, parsePackageName(name).packageName);
             }
-        });
+        }, file);
         return unresolvedImports || emptyArray;
     });
 }

--- a/src/services/codefixes/convertToEsModule.ts
+++ b/src/services/codefixes/convertToEsModule.ts
@@ -107,7 +107,7 @@ function fixImportOfModuleExports(
     quotePreference: QuotePreference,
 ) {
     for (const moduleSpecifier of importingFile.imports) {
-        const imported = program.resolvedModules?.get(importingFile.path)?.get(moduleSpecifier.text, getModeForUsageLocation(importingFile, moduleSpecifier))?.resolvedModule;
+        const imported = program.getResolvedModule(importingFile, moduleSpecifier.text, getModeForUsageLocation(importingFile, moduleSpecifier))?.resolvedModule;
         if (!imported || imported.resolvedFileName !== exportingFile.fileName) {
             continue;
         }

--- a/src/services/codefixes/fixImportNonExportedMember.ts
+++ b/src/services/codefixes/fixImportNonExportedMember.ts
@@ -119,7 +119,7 @@ function getInfo(sourceFile: SourceFile, pos: number, program: Program): Info | 
         const moduleSpecifier = isStringLiteral(importDeclaration.moduleSpecifier) ? importDeclaration.moduleSpecifier.text : undefined;
         if (moduleSpecifier === undefined) return undefined;
 
-        const resolvedModule = program.resolvedModules?.get(sourceFile.path)?.get(moduleSpecifier, /*mode*/ undefined)?.resolvedModule;
+        const resolvedModule = program.getResolvedModule(sourceFile, moduleSpecifier, /*mode*/ undefined)?.resolvedModule;
         if (resolvedModule === undefined) return undefined;
 
         const moduleSourceFile = program.getSourceFile(resolvedModule.resolvedFileName);

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -182,7 +182,7 @@ function convertSemanticMeaningToSymbolFlags(meaning: SemanticMeaning): SymbolFl
 function getResolvedSourceFileFromImportDeclaration(sourceFile: SourceFile, context: CodeFixContextBase, importDeclaration: ImportDeclaration): SourceFile | undefined {
     if (!importDeclaration || !isStringLiteralLike(importDeclaration.moduleSpecifier)) return undefined;
 
-    const resolvedModule = context.program.resolvedModules?.get(sourceFile.path)?.get(importDeclaration.moduleSpecifier.text, getModeForUsageLocation(sourceFile, importDeclaration.moduleSpecifier))?.resolvedModule;
+    const resolvedModule = context.program.getResolvedModule(sourceFile, importDeclaration.moduleSpecifier.text, getModeForUsageLocation(sourceFile, importDeclaration.moduleSpecifier))?.resolvedModule;
     if (!resolvedModule) return undefined;
 
     return context.program.getSourceFile(resolvedModule.resolvedFileName);

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -1427,7 +1427,7 @@ function promoteFromTypeOnly(
         // Change .ts extension to .js if necessary
         if (!compilerOptions.allowImportingTsExtensions) {
             const moduleSpecifier = tryGetModuleSpecifierFromDeclaration(importClause.parent);
-            const resolvedModule = moduleSpecifier && program.resolvedModules?.get(sourceFile.path)?.get(moduleSpecifier.text, getModeForUsageLocation(sourceFile, moduleSpecifier))?.resolvedModule;
+            const resolvedModule = moduleSpecifier && program.getResolvedModule(sourceFile, moduleSpecifier.text, getModeForUsageLocation(sourceFile, moduleSpecifier))?.resolvedModule;
             if (resolvedModule?.resolvedUsingTsExtension) {
                 const changedExtension = changeAnyExtension(moduleSpecifier!.text, getOutputExtension(moduleSpecifier!.text, compilerOptions));
                 changes.replaceNode(sourceFile, moduleSpecifier!, factory.createStringLiteral(changedExtension));

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1009,7 +1009,7 @@ export namespace Core {
             if (!options.implementations && isStringLiteralLike(node)) {
                 if (isModuleSpecifierLike(node)) {
                     const fileIncludeReasons = program.getFileIncludeReasons();
-                    const referencedFileName = program.resolvedModules?.get(node.getSourceFile().path)?.get(node.text, getModeForUsageLocation(node.getSourceFile(), node))?.resolvedModule?.resolvedFileName;
+                    const referencedFileName = program.getResolvedModule(node.getSourceFile(), node.text, getModeForUsageLocation(node.getSourceFile(), node))?.resolvedModule?.resolvedFileName;
                     const referencedFile = referencedFileName ? program.getSourceFile(referencedFileName) : undefined;
                     if (referencedFile) {
                         return [{ definition: { type: DefinitionKind.String, node }, references: getReferencesForNonModule(referencedFile, fileIncludeReasons, program) || emptyArray }];

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -249,7 +249,7 @@ function getSourceFileToImport(
     else {
         const mode = getModeForUsageLocation(importingSourceFile, importLiteral);
         const resolved = host.resolveModuleNameLiterals || !host.resolveModuleNames ?
-            program.resolvedModules?.get(importingSourceFile.path)?.get(importLiteral.text, mode) :
+            program.getResolvedModule(importingSourceFile, importLiteral.text, mode) :
             host.getResolvedModuleWithFailedLookupLocationsFromCache && host.getResolvedModuleWithFailedLookupLocationsFromCache(importLiteral.text, importingSourceFile.fileName, mode);
         return getSourceFileToImportFromResolved(importLiteral, resolved, oldToNew, program.getSourceFiles());
     }

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -310,7 +310,7 @@ function getTargetFileImportsAndAddExportInOldFile(
             forEachImportInStatement(oldStatement, i => {
                 // Recomputing module specifier
                 const moduleSpecifier = moduleSpecifierFromImport(i);
-                const resolved = program.resolvedModules?.get(oldFile.path)?.get(moduleSpecifier.text, getModeForUsageLocation(oldFile, moduleSpecifier));
+                const resolved = program.getResolvedModule(oldFile, moduleSpecifier.text, getModeForUsageLocation(oldFile, moduleSpecifier));
                 const fileName = resolved?.resolvedModule?.resolvedFileName;
                 if (fileName && targetSourceFile) {
                     const newModuleSpecifier = getModuleSpecifier(program.getCompilerOptions(), targetSourceFile, targetSourceFile.path, fileName, createModuleSpecifierResolutionHost(program, host));

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -88,7 +88,7 @@ export function computeSuggestionDiagnostics(sourceFile: SourceFile, program: Pr
             const importNode = importFromModuleSpecifier(moduleSpecifier);
             const name = importNameForConvertToDefaultImport(importNode);
             if (!name) continue;
-            const module = program.resolvedModules?.get(sourceFile.path)?.get(moduleSpecifier.text, getModeForUsageLocation(sourceFile, moduleSpecifier))?.resolvedModule;
+            const module = program.getResolvedModule(sourceFile, moduleSpecifier.text, getModeForUsageLocation(sourceFile, moduleSpecifier))?.resolvedModule;
             const resolvedFile = module && program.getSourceFile(module.resolvedFileName);
             if (resolvedFile && resolvedFile.externalModuleIndicator && resolvedFile.externalModuleIndicator !== true && isExportAssignment(resolvedFile.externalModuleIndicator) && resolvedFile.externalModuleIndicator.isExportEquals) {
                 diags.push(createDiagnosticForNode(name, Diagnostics.Import_may_be_converted_to_a_default_import));

--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -19,13 +19,13 @@ import {
 } from "./helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: Reuse program structure:: General", () => {
-    function baselineCache<T>(
+    function baselineCache<File, T>(
         baselines: string[],
         cacheType: string,
-        file: ts.SourceFile,
+        file: File,
         forEach: (
             callback: (resolvedModule: T, moduleName: string, mode: ts.ResolutionMode) => void,
-            file: ts.SourceFile | undefined,
+            file: File,
         ) => void,
     ) {
         let addedHeader = false;
@@ -47,6 +47,7 @@ describe("unittests:: Reuse program structure:: General", () => {
             baselineCache(baselines, "resolvedTypeReferenceDirectiveNames", f, program.forEachResolvedTypeReferenceDirective);
             baselines.push("");
         });
+        baselineCache(baselines, "automaticTypeDirectiveResolutions", /*file*/ undefined, cb => program.getAutomaticTypeDirectiveResolutions().forEach(cb));
         host ??= (program as ProgramWithSourceTexts).host;
         host.getTrace().forEach(trace => baselines.push(Utils.sanitizeTraceResolutionLogEntry(trace)));
         host.clearTrace();

--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -34,7 +34,7 @@ describe("unittests:: Reuse program structure:: General", () => {
         function baselineResolution(resolved: T, key: string, mode: ts.ResolutionMode) {
             if (!addedHeader) {
                 addedHeader = true;
-                baselines.push(`${cacheType}: `);
+                baselines.push(`${cacheType}:`);
             }
             baselines.push(`${key}: ${mode ? ts.getNameOfCompilerOptionValue(mode, ts.moduleOptionDeclaration.type) + ": " : ""}${JSON.stringify(resolved, /*replacer*/ undefined, 2)}`);
         }

--- a/src/testRunner/unittests/tsserver/symlinkCache.ts
+++ b/src/testRunner/unittests/tsserver/symlinkCache.ts
@@ -82,7 +82,7 @@ describe("unittests:: tsserver:: symlinkCache", () => {
                 resolvedFileName: "/one/two/foo",
             },
         });
-        cache.setSymlinksFromResolutions(/*resolvedModules*/ undefined, /*resolvedTypeReferenceDirectiveNames*/ undefined, map);
+        cache.setSymlinksFromResolutions(ts.noop, ts.noop, map);
     });
 });
 

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -2314,7 +2314,7 @@ describe("unittests:: tsserver:: typingsInstaller:: recomputing resolutions of u
         ts.server.updateProjectIfDirty(project);
         const program = project.getLanguageService().getProgram()!;
         const sourceFile = program.getSourceFileByPath(appPath)!;
-        const foooResolution = program.resolvedModules!.get(sourceFile.path)!.get("fooo", /*mode*/ undefined)!.resolvedModule!;
+        const foooResolution = program.getResolvedModule(sourceFile, "fooo", /*mode*/ undefined)!.resolvedModule!;
         assert.equal(foooResolution.resolvedFileName, foooPath);
         return foooResolution;
     }

--- a/tests/baselines/reference/reuseProgramStructure/can-reuse-ambient-module-declarations-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/can-reuse-ambient-module-declarations-from-non-modified-files.js
@@ -3,7 +3,7 @@ File: /a/b/app.ts
 
 import * as fs from 'fs'
 
-resolvedModules: 
+resolvedModules:
 fs: {
   "failedLookupLocations": [
     "/a/b/fs.ts",
@@ -77,7 +77,7 @@ File: /a/b/app.ts
 
 import * as fs from 'fs'
 var x = 1;
-resolvedModules: 
+resolvedModules:
 fs: {
   "failedLookupLocations": [
     "/a/b/fs.ts",
@@ -124,7 +124,7 @@ File: /a/b/app.ts
 
 import * as fs from 'fs'
 var y = 1;
-resolvedModules: 
+resolvedModules:
 fs: {
   "failedLookupLocations": [
     "/a/b/fs.ts",

--- a/tests/baselines/reference/reuseProgramStructure/can-reuse-ambient-module-declarations-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/can-reuse-ambient-module-declarations-from-non-modified-files.js
@@ -32,14 +32,11 @@ fs: {
     "/fs.jsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a/b/node.d.ts
 
 
 declare module 'fs' {}
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 ======== Resolving module 'fs' from '/a/b/app.ts'. ========
 Module resolution kind is not specified, using 'Classic'.
@@ -109,14 +106,11 @@ fs: {
     "/fs.jsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a/b/node.d.ts
 
 
 declare module 'fs' {}
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 Module 'fs' was resolved as ambient module declared in '/a/b/node.d.ts' since this file was not modified.
 
@@ -159,14 +153,11 @@ fs: {
     "/fs.jsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a/b/node.d.ts
 
 
 declare var process: any
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 ======== Resolving module 'fs' from '/a/b/app.ts'. ========
 Module resolution kind is not specified, using 'Classic'.

--- a/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
@@ -36,7 +36,7 @@ File: f1.ts
 import { B } from './b1';
 export let BB = B;
 declare module './b1' { interface B { y: string; } }
-resolvedModules: 
+resolvedModules:
 ./b1: {
   "resolvedModule": {
     "resolvedFileName": "b1.ts",
@@ -45,7 +45,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs1: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -63,7 +63,7 @@ File: f2.ts
 import { B } from './b2';
 import { BB } from './f1';
 (new BB).x; (new BB).y;
-resolvedModules: 
+resolvedModules:
 ./b2: {
   "resolvedModule": {
     "resolvedFileName": "b2.ts",
@@ -80,7 +80,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -161,7 +161,7 @@ File: f1.ts
 import { B } from './b1';
 export let BB = B;
 declare module './b1' { interface B { y: string; } }
-resolvedModules: 
+resolvedModules:
 ./b1: {
   "resolvedModule": {
     "resolvedFileName": "b1.ts",
@@ -170,7 +170,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs1: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -188,7 +188,7 @@ File: f2.ts
 import { B } from './b2';
 import { BB } from './f1';
 (new BB).x; (new BB).y;
-resolvedModules: 
+resolvedModules:
 ./b2: {
   "resolvedModule": {
     "resolvedFileName": "b2.ts",
@@ -205,7 +205,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -275,7 +275,7 @@ File: f1.ts
 import { B } from './b1';
 export let BB = B;
 declare module './b1' { interface B { y: string; } }
-resolvedModules: 
+resolvedModules:
 ./b1: {
   "resolvedModule": {
     "resolvedFileName": "b1.ts",
@@ -291,7 +291,7 @@ File: f2.ts
 import { B } from './b2';
 import { BB } from './f1';
 (new BB).x; (new BB).y;
-resolvedModules: 
+resolvedModules:
 ./b2: {
   "resolvedModule": {
     "resolvedFileName": "b2.ts",
@@ -308,7 +308,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -373,7 +373,7 @@ File: f1.ts
 import { B } from './b1';
 export let BB = B;
 declare module './b1' { interface B { y: string; } }
-resolvedModules: 
+resolvedModules:
 ./b1: {
   "resolvedModule": {
     "resolvedFileName": "b1.ts",
@@ -389,7 +389,7 @@ File: f2.ts
 import { B } from './b2';
 import { BB } from './f1';
 (new BB).x; (new BB).y;
-resolvedModules: 
+resolvedModules:
 ./b2: {
   "resolvedModule": {
     "resolvedFileName": "b2.ts",
@@ -406,7 +406,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -470,7 +470,7 @@ File: f1.ts
 
 import { B } from './b1';
 declare module './b1' { interface B { y: string; } }
-resolvedModules: 
+resolvedModules:
 ./b1: {
   "resolvedModule": {
     "resolvedFileName": "b1.ts",
@@ -486,7 +486,7 @@ File: f2.ts
 import { B } from './b2';
 import { BB } from './f1';
 (new BB).x; (new BB).y;
-resolvedModules: 
+resolvedModules:
 ./b2: {
   "resolvedModule": {
     "resolvedFileName": "b2.ts",
@@ -503,7 +503,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -565,7 +565,7 @@ File: f1.ts
 
 import { B } from './b1';
 
-resolvedModules: 
+resolvedModules:
 ./b1: {
   "resolvedModule": {
     "resolvedFileName": "b1.ts",
@@ -581,7 +581,7 @@ File: f2.ts
 import { B } from './b2';
 import { BB } from './f1';
 (new BB).x; (new BB).y;
-resolvedModules: 
+resolvedModules:
 ./b2: {
   "resolvedModule": {
     "resolvedFileName": "b2.ts",
@@ -598,7 +598,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -670,7 +670,7 @@ File: f2.ts
 import { B } from './b2';
 import { BB } from './f1';
 (new BB).x; (new BB).y;
-resolvedModules: 
+resolvedModules:
 ./b2: {
   "resolvedModule": {
     "resolvedFileName": "b2.ts",
@@ -687,7 +687,7 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs2: {
   "resolvedTypeReferenceDirective": {
     "primary": true,

--- a/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
+++ b/tests/baselines/reference/reuseProgramStructure/can-reuse-module-resolutions-from-non-modified-files.js
@@ -3,43 +3,31 @@ File: a1.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a2.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b1.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b2.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs1/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs2/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f1.ts
 /// <reference path="a1.ts"/>
@@ -141,43 +129,31 @@ File: a1.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a2.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b1.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b2.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs1/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs2/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f1.ts
 /// <reference path="a1.ts"/>
@@ -268,43 +244,31 @@ File: a1.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a2.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b1.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b2.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs1/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs2/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f1.ts
 /// <reference path="a1.ts"/>
@@ -320,7 +284,6 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f2.ts
 /// <reference path="a2.ts"/>
@@ -379,43 +342,31 @@ File: a1.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a2.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b1.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b2.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs1/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs2/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f1.ts
 
@@ -431,7 +382,6 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f2.ts
 /// <reference path="a2.ts"/>
@@ -490,43 +440,31 @@ File: a1.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a2.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b1.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b2.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs1/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs2/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f1.ts
 
@@ -541,7 +479,6 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f2.ts
 /// <reference path="a2.ts"/>
@@ -598,43 +535,31 @@ File: a1.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a2.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b1.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b2.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs1/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs2/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f1.ts
 
@@ -649,7 +574,6 @@ resolvedModules:
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f2.ts
 /// <reference path="a2.ts"/>
@@ -709,50 +633,36 @@ File: a1.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a2.ts
 
 
 let x = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b1.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b2.ts
 
 export class B { x: number; }
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs1/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: node_modules/@types/typerefs2/index.d.ts
 
 
 declare let z: string;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f1.ts
 
 
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: f2.ts
 /// <reference path="a2.ts"/>

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-a-single-module-of-a-package.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-a-single-module-of-a-package.js
@@ -3,8 +3,6 @@ File: /node_modules/b/internal.d.ts
 
 
 export const b = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -31,7 +29,6 @@ resolvedModules:
     "/node_modules/b/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -61,7 +58,6 @@ b: {
     "/node_modules/b/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -74,8 +70,6 @@ File: /node_modules/b/internal.d.ts
 
 
 export const b = 2;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -102,7 +96,6 @@ resolvedModules:
     "/node_modules/b/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -132,7 +125,6 @@ b: {
     "/node_modules/b/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-a-single-module-of-a-package.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-a-single-module-of-a-package.js
@@ -8,7 +8,7 @@ File: /node_modules/b/index.d.ts
 
 export * from './internal';
 
-resolvedModules: 
+resolvedModules:
 ./internal: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/internal.d.ts",
@@ -34,7 +34,7 @@ File: /a.ts
 
 import {b} from 'b'
 var a = b;
-resolvedModules: 
+resolvedModules:
 b: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/index.d.ts",
@@ -75,7 +75,7 @@ File: /node_modules/b/index.d.ts
 
 export * from './internal';
 
-resolvedModules: 
+resolvedModules:
 ./internal: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/internal.d.ts",
@@ -101,7 +101,7 @@ File: /a.ts
 
 import {b} from 'b'
 var a = b;
-resolvedModules: 
+resolvedModules:
 b: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -58,14 +53,11 @@ b: {
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -75,7 +67,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-imports.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -44,7 +44,7 @@ File: c.ts
 
 import x from 'b'
 var z = 1;
-resolvedModules: 
+resolvedModules:
 b: {
   "resolvedModule": {
     "resolvedFileName": "b.ts",
@@ -67,7 +67,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,15 +44,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 /// <reference path='b.ts'/>
@@ -65,8 +56,6 @@ File: a.ts
                 
 
 var x = 1
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-tripleslash-references.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -57,7 +57,7 @@ File: a.ts
 /// <reference types="typerefs1" />
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs1: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs1/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-directives.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,15 +44,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -66,7 +57,6 @@ File: a.ts
 /// <reference types="typerefs1" />
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs1: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -31,7 +31,7 @@ typerefs: {
   ]
 }
 
-automaticTypeDirectiveResolutions: 
+automaticTypeDirectiveResolutions:
 a: {
   "failedLookupLocations": [
     "node_modules/@types/a/package.json",
@@ -71,7 +71,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -85,7 +85,7 @@ typerefs: {
   ]
 }
 
-automaticTypeDirectiveResolutions: 
+automaticTypeDirectiveResolutions:
 b: {
   "failedLookupLocations": [
     "node_modules/@types/b/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
@@ -31,6 +31,19 @@ typerefs: {
   ]
 }
 
+automaticTypeDirectiveResolutions: 
+a: {
+  "failedLookupLocations": [
+    "node_modules/@types/a/package.json",
+    "node_modules/@types/a/index.d.ts",
+    "node_modules/a/package.json",
+    "node_modules/a.d.ts",
+    "node_modules/a/index.d.ts",
+    "node_modules/@types/a/package.json",
+    "node_modules/@types/a.d.ts",
+    "node_modules/@types/a/index.d.ts"
+  ]
+}
 
 MissingPaths:: ["non-existing-file.ts","lib.d.ts"]
 
@@ -72,6 +85,19 @@ typerefs: {
   ]
 }
 
+automaticTypeDirectiveResolutions: 
+b: {
+  "failedLookupLocations": [
+    "node_modules/@types/b/package.json",
+    "node_modules/@types/b/index.d.ts",
+    "node_modules/b/package.json",
+    "node_modules/b.d.ts",
+    "node_modules/b/index.d.ts",
+    "node_modules/@types/b/package.json",
+    "node_modules/@types/b.d.ts",
+    "node_modules/@types/b/index.d.ts"
+  ]
+}
 
 MissingPaths:: ["non-existing-file.ts","lib.d.ts"]
 

--- a/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-affects-type-references.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,15 +44,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -67,7 +58,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,15 +44,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -67,7 +58,6 @@ File: a.ts
 
 
 var x = 100
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-does-not-affect-imports-or-type-refs.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -58,7 +58,7 @@ File: a.ts
 
 
 var x = 100
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -31,7 +31,7 @@ typerefs: {
   ]
 }
 
-automaticTypeDirectiveResolutions: 
+automaticTypeDirectiveResolutions:
 a: {
   "failedLookupLocations": [
     "node_modules/@types/a/package.json",
@@ -71,7 +71,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -85,7 +85,7 @@ typerefs: {
   ]
 }
 
-automaticTypeDirectiveResolutions: 
+automaticTypeDirectiveResolutions:
 a: {
   "failedLookupLocations": [
     "node_modules/@types/a/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
@@ -31,6 +31,19 @@ typerefs: {
   ]
 }
 
+automaticTypeDirectiveResolutions: 
+a: {
+  "failedLookupLocations": [
+    "node_modules/@types/a/package.json",
+    "node_modules/@types/a/index.d.ts",
+    "node_modules/a/package.json",
+    "node_modules/a.d.ts",
+    "node_modules/a/index.d.ts",
+    "node_modules/@types/a/package.json",
+    "node_modules/@types/a.d.ts",
+    "node_modules/@types/a/index.d.ts"
+  ]
+}
 
 MissingPaths:: ["non-existing-file.ts","lib.d.ts"]
 
@@ -72,6 +85,19 @@ typerefs: {
   ]
 }
 
+automaticTypeDirectiveResolutions: 
+a: {
+  "failedLookupLocations": [
+    "node_modules/@types/a/package.json",
+    "node_modules/@types/a/index.d.ts",
+    "node_modules/a/package.json",
+    "node_modules/a.d.ts",
+    "node_modules/a/index.d.ts",
+    "node_modules/@types/a/package.json",
+    "node_modules/@types/a.d.ts",
+    "node_modules/@types/a/index.d.ts"
+  ]
+}
 
 MissingPaths:: ["non-existing-file.ts","lib.d.ts"]
 

--- a/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
+++ b/tests/baselines/reference/reuseProgramStructure/change-doesnot-affect-type-references.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,15 +44,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -67,7 +58,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "/a/b/node_modules/@types/typerefs/package.json",
@@ -62,7 +62,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "/a/c/node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/config-path-changes.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -53,15 +48,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -71,7 +62,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
+++ b/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
@@ -3,7 +3,7 @@ File: file1.ts
 
 import * as a from "a";
 const myX: number = a.x;
-resolvedModules: 
+resolvedModules:
 a: {
   "failedLookupLocations": [
     "node_modules/a/package.json",
@@ -68,7 +68,7 @@ File: file1.ts
 
 import * as a from "a";
 const myX: number = a.x;
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
+++ b/tests/baselines/reference/reuseProgramStructure/fetches-imports-after-npm-install.js
@@ -23,14 +23,11 @@ a: {
     "node_modules/a/index.jsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: file2.ts
 
 
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 ======== Resolving module 'a' from 'file1.ts'. ========
 Explicitly specified module resolution kind: 'Node10'.
@@ -66,8 +63,6 @@ File: node_modules/a/index.d.ts
 
 export declare let x: number;
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: file1.ts
 
@@ -90,14 +85,11 @@ a: {
     "node_modules/a/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: file2.ts
 /// <reference no-default-lib="true"/>
 
 
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 ======== Resolving module 'a' from 'file1.ts'. ========
 Explicitly specified module resolution kind: 'Node10'.

--- a/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,22 +44,16 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: non-existing-file.ts
 
 
 var x = 1
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -74,7 +63,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-file-is-created.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -63,7 +63,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -58,7 +58,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
+++ b/tests/baselines/reference/reuseProgramStructure/missing-files-remain-missing.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,15 +44,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -67,7 +58,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -58,7 +58,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/module-kind-changes.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -49,15 +44,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -67,7 +58,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/redirect-no-change.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-no-change.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -123,8 +116,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -154,14 +145,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -191,7 +179,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -230,7 +217,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-no-change.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-no-change.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -121,7 +121,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -155,7 +155,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -184,7 +184,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 const x = 1;
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export = class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -125,8 +118,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -156,14 +147,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -193,7 +181,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -232,7 +219,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-previous-duplicate-packages.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -123,7 +123,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -157,7 +157,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -186,7 +186,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -123,8 +116,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; private y: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -149,14 +140,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -186,7 +174,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -225,7 +212,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-target-changes.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -121,7 +121,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -150,7 +150,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -179,7 +179,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -123,8 +116,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -154,14 +145,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; private y: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -191,7 +179,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -230,7 +217,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-underlying-changes.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -121,7 +121,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -155,7 +155,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -184,7 +184,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-no-change.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-no-change.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -123,8 +116,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -154,14 +145,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -191,7 +179,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -230,7 +217,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-no-change.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-no-change.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -121,7 +121,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -155,7 +155,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -184,7 +184,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 const x = 1;
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export = class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -125,8 +118,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -156,14 +147,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -193,7 +181,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -232,7 +219,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-previous-duplicate-packages.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -123,7 +123,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -157,7 +157,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -186,7 +186,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -123,8 +116,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; private y: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -149,14 +140,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -186,7 +174,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -225,7 +212,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-target-changes.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -121,7 +121,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -150,7 +150,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -179,7 +179,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
@@ -3,8 +3,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -34,14 +32,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -71,7 +66,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -110,7 +104,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -123,8 +116,6 @@ File: /node_modules/a/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/a/index.d.ts
 
@@ -154,14 +145,11 @@ x: {
     "/node_modules/a/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/node_modules/x/index.d.ts
 
 
 export default class X { private x: number; private y: number; }
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /node_modules/b/index.d.ts
 
@@ -191,7 +179,6 @@ x: {
     "/node_modules/b/node_modules/x/package.json"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 
@@ -230,7 +217,6 @@ b: {
     "/node_modules/b/index.tsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/redirect-with-getSourceFileByPath-underlying-changes.js
@@ -8,7 +8,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -42,7 +42,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -71,7 +71,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",
@@ -121,7 +121,7 @@ File: /node_modules/a/index.d.ts
 
 import X from "x";
 export function a(x: X): void;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/node_modules/x/index.d.ts",
@@ -155,7 +155,7 @@ File: /node_modules/b/index.d.ts
 
 import X from "x";
 export const b: X;
-resolvedModules: 
+resolvedModules:
 x: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/b/node_modules/x/index.d.ts",
@@ -184,7 +184,7 @@ File: /a.ts
 
 import { a } from "a"; import { b } from "b";
 a(b)
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/node_modules/a/index.d.ts",

--- a/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
@@ -8,7 +8,7 @@ File: a.ts
 
 import {_} from 'b'
 var x = 1
-resolvedModules: 
+resolvedModules:
 b: {
   "resolvedModule": {
     "resolvedFileName": "b.ts",
@@ -35,7 +35,7 @@ File: a.ts
 
 import {_} from 'b'
 var x = 2
-resolvedModules: 
+resolvedModules:
 b: {
   "resolvedModule": {
     "resolvedFileName": "b.ts",
@@ -76,7 +76,7 @@ import x from 'b'
                 import y from 'c'
                 
 var x = 2
-resolvedModules: 
+resolvedModules:
 b: {
   "resolvedModule": {
     "resolvedFileName": "b.ts",

--- a/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolution-cache-follows-imports.js
@@ -3,8 +3,6 @@ File: b.ts
 
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -19,7 +17,6 @@ b: {
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -33,8 +30,6 @@ File: b.ts
 
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -49,7 +44,6 @@ b: {
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -63,8 +57,6 @@ File: a.ts
 
 
 var x = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -77,8 +69,6 @@ File: b.ts
 
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -107,7 +97,6 @@ c: {
     "c.jsx"
   ]
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
@@ -8,7 +8,7 @@ File: /a.ts
 /// <reference types='typedefs'/>
 
 var x = $
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typedefs: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -37,7 +37,7 @@ File: /a.ts
 /// <reference types='typedefs'/>
 
 var x = 2
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typedefs: {
   "resolvedTypeReferenceDirective": {
     "primary": true,
@@ -80,7 +80,7 @@ File: /a.ts
                 
 
 var x = 2
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typedefs: {
   "resolvedTypeReferenceDirective": {
     "primary": true,

--- a/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolved-type-directives-cache-follows-type-directives.js
@@ -3,14 +3,11 @@ File: /types/typedefs/index.d.ts
 
 
 declare var $: number
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 /// <reference types='typedefs'/>
 
 var x = $
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typedefs: {
   "resolvedTypeReferenceDirective": {
@@ -35,14 +32,11 @@ File: /types/typedefs/index.d.ts
 
 
 declare var $: number
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 /// <reference types='typedefs'/>
 
 var x = 2
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typedefs: {
   "resolvedTypeReferenceDirective": {
@@ -67,8 +61,6 @@ File: /a.ts
 
 
 var x = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -81,8 +73,6 @@ File: /types/typedefs/index.d.ts
 
 
 declare var $: number
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: /a.ts
 /// <reference types="typedefs"/>
@@ -90,7 +80,6 @@ File: /a.ts
                 
 
 var x = 2
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typedefs: {
   "resolvedTypeReferenceDirective": {

--- a/tests/baselines/reference/reuseProgramStructure/resolvedImports-after-re-using-an-ambient-external-module-declaration.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolvedImports-after-re-using-an-ambient-external-module-declaration.js
@@ -12,7 +12,6 @@ a: {
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -34,7 +33,6 @@ a: {
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/resolvedImports-after-re-using-an-ambient-external-module-declaration.js
+++ b/tests/baselines/reference/reuseProgramStructure/resolvedImports-after-re-using-an-ambient-external-module-declaration.js
@@ -3,7 +3,7 @@ File: /a.ts
 
 
 import * as a from "a";
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/a.ts",
@@ -24,7 +24,7 @@ File: /a.ts
 
 
 import * as aa from "a";
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/a.ts",

--- a/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
@@ -17,7 +17,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",
@@ -60,7 +60,7 @@ File: a.ts
 
 
 var x = 1
-resolvedTypeReferenceDirectiveNames: 
+resolvedTypeReferenceDirectiveNames:
 typerefs: {
   "failedLookupLocations": [
     "node_modules/@types/typerefs/package.json",

--- a/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
+++ b/tests/baselines/reference/reuseProgramStructure/rootdir-changes.js
@@ -3,15 +3,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -21,7 +17,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [
@@ -51,15 +46,11 @@ File: c.ts
 
 
 var z = 1;
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: b.ts
 /// <reference path='c.ts'/>
 
 var y = 2
-resolvedModules: undefined
-resolvedTypeReferenceDirectiveNames: undefined
 
 File: a.ts
 
@@ -69,7 +60,6 @@ File: a.ts
 
 
 var x = 1
-resolvedModules: undefined
 resolvedTypeReferenceDirectiveNames: 
 typerefs: {
   "failedLookupLocations": [

--- a/tests/baselines/reference/reuseProgramStructure/works-with-updated-SourceFiles.js
+++ b/tests/baselines/reference/reuseProgramStructure/works-with-updated-SourceFiles.js
@@ -12,7 +12,6 @@ a: {
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]
@@ -35,7 +34,6 @@ a: {
     "resolvedUsingTsExtension": false
   }
 }
-resolvedTypeReferenceDirectiveNames: undefined
 
 
 MissingPaths:: ["lib.d.ts"]

--- a/tests/baselines/reference/reuseProgramStructure/works-with-updated-SourceFiles.js
+++ b/tests/baselines/reference/reuseProgramStructure/works-with-updated-SourceFiles.js
@@ -3,7 +3,7 @@ File: /a.ts
 
 
 import * as a from "a";a;
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/a.ts",
@@ -25,7 +25,7 @@ File: /a.ts
 'use strict';
 
 import * as a from "a";a;
-resolvedModules: 
+resolvedModules:
 a: {
   "resolvedModule": {
     "resolvedFileName": "/a.ts",


### PR DESCRIPTION
Even though `resolvedModules` and `resolvedTypeReferenceDirectiveNames` are marked internal, it wont stop API users from using them directly so for now i have added `getResolvedModule` and `forEachResolvedModule` and their corresponding type ref APIs on program.
This is in anticipation of using module resolution cache when available as module resolution storage rather than custom map here. I might not be able to get that before Friday so just creating infra for future improvements. 