### PR TITLE
Recognize `export * as default` as a syntactic default export for synthetic default detection

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4022,7 +4022,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function isSyntacticDefault(node: Node) {
-        return ((isExportAssignment(node) && !node.isExportEquals) || hasSyntacticModifier(node, ModifierFlags.Default) || isExportSpecifier(node));
+        return ((isExportAssignment(node) && !node.isExportEquals)
+            || hasSyntacticModifier(node, ModifierFlags.Default)
+            || isExportSpecifier(node)
+            || isNamespaceExport(node));
     }
 
     function getUsageModeForExpression(usage: Expression) {

--- a/tests/baselines/reference/exportAsNamespace5.js
+++ b/tests/baselines/reference/exportAsNamespace5.js
@@ -2,6 +2,7 @@
 
 //// [three.d.ts]
 export type Named = 0;
+declare const Named: 0;
 
 //// [two.d.ts]
 export * as default from "./three";
@@ -9,7 +10,9 @@ export * as default from "./three";
 //// [one.ts]
 import ns from "./two";
 type Alias = ns.Named;
+ns.Named;
 
 
 //// [one.js]
-export {};
+import ns from "./two";
+ns.Named;

--- a/tests/baselines/reference/exportAsNamespace5.js
+++ b/tests/baselines/reference/exportAsNamespace5.js
@@ -1,0 +1,15 @@
+//// [tests/cases/conformance/es2020/modules/exportAsNamespace5.ts] ////
+
+//// [three.d.ts]
+export type Named = 0;
+
+//// [two.d.ts]
+export * as default from "./three";
+
+//// [one.ts]
+import ns from "./two";
+type Alias = ns.Named;
+
+
+//// [one.js]
+export {};

--- a/tests/baselines/reference/exportAsNamespace5.symbols
+++ b/tests/baselines/reference/exportAsNamespace5.symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/es2020/modules/exportAsNamespace5.ts] ////
+
+=== three.d.ts ===
+export type Named = 0;
+>Named : Symbol(Named, Decl(three.d.ts, 0, 0))
+
+=== two.d.ts ===
+export * as default from "./three";
+>default : Symbol(default, Decl(two.d.ts, 0, 6))
+
+=== one.ts ===
+import ns from "./two";
+>ns : Symbol(ns, Decl(one.ts, 0, 6))
+
+type Alias = ns.Named;
+>Alias : Symbol(Alias, Decl(one.ts, 0, 23))
+>ns : Symbol(ns, Decl(one.ts, 0, 6))
+>Named : Symbol(ns.Named, Decl(three.d.ts, 0, 0))
+

--- a/tests/baselines/reference/exportAsNamespace5.symbols
+++ b/tests/baselines/reference/exportAsNamespace5.symbols
@@ -2,7 +2,10 @@
 
 === three.d.ts ===
 export type Named = 0;
->Named : Symbol(Named, Decl(three.d.ts, 0, 0))
+>Named : Symbol(Named, Decl(three.d.ts, 0, 0), Decl(three.d.ts, 1, 13))
+
+declare const Named: 0;
+>Named : Symbol(Named, Decl(three.d.ts, 0, 0), Decl(three.d.ts, 1, 13))
 
 === two.d.ts ===
 export * as default from "./three";
@@ -15,5 +18,10 @@ import ns from "./two";
 type Alias = ns.Named;
 >Alias : Symbol(Alias, Decl(one.ts, 0, 23))
 >ns : Symbol(ns, Decl(one.ts, 0, 6))
->Named : Symbol(ns.Named, Decl(three.d.ts, 0, 0))
+>Named : Symbol(ns.Named, Decl(three.d.ts, 0, 0), Decl(three.d.ts, 1, 13))
+
+ns.Named;
+>ns.Named : Symbol(ns.Named, Decl(three.d.ts, 0, 0), Decl(three.d.ts, 1, 13))
+>ns : Symbol(ns, Decl(one.ts, 0, 6))
+>Named : Symbol(ns.Named, Decl(three.d.ts, 0, 0), Decl(three.d.ts, 1, 13))
 

--- a/tests/baselines/reference/exportAsNamespace5.types
+++ b/tests/baselines/reference/exportAsNamespace5.types
@@ -4,6 +4,9 @@
 export type Named = 0;
 >Named : 0
 
+declare const Named: 0;
+>Named : 0
+
 === two.d.ts ===
 export * as default from "./three";
 >default : typeof import("three")
@@ -15,4 +18,9 @@ import ns from "./two";
 type Alias = ns.Named;
 >Alias : 0
 >ns : any
+
+ns.Named;
+>ns.Named : 0
+>ns : typeof ns
+>Named : 0
 

--- a/tests/baselines/reference/exportAsNamespace5.types
+++ b/tests/baselines/reference/exportAsNamespace5.types
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/es2020/modules/exportAsNamespace5.ts] ////
+
+=== three.d.ts ===
+export type Named = 0;
+>Named : 0
+
+=== two.d.ts ===
+export * as default from "./three";
+>default : typeof import("three")
+
+=== one.ts ===
+import ns from "./two";
+>ns : typeof ns
+
+type Alias = ns.Named;
+>Alias : 0
+>ns : any
+

--- a/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
+++ b/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
@@ -3,6 +3,7 @@
 
 // @filename: three.d.ts
 export type Named = 0;
+declare const Named: 0;
 
 // @filename: two.d.ts
 export * as default from "./three";
@@ -10,3 +11,4 @@ export * as default from "./three";
 // @filename: one.ts
 import ns from "./two";
 type Alias = ns.Named;
+ns.Named;

--- a/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
+++ b/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
@@ -1,0 +1,12 @@
+// @module: esnext
+// @moduleResolution: bundler
+
+// @filename: three.d.ts
+export type Named = 0;
+
+// @filename: two.d.ts
+export * as default from "./three";
+
+// @filename: one.ts
+import ns from "./two";
+type Alias = ns.Named;


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #55829 
