### PR TITLE
Fix new-release-branch workflow

### DIFF
--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -21,15 +21,15 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
       - uses: actions/setup-node@v3
       - run: |
           npm --version
           # corepack enable npm
           npm install -g $(jq -r '.packageManager' < package.json)
           npm --version
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 5
       - run: |
           git checkout -b ${{ github.event.client_payload.branch_name }}
           sed -i -e 's/"version": ".*"/"version": "${{ github.event.client_payload.package_version }}"/g' package.json

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -21,10 +21,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-node@v3
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.branch_name }}
+      - uses: actions/setup-node@v3
       - run: |
           npm --version
           # corepack enable npm


### PR DESCRIPTION
This is the only workflow which didn't checkout first, so I put this in the wrong place.

Okay, technically set-version does too, but I didn't make this mistake there, somehow.