### PR TITLE
Bail early in getNarrowedTypeWorker if type is candidate

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28163,6 +28163,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (type.flags & TypeFlags.AnyOrUnknown) {
                 return candidate;
             }
+
+            // TODO(jakebailey): should this just be type === candidate?
+            if (isTypeIdenticalTo(type, candidate)) {
+                return candidate;
+            }
+
             // We first attempt to filter the current type, narrowing constituents as appropriate and removing
             // constituents that are unrelated to the candidate.
             const isRelated = checkDerived ? isTypeDerivedFrom : isTypeSubtypeOf;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28154,6 +28154,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         function getNarrowedTypeWorker(type: Type, candidate: Type, assumeTrue: boolean, checkDerived: boolean) {
             if (!assumeTrue) {
+                if (type === candidate) {
+                    return neverType;
+                }
                 if (checkDerived) {
                     return filterType(type, t => !isTypeDerivedFrom(t, candidate));
                 }
@@ -28163,9 +28166,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (type.flags & TypeFlags.AnyOrUnknown) {
                 return candidate;
             }
-
-            // TODO(jakebailey): should this just be type === candidate?
-            if (isTypeIdenticalTo(type, candidate)) {
+            if (type === candidate) {
                 return candidate;
             }
 


### PR DESCRIPTION
This technically handles https://github.com/microsoft/TypeScript/issues/52345#issuecomment-1737898885 and maybe #55948, bringing it back to <=4.7 levels, but I think it's a little silly to narrow something to itself. But, probably cheap to check anyhow.