### PR TITLE
fix(55637): Incorrect ES5 transpilation for 'this' usage in lambda as a constructor default parameter

### DIFF
--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -1428,6 +1428,9 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
             hierarchyFacts |= HierarchyFacts.ConstructorWithCapturedSuper;
         }
 
+        addDefaultValueAssignmentsIfNeeded(statements, constructor);
+        addRestParameterIfNeeded(statements, constructor, hasSynthesizedSuper);
+
         const mayReplaceThis = transformConstructorBodyWorker(
             prologue,
             statements,
@@ -1441,9 +1444,6 @@ export function transformES2015(context: TransformationContext): (x: SourceFile 
             /*isFirstStatement*/ true, // NOTE: this will be recalculated inside of transformConstructorBodyWorker
         );
 
-        // Add parameter defaults at the beginning of the output, with prologue statements
-        addDefaultValueAssignmentsIfNeeded(prologue, constructor);
-        addRestParameterIfNeeded(prologue, constructor, hasSynthesizedSuper);
         insertCaptureNewTargetIfNeeded(prologue, constructor);
         factory.mergeLexicalEnvironment(prologue, endLexicalEnvironment());
 

--- a/tests/baselines/reference/thisInConstructorParameter3.js
+++ b/tests/baselines/reference/thisInConstructorParameter3.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/thisInConstructorParameter3.ts] ////
+
+//// [thisInConstructorParameter3.ts]
+class C {
+    constructor(cb = (a: { }) => this.m(a)) {
+        cb({ });
+    }
+
+    private m(a: any): boolean {
+        a;
+        return true;
+    }
+}
+
+
+//// [thisInConstructorParameter3.js]
+var C = /** @class */ (function () {
+    function C(cb) {
+        var _this = this;
+        if (cb === void 0) { cb = function (a) { return _this.m(a); }; }
+        cb({});
+    }
+    C.prototype.m = function (a) {
+        a;
+        return true;
+    };
+    return C;
+}());

--- a/tests/baselines/reference/thisInConstructorParameter3.symbols
+++ b/tests/baselines/reference/thisInConstructorParameter3.symbols
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/thisInConstructorParameter3.ts] ////
+
+=== thisInConstructorParameter3.ts ===
+class C {
+>C : Symbol(C, Decl(thisInConstructorParameter3.ts, 0, 0))
+
+    constructor(cb = (a: { }) => this.m(a)) {
+>cb : Symbol(cb, Decl(thisInConstructorParameter3.ts, 1, 16))
+>a : Symbol(a, Decl(thisInConstructorParameter3.ts, 1, 22))
+>this.m : Symbol(C.m, Decl(thisInConstructorParameter3.ts, 3, 5))
+>this : Symbol(C, Decl(thisInConstructorParameter3.ts, 0, 0))
+>m : Symbol(C.m, Decl(thisInConstructorParameter3.ts, 3, 5))
+>a : Symbol(a, Decl(thisInConstructorParameter3.ts, 1, 22))
+
+        cb({ });
+>cb : Symbol(cb, Decl(thisInConstructorParameter3.ts, 1, 16))
+    }
+
+    private m(a: any): boolean {
+>m : Symbol(C.m, Decl(thisInConstructorParameter3.ts, 3, 5))
+>a : Symbol(a, Decl(thisInConstructorParameter3.ts, 5, 14))
+
+        a;
+>a : Symbol(a, Decl(thisInConstructorParameter3.ts, 5, 14))
+
+        return true;
+    }
+}
+

--- a/tests/baselines/reference/thisInConstructorParameter3.types
+++ b/tests/baselines/reference/thisInConstructorParameter3.types
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/thisInConstructorParameter3.ts] ////
+
+=== thisInConstructorParameter3.ts ===
+class C {
+>C : C
+
+    constructor(cb = (a: { }) => this.m(a)) {
+>cb : (a: {}) => boolean
+>(a: { }) => this.m(a) : (a: {}) => boolean
+>a : {}
+>this.m(a) : boolean
+>this.m : (a: any) => boolean
+>this : this
+>m : (a: any) => boolean
+>a : {}
+
+        cb({ });
+>cb({ }) : boolean
+>cb : (a: {}) => boolean
+>{ } : {}
+    }
+
+    private m(a: any): boolean {
+>m : (a: any) => boolean
+>a : any
+
+        a;
+>a : any
+
+        return true;
+>true : true
+    }
+}
+

--- a/tests/cases/compiler/thisInConstructorParameter3.ts
+++ b/tests/cases/compiler/thisInConstructorParameter3.ts
@@ -1,0 +1,11 @@
+// @target: es5
+class C {
+    constructor(cb = (a: { }) => this.m(a)) {
+        cb({ });
+    }
+
+    private m(a: any): boolean {
+        a;
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #55637