### PR TITLE
Update dprint-typescript to 0.88.1, reformat

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -51,7 +51,7 @@
     ],
     // Note: if adding new languages, make sure settings.template.json is updated too.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.87.1.wasm",
+        "https://plugins.dprint.dev/typescript-0.88.1.wasm",
         "https://plugins.dprint.dev/prettier-0.27.0.json@3557a62b4507c55a47d8cde0683195b14d13c41dda66d0f0b0e111aed107e2fe",
         "https://plugins.dprint.dev/json-0.17.4.wasm"
     ]

--- a/src/testRunner/unittests/services/colorization.ts
+++ b/src/testRunner/unittests/services/colorization.ts
@@ -237,7 +237,7 @@ describe("unittests:: services:: Colorization", () => {
         it("LexicallyClassifiesConflictTokens", () => {
             // Test conflict markers.
             testLexicalClassification(
-"class C {\r\n\
+                "class C {\r\n\
 <<<<<<< HEAD\r\n\
     v = 1;\r\n\
 =======\r\n\
@@ -260,7 +260,7 @@ describe("unittests:: services:: Colorization", () => {
             );
 
             testLexicalClassification(
-"<<<<<<< HEAD\r\n\
+                "<<<<<<< HEAD\r\n\
 class C { }\r\n\
 =======\r\n\
 class D { }\r\n\
@@ -277,7 +277,7 @@ class D { }\r\n\
             );
 
             testLexicalClassification(
-"class C {\r\n\
+                "class C {\r\n\
 <<<<<<< HEAD\r\n\
     v = 1;\r\n\
 ||||||| merged common ancestors\r\n\
@@ -303,7 +303,7 @@ class D { }\r\n\
             );
 
             testLexicalClassification(
-"<<<<<<< HEAD\r\n\
+                "<<<<<<< HEAD\r\n\
 class C { }\r\n\
 ||||||| merged common ancestors\r\n\
 class E { }\r\n\


### PR DESCRIPTION
This fixes a formatting bug when using multi-line strings.