### PR TITLE
Fix plugin reload

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1111,6 +1111,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
         // signal language service to release source files acquired from document registry
         this.languageService.dispose();
         this.languageService = undefined!;
+        this.originalLanguageService = undefined!;
     }
 
     private detachScriptInfoIfNotRoot(uncheckedFilename: string) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #55928

This PR adds `originalLanguageService` field to `Project` and makes `languageService` be a shallow clone of it (`this.languageService = { ...this.originalLanguageService };`).

Then before applying plugins `this.languageService = { ...this.originalLanguageService };` is run to restore it and avoid plugins double decorating it after a reload. I have only done this for `ConfiguredProject` because I couldn't find an equivalent of `enablePluginsWithOptions` for other project types.