### PR TITLE
fix(55841) - Array/Tuple indexed by `never` behaving like indexed by `number`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17783,6 +17783,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (objectType.flags & (TypeFlags.Any | TypeFlags.Never)) {
                 return objectType;
             }
+            if (indexType.flags & TypeFlags.Never) {
+                return neverType;
+            }
             // If no index signature is applicable, we default to the string index signature. In effect, this means the string
             // index signature applies even when accessing with a symbol-like type.
             const indexInfo = getApplicableIndexInfo(objectType, indexType) || getIndexInfoOfType(objectType, stringType);
@@ -17813,9 +17816,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     return getUnionType([indexInfo.type, missingType]);
                 }
                 return indexInfo.type;
-            }
-            if (indexType.flags & TypeFlags.Never) {
-                return neverType;
             }
             if (isJSLiteralType(objectType)) {
                 return anyType;

--- a/tests/baselines/reference/indexIntoArrayTupleObjectWithNever.js
+++ b/tests/baselines/reference/indexIntoArrayTupleObjectWithNever.js
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/indexIntoArrayTupleObjectWithNever.ts] ////
+
+//// [indexIntoArrayTupleObjectWithNever.ts]
+type A = { a: 42 }[never]
+
+type B = [42][never]
+
+type C = Array<42>[never]
+
+//// [indexIntoArrayTupleObjectWithNever.js]

--- a/tests/baselines/reference/indexIntoArrayTupleObjectWithNever.symbols
+++ b/tests/baselines/reference/indexIntoArrayTupleObjectWithNever.symbols
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/indexIntoArrayTupleObjectWithNever.ts] ////
+
+=== indexIntoArrayTupleObjectWithNever.ts ===
+type A = { a: 42 }[never]
+>A : Symbol(A, Decl(indexIntoArrayTupleObjectWithNever.ts, 0, 0))
+>a : Symbol(a, Decl(indexIntoArrayTupleObjectWithNever.ts, 0, 10))
+
+type B = [42][never]
+>B : Symbol(B, Decl(indexIntoArrayTupleObjectWithNever.ts, 0, 25))
+
+type C = Array<42>[never]
+>C : Symbol(C, Decl(indexIntoArrayTupleObjectWithNever.ts, 2, 20))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/indexIntoArrayTupleObjectWithNever.types
+++ b/tests/baselines/reference/indexIntoArrayTupleObjectWithNever.types
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/indexIntoArrayTupleObjectWithNever.ts] ////
+
+=== indexIntoArrayTupleObjectWithNever.ts ===
+type A = { a: 42 }[never]
+>A : never
+>a : 42
+
+type B = [42][never]
+>B : never
+
+type C = Array<42>[never]
+>C : never
+

--- a/tests/cases/compiler/indexIntoArrayTupleObjectWithNever.ts
+++ b/tests/cases/compiler/indexIntoArrayTupleObjectWithNever.ts
@@ -1,0 +1,5 @@
+type A = { a: 42 }[never]
+
+type B = [42][never]
+
+type C = Array<42>[never]

--- a/tests/cases/fourslash/quickInfoNestedGenericCalls.ts
+++ b/tests/cases/fourslash/quickInfoNestedGenericCalls.ts
@@ -14,9 +14,9 @@ verify.quickInfoAt("1", `const m: <"foo">(s: {
 
 // the exact generic type params are not important in this test (they could change with changes to the inference algorithm)
 // it's important though that they both display the same types
-verify.quickInfoAt("2", `const $: <unknown, string>(s: string) => {
-    $: unknown;
+verify.quickInfoAt("2", `const $: <never, never>(s: never) => {
+    $: never;
 }`);
-verify.quickInfoAt("3", `const $: <unknown, string>(s: string) => {
-    $: unknown;
+verify.quickInfoAt("3", `const $: <never, never>(s: never) => {
+    $: never;
 }`);


### PR DESCRIPTION
Fixes #55841 by doing the check before the one about index signatures.

Closed because: even if `{ a: 42 }[never]` is already computed as `never`, something like `Record<string, boolean>[never]` is `boolean`, not `never`. So the current behaviour of arrays/tuples is not consistent with the one of object literals, but is consistent with other cases.
