### PR TITLE
Prefer local module specifier over relative node_modules ones in auto-import, even when it reaches into a monorepo package

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -877,7 +877,7 @@ function getNewImportFixes(
     const rejectNodeModulesRelativePaths = moduleResolutionUsesNodeModules(moduleResolution);
     const getModuleSpecifiers = fromCacheOnly
         ? (moduleSymbol: Symbol) => ({ moduleSpecifiers: moduleSpecifiers.tryGetModuleSpecifiersFromCache(moduleSymbol, sourceFile, moduleSpecifierResolutionHost, preferences), computedWithoutCache: false })
-        : (moduleSymbol: Symbol, checker: TypeChecker) => moduleSpecifiers.getModuleSpecifiersWithCacheInfo(moduleSymbol, checker, compilerOptions, sourceFile, moduleSpecifierResolutionHost, preferences);
+        : (moduleSymbol: Symbol, checker: TypeChecker) => moduleSpecifiers.getModuleSpecifiersWithCacheInfo(moduleSymbol, checker, compilerOptions, sourceFile, moduleSpecifierResolutionHost, preferences, /*options*/ undefined, /*forAutoImport*/ true);
 
     let computedWithoutCacheCount = 0;
     const fixes = flatMap(exportInfo, (exportInfo, i) => {

--- a/tests/cases/fourslash/server/autoImportRelativePathToMonorepoPackage.ts
+++ b/tests/cases/fourslash/server/autoImportRelativePathToMonorepoPackage.ts
@@ -1,0 +1,27 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+//// {
+////   "compilerOptions": {
+////     "module": "nodenext"
+////   }
+//// }
+
+// @Filename: /packages/app/dist/index.d.ts
+//// import {} from "utils";
+//// export const app: number;
+
+// @Filename: /packages/utils/package.json
+//// { "name": "utils", "version": "1.0.0", "main": "dist/index.js" }
+
+// @Filename: /packages/utils/dist/index.d.ts
+//// export const x: number;
+
+// @link: /packages/utils -> /packages/app/node_modules/utils
+
+// @Filename: /script.ts
+//// import {} from "./packages/app/dist/index.js";
+//// x/**/
+
+goTo.marker("");
+verify.importFixModuleSpecifiers("", ["./packages/utils/dist/index.js"]);


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #52635, probably

As described in the big comment, `computeModuleSpecifiers` returns relative module specifiers that include `/node_modules/` at a higher priority than ones that reach into a symlinked monorepo package. Both possible module specifiers are likely to be unportable, but the `node_modules` one specifically triggers the declaration emitter to issue a portability error, which is what you want (probably) when this happens during declaration emit. But the same code path is used for auto-imports, which subsequently filters out module specifiers containing `/node_modules/`, but at this point has already committed to offering an auto-import. So, for auto-imports, of the two bad possible answers, we want to ensure we return the one that doesn’t contain `/node_modules/`.