### PR TITLE
Allow valid contextual keyword completions even when an auto-import by the same name exists

### DIFF
--- a/tests/cases/fourslash/completionsImportTypeKeyword.ts
+++ b/tests/cases/fourslash/completionsImportTypeKeyword.ts
@@ -1,0 +1,32 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /os.d.ts
+//// declare module "os" {
+////   export function type(): string;
+//// }
+
+// @Filename: /index.ts
+//// type/**/
+
+verify.completions({
+  marker: "",
+  includes: [
+    {
+      name: "type",
+      sortText: completion.SortText.GlobalsOrKeywords,
+    },
+    {
+      name: "type",
+      source: "os",
+      sourceDisplay: "os",
+      hasAction: true,
+      sortText: completion.SortText.AutoImportSuggestions
+    }
+  ],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    allowIncompleteCompletions: true,
+  },
+});


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

See code comment and linked issue comments for description.

Fixes #55607
