### PR TITLE
Partially revert PR 55723 to fix OOM in testing

### DIFF
--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -366,7 +366,12 @@ export class CompilerHost implements ts.CompilerHost {
         // reused across multiple tests. In that case, we cache the SourceFile we parse
         // so that it can be reused across multiple tests to avoid the cost of
         // repeatedly parsing the same file over and over (such as lib.d.ts).
-        const cacheKey = this.vfs.shadowRoot && `SourceFile[languageVersionOrOptions=${languageVersionOrOptions !== undefined ? JSON.stringify(languageVersionOrOptions) : undefined},setParentNodes=${this._setParentNodes}]`;
+
+        // TODO(jakebailey): the below is totally wrong; languageVersionOrOptions can be an object,
+        // and so any options bag will be keyed as "[object Object]", and we'll incorrectly share
+        // SourceFiles parsed with different options. But fixing this doesn't expose any bugs and
+        // doubles the memory usage of a test run, so I'm leaving it for now.
+        const cacheKey = this.vfs.shadowRoot && `SourceFile[languageVersionOrOptions=${languageVersionOrOptions},setParentNodes=${this._setParentNodes}]`;
         if (cacheKey) {
             const meta = this.vfs.filemeta(canonicalFileName);
             const sourceFileFromMetadata = meta.get(cacheKey) as ts.SourceFile | undefined;


### PR DESCRIPTION
#55723 fixes an actual bug in our testing infrastructure, but doubles memory usage on my machine, causing OOMs where I hit the max memory limit of my system and the OS starts killing processes.

This PR effectively reverts that change. I hate this, but I hate OOMing my machine more and #55723 was not supposed to have caused any behavior changes.