### PR TITLE
Update lib.dom.d.ts: `MutationObserverInit.attributeFilter` can accept an iterator

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -894,7 +894,7 @@ interface MutationObserverInit {
     /**
      * Set to a list of attribute local names (without namespace) if not all attribute mutations need to be observed and attributes is true or omitted.
      */
-    attributeFilter?: string[];
+    attributeFilter?: string[] || IterableIterator<string>;
     /**
      * Set to true if attributes is true or omitted and target's attribute value before the mutation needs to be recorded.
      */


### PR DESCRIPTION
Re-opening of https://github.com/microsoft/TypeScript/pull/50031. Please see description there.

Please point me to guidance on how to make this change, and I'll update the PR.

Closes #55990