### PR TITLE
Reuse more input nodes when they contain local type parameter references

### DIFF
--- a/tests/baselines/reference/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations.types
+++ b/tests/baselines/reference/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations.types
@@ -13,7 +13,7 @@ module A {
     }
 
     export var UnitSquare : {
->UnitSquare : { top: {    left: Point;    right: Point;}; bottom: {    left: Point;    right: Point;}; }
+>UnitSquare : { top: { left: Point; right: Point; }; bottom: { left: Point; right: Point; }; }
 
         top: { left: Point, right: Point },
 >top : { left: Point; right: Point; }

--- a/tests/baselines/reference/FunctionAndModuleWithSameNameAndCommonRoot.types
+++ b/tests/baselines/reference/FunctionAndModuleWithSameNameAndCommonRoot.types
@@ -35,7 +35,7 @@ module A {
 
 === test.ts ===
 var fn: () => { x: number; y: number };
->fn : () => {    x: number;    y: number;}
+>fn : () => { x: number; y: number; }
 >x : number
 >y : number
 

--- a/tests/baselines/reference/FunctionAndModuleWithSameNameAndDifferentCommonRoot.types
+++ b/tests/baselines/reference/FunctionAndModuleWithSameNameAndDifferentCommonRoot.types
@@ -35,7 +35,7 @@ module B {
 
 === test.ts ===
 var fn: () => { x: number; y: number };
->fn : () => {    x: number;    y: number;}
+>fn : () => { x: number; y: number; }
 >x : number
 >y : number
 

--- a/tests/baselines/reference/ModuleWithExportedAndNonExportedImportAlias.types
+++ b/tests/baselines/reference/ModuleWithExportedAndNonExportedImportAlias.types
@@ -84,7 +84,7 @@ var p = Geometry.Origin;
 >Origin : A.Point
 
 var line: { start: { x: number; y: number }; end: { x: number; y: number; } };
->line : { start: {    x: number;    y: number;}; end: {    x: number;    y: number;}; }
+>line : { start: { x: number; y: number; }; end: { x: number; y: number; }; }
 >start : { x: number; y: number; }
 >x : number
 >y : number

--- a/tests/baselines/reference/accessorsOverrideProperty8.types
+++ b/tests/baselines/reference/accessorsOverrideProperty8.types
@@ -16,7 +16,7 @@ type AnyCtor<P extends object> = new (...a: any[]) => P
 >a : any[]
 
 declare function classWithProperties<T extends { [key: string]: Types }, P extends object>(properties: T, klass: AnyCtor<P>): {
->classWithProperties : <T extends { [key: string]: Types; }, P extends object>(properties: T, klass: AnyCtor<P>) => {    new (): P & Properties<T>;    prototype: P & Properties<T>;}
+>classWithProperties : <T extends { [key: string]: Types; }, P extends object>(properties: T, klass: AnyCtor<P>) => { new (): P & Properties<T>; prototype: P & Properties<T>; }
 >key : string
 >properties : T
 >klass : AnyCtor<P>

--- a/tests/baselines/reference/aliasUsageInObjectLiteral.types
+++ b/tests/baselines/reference/aliasUsageInObjectLiteral.types
@@ -30,7 +30,7 @@ var b: { x: IHasVisualizationModel } = { x: moduleA };
 >moduleA : typeof moduleA
 
 var c: { y: { z: IHasVisualizationModel } } = { y: { z: moduleA } };
->c : { y: {    z: IHasVisualizationModel;}; }
+>c : { y: { z: IHasVisualizationModel; }; }
 >y : { z: IHasVisualizationModel; }
 >z : IHasVisualizationModel
 >{ y: { z: moduleA } } : { y: { z: typeof moduleA; }; }

--- a/tests/baselines/reference/anyAssignabilityInInheritance.types
+++ b/tests/baselines/reference/anyAssignabilityInInheritance.types
@@ -85,7 +85,7 @@ var r3 = foo3(a); // any
 >a : any
 
 declare function foo7(x: { bar: number }): { bar: number };
->foo7 : { (x: {    bar: number;}): {    bar: number;}; (x: any): any; }
+>foo7 : { (x: { bar: number; }): { bar: number; }; (x: any): any; }
 >x : { bar: number; }
 >bar : number
 >bar : number

--- a/tests/baselines/reference/argumentExpressionContextualTyping.types
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.types
@@ -47,7 +47,7 @@ var o = { x: ["string", 1], y: { c: true, d: "world", e: 3 } };
 >3 : 3
 
 var o1: { x: [string, number], y: { c: boolean, d: string, e: number } } = { x: ["string", 1], y: { c: true, d: "world", e: 3 } };
->o1 : { x: [string, number]; y: {    c: boolean;    d: string;    e: number;}; }
+>o1 : { x: [string, number]; y: { c: boolean; d: string; e: number; }; }
 >x : [string, number]
 >y : { c: boolean; d: string; e: number; }
 >c : boolean

--- a/tests/baselines/reference/arrayLiteralWithMultipleBestCommonTypes.types
+++ b/tests/baselines/reference/arrayLiteralWithMultipleBestCommonTypes.types
@@ -58,28 +58,28 @@ var es = [(x: string) => 2, (x: Object) => 1]; // { (x:string) => number }[]
 >1 : 1
 
 var fs = [(a: { x: number; y?: number }) => 1, (b: { x: number; z?: number }) => 2]; // (a: { x: number; y?: number }) => number[]
->fs : (((a: {    x: number;    y?: number;}) => number) | ((b: {    x: number;    z?: number;}) => number))[]
->[(a: { x: number; y?: number }) => 1, (b: { x: number; z?: number }) => 2] : (((a: {    x: number;    y?: number;}) => number) | ((b: {    x: number;    z?: number;}) => number))[]
->(a: { x: number; y?: number }) => 1 : (a: {    x: number;    y?: number;}) => number
+>fs : (((a: { x: number; y?: number; }) => number) | ((b: { x: number; z?: number; }) => number))[]
+>[(a: { x: number; y?: number }) => 1, (b: { x: number; z?: number }) => 2] : (((a: { x: number; y?: number; }) => number) | ((b: { x: number; z?: number; }) => number))[]
+>(a: { x: number; y?: number }) => 1 : (a: { x: number; y?: number; }) => number
 >a : { x: number; y?: number; }
 >x : number
 >y : number
 >1 : 1
->(b: { x: number; z?: number }) => 2 : (b: {    x: number;    z?: number;}) => number
+>(b: { x: number; z?: number }) => 2 : (b: { x: number; z?: number; }) => number
 >b : { x: number; z?: number; }
 >x : number
 >z : number
 >2 : 2
 
 var gs = [(b: { x: number; z?: number }) => 2, (a: { x: number; y?: number }) => 1]; // (b: { x: number; z?: number }) => number[]
->gs : (((b: {    x: number;    z?: number;}) => number) | ((a: {    x: number;    y?: number;}) => number))[]
->[(b: { x: number; z?: number }) => 2, (a: { x: number; y?: number }) => 1] : (((b: {    x: number;    z?: number;}) => number) | ((a: {    x: number;    y?: number;}) => number))[]
->(b: { x: number; z?: number }) => 2 : (b: {    x: number;    z?: number;}) => number
+>gs : (((b: { x: number; z?: number; }) => number) | ((a: { x: number; y?: number; }) => number))[]
+>[(b: { x: number; z?: number }) => 2, (a: { x: number; y?: number }) => 1] : (((b: { x: number; z?: number; }) => number) | ((a: { x: number; y?: number; }) => number))[]
+>(b: { x: number; z?: number }) => 2 : (b: { x: number; z?: number; }) => number
 >b : { x: number; z?: number; }
 >x : number
 >z : number
 >2 : 2
->(a: { x: number; y?: number }) => 1 : (a: {    x: number;    y?: number;}) => number
+>(a: { x: number; y?: number }) => 1 : (a: { x: number; y?: number; }) => number
 >a : { x: number; y?: number; }
 >x : number
 >y : number

--- a/tests/baselines/reference/arraySigChecking.types
+++ b/tests/baselines/reference/arraySigChecking.types
@@ -52,7 +52,7 @@ myArray = [[1, 2]];
 >2 : 2
 
 function isEmpty(l: { length: number }) {
->isEmpty : (l: {    length: number;}) => boolean
+>isEmpty : (l: { length: number; }) => boolean
 >l : { length: number; }
 >length : number
 

--- a/tests/baselines/reference/assignmentCompatBug5.types
+++ b/tests/baselines/reference/assignmentCompatBug5.types
@@ -2,7 +2,7 @@
 
 === assignmentCompatBug5.ts ===
 function foo1(x: { a: number; }) { }
->foo1 : (x: {    a: number;}) => void
+>foo1 : (x: { a: number; }) => void
 >x : { a: number; }
 >a : number
 

--- a/tests/baselines/reference/assignmentCompatFunctionsWithOptionalArgs.types
+++ b/tests/baselines/reference/assignmentCompatFunctionsWithOptionalArgs.types
@@ -2,7 +2,7 @@
 
 === assignmentCompatFunctionsWithOptionalArgs.ts ===
 function foo(x: { id: number; name?: string; }): void;
->foo : (x: {    id: number;    name?: string;}) => void
+>foo : (x: { id: number; name?: string; }) => void
 >x : { id: number; name?: string; }
 >id : number
 >name : string

--- a/tests/baselines/reference/assignmentCompatOnNew.types
+++ b/tests/baselines/reference/assignmentCompatOnNew.types
@@ -5,7 +5,7 @@ class Foo{};
 >Foo : Foo
 
 function bar(x: {new(): Foo;}){}
->bar : (x: {    new (): Foo;}) => void
+>bar : (x: { new (): Foo; }) => void
 >x : new () => Foo
 
 bar(Foo); // Error, but should be allowed

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures3.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures3.types
@@ -355,7 +355,7 @@ b13 = a13; // ok
 >a13 : (x: Base[], y: Derived[]) => Derived[]
 
 var b14: <T>(x: { a: T; b: T }) => T; 
->b14 : <T>(x: { a: T; b: T; }) => T
+>b14 : <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures3.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures3.types
@@ -76,7 +76,7 @@ var a10: (...x: Derived[]) => Derived;
 >x : Derived[]
 
 var a11: (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -94,7 +94,7 @@ var a13: (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
 >y : Derived[]
 
 var a14: (x: { a: string; b: number }) => Object;
->a14 : (x: {    a: string;    b: number;}) => Object
+>a14 : (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -276,10 +276,10 @@ b8 = a8; // ok
 >a8 : (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
 
 var b9: <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => U; 
->b9 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>b9 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -355,7 +355,7 @@ b13 = a13; // ok
 >a13 : (x: Base[], y: Derived[]) => Derived[]
 
 var b14: <T>(x: { a: T; b: T }) => T; 
->b14 : <T>(x: {    a: T;    b: T;}) => T
+>b14 : <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures4.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures4.types
@@ -224,7 +224,7 @@ module Errors {
 >a12 : (x: Base[], y: Derived2[]) => Derived[]
 
         var b15: <T>(x: { a: T; b: T }) => T; 
->b15 : <T>(x: { a: T; b: T; }) => T
+>b15 : <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -240,7 +240,7 @@ module Errors {
 >a15 : (x: { a: string; b: number; }) => number
 
         var b15a: <T extends Base>(x: { a: T; b: T }) => number; 
->b15a : <T extends Base>(x: { a: T; b: T; }) => number
+>b15a : <T extends Base>(x: {    a: T;    b: T;}) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures4.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures4.types
@@ -52,7 +52,7 @@ module Errors {
 >x : Base[]
 
         var a11: (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -75,7 +75,7 @@ module Errors {
 
             };
         var a15: (x: { a: string; b: number }) => number;
->a15 : (x: {    a: string;    b: number;}) => number
+>a15 : (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -160,10 +160,10 @@ module Errors {
 >a7 : (x: (arg: Base) => Derived) => (r: Base) => Derived2
 
         var b8: <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U; 
->b8 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: number;}) => U) => (r: T) => U
+>b8 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: number;}) => U
+>y : (arg2: { foo: number; }) => U
 >arg2 : { foo: number; }
 >foo : number
 >r : T
@@ -224,7 +224,7 @@ module Errors {
 >a12 : (x: Base[], y: Derived2[]) => Derived[]
 
         var b15: <T>(x: { a: T; b: T }) => T; 
->b15 : <T>(x: {    a: T;    b: T;}) => T
+>b15 : <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -240,7 +240,7 @@ module Errors {
 >a15 : (x: { a: string; b: number; }) => number
 
         var b15a: <T extends Base>(x: { a: T; b: T }) => number; 
->b15a : <T extends Base>(x: {    a: T;    b: T;}) => number
+>b15a : <T extends Base>(x: { a: T; b: T; }) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures5.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures5.types
@@ -50,7 +50,7 @@ var a6: <T extends Base>(x: (arg: T) => Derived) => T;
 >arg : T
 
 var a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -58,13 +58,13 @@ var a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
 >bar : T
 
 var a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: { a: T; b: T; }) => T[]
+>a15 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
 var a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -194,7 +194,7 @@ b6 = a6; // ok
 >a6 : <T extends Base>(x: (arg: T) => Derived) => T
 
 var b11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>b11 : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -212,7 +212,7 @@ b11 = a11; // ok
 >a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b15: <U, V>(x: { a: U; b: V; }) => U[]; 
->b15 : <U, V>(x: { a: U; b: V; }) => U[]
+>b15 : <U, V>(x: {    a: U;    b: V;}) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
@@ -228,7 +228,7 @@ b15 = a15; // ok
 >a15 : <T>(x: { a: T; b: T; }) => T[]
 
 var b16: <T>(x: { a: T; b: T }) => T[]; 
->b16 : <T>(x: { a: T; b: T; }) => T[]
+>b16 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures5.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures5.types
@@ -50,7 +50,7 @@ var a6: <T extends Base>(x: (arg: T) => Derived) => T;
 >arg : T
 
 var a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -58,13 +58,13 @@ var a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
 >bar : T
 
 var a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
 var a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -194,7 +194,7 @@ b6 = a6; // ok
 >a6 : <T extends Base>(x: (arg: T) => Derived) => T
 
 var b11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>b11 : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -212,7 +212,7 @@ b11 = a11; // ok
 >a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b15: <U, V>(x: { a: U; b: V; }) => U[]; 
->b15 : <U, V>(x: {    a: U;    b: V;}) => U[]
+>b15 : <U, V>(x: { a: U; b: V; }) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
@@ -228,7 +228,7 @@ b15 = a15; // ok
 >a15 : <T>(x: { a: T; b: T; }) => T[]
 
 var b16: <T>(x: { a: T; b: T }) => T[]; 
->b16 : <T>(x: {    a: T;    b: T;}) => T[]
+>b16 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures6.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures6.types
@@ -51,7 +51,7 @@ interface A {
 >arg : T
 
     a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -59,13 +59,13 @@ interface A {
 >bar : T
 
     a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: { a: T; b: T; }) => T[]
+>a15 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -167,7 +167,7 @@ b5 = x.a5;
 >a5 : <T, U>(x: (arg: T) => U) => T
 
 var b11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>b11 : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -189,7 +189,7 @@ b11 = x.a11;
 >a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b16: <T>(x: { a: T; b: T }) => T[]; 
->b16 : <T>(x: { a: T; b: T; }) => T[]
+>b16 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures6.types
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures6.types
@@ -51,7 +51,7 @@ interface A {
 >arg : T
 
     a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -59,13 +59,13 @@ interface A {
 >bar : T
 
     a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -167,7 +167,7 @@ b5 = x.a5;
 >a5 : <T, U>(x: (arg: T) => U) => T
 
 var b11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>b11 : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -189,7 +189,7 @@ b11 = x.a11;
 >a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b16: <T>(x: { a: T; b: T }) => T[]; 
->b16 : <T>(x: {    a: T;    b: T;}) => T[]
+>b16 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures3.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures3.types
@@ -355,7 +355,7 @@ b13 = a13; // ok
 >a13 : new (x: Base[], y: Derived[]) => Derived[]
 
 var b14: new <T>(x: { a: T; b: T }) => T; 
->b14 : new <T>(x: { a: T; b: T; }) => T
+>b14 : new <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures3.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures3.types
@@ -76,7 +76,7 @@ var a10: new (...x: Derived[]) => Derived;
 >x : Derived[]
 
 var a11: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -94,7 +94,7 @@ var a13: new (x: Array<Base>, y: Array<Derived>) => Array<Derived>;
 >y : Derived[]
 
 var a14: new (x: { a: string; b: number }) => Object;
->a14 : new (x: {    a: string;    b: number;}) => Object
+>a14 : new (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -276,10 +276,10 @@ b8 = a8; // ok
 >a8 : new (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived
 
 var b9: new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => U; 
->b9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>b9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -355,7 +355,7 @@ b13 = a13; // ok
 >a13 : new (x: Base[], y: Derived[]) => Derived[]
 
 var b14: new <T>(x: { a: T; b: T }) => T; 
->b14 : new <T>(x: {    a: T;    b: T;}) => T
+>b14 : new <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures4.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures4.types
@@ -52,7 +52,7 @@ module Errors {
 >x : Base[]
 
         var a11: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -75,7 +75,7 @@ module Errors {
 
             };
         var a15: new (x: { a: string; b: number }) => number;
->a15 : new (x: {    a: string;    b: number;}) => number
+>a15 : new (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -160,10 +160,10 @@ module Errors {
 >a7 : new (x: (arg: Base) => Derived) => (r: Base) => Derived2
 
         var b8: new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U; 
->b8 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: number;}) => U) => (r: T) => U
+>b8 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: number;}) => U
+>y : (arg2: { foo: number; }) => U
 >arg2 : { foo: number; }
 >foo : number
 >r : T
@@ -224,7 +224,7 @@ module Errors {
 >a12 : new (x: Base[], y: Derived2[]) => Derived[]
 
         var b15: new <T>(x: { a: T; b: T }) => T; 
->b15 : new <T>(x: {    a: T;    b: T;}) => T
+>b15 : new <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -240,7 +240,7 @@ module Errors {
 >a15 : new (x: { a: string; b: number; }) => number
 
         var b15a: new <T extends Base>(x: { a: T; b: T }) => number; 
->b15a : new <T extends Base>(x: {    a: T;    b: T;}) => number
+>b15a : new <T extends Base>(x: { a: T; b: T; }) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures4.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures4.types
@@ -224,7 +224,7 @@ module Errors {
 >a12 : new (x: Base[], y: Derived2[]) => Derived[]
 
         var b15: new <T>(x: { a: T; b: T }) => T; 
->b15 : new <T>(x: { a: T; b: T; }) => T
+>b15 : new <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -240,7 +240,7 @@ module Errors {
 >a15 : new (x: { a: string; b: number; }) => number
 
         var b15a: new <T extends Base>(x: { a: T; b: T }) => number; 
->b15a : new <T extends Base>(x: { a: T; b: T; }) => number
+>b15a : new <T extends Base>(x: {    a: T;    b: T;}) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures5.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures5.types
@@ -50,7 +50,7 @@ var a6: new <T extends Base>(x: new (arg: T) => Derived) => T;
 >arg : T
 
 var a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -58,13 +58,13 @@ var a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
 >bar : T
 
 var a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: { a: T; b: T; }) => T[]
+>a15 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
 var a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -194,7 +194,7 @@ b6 = a6; // ok
 >a6 : new <T extends Base>(x: new (arg: T) => Derived) => T
 
 var b11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>b11 : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -212,7 +212,7 @@ b11 = a11; // ok
 >a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b15: new <U, V>(x: { a: U; b: V; }) => U[]; 
->b15 : new <U, V>(x: { a: U; b: V; }) => U[]
+>b15 : new <U, V>(x: {    a: U;    b: V;}) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
@@ -228,7 +228,7 @@ b15 = a15; // ok
 >a15 : new <T>(x: { a: T; b: T; }) => T[]
 
 var b16: new <T>(x: { a: T; b: T }) => T[]; 
->b16 : new <T>(x: { a: T; b: T; }) => T[]
+>b16 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures5.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures5.types
@@ -50,7 +50,7 @@ var a6: new <T extends Base>(x: new (arg: T) => Derived) => T;
 >arg : T
 
 var a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -58,13 +58,13 @@ var a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
 >bar : T
 
 var a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
 var a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -194,7 +194,7 @@ b6 = a6; // ok
 >a6 : new <T extends Base>(x: new (arg: T) => Derived) => T
 
 var b11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>b11 : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -212,7 +212,7 @@ b11 = a11; // ok
 >a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b15: new <U, V>(x: { a: U; b: V; }) => U[]; 
->b15 : new <U, V>(x: {    a: U;    b: V;}) => U[]
+>b15 : new <U, V>(x: { a: U; b: V; }) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
@@ -228,7 +228,7 @@ b15 = a15; // ok
 >a15 : new <T>(x: { a: T; b: T; }) => T[]
 
 var b16: new <T>(x: { a: T; b: T }) => T[]; 
->b16 : new <T>(x: {    a: T;    b: T;}) => T[]
+>b16 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures6.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures6.types
@@ -51,7 +51,7 @@ interface A {
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -59,13 +59,13 @@ interface A {
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: { a: T; b: T; }) => T[]
+>a15 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -167,7 +167,7 @@ b5 = x.a5;
 >a5 : new <T, U>(x: (arg: T) => U) => T
 
 var b11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>b11 : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -189,7 +189,7 @@ b11 = x.a11;
 >a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b16: new <T>(x: { a: T; b: T }) => T[]; 
->b16 : new <T>(x: { a: T; b: T; }) => T[]
+>b16 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures6.types
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures6.types
@@ -51,7 +51,7 @@ interface A {
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -59,13 +59,13 @@ interface A {
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -167,7 +167,7 @@ b5 = x.a5;
 >a5 : new <T, U>(x: (arg: T) => U) => T
 
 var b11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->b11 : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>b11 : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -189,7 +189,7 @@ b11 = x.a11;
 >a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var b16: new <T>(x: { a: T; b: T }) => T[]; 
->b16 : new <T>(x: {    a: T;    b: T;}) => T[]
+>b16 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/assignmentToParenthesizedIdentifiers.types
+++ b/tests/baselines/reference/assignmentToParenthesizedIdentifiers.types
@@ -186,7 +186,7 @@ fn = () => 3; // Bug 823548: Should be error (fn is not a reference)
 >3 : 3
 
 function fn2(x: number, y: { t: number }) {
->fn2 : (x: number, y: {    t: number;}) => void
+>fn2 : (x: number, y: { t: number; }) => void
 >x : number
 >y : { t: number; }
 >t : number

--- a/tests/baselines/reference/asyncFunctionReturnExpressionErrorSpans.types
+++ b/tests/baselines/reference/asyncFunctionReturnExpressionErrorSpans.types
@@ -3,10 +3,10 @@
 === asyncFunctionReturnExpressionErrorSpans.ts ===
 interface Foo {
     bar: {
->bar : { baz: {    inner: {        thing: string;    };}; }
+>bar : { baz: { inner: { thing: string; }; }; }
 
         baz: {
->baz : { inner: {    thing: string;}; }
+>baz : { inner: { thing: string; }; }
 
             inner: {
 >inner : { thing: string; }

--- a/tests/baselines/reference/awaitUnionPromise.types
+++ b/tests/baselines/reference/awaitUnionPromise.types
@@ -17,7 +17,7 @@ interface IAsyncEnumerator<T> {
 >next3 : () => Promise<T | {}>
 
     next4(): Promise<T | { x: string }>;
->next4 : () => Promise<T | {    x: string;}>
+>next4 : () => Promise<T | { x: string; }>
 >x : string
 }
 

--- a/tests/baselines/reference/callChain.2.types
+++ b/tests/baselines/reference/callChain.2.types
@@ -19,8 +19,8 @@ o2?.b();
 >b : () => number
 
 declare const o3: { b: (() => { c: string }) | undefined };
->o3 : { b: (() => {    c: string;}) | undefined; }
->b : () => {    c: string;}
+>o3 : { b: (() => { c: string; }) | undefined; }
+>b : () => { c: string; }
 >c : string
 
 o3.b?.().c;

--- a/tests/baselines/reference/callChain.3.types
+++ b/tests/baselines/reference/callChain.3.types
@@ -5,7 +5,7 @@ declare function absorb<T>(): T;
 >absorb : <T>() => T
 
 declare const a: { m?<T>(obj: {x: T}): T } | undefined;
->a : { m?<T>(obj: { x: T; }): T; } | undefined
+>a : { m?<T>(obj: {    x: T;}): T; } | undefined
 >m : (<T>(obj: {    x: T;}) => T) | undefined
 >obj : { x: T; }
 >x : T

--- a/tests/baselines/reference/callChain.3.types
+++ b/tests/baselines/reference/callChain.3.types
@@ -5,8 +5,8 @@ declare function absorb<T>(): T;
 >absorb : <T>() => T
 
 declare const a: { m?<T>(obj: {x: T}): T } | undefined;
->a : { m?<T>(obj: {    x: T;}): T; } | undefined
->m : (<T>(obj: {    x: T;}) => T) | undefined
+>a : { m?<T>(obj: { x: T; }): T; } | undefined
+>m : (<T>(obj: { x: T; }) => T) | undefined
 >obj : { x: T; }
 >x : T
 

--- a/tests/baselines/reference/callChain.types
+++ b/tests/baselines/reference/callChain.types
@@ -108,8 +108,8 @@ o2?.["b"](1, ...[2, 3], 4);
 >4 : 4
 
 declare const o3: { b: ((...args: any[]) => { c: string }) | undefined };
->o3 : { b: ((...args: any[]) => {    c: string;}) | undefined; }
->b : ((...args: any[]) => {    c: string;}) | undefined
+>o3 : { b: ((...args: any[]) => { c: string; }) | undefined; }
+>b : ((...args: any[]) => { c: string; }) | undefined
 >args : any[]
 >c : string
 

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
@@ -233,7 +233,7 @@ interface I extends A {
 >y : T
 
     a14: <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : <T, U>(x: { a: T; b: U; }) => T
+>a14 : <T, U>(x: {    a: T;    b: U;}) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
@@ -78,7 +78,7 @@ interface A { // T
 >x : Derived[]
 
     a11: (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -96,7 +96,7 @@ interface A { // T
 >y : Derived[]
 
     a14: (x: { a: string; b: number }) => Object;
->a14 : (x: {    a: string;    b: number;}) => Object
+>a14 : (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -204,10 +204,10 @@ interface I extends A {
 >r : T
 
     a9: <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => U; // ok, same as a8 with compatible object literal
->a9 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>a9 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -233,7 +233,7 @@ interface I extends A {
 >y : T
 
     a14: <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : <T, U>(x: {    a: T;    b: U;}) => T
+>a14 : <T, U>(x: { a: T; b: U; }) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance3.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance3.types
@@ -52,7 +52,7 @@ module Errors {
 >x : Base[]
 
             a11: (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -75,7 +75,7 @@ module Errors {
 
             };
             a15: (x: { a: string; b: number }) => number;
->a15 : (x: {    a: string;    b: number;}) => number
+>a15 : (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -154,10 +154,10 @@ module Errors {
 
         interface I4 extends A {
             a8: <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U; // error, type mismatch
->a8 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: number;}) => U) => (r: T) => U
+>a8 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: number;}) => U
+>y : (arg2: { foo: number; }) => U
 >arg2 : { foo: number; }
 >foo : number
 >r : T
@@ -185,7 +185,7 @@ module Errors {
 
         interface I6 extends A {
             a15: <T>(x: { a: T; b: T }) => T; // error, T is {} which isn't an acceptable return type
->a15 : <T>(x: {    a: T;    b: T;}) => T
+>a15 : <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -193,7 +193,7 @@ module Errors {
 
         interface I7 extends A {
             a15: <T extends Base>(x: { a: T; b: T }) => number; // error, T defaults to Base, which is not compatible with number or string
->a15 : <T extends Base>(x: {    a: T;    b: T;}) => number
+>a15 : <T extends Base>(x: { a: T; b: T; }) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance3.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance3.types
@@ -185,7 +185,7 @@ module Errors {
 
         interface I6 extends A {
             a15: <T>(x: { a: T; b: T }) => T; // error, T is {} which isn't an acceptable return type
->a15 : <T>(x: { a: T; b: T; }) => T
+>a15 : <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -193,7 +193,7 @@ module Errors {
 
         interface I7 extends A {
             a15: <T extends Base>(x: { a: T; b: T }) => number; // error, T defaults to Base, which is not compatible with number or string
->a15 : <T extends Base>(x: { a: T; b: T; }) => number
+>a15 : <T extends Base>(x: {    a: T;    b: T;}) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance4.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance4.types
@@ -52,7 +52,7 @@ interface A { // T
 >arg : T
 
     a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -60,13 +60,13 @@ interface A { // T
 >bar : T
 
     a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -140,7 +140,7 @@ interface I extends A {
 >arg : T
 
     a11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; // ok
->a11 : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>a11 : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -148,13 +148,13 @@ interface I extends A {
 >bar : U
 
     a15: <U, V>(x: { a: U; b: V; }) => U[]; // ok, T = U, T = V
->a15 : <U, V>(x: {    a: U;    b: V;}) => U[]
+>a15 : <U, V>(x: { a: U; b: V; }) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 
     a16: <T>(x: { a: T; b: T }) => T[]; // ok, more general parameter type
->a16 : <T>(x: {    a: T;    b: T;}) => T[]
+>a16 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance4.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance4.types
@@ -52,7 +52,7 @@ interface A { // T
 >arg : T
 
     a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -60,13 +60,13 @@ interface A { // T
 >bar : T
 
     a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: { a: T; b: T; }) => T[]
+>a15 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -140,7 +140,7 @@ interface I extends A {
 >arg : T
 
     a11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; // ok
->a11 : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>a11 : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -148,13 +148,13 @@ interface I extends A {
 >bar : U
 
     a15: <U, V>(x: { a: U; b: V; }) => U[]; // ok, T = U, T = V
->a15 : <U, V>(x: { a: U; b: V; }) => U[]
+>a15 : <U, V>(x: {    a: U;    b: V;}) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 
     a16: <T>(x: { a: T; b: T }) => T[]; // ok, more general parameter type
->a16 : <T>(x: { a: T; b: T; }) => T[]
+>a16 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
@@ -183,7 +183,7 @@ interface I extends B {
 >y : T
 
     a14: <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : <T, U>(x: { a: T; b: U; }) => T
+>a14 : <T, U>(x: {    a: T;    b: U;}) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
@@ -79,7 +79,7 @@ interface A { // T
 >x : Derived[]
 
     a11: (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -97,7 +97,7 @@ interface A { // T
 >y : Derived[]
 
     a14: (x: { a: string; b: number }) => Object;
->a14 : (x: {    a: string;    b: number;}) => Object
+>a14 : (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -154,10 +154,10 @@ interface I extends B {
 >r : T
 
     a9: <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => U; // ok, same as a8 with compatible object literal
->a9 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>a9 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -183,7 +183,7 @@ interface I extends B {
 >y : T
 
     a14: <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : <T, U>(x: {    a: T;    b: U;}) => T
+>a14 : <T, U>(x: { a: T; b: U; }) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance6.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance6.types
@@ -54,7 +54,7 @@ interface A { // T
 >arg : T
 
     a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -62,13 +62,13 @@ interface A { // T
 >bar : T
 
     a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: { a: T; b: T; }) => T[]
+>a15 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -109,7 +109,7 @@ interface I5<T> extends A {
 
 interface I7<T> extends A {
     a11: <U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->a11 : <U>(x: {    foo: T;}, y: { foo: U; bar: U; }) => Base
+>a11 : <U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance6.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance6.types
@@ -54,7 +54,7 @@ interface A { // T
 >arg : T
 
     a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -62,13 +62,13 @@ interface A { // T
 >bar : T
 
     a15: <T>(x: { a: T; b: T }) => T[];
->a15 : <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -109,7 +109,7 @@ interface I5<T> extends A {
 
 interface I7<T> extends A {
     a11: <U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->a11 : <U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>a11 : <U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -119,7 +119,7 @@ interface I7<T> extends A {
 
 interface I9<T> extends A {
     a16: (x: { a: T; b: T }) => T[]; 
->a16 : (x: {    a: T;    b: T;}) => T[]
+>a16 : (x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/callsOnComplexSignatures.types
+++ b/tests/baselines/reference/callsOnComplexSignatures.types
@@ -112,17 +112,17 @@ function test3(items: string[] | number[]) {
 }
 
 function test4(
->test4 : (arg1: ((...objs: {    x: number;}[]) => number) | ((...objs: {    y: number;}[]) => number), arg2: ((a: {    x: number;}, b: object) => number) | ((a: object, b: {    x: number;}) => number), arg3: ((a: {    x: number;}, ...objs: {    y: number;}[]) => number) | ((...objs: {    x: number;}[]) => number), arg4: ((a?: {    x: number;}, b?: {    x: number;}) => number) | ((a?: {    y: number;}) => number), arg5: ((a?: {    x: number;}, ...b: {    x: number;}[]) => number) | ((a?: {    y: number;}) => number), arg6: ((a?: {    x: number;}, b?: {    x: number;}) => number) | ((...a: {    y: number;}[]) => number)) => void
+>test4 : (arg1: ((...objs: { x: number; }[]) => number) | ((...objs: { y: number; }[]) => number), arg2: ((a: { x: number; }, b: object) => number) | ((a: object, b: { x: number; }) => number), arg3: ((a: { x: number; }, ...objs: { y: number; }[]) => number) | ((...objs: { x: number; }[]) => number), arg4: ((a?: { x: number; }, b?: { x: number; }) => number) | ((a?: { y: number; }) => number), arg5: ((a?: { x: number; }, ...b: { x: number; }[]) => number) | ((a?: { y: number; }) => number), arg6: ((a?: { x: number; }, b?: { x: number; }) => number) | ((...a: { y: number; }[]) => number)) => void
 
     arg1: ((...objs: {x: number}[]) => number) | ((...objs: {y: number}[]) => number),
->arg1 : ((...objs: {    x: number;}[]) => number) | ((...objs: {    y: number;}[]) => number)
+>arg1 : ((...objs: { x: number; }[]) => number) | ((...objs: { y: number; }[]) => number)
 >objs : { x: number; }[]
 >x : number
 >objs : { y: number; }[]
 >y : number
 
     arg2: ((a: {x: number}, b: object) => number) | ((a: object, b: {x: number}) => number),
->arg2 : ((a: {    x: number;}, b: object) => number) | ((a: object, b: {    x: number;}) => number)
+>arg2 : ((a: { x: number; }, b: object) => number) | ((a: object, b: { x: number; }) => number)
 >a : { x: number; }
 >x : number
 >b : object
@@ -131,7 +131,7 @@ function test4(
 >x : number
 
     arg3: ((a: {x: number}, ...objs: {y: number}[]) => number) | ((...objs: {x: number}[]) => number),
->arg3 : ((a: {    x: number;}, ...objs: {    y: number;}[]) => number) | ((...objs: {    x: number;}[]) => number)
+>arg3 : ((a: { x: number; }, ...objs: { y: number; }[]) => number) | ((...objs: { x: number; }[]) => number)
 >a : { x: number; }
 >x : number
 >objs : { y: number; }[]
@@ -140,7 +140,7 @@ function test4(
 >x : number
 
     arg4: ((a?: {x: number}, b?: {x: number}) => number) | ((a?: {y: number}) => number),
->arg4 : ((a?: {    x: number;}, b?: {    x: number;}) => number) | ((a?: {    y: number;}) => number)
+>arg4 : ((a?: { x: number; }, b?: { x: number; }) => number) | ((a?: { y: number; }) => number)
 >a : { x: number; } | undefined
 >x : number
 >b : { x: number; } | undefined
@@ -149,7 +149,7 @@ function test4(
 >y : number
 
     arg5: ((a?: {x: number}, ...b: {x: number}[]) => number) | ((a?: {y: number}) => number),
->arg5 : ((a?: {    x: number;}, ...b: {    x: number;}[]) => number) | ((a?: {    y: number;}) => number)
+>arg5 : ((a?: { x: number; }, ...b: { x: number; }[]) => number) | ((a?: { y: number; }) => number)
 >a : { x: number; } | undefined
 >x : number
 >b : { x: number; }[]
@@ -158,7 +158,7 @@ function test4(
 >y : number
 
     arg6: ((a?: {x: number}, b?: {x: number}) => number) | ((...a: {y: number}[]) => number),
->arg6 : ((a?: {    x: number;}, b?: {    x: number;}) => number) | ((...a: {    y: number;}[]) => number)
+>arg6 : ((a?: { x: number; }, b?: { x: number; }) => number) | ((...a: { y: number; }[]) => number)
 >a : { x: number; } | undefined
 >x : number
 >b : { x: number; } | undefined
@@ -360,7 +360,7 @@ function test5() {
 
     // Union of all intrinsics and components of `any`
     function App(props: { component:React.ReactType }) {
->App : (props: {    component: React.ReactType;}) => JSX.Element
+>App : (props: { component: React.ReactType; }) => JSX.Element
 >props : { component: React.ReactType; }
 >component : React.ReactType<any>
 >React : any

--- a/tests/baselines/reference/chainedSpecializationToObjectTypeLiteral.types
+++ b/tests/baselines/reference/chainedSpecializationToObjectTypeLiteral.types
@@ -18,7 +18,7 @@ interface Sequence<T> {
 >value : T
 
     groupBy<K>(keySelector: (value: T) => K): Sequence<{ key: K; items: T[]; }>;
->groupBy : <K>(keySelector: (value: T) => K) => Sequence<{    key: K;    items: T[];}>
+>groupBy : <K>(keySelector: (value: T) => K) => Sequence<{ key: K; items: T[]; }>
 >keySelector : (value: T) => K
 >value : T
 >key : K

--- a/tests/baselines/reference/checkJsxSubtleSkipContextSensitiveBug.types
+++ b/tests/baselines/reference/checkJsxSubtleSkipContextSensitiveBug.types
@@ -29,7 +29,7 @@ class AsyncLoader<TResult> extends React.Component<AsyncLoaderProps<TResult>> {
 }
 
 async function load(): Promise<{ success: true } | ErrorResult> {
->load : () => Promise<{    success: true;} | ErrorResult>
+>load : () => Promise<{ success: true; } | ErrorResult>
 >success : true
 >true : true
 

--- a/tests/baselines/reference/checkObjectDefineProperty.types
+++ b/tests/baselines/reference/checkObjectDefineProperty.types
@@ -179,7 +179,7 @@ Object.defineProperty(x, "zipStr", {
  * @param {{name: string}} named
  */
 function takeName(named) { return named.name; }
->takeName : (named: {    name: string;}) => string
+>takeName : (named: { name: string; }) => string
 >named : { name: string; }
 >named.name : string
 >named : { name: string; }

--- a/tests/baselines/reference/circularInstantiationExpression.types
+++ b/tests/baselines/reference/circularInstantiationExpression.types
@@ -8,6 +8,6 @@ declare function foo<T>(t: T): typeof foo<T>;
 
 foo("");
 >foo("") : (t: string) => any
->foo : <T>(t: T) => (t: T) => any
+>foo : <T>(t: T) => typeof foo<T>
 >"" : ""
 

--- a/tests/baselines/reference/classExtendsInterfaceInExpression.types
+++ b/tests/baselines/reference/classExtendsInterfaceInExpression.types
@@ -4,7 +4,7 @@
 interface A {}
 
 function factory(a: any): {new(): Object} {
->factory : (a: any) => {    new (): Object;}
+>factory : (a: any) => { new (): Object; }
 >a : any
 
   return null;

--- a/tests/baselines/reference/coAndContraVariantInferences.types
+++ b/tests/baselines/reference/coAndContraVariantInferences.types
@@ -20,10 +20,10 @@ declare function fab(arg: A | B): void;
 >arg : A | B
 
 declare function foo<T>(x: { kind: T }, f: (arg: { kind: T }) => void): void;
->foo : <T>(x: {    kind: T;}, f: (arg: {    kind: T;}) => void) => void
+>foo : <T>(x: { kind: T; }, f: (arg: { kind: T; }) => void) => void
 >x : { kind: T; }
 >kind : T
->f : (arg: {    kind: T;}) => void
+>f : (arg: { kind: T; }) => void
 >arg : { kind: T; }
 >kind : T
 

--- a/tests/baselines/reference/complicatedPrivacy.types
+++ b/tests/baselines/reference/complicatedPrivacy.types
@@ -45,7 +45,7 @@ module m1 {
     }
 
     export function f2(arg1: { x?: C1, y: number }) {
->f2 : (arg1: {    x?: C1;    y: number;}) => void
+>f2 : (arg1: { x?: C1; y: number; }) => void
 >arg1 : { x?: C1; y: number; }
 >x : C1
 >y : number
@@ -62,7 +62,7 @@ module m1 {
     }
 
     export function f4(arg1: 
->f4 : (arg1: {    [number]: C1;}) => void
+>f4 : (arg1: { [number]: C1; }) => void
 >arg1 : {}
     {
     [number]: C1; // Used to be indexer, now it is a computed property

--- a/tests/baselines/reference/computedPropertiesInDestructuring1.types
+++ b/tests/baselines/reference/computedPropertiesInDestructuring1.types
@@ -51,32 +51,32 @@ let [{[foo2()]: bar5}] = [{bar: "bar"}];
 >"bar" : "bar"
 
 function f1({["bar"]: x}: { bar: number }) {}
->f1 : ({ ["bar"]: x }: {    bar: number;}) => void
+>f1 : ({ ["bar"]: x }: { bar: number; }) => void
 >"bar" : "bar"
 >x : number
 >bar : number
 
 function f2({[foo]: x}: { bar: number }) {}
->f2 : ({ [foo]: x }: {    bar: number;}) => void
+>f2 : ({ [foo]: x }: { bar: number; }) => void
 >foo : string
 >x : any
 >bar : number
 
 function f3({[foo2()]: x}: { bar: number }) {}
->f3 : ({ [foo2()]: x }: {    bar: number;}) => void
+>f3 : ({ [foo2()]: x }: { bar: number; }) => void
 >foo2() : string
 >foo2 : () => string
 >x : any
 >bar : number
 
 function f4([{[foo]: x}]: [{ bar: number }]) {}
->f4 : ([{ [foo]: x }]: [{    bar: number;}]) => void
+>f4 : ([{ [foo]: x }]: [{ bar: number; }]) => void
 >foo : string
 >x : any
 >bar : number
 
 function f5([{[foo2()]: x}]: [{ bar: number }]) {}
->f5 : ([{ [foo2()]: x }]: [{    bar: number;}]) => void
+>f5 : ([{ [foo2()]: x }]: [{ bar: number; }]) => void
 >foo2() : string
 >foo2 : () => string
 >x : any

--- a/tests/baselines/reference/computedPropertiesInDestructuring1_ES6.types
+++ b/tests/baselines/reference/computedPropertiesInDestructuring1_ES6.types
@@ -58,32 +58,32 @@ let [{[foo2()]: bar5}] = [{bar: "bar"}];
 >"bar" : "bar"
 
 function f1({["bar"]: x}: { bar: number }) {}
->f1 : ({ ["bar"]: x }: {    bar: number;}) => void
+>f1 : ({ ["bar"]: x }: { bar: number; }) => void
 >"bar" : "bar"
 >x : number
 >bar : number
 
 function f2({[foo]: x}: { bar: number }) {}
->f2 : ({ [foo]: x }: {    bar: number;}) => void
+>f2 : ({ [foo]: x }: { bar: number; }) => void
 >foo : string
 >x : any
 >bar : number
 
 function f3({[foo2()]: x}: { bar: number }) {}
->f3 : ({ [foo2()]: x }: {    bar: number;}) => void
+>f3 : ({ [foo2()]: x }: { bar: number; }) => void
 >foo2() : string
 >foo2 : () => string
 >x : any
 >bar : number
 
 function f4([{[foo]: x}]: [{ bar: number }]) {}
->f4 : ([{ [foo]: x }]: [{    bar: number;}]) => void
+>f4 : ([{ [foo]: x }]: [{ bar: number; }]) => void
 >foo : string
 >x : any
 >bar : number
 
 function f5([{[foo2()]: x}]: [{ bar: number }]) {}
->f5 : ([{ [foo2()]: x }]: [{    bar: number;}]) => void
+>f5 : ([{ [foo2()]: x }]: [{ bar: number; }]) => void
 >foo2() : string
 >foo2 : () => string
 >x : any

--- a/tests/baselines/reference/conditionalTypeAssignabilityWhenDeferred.types
+++ b/tests/baselines/reference/conditionalTypeAssignabilityWhenDeferred.types
@@ -19,7 +19,7 @@ function select<
 >valueProp : TValueProp
 
 export function func<XX extends string>(x: XX, tipos: { value: XX }[]) {
->func : <XX extends string>(x: XX, tipos: {    value: XX;}[]) => void
+>func : <XX extends string>(x: XX, tipos: { value: XX; }[]) => void
 >x : XX
 >tipos : { value: XX; }[]
 >value : XX
@@ -100,7 +100,7 @@ function f<T>(t: T) {
 }
 
 function f2<T>(t1: { x: T; y: T }, t2: T extends T ? { x: T; y: T } : never) {
->f2 : <T>(t1: {    x: T;    y: T;}, t2: T extends T ? {    x: T;    y: T;} : never) => void
+>f2 : <T>(t1: { x: T; y: T; }, t2: T extends T ? { x: T; y: T; } : never) => void
 >t1 : { x: T; y: T; }
 >x : T
 >y : T

--- a/tests/baselines/reference/conditionalTypeDoesntSpinForever.types
+++ b/tests/baselines/reference/conditionalTypeDoesntSpinForever.types
@@ -40,7 +40,7 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >name : any
 
       name: <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {name: TYPE}>
->name : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & { name: TYPE; }>
+>name : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {    name: TYPE;}>
 >t : TYPE
 >name : TYPE
     }
@@ -176,7 +176,7 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >record : any
 
       identifier: <TYPE extends Partial<SO_FAR["record"]>>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {identifier: TYPE}>
->identifier : <TYPE extends Partial<SO_FAR["record"]>>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & { identifier: TYPE; }>
+>identifier : <TYPE extends Partial<SO_FAR["record"]>>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {    identifier: TYPE;}>
 >t : TYPE
 >identifier : TYPE
 
@@ -236,7 +236,7 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >record : any
 
       record: <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {record: TYPE}>
->record : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & { record: TYPE; }>
+>record : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {    record: TYPE;}>
 >t : TYPE
 >record : TYPE
     }

--- a/tests/baselines/reference/conditionalTypeDoesntSpinForever.types
+++ b/tests/baselines/reference/conditionalTypeDoesntSpinForever.types
@@ -40,7 +40,7 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >name : any
 
       name: <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {name: TYPE}>
->name : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {    name: TYPE;}>
+>name : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & { name: TYPE; }>
 >t : TYPE
 >name : TYPE
     }
@@ -92,12 +92,12 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >storedAs : any
 
       storedAsJsonEncodedRedisString: () => BuildPubSubRecordType<SO_FAR & {storedAs: PubSubRecordIsStoredInRedisAsA.jsonEncodedRedisString}>;
->storedAsJsonEncodedRedisString : () => BuildPubSubRecordType<SO_FAR & {    storedAs: PubSubRecordIsStoredInRedisAsA.jsonEncodedRedisString;}>
+>storedAsJsonEncodedRedisString : () => BuildPubSubRecordType<SO_FAR & { storedAs: PubSubRecordIsStoredInRedisAsA.jsonEncodedRedisString; }>
 >storedAs : PubSubRecordIsStoredInRedisAsA.jsonEncodedRedisString
 >PubSubRecordIsStoredInRedisAsA : any
 
       storedRedisHash: () => BuildPubSubRecordType<SO_FAR & {storedAs: PubSubRecordIsStoredInRedisAsA.redisHash}>;
->storedRedisHash : () => BuildPubSubRecordType<SO_FAR & {    storedAs: PubSubRecordIsStoredInRedisAsA.redisHash;}>
+>storedRedisHash : () => BuildPubSubRecordType<SO_FAR & { storedAs: PubSubRecordIsStoredInRedisAsA.redisHash; }>
 >storedAs : PubSubRecordIsStoredInRedisAsA.redisHash
 >PubSubRecordIsStoredInRedisAsA : any
     }
@@ -176,7 +176,7 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >record : any
 
       identifier: <TYPE extends Partial<SO_FAR["record"]>>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {identifier: TYPE}>
->identifier : <TYPE extends Partial<SO_FAR["record"]>>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {    identifier: TYPE;}>
+>identifier : <TYPE extends Partial<SO_FAR["record"]>>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & { identifier: TYPE; }>
 >t : TYPE
 >identifier : TYPE
 
@@ -236,7 +236,7 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >record : any
 
       record: <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {record: TYPE}>
->record : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & {    record: TYPE;}>
+>record : <TYPE>(t?: TYPE) => BuildPubSubRecordType<SO_FAR & { record: TYPE; }>
 >t : TYPE
 >record : TYPE
     }
@@ -288,12 +288,12 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >maxMsToWaitBeforePublishing : any
 
       maxMsToWaitBeforePublishing: (t: number) => BuildPubSubRecordType<SO_FAR & {maxMsToWaitBeforePublishing: number}>,
->maxMsToWaitBeforePublishing : (t: number) => BuildPubSubRecordType<SO_FAR & {    maxMsToWaitBeforePublishing: number;}>
+>maxMsToWaitBeforePublishing : (t: number) => BuildPubSubRecordType<SO_FAR & { maxMsToWaitBeforePublishing: number; }>
 >t : number
 >maxMsToWaitBeforePublishing : number
 
       neverDelayPublishing: () => BuildPubSubRecordType<SO_FAR & {maxMsToWaitBeforePublishing: 0}>,
->neverDelayPublishing : () => BuildPubSubRecordType<SO_FAR & {    maxMsToWaitBeforePublishing: 0;}>
+>neverDelayPublishing : () => BuildPubSubRecordType<SO_FAR & { maxMsToWaitBeforePublishing: 0; }>
 >maxMsToWaitBeforePublishing : 0
     }
   

--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -649,7 +649,7 @@ type Foo<T> = T extends string ? boolean : number;
 type Bar<T> = T extends string ? boolean : number;
 declare const convert: <U>(value: Foo<U>) => Bar<U>;
 type Baz<T> = Foo<T>;
-declare const convert2: <T>(value: Foo<T>) => Foo<T>;
+declare const convert2: <T>(value: Foo<T>) => Baz<T>;
 declare function f31<T>(): void;
 declare function f32<T, U>(): void;
 declare function f33<T, U>(): void;

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -136,7 +136,7 @@ type T15 = Extract<Options, { q: "a" }>;  // never
 >q : "a"
 
 declare function f5<T extends Options, K extends string>(p: K): Extract<T, { k: K }>;
->f5 : <T extends Options, K extends string>(p: K) => Extract<T, {    k: K;}>
+>f5 : <T extends Options, K extends string>(p: K) => Extract<T, { k: K; }>
 >p : K
 >k : K
 

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -789,8 +789,8 @@ type Baz<T> = Foo<T>;
 >Baz : Baz<T>
 
 const convert2 = <T>(value: Foo<T>): Baz<T> => value;
->convert2 : <T>(value: Foo<T>) => Foo<T>
-><T>(value: Foo<T>): Baz<T> => value : <T>(value: Foo<T>) => Foo<T>
+>convert2 : <T>(value: Foo<T>) => Baz<T>
+><T>(value: Foo<T>): Baz<T> => value : <T>(value: Foo<T>) => Baz<T>
 >value : Foo<T>
 >value : Foo<T>
 

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -151,13 +151,13 @@ type Bar = { bar: string };
 >bar : string
 
 declare function fooBar(x: { foo: string, bar: string }): void;
->fooBar : (x: {    foo: string;    bar: string;}) => void
+>fooBar : (x: { foo: string; bar: string; }) => void
 >x : { foo: string; bar: string; }
 >foo : string
 >bar : string
 
 declare function fooBat(x: { foo: string, bat: string }): void;
->fooBat : (x: {    foo: string;    bat: string;}) => void
+>fooBat : (x: { foo: string; bat: string; }) => void
 >x : { foo: string; bat: string; }
 >foo : string
 >bat : string

--- a/tests/baselines/reference/conditionalTypesSimplifyWhenTrivial.types
+++ b/tests/baselines/reference/conditionalTypesSimplifyWhenTrivial.types
@@ -59,8 +59,8 @@ type ExcludeWithDefault<T, U, D = never> = T extends U ? D : T;
 >ExcludeWithDefault : ExcludeWithDefault<T, U, D>
 
 const fn5 = <Params>(
->fn5 : <Params>(params: Pick<Params, ExcludeWithDefault<keyof Params, never, never>>) => Params
-><Params>(    params: Pick<Params, ExcludeWithDefault<keyof Params, never>>,): Params => params : <Params>(params: Pick<Params, ExcludeWithDefault<keyof Params, never, never>>) => Params
+>fn5 : <Params>(params: Pick<Params, ExcludeWithDefault<keyof Params, never>>) => Params
+><Params>(    params: Pick<Params, ExcludeWithDefault<keyof Params, never>>,): Params => params : <Params>(params: Pick<Params, ExcludeWithDefault<keyof Params, never>>) => Params
 
     params: Pick<Params, ExcludeWithDefault<keyof Params, never>>,
 >params : Pick<Params, ExcludeWithDefault<keyof Params, never, never>>
@@ -83,8 +83,8 @@ function fn6<T>(x: ExcludeWithDefault<T, never>) {
 }
 
 const fn7 = <Params>(
->fn7 : <Params>(params: Pick<Params, ExtractWithDefault<keyof Params, keyof Params, never>>) => Params
-><Params>(    params: Pick<Params, ExtractWithDefault<keyof Params, keyof Params>>,): Params => params : <Params>(params: Pick<Params, ExtractWithDefault<keyof Params, keyof Params, never>>) => Params
+>fn7 : <Params>(params: Pick<Params, ExtractWithDefault<keyof Params, keyof Params>>) => Params
+><Params>(    params: Pick<Params, ExtractWithDefault<keyof Params, keyof Params>>,): Params => params : <Params>(params: Pick<Params, ExtractWithDefault<keyof Params, keyof Params>>) => Params
 
     params: Pick<Params, ExtractWithDefault<keyof Params, keyof Params>>,
 >params : Pick<Params, ExtractWithDefault<keyof Params, keyof Params, never>>

--- a/tests/baselines/reference/conflictingDeclarationsImportFromNamespace2.types
+++ b/tests/baselines/reference/conflictingDeclarationsImportFromNamespace2.types
@@ -9,7 +9,7 @@ declare module "./index" {
 
     interface LoDashStatic {
       pick: <T extends object, U extends keyof T>(
->pick : <T extends object, U extends keyof T>(object: T, ...props: U[]) => Pick<T, U>
+>pick : <T extends object, U extends keyof T>(object: T, ...props: Array<U>) => Pick<T, U>
 
         object: T,
 >object : T

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
@@ -233,7 +233,7 @@ interface I extends A {
 >y : T
 
     a14: new <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : new <T, U>(x: { a: T; b: U; }) => T
+>a14 : new <T, U>(x: {    a: T;    b: U;}) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
@@ -78,7 +78,7 @@ interface A { // T
 >x : Derived[]
 
     a11: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -96,7 +96,7 @@ interface A { // T
 >y : Derived[]
 
     a14: new (x: { a: string; b: number }) => Object;
->a14 : new (x: {    a: string;    b: number;}) => Object
+>a14 : new (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -204,10 +204,10 @@ interface I extends A {
 >r : T
 
     a9: new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => U; // ok, same as a8 with compatible object literal
->a9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>a9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -233,7 +233,7 @@ interface I extends A {
 >y : T
 
     a14: new <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : new <T, U>(x: {    a: T;    b: U;}) => T
+>a14 : new <T, U>(x: { a: T; b: U; }) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.types
@@ -161,7 +161,7 @@ module Errors {
 
         interface I6 extends A {
             a15: new <T>(x: { a: T; b: T }) => T; // error, T is {} which isn't an acceptable return type
->a15 : new <T>(x: { a: T; b: T; }) => T
+>a15 : new <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -169,7 +169,7 @@ module Errors {
 
         interface I7 extends A {
             a15: new <T extends Base>(x: { a: T; b: T }) => number; // error, T defaults to Base, which is not compatible with number or string
->a15 : new <T extends Base>(x: { a: T; b: T; }) => number
+>a15 : new <T extends Base>(x: {    a: T;    b: T;}) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.types
@@ -52,7 +52,7 @@ module Errors {
 >x : Base[]
 
             a11: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -75,7 +75,7 @@ module Errors {
 
             };
             a15: new (x: { a: string; b: number }) => number;
->a15 : new (x: {    a: string;    b: number;}) => number
+>a15 : new (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -130,10 +130,10 @@ module Errors {
 
         interface I4 extends A {
             a8: new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U; // error, type mismatch
->a8 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: number;}) => U) => (r: T) => U
+>a8 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: number;}) => U
+>y : (arg2: { foo: number; }) => U
 >arg2 : { foo: number; }
 >foo : number
 >r : T
@@ -161,7 +161,7 @@ module Errors {
 
         interface I6 extends A {
             a15: new <T>(x: { a: T; b: T }) => T; // error, T is {} which isn't an acceptable return type
->a15 : new <T>(x: {    a: T;    b: T;}) => T
+>a15 : new <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -169,7 +169,7 @@ module Errors {
 
         interface I7 extends A {
             a15: new <T extends Base>(x: { a: T; b: T }) => number; // error, T defaults to Base, which is not compatible with number or string
->a15 : new <T extends Base>(x: {    a: T;    b: T;}) => number
+>a15 : new <T extends Base>(x: { a: T; b: T; }) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance4.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance4.types
@@ -52,7 +52,7 @@ interface A { // T
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -60,13 +60,13 @@ interface A { // T
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: { a: T; b: T; }) => T[]
+>a15 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -160,7 +160,7 @@ interface I extends A {
 >arg : T
 
     a11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; // ok
->a11 : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>a11 : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -168,13 +168,13 @@ interface I extends A {
 >bar : U
 
     a15: new <U, V>(x: { a: U; b: V; }) => U[]; // ok, T = U, T = V
->a15 : new <U, V>(x: { a: U; b: V; }) => U[]
+>a15 : new <U, V>(x: {    a: U;    b: V;}) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 
     a16: new <T>(x: { a: T; b: T }) => T[]; // ok, more general parameter type
->a16 : new <T>(x: { a: T; b: T; }) => T[]
+>a16 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance4.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance4.types
@@ -52,7 +52,7 @@ interface A { // T
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -60,13 +60,13 @@ interface A { // T
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -160,7 +160,7 @@ interface I extends A {
 >arg : T
 
     a11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; // ok
->a11 : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>a11 : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -168,13 +168,13 @@ interface I extends A {
 >bar : U
 
     a15: new <U, V>(x: { a: U; b: V; }) => U[]; // ok, T = U, T = V
->a15 : new <U, V>(x: {    a: U;    b: V;}) => U[]
+>a15 : new <U, V>(x: { a: U; b: V; }) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 
     a16: new <T>(x: { a: T; b: T }) => T[]; // ok, more general parameter type
->a16 : new <T>(x: {    a: T;    b: T;}) => T[]
+>a16 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
@@ -183,7 +183,7 @@ interface I extends B {
 >y : T
 
     a14: new <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : new <T, U>(x: { a: T; b: U; }) => T
+>a14 : new <T, U>(x: {    a: T;    b: U;}) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
@@ -79,7 +79,7 @@ interface A { // T
 >x : Derived[]
 
     a11: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -97,7 +97,7 @@ interface A { // T
 >y : Derived[]
 
     a14: new (x: { a: string; b: number }) => Object;
->a14 : new (x: {    a: string;    b: number;}) => Object
+>a14 : new (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -154,10 +154,10 @@ interface I extends B {
 >r : T
 
     a9: new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => U; // ok, same as a8 with compatible object literal
->a9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>a9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -183,7 +183,7 @@ interface I extends B {
 >y : T
 
     a14: new <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : new <T, U>(x: {    a: T;    b: U;}) => T
+>a14 : new <T, U>(x: { a: T; b: U; }) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance6.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance6.types
@@ -54,7 +54,7 @@ interface A { // T
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -62,13 +62,13 @@ interface A { // T
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: { a: T; b: T; }) => T[]
+>a15 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -109,7 +109,7 @@ interface I5<T> extends A {
 
 interface I7<T> extends A {
     a11: new <U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->a11 : new <U>(x: {    foo: T;}, y: { foo: U; bar: U; }) => Base
+>a11 : new <U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance6.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance6.types
@@ -54,7 +54,7 @@ interface A { // T
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -62,13 +62,13 @@ interface A { // T
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -109,7 +109,7 @@ interface I5<T> extends A {
 
 interface I7<T> extends A {
     a11: new <U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->a11 : new <U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>a11 : new <U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -119,7 +119,7 @@ interface I7<T> extends A {
 
 interface I9<T> extends A {
     a16: new (x: { a: T; b: T }) => T[]; 
->a16 : new (x: {    a: T;    b: T;}) => T[]
+>a16 : new (x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/constructorAsType.types
+++ b/tests/baselines/reference/constructorAsType.types
@@ -2,7 +2,7 @@
 
 === constructorAsType.ts ===
 var Person:new () => {name: string;} = function () {return {name:"joe"};};
->Person : new () => {    name: string;}
+>Person : new () => { name: string; }
 >name : string
 >function () {return {name:"joe"};} : () => { name: string; }
 >{name:"joe"} : { name: string; }
@@ -10,7 +10,7 @@ var Person:new () => {name: string;} = function () {return {name:"joe"};};
 >"joe" : "joe"
 
 var Person2:{new() : {name:string;};};
->Person2 : new () => {    name: string;}
+>Person2 : new () => { name: string; }
 >name : string
 
 Person = Person2;

--- a/tests/baselines/reference/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.types
+++ b/tests/baselines/reference/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.types
@@ -13,7 +13,7 @@ interface FullRule {
 >validate : string | RegExp | Validate
 
     normalize?: (match: {x: string}) => void;
->normalize : ((match: {    x: string;}) => void) | undefined
+>normalize : ((match: { x: string; }) => void) | undefined
 >match : { x: string; }
 >x : string
 }

--- a/tests/baselines/reference/contextualSignatureConditionalTypeInstantiationUsingDefault.types
+++ b/tests/baselines/reference/contextualSignatureConditionalTypeInstantiationUsingDefault.types
@@ -20,7 +20,7 @@ type ActionFunction<TEvent extends { type: string }> = (event: TEvent) => void;
 >event : TEvent
 
 declare function createMachine<
->createMachine : <TTypesMeta extends TypegenDisabled | TypegenEnabled = TypegenDisabled>(config: {    types?: TTypesMeta;}, implementations: TTypesMeta extends TypegenEnabled ? ActionFunction<{    type: "test";}> : ActionFunction<{    type: string;}>) => void
+>createMachine : <TTypesMeta extends TypegenDisabled | TypegenEnabled = TypegenDisabled>(config: { types?: TTypesMeta; }, implementations: TTypesMeta extends TypegenEnabled ? ActionFunction<{ type: "test"; }> : ActionFunction<{ type: string; }>) => void
 
   TTypesMeta extends TypegenEnabled | TypegenDisabled = TypegenDisabled
 >(

--- a/tests/baselines/reference/contextualTypeFromJSDoc.types
+++ b/tests/baselines/reference/contextualTypeFromJSDoc.types
@@ -24,7 +24,7 @@ const arr = [
 
 /** @return {Array<[string, {x?:number, y?:number}]>} */
 function f() {
->f : () => Array<[string, {    x?: number;    y?: number;}]>
+>f : () => Array<[string, { x?: number; y?: number; }]>
 
     return [
 >[        ['a', { x: 1 }],        ['b', { y: 2 }]    ] : ([string, { x: number; }] | [string, { y: number; }])[]

--- a/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.types
+++ b/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.types
@@ -31,7 +31,7 @@ f("a", {
 });
 
 function g<
->g : <K extends "a" | "b">(x: ({    a: string;} & {    b: string;})[K], y: string) => void
+>g : <K extends "a" | "b">(x: ({ a: string; } & { b: string; })[K], y: string) => void
 
     K extends "a" | "b">(x: ({ a: string } & { b: string })[K], y: string) {
 >x : ({ a: string; } & { b: string; })[K]

--- a/tests/baselines/reference/contextualTyping25.types
+++ b/tests/baselines/reference/contextualTyping25.types
@@ -2,7 +2,7 @@
 
 === contextualTyping25.ts ===
 function foo(param:{id:number;}){}; foo(<{id:number;}>({}));
->foo : (param: {    id: number;}) => void
+>foo : (param: { id: number; }) => void
 >param : { id: number; }
 >id : number
 >foo(<{id:number;}>({})) : void

--- a/tests/baselines/reference/contextualTyping26.types
+++ b/tests/baselines/reference/contextualTyping26.types
@@ -2,7 +2,7 @@
 
 === contextualTyping26.ts ===
 function foo(param:{id:number;}){}; foo(<{id:number;}>({}));
->foo : (param: {    id: number;}) => void
+>foo : (param: { id: number; }) => void
 >param : { id: number; }
 >id : number
 >foo(<{id:number;}>({})) : void

--- a/tests/baselines/reference/contextualTyping27.types
+++ b/tests/baselines/reference/contextualTyping27.types
@@ -2,7 +2,7 @@
 
 === contextualTyping27.ts ===
 function foo(param:{id:number;}){}; foo(<{id:number;}>({}));
->foo : (param: {    id: number;}) => void
+>foo : (param: { id: number; }) => void
 >param : { id: number; }
 >id : number
 >foo(<{id:number;}>({})) : void

--- a/tests/baselines/reference/contextualTypingOfOptionalMembers.types
+++ b/tests/baselines/reference/contextualTypingOfOptionalMembers.types
@@ -174,7 +174,7 @@ interface ActionsObjectOr<State> {
 }
 
 declare function App4<State, Actions extends ActionsObjectOr<State>>(props: Options<State, Actions>["actions"] & { state: State }): JSX.Element;
->App4 : <State, Actions extends ActionsObjectOr<State>>(props: Options<State, Actions>["actions"] & {    state: State;}) => JSX.Element
+>App4 : <State, Actions extends ActionsObjectOr<State>>(props: Options<State, Actions>["actions"] & { state: State; }) => JSX.Element
 >props : (string | Actions) & { state: State; }
 >state : State
 >JSX : any

--- a/tests/baselines/reference/contextuallyTypedJsxChildren.types
+++ b/tests/baselines/reference/contextuallyTypedJsxChildren.types
@@ -17,7 +17,7 @@ declare namespace DropdownMenu {
   }
   interface PropsWithChildren extends BaseProps {
     children(props: { onClose: () => void }): JSX.Element;
->children : (props: {    onClose: () => void;}) => JSX.Element
+>children : (props: { onClose: () => void; }) => JSX.Element
 >props : { onClose: () => void; }
 >onClose : () => void
 >JSX : any

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).types
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=false).types
@@ -9,7 +9,7 @@ declare function match<T>(cb: (value: T) => boolean): T;
 >value : T
 
 declare function foo(pos: { x?: number; y?: number }): boolean;
->foo : (pos: {    x?: number;    y?: number;}) => boolean
+>foo : (pos: { x?: number; y?: number; }) => boolean
 >pos : { x?: number | undefined; y?: number | undefined; }
 >x : number | undefined
 >y : number | undefined

--- a/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=true).types
+++ b/tests/baselines/reference/contextuallyTypedOptionalProperty(exactoptionalpropertytypes=true).types
@@ -9,7 +9,7 @@ declare function match<T>(cb: (value: T) => boolean): T;
 >value : T
 
 declare function foo(pos: { x?: number; y?: number }): boolean;
->foo : (pos: {    x?: number;    y?: number;}) => boolean
+>foo : (pos: { x?: number; y?: number; }) => boolean
 >pos : { x?: number; y?: number; }
 >x : number | undefined
 >y : number | undefined

--- a/tests/baselines/reference/contextuallyTypedParametersWithInitializers.types
+++ b/tests/baselines/reference/contextuallyTypedParametersWithInitializers.types
@@ -11,13 +11,13 @@ declare function id2<T extends (x: any) => any>(input: T): T;
 >input : T
 
 declare function id3<T extends (x: { foo: any }) => any>(input: T): T;
->id3 : <T extends (x: {    foo: any;}) => any>(input: T) => T
+>id3 : <T extends (x: { foo: any; }) => any>(input: T) => T
 >x : { foo: any; }
 >foo : any
 >input : T
 
 declare function id4<T extends (x: { foo?: number }) => any>(input: T): T;
->id4 : <T extends (x: {    foo?: number;}) => any>(input: T) => T
+>id4 : <T extends (x: { foo?: number; }) => any>(input: T) => T
 >x : { foo?: number | undefined; }
 >foo : number | undefined
 >input : T

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.types
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.types
@@ -13,8 +13,8 @@ namespace JSX {
 }
 
 const FooComponent = (props: { foo: "A" | "B" | "C" }) => <span>{props.foo}</span>;
->FooComponent : (props: {    foo: "A" | "B" | "C";}) => JSX.Element
->(props: { foo: "A" | "B" | "C" }) => <span>{props.foo}</span> : (props: {    foo: "A" | "B" | "C";}) => JSX.Element
+>FooComponent : (props: { foo: "A" | "B" | "C"; }) => JSX.Element
+>(props: { foo: "A" | "B" | "C" }) => <span>{props.foo}</span> : (props: { foo: "A" | "B" | "C"; }) => JSX.Element
 >props : { foo: "A" | "B" | "C"; }
 >foo : "A" | "B" | "C"
 ><span>{props.foo}</span> : JSX.Element

--- a/tests/baselines/reference/controlFlowAliasing.types
+++ b/tests/baselines/reference/controlFlowAliasing.types
@@ -138,7 +138,7 @@ function f14(x: number | null | undefined): number | null {
 }
 
 function f15(obj: { readonly x: string | number }) {
->f15 : (obj: {    readonly x: string | number;}) => void
+>f15 : (obj: { readonly x: string | number; }) => void
 >obj : { readonly x: string | number; }
 >x : string | number
 
@@ -163,7 +163,7 @@ function f15(obj: { readonly x: string | number }) {
 }
 
 function f16(obj: { readonly x: string | number }) {
->f16 : (obj: {    readonly x: string | number;}) => void
+>f16 : (obj: { readonly x: string | number; }) => void
 >obj : { readonly x: string | number; }
 >x : string | number
 
@@ -249,7 +249,7 @@ function f18(obj: readonly [string | number]) {
 }
 
 function f20(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f20 : (obj: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f20 : (obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -281,7 +281,7 @@ function f20(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
 }
 
 function f21(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f21 : (obj: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f21 : (obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -313,7 +313,7 @@ function f21(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
 }
 
 function f22(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f22 : (obj: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f22 : (obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -345,7 +345,7 @@ function f22(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
 }
 
 function f23(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f23 : (obj: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f23 : (obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -382,7 +382,7 @@ function f23(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
 }
 
 function f24(arg: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f24 : (arg: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f24 : (arg: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >arg : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -418,7 +418,7 @@ function f24(arg: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
 }
 
 function f25(arg: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f25 : (arg: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f25 : (arg: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >arg : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -454,8 +454,8 @@ function f25(arg: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
 }
 
 function f26(outer: { readonly obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number } }) {
->f26 : (outer: {    readonly obj: {        kind: 'foo';        foo: string;    } | {        kind: 'bar';        bar: number;    };}) => void
->outer : { readonly obj: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}; }
+>f26 : (outer: { readonly obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }; }) => void
+>outer : { readonly obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }; }
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -493,8 +493,8 @@ function f26(outer: { readonly obj: { kind: 'foo', foo: string } | { kind: 'bar'
 }
 
 function f27(outer: { obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number } }) {
->f27 : (outer: {    obj: {        kind: 'foo';        foo: string;    } | {        kind: 'bar';        bar: number;    };}) => void
->outer : { obj: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}; }
+>f27 : (outer: { obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }; }) => void
+>outer : { obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }; }
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string
@@ -532,7 +532,7 @@ function f27(outer: { obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: nu
 }
 
 function f28(obj?: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f28 : (obj?: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f28 : (obj?: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; } | undefined
 >kind : "foo"
 >foo : string
@@ -642,7 +642,7 @@ function f31(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
 }
 
 function f32(obj: { kind: 'foo', foo: string } | { kind: 'bar', bar: number }) {
->f32 : (obj: {    kind: 'foo';    foo: string;} | {    kind: 'bar';    bar: number;}) => void
+>f32 : (obj: { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }) => void
 >obj : { kind: 'foo'; foo: string; } | { kind: 'bar'; bar: number; }
 >kind : "foo"
 >foo : string

--- a/tests/baselines/reference/controlFlowArrays.types
+++ b/tests/baselines/reference/controlFlowArrays.types
@@ -617,7 +617,7 @@ function f18() {
 // Repro from #39470
 
 declare function foo(arg: { val: number }[]): void;
->foo : (arg: {    val: number;}[]) => void
+>foo : (arg: { val: number; }[]) => void
 >arg : { val: number; }[]
 >val : number
 

--- a/tests/baselines/reference/controlFlowGenericTypes.types
+++ b/tests/baselines/reference/controlFlowGenericTypes.types
@@ -2,7 +2,7 @@
 
 === controlFlowGenericTypes.ts ===
 function f1<T extends string | undefined>(x: T, y: { a: T }, z: [T]): string {
->f1 : <T extends string | undefined>(x: T, y: {    a: T;}, z: [T]) => string
+>f1 : <T extends string | undefined>(x: T, y: { a: T; }, z: [T]) => string
 >x : T
 >y : { a: T; }
 >a : T

--- a/tests/baselines/reference/controlFlowIterationErrorsAsync.types
+++ b/tests/baselines/reference/controlFlowIterationErrorsAsync.types
@@ -348,7 +348,7 @@ async () => {
 // repro #43047#issuecomment-874221939
 
 declare function myQuery(input: { lastId: number | undefined }): Promise<{ entities: number[] }>;
->myQuery : (input: {    lastId: number | undefined;}) => Promise<{    entities: number[];}>
+>myQuery : (input: { lastId: number | undefined; }) => Promise<{ entities: number[]; }>
 >input : { lastId: number | undefined; }
 >lastId : number | undefined
 >entities : number[]

--- a/tests/baselines/reference/controlFlowOptionalChain.types
+++ b/tests/baselines/reference/controlFlowOptionalChain.types
@@ -321,8 +321,8 @@ o4.x.y;
 >y : boolean
 
 declare const o5: { x?: { y: { z?: { w: boolean } } } };
->o5 : { x?: { y: {    z?: {        w: boolean;    };}; } | undefined; }
->x : { y: {    z?: {        w: boolean;    };}; } | undefined
+>o5 : { x?: { y: { z?: { w: boolean; }; }; } | undefined; }
+>x : { y: { z?: { w: boolean; }; }; } | undefined
 >y : { z?: { w: boolean; } | undefined; }
 >z : { w: boolean; } | undefined
 >w : boolean

--- a/tests/baselines/reference/correlatedUnions.js
+++ b/tests/baselines/reference/correlatedUnions.js
@@ -602,7 +602,7 @@ type SameKeys<T> = {
     };
 };
 type MappedFromOriginal = SameKeys<Original>;
-declare const getStringAndNumberFromOriginalAndMapped: <K extends keyof Original, N extends keyof Original[K]>(original: Original, mappedFromOriginal: MappedFromOriginal, key: K, nestedKey: N) => [Original[K][N], SameKeys<Original>[K][N]];
+declare const getStringAndNumberFromOriginalAndMapped: <K extends keyof Original, N extends keyof Original[K]>(original: Original, mappedFromOriginal: MappedFromOriginal, key: K, nestedKey: N) => [Original[K][N], MappedFromOriginal[K][N]];
 interface Config {
     string: string;
     number: number;

--- a/tests/baselines/reference/correlatedUnions.types
+++ b/tests/baselines/reference/correlatedUnions.types
@@ -797,8 +797,8 @@ type MappedFromOriginal = SameKeys<Original>;
 >MappedFromOriginal : SameKeys<Original>
 
 const getStringAndNumberFromOriginalAndMapped = <
->getStringAndNumberFromOriginalAndMapped : <K extends keyof Original, N extends keyof Original[K]>(original: Original, mappedFromOriginal: MappedFromOriginal, key: K, nestedKey: N) => [Original[K][N], SameKeys<Original>[K][N]]
-><  K extends KeyOfOriginal,  N extends NestedKeyOfOriginalFor<K>>(  original: Original,  mappedFromOriginal: MappedFromOriginal,  key: K,  nestedKey: N): [Original[K][N], MappedFromOriginal[K][N]] => {  return [original[key][nestedKey], mappedFromOriginal[key][nestedKey]];} : <K extends keyof Original, N extends keyof Original[K]>(original: Original, mappedFromOriginal: MappedFromOriginal, key: K, nestedKey: N) => [Original[K][N], SameKeys<Original>[K][N]]
+>getStringAndNumberFromOriginalAndMapped : <K extends keyof Original, N extends keyof Original[K]>(original: Original, mappedFromOriginal: MappedFromOriginal, key: K, nestedKey: N) => [Original[K][N], MappedFromOriginal[K][N]]
+><  K extends KeyOfOriginal,  N extends NestedKeyOfOriginalFor<K>>(  original: Original,  mappedFromOriginal: MappedFromOriginal,  key: K,  nestedKey: N): [Original[K][N], MappedFromOriginal[K][N]] => {  return [original[key][nestedKey], mappedFromOriginal[key][nestedKey]];} : <K extends keyof Original, N extends keyof Original[K]>(original: Original, mappedFromOriginal: MappedFromOriginal, key: K, nestedKey: N) => [Original[K][N], MappedFromOriginal[K][N]]
 
   K extends KeyOfOriginal,
   N extends NestedKeyOfOriginalFor<K>

--- a/tests/baselines/reference/declarationEmitAliasFromIndirectFile.types
+++ b/tests/baselines/reference/declarationEmitAliasFromIndirectFile.types
@@ -2,7 +2,7 @@
 
 === locale.d.ts ===
 export type Locale = {
->Locale : { weekdays: {    shorthand: [string, string, string, string, string, string, string];    longhand: [string, string, string, string, string, string, string];}; }
+>Locale : { weekdays: { shorthand: [string, string, string, string, string, string, string]; longhand: [string, string, string, string, string, string, string]; }; }
 
     weekdays: {
 >weekdays : { shorthand: [string, string, string, string, string, string, string]; longhand: [string, string, string, string, string, string, string]; }
@@ -16,7 +16,7 @@ export type Locale = {
     };
 };
 export type CustomLocale = {
->CustomLocale : { weekdays: {    shorthand: [string, string, string, string, string, string, string];    longhand: [string, string, string, string, string, string, string];}; }
+>CustomLocale : { weekdays: { shorthand: [string, string, string, string, string, string, string]; longhand: [string, string, string, string, string, string, string]; }; }
 
     weekdays: {
 >weekdays : { shorthand: [string, string, string, string, string, string, string]; longhand: [string, string, string, string, string, string, string]; }

--- a/tests/baselines/reference/declarationEmitDestructuring1.types
+++ b/tests/baselines/reference/declarationEmitDestructuring1.types
@@ -14,7 +14,7 @@ function far([a, [b], [[c]]]: [number, boolean[], string[][]]): void { }
 >c : string
 
 function bar({a1, b1, c1}: { a1: number, b1: boolean, c1: string }): void { }
->bar : ({ a1, b1, c1 }: {    a1: number;    b1: boolean;    c1: string;}) => void
+>bar : ({ a1, b1, c1 }: { a1: number; b1: boolean; c1: string; }) => void
 >a1 : number
 >b1 : boolean
 >c1 : string
@@ -23,7 +23,7 @@ function bar({a1, b1, c1}: { a1: number, b1: boolean, c1: string }): void { }
 >c1 : string
 
 function baz({a2, b2: {b1, c1}}: { a2: number, b2: { b1: boolean, c1: string } }): void { } 
->baz : ({ a2, b2: { b1, c1 } }: {    a2: number;    b2: {        b1: boolean;        c1: string;    };}) => void
+>baz : ({ a2, b2: { b1, c1 } }: { a2: number; b2: { b1: boolean; c1: string; }; }) => void
 >a2 : number
 >b2 : any
 >b1 : boolean

--- a/tests/baselines/reference/declarationEmitDestructuringOptionalBindingParametersInOverloads.types
+++ b/tests/baselines/reference/declarationEmitDestructuringOptionalBindingParametersInOverloads.types
@@ -13,7 +13,7 @@ function foo(...rest: any[]) {
 }
 
 function foo2( { x, y, z }?: { x: string; y: number; z: boolean });
->foo2 : ({ x, y, z }?: {    x: string;    y: number;    z: boolean;}) => any
+>foo2 : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => any
 >x : string
 >y : number
 >z : boolean

--- a/tests/baselines/reference/declarationEmitDestructuringWithOptionalBindingParameters.types
+++ b/tests/baselines/reference/declarationEmitDestructuringWithOptionalBindingParameters.types
@@ -8,7 +8,7 @@ function foo([x,y,z]?: [string, number, boolean]) {
 >z : boolean
 }
 function foo1( { x, y, z }?: { x: string; y: number; z: boolean }) {
->foo1 : ({ x, y, z }?: {    x: string;    y: number;    z: boolean;}) => void
+>foo1 : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => void
 >x : string
 >y : number
 >z : boolean

--- a/tests/baselines/reference/declarationEmitDistributiveConditionalWithInfer.types
+++ b/tests/baselines/reference/declarationEmitDistributiveConditionalWithInfer.types
@@ -7,7 +7,7 @@ export const fun = (
 >(    subFun: <Collection, Field extends keyof Collection>()        => FlatArray<Collection[Field], 0>[]) => { } : (subFun: <Collection, Field extends keyof Collection>() => (Collection[Field] extends readonly (infer InnerArr)[] ? InnerArr : Collection[Field])[]) => void
 
     subFun: <Collection, Field extends keyof Collection>()
->subFun : <Collection, Field extends keyof Collection>() => (Collection[Field] extends readonly (infer InnerArr)[] ? InnerArr : Collection[Field])[]
+>subFun : <Collection, Field extends keyof Collection>() => FlatArray<Collection[Field], 0>[]
 
         => FlatArray<Collection[Field], 0>[]) => { };
 

--- a/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.types
+++ b/tests/baselines/reference/declarationEmitDuplicateParameterDestructuring.types
@@ -2,8 +2,8 @@
 
 === declarationEmitDuplicateParameterDestructuring.ts ===
 export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
->fn1 : ({ prop: a, prop: b }: {    prop: number;}) => number
->({ prop: a, prop: b }: { prop: number }) => a + b : ({ prop: a, prop: b }: {    prop: number;}) => number
+>fn1 : ({ prop: a, prop: b }: { prop: number; }) => number
+>({ prop: a, prop: b }: { prop: number }) => a + b : ({ prop: a, prop: b }: { prop: number; }) => number
 >prop : any
 >a : number
 >prop : any
@@ -14,8 +14,8 @@ export const fn1 = ({ prop: a, prop: b }: { prop: number }) => a + b;
 >b : number
 
 export const fn2 = ({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b;
->fn2 : ({ prop: a }: {    prop: number;}, { prop: b }: {    prop: number;}) => number
->({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b : ({ prop: a }: {    prop: number;}, { prop: b }: {    prop: number;}) => number
+>fn2 : ({ prop: a }: { prop: number; }, { prop: b }: { prop: number; }) => number
+>({ prop: a }: { prop: number }, { prop: b }: { prop: number }) => a + b : ({ prop: a }: { prop: number; }, { prop: b }: { prop: number; }) => number
 >prop : any
 >a : number
 >prop : number

--- a/tests/baselines/reference/declarationEmitOptionalMethod.types
+++ b/tests/baselines/reference/declarationEmitOptionalMethod.types
@@ -2,8 +2,8 @@
 
 === declarationEmitOptionalMethod.ts ===
 export const Foo = (opts: {
->Foo : (opts: {    a?(): void;    b?: () => void;}) => {    c?(): void;    d?: () => void;}
->(opts: {    a?(): void,    b?: () => void,}): {    c?(): void,    d?: () => void,} => ({  }) : (opts: {    a?(): void;    b?: () => void;}) => {    c?(): void;    d?: () => void;}
+>Foo : (opts: { a?(): void; b?: () => void; }) => { c?(): void; d?: () => void; }
+>(opts: {    a?(): void,    b?: () => void,}): {    c?(): void,    d?: () => void,} => ({  }) : (opts: { a?(): void; b?: () => void; }) => { c?(): void; d?: () => void; }
 >opts : { a?(): void; b?: (() => void) | undefined; }
 
     a?(): void,

--- a/tests/baselines/reference/declarationEmitPrivatePromiseLikeInterface.js
+++ b/tests/baselines/reference/declarationEmitPrivatePromiseLikeInterface.js
@@ -72,6 +72,6 @@ export interface HttpResponse<D extends unknown, E extends unknown = unknown> ex
     error: E;
 }
 export declare class HttpClient<SecurityDataType = unknown> {
-    request: <T = any, E = any>() => TPromise<HttpResponse<T, E>, any>;
+    request: <T = any, E = any>() => TPromise<HttpResponse<T, E>>;
 }
 export {};

--- a/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.js
+++ b/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.js
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts] ////
+
+//// [index.d.ts]
+export type Whatever = {x: string, y: number};
+export type Props<T, TThing = Whatever> = Omit<TThing, "y"> & Partial<TThing> & T;
+
+//// [index.ts]
+import { Props } from "react-select";
+
+export const CustomSelect1 = <Option,>(x: Props<Option> & {}) => {}
+export function CustomSelect2<Option,>(x: Props<Option> & {}) {}
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CustomSelect2 = exports.CustomSelect1 = void 0;
+var CustomSelect1 = function (x) { };
+exports.CustomSelect1 = CustomSelect1;
+function CustomSelect2(x) { }
+exports.CustomSelect2 = CustomSelect2;
+
+
+//// [index.d.ts]
+import { Props } from "react-select";
+export declare const CustomSelect1: <Option>(x: Props<Option> & {}) => void;
+export declare function CustomSelect2<Option>(x: Props<Option> & {}): void;

--- a/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.symbols
+++ b/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.symbols
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts] ////
+
+=== node_modules/react-select/index.d.ts ===
+export type Whatever = {x: string, y: number};
+>Whatever : Symbol(Whatever, Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(index.d.ts, 0, 24))
+>y : Symbol(y, Decl(index.d.ts, 0, 34))
+
+export type Props<T, TThing = Whatever> = Omit<TThing, "y"> & Partial<TThing> & T;
+>Props : Symbol(Props, Decl(index.d.ts, 0, 46))
+>T : Symbol(T, Decl(index.d.ts, 1, 18))
+>TThing : Symbol(TThing, Decl(index.d.ts, 1, 20))
+>Whatever : Symbol(Whatever, Decl(index.d.ts, 0, 0))
+>Omit : Symbol(Omit, Decl(lib.es5.d.ts, --, --))
+>TThing : Symbol(TThing, Decl(index.d.ts, 1, 20))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>TThing : Symbol(TThing, Decl(index.d.ts, 1, 20))
+>T : Symbol(T, Decl(index.d.ts, 1, 18))
+
+=== index.ts ===
+import { Props } from "react-select";
+>Props : Symbol(Props, Decl(index.ts, 0, 8))
+
+export const CustomSelect1 = <Option,>(x: Props<Option> & {}) => {}
+>CustomSelect1 : Symbol(CustomSelect1, Decl(index.ts, 2, 12))
+>Option : Symbol(Option, Decl(index.ts, 2, 30))
+>x : Symbol(x, Decl(index.ts, 2, 39))
+>Props : Symbol(Props, Decl(index.ts, 0, 8))
+>Option : Symbol(Option, Decl(index.ts, 2, 30))
+
+export function CustomSelect2<Option,>(x: Props<Option> & {}) {}
+>CustomSelect2 : Symbol(CustomSelect2, Decl(index.ts, 2, 67))
+>Option : Symbol(Option, Decl(index.ts, 3, 30))
+>x : Symbol(x, Decl(index.ts, 3, 39))
+>Props : Symbol(Props, Decl(index.ts, 0, 8))
+>Option : Symbol(Option, Decl(index.ts, 3, 30))
+

--- a/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.types
+++ b/tests/baselines/reference/declarationEmitReusesLambdaParameterNodes.types
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts] ////
+
+=== node_modules/react-select/index.d.ts ===
+export type Whatever = {x: string, y: number};
+>Whatever : { x: string; y: number; }
+>x : string
+>y : number
+
+export type Props<T, TThing = Whatever> = Omit<TThing, "y"> & Partial<TThing> & T;
+>Props : Props<T, TThing>
+
+=== index.ts ===
+import { Props } from "react-select";
+>Props : any
+
+export const CustomSelect1 = <Option,>(x: Props<Option> & {}) => {}
+>CustomSelect1 : <Option>(x: Props<Option> & {}) => void
+><Option,>(x: Props<Option> & {}) => {} : <Option>(x: Props<Option> & {}) => void
+>x : Omit<import("node_modules/react-select/index").Whatever, "y"> & Partial<import("node_modules/react-select/index").Whatever> & Option
+
+export function CustomSelect2<Option,>(x: Props<Option> & {}) {}
+>CustomSelect2 : <Option>(x: Props<Option> & {}) => void
+>x : Omit<import("node_modules/react-select/index").Whatever, "y"> & Partial<import("node_modules/react-select/index").Whatever> & Option
+

--- a/tests/baselines/reference/declarationMapsMultifile.types
+++ b/tests/baselines/reference/declarationMapsMultifile.types
@@ -5,7 +5,7 @@ export class Foo {
 >Foo : Foo
 
     doThing(x: {a: number}) {
->doThing : (x: {    a: number;}) => { b: number; }
+>doThing : (x: { a: number; }) => { b: number; }
 >x : { a: number; }
 >a : number
 

--- a/tests/baselines/reference/declarationMapsOutFile.types
+++ b/tests/baselines/reference/declarationMapsOutFile.types
@@ -5,7 +5,7 @@ export class Foo {
 >Foo : Foo
 
     doThing(x: {a: number}) {
->doThing : (x: {    a: number;}) => { b: number; }
+>doThing : (x: { a: number; }) => { b: number; }
 >x : { a: number; }
 >a : number
 

--- a/tests/baselines/reference/declarationMapsOutFile2.types
+++ b/tests/baselines/reference/declarationMapsOutFile2.types
@@ -5,7 +5,7 @@ class Foo {
 >Foo : Foo
 
     doThing(x: {a: number}) {
->doThing : (x: {    a: number;}) => { b: number; }
+>doThing : (x: { a: number; }) => { b: number; }
 >x : { a: number; }
 >a : number
 

--- a/tests/baselines/reference/declarationMapsWithSourceMap.types
+++ b/tests/baselines/reference/declarationMapsWithSourceMap.types
@@ -5,7 +5,7 @@ class Foo {
 >Foo : Foo
 
     doThing(x: {a: number}) {
->doThing : (x: {    a: number;}) => { b: number; }
+>doThing : (x: { a: number; }) => { b: number; }
 >x : { a: number; }
 >a : number
 

--- a/tests/baselines/reference/deepExcessPropertyCheckingWhenTargetIsIntersection.types
+++ b/tests/baselines/reference/deepExcessPropertyCheckingWhenTargetIsIntersection.types
@@ -45,10 +45,10 @@ TestComponent({icon: { props: { INVALID_PROP_NAME: 'share', ariaLabel: 'test lab
 >'test label' : "test label"
 
 const TestComponent2: StatelessComponent<TestProps | {props2: {x: number}}> = (props) => {
->TestComponent2 : StatelessComponent<TestProps | { props2: {    x: number;}; }>
+>TestComponent2 : StatelessComponent<TestProps | { props2: { x: number; }; }>
 >props2 : { x: number; }
 >x : number
->(props) => {  return null;} : (props: (TestProps | { props2: {    x: number;}; }) & { children?: number; }) => any
+>(props) => {  return null;} : (props: (TestProps | { props2: { x: number; }; }) & { children?: number; }) => any
 >props : (TestProps | { props2: { x: number; }; }) & { children?: number; }
 
   return null;

--- a/tests/baselines/reference/deeplyNestedAssignabilityIssue.types
+++ b/tests/baselines/reference/deeplyNestedAssignabilityIssue.types
@@ -8,10 +8,10 @@ interface A {
 
 interface Large {
     something: {
->something : { another: {    more: {        thing: A;    };    yetstill: {        another: A;    };}; }
+>something : { another: { more: { thing: A; }; yetstill: { another: A; }; }; }
 
         another: {
->another : { more: {    thing: A;}; yetstill: {    another: A;}; }
+>another : { more: { thing: A; }; yetstill: { another: A; }; }
 
             more: {
 >more : { thing: A; }

--- a/tests/baselines/reference/deeplyNestedMappedTypes.types
+++ b/tests/baselines/reference/deeplyNestedMappedTypes.types
@@ -7,20 +7,20 @@ type Id<T> = { [K in keyof T]: Id<T[K]> };
 >Id : Id<T>
 
 type Foo1 = Id<{ x: { y: { z: { a: { b: { c: number } } } } } }>;
->Foo1 : Id<{ x: {    y: {        z: {            a: {                b: {                    c: number;                };            };        };    };}; }>
->x : { y: {    z: {        a: {            b: {                c: number;            };        };    };}; }
->y : { z: {    a: {        b: {            c: number;        };    };}; }
->z : { a: {    b: {        c: number;    };}; }
->a : { b: {    c: number;}; }
+>Foo1 : Id<{ x: { y: { z: { a: { b: { c: number; }; }; }; }; }; }>
+>x : { y: { z: { a: { b: { c: number; }; }; }; }; }
+>y : { z: { a: { b: { c: number; }; }; }; }
+>z : { a: { b: { c: number; }; }; }
+>a : { b: { c: number; }; }
 >b : { c: number; }
 >c : number
 
 type Foo2 = Id<{ x: { y: { z: { a: { b: { c: string } } } } } }>;
->Foo2 : Id<{ x: {    y: {        z: {            a: {                b: {                    c: string;                };            };        };    };}; }>
->x : { y: {    z: {        a: {            b: {                c: string;            };        };    };}; }
->y : { z: {    a: {        b: {            c: string;        };    };}; }
->z : { a: {    b: {        c: string;    };}; }
->a : { b: {    c: string;}; }
+>Foo2 : Id<{ x: { y: { z: { a: { b: { c: string; }; }; }; }; }; }>
+>x : { y: { z: { a: { b: { c: string; }; }; }; }; }
+>y : { z: { a: { b: { c: string; }; }; }; }
+>z : { a: { b: { c: string; }; }; }
+>a : { b: { c: string; }; }
 >b : { c: string; }
 >c : string
 
@@ -35,20 +35,20 @@ type Id2<T> = { [K in keyof T]: Id2<Id2<T[K]>> };
 >Id2 : Id2<T>
 
 type Foo3 = Id2<{ x: { y: { z: { a: { b: { c: number } } } } } }>;
->Foo3 : Id2<{ x: {    y: {        z: {            a: {                b: {                    c: number;                };            };        };    };}; }>
->x : { y: {    z: {        a: {            b: {                c: number;            };        };    };}; }
->y : { z: {    a: {        b: {            c: number;        };    };}; }
->z : { a: {    b: {        c: number;    };}; }
->a : { b: {    c: number;}; }
+>Foo3 : Id2<{ x: { y: { z: { a: { b: { c: number; }; }; }; }; }; }>
+>x : { y: { z: { a: { b: { c: number; }; }; }; }; }
+>y : { z: { a: { b: { c: number; }; }; }; }
+>z : { a: { b: { c: number; }; }; }
+>a : { b: { c: number; }; }
 >b : { c: number; }
 >c : number
 
 type Foo4 = Id2<{ x: { y: { z: { a: { b: { c: string } } } } } }>;
->Foo4 : Id2<{ x: {    y: {        z: {            a: {                b: {                    c: string;                };            };        };    };}; }>
->x : { y: {    z: {        a: {            b: {                c: string;            };        };    };}; }
->y : { z: {    a: {        b: {            c: string;        };    };}; }
->z : { a: {    b: {        c: string;    };}; }
->a : { b: {    c: string;}; }
+>Foo4 : Id2<{ x: { y: { z: { a: { b: { c: string; }; }; }; }; }; }>
+>x : { y: { z: { a: { b: { c: string; }; }; }; }; }
+>y : { z: { a: { b: { c: string; }; }; }; }
+>z : { a: { b: { c: string; }; }; }
+>a : { b: { c: string; }; }
 >b : { c: string; }
 >c : string
 
@@ -65,19 +65,19 @@ type RequiredDeep<T> = { [K in keyof T]-?: RequiredDeep<T[K]> };
 >RequiredDeep : RequiredDeep<T>
 
 type A = { a?: { b: { c: 1 | { d: 2000 } }}}
->A : { a?: { b: {    c: 1 | {        d: 2000;    };}; } | undefined; }
->a : { b: {    c: 1 | {        d: 2000;    };}; } | undefined
->b : { c: 1 | {    d: 2000;}; }
+>A : { a?: { b: { c: 1 | { d: 2000; }; }; } | undefined; }
+>a : { b: { c: 1 | { d: 2000; }; }; } | undefined
+>b : { c: 1 | { d: 2000; }; }
 >c : { d: 2000; } | 1
 >d : 2000
 
 type B = { a?: { b: { c: { d: { e: { f: { g: 2 }}}}, x: 1000 }}}
->B : { a?: { b: {    c: {        d: {            e: {                f: {                    g: 2;                };            };        };    };    x: 1000;}; } | undefined; }
->a : { b: {    c: {        d: {            e: {                f: {                    g: 2;                };            };        };    };    x: 1000;}; } | undefined
->b : { c: {    d: {        e: {            f: {                g: 2;            };        };    };}; x: 1000; }
->c : { d: {    e: {        f: {            g: 2;        };    };}; }
->d : { e: {    f: {        g: 2;    };}; }
->e : { f: {    g: 2;}; }
+>B : { a?: { b: { c: { d: { e: { f: { g: 2; }; }; }; }; x: 1000; }; } | undefined; }
+>a : { b: { c: { d: { e: { f: { g: 2; }; }; }; }; x: 1000; }; } | undefined
+>b : { c: { d: { e: { f: { g: 2; }; }; }; }; x: 1000; }
+>c : { d: { e: { f: { g: 2; }; }; }; }
+>d : { e: { f: { g: 2; }; }; }
+>e : { f: { g: 2; }; }
 >f : { g: 2; }
 >g : 2
 >x : 1000

--- a/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.types
+++ b/tests/baselines/reference/defaultDeclarationEmitNamedCorrectly.types
@@ -9,8 +9,8 @@ export interface Things<P, T> {
 >t : T
 }
 export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
->make : <P, CTor>(x: {    new (): CTor & {        props: P;    };}) => Things<P, CTor>
->x : new () => CTor & {    props: P;}
+>make : <P, CTor>(x: { new (): CTor & { props: P; }; }) => Things<P, CTor>
+>x : new () => CTor & { props: P; }
 >props : P
 
     return null as any;

--- a/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.types
+++ b/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.types
@@ -12,8 +12,8 @@ export interface Things<P, T> {
 >t : T
 }
 export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
->make : <P, CTor>(x: {    new (): CTor & {        props: P;    };}) => Things<P, CTor>
->x : new () => CTor & {    props: P;}
+>make : <P, CTor>(x: { new (): CTor & { props: P; }; }) => Things<P, CTor>
+>x : new () => CTor & { props: P; }
 >props : P
 
     return null as any;

--- a/tests/baselines/reference/deleteChain.types
+++ b/tests/baselines/reference/deleteChain.types
@@ -19,7 +19,7 @@ delete (o1?.b);
 >b : string | undefined
 
 declare const o2: undefined | { b: { c: string } };
->o2 : { b: {    c: string;}; } | undefined
+>o2 : { b: { c: string; }; } | undefined
 >b : { c: string; }
 >c : string
 
@@ -41,7 +41,7 @@ delete (o2?.b.c);
 >c : string | undefined
 
 declare const o3: { b: undefined | { c: string } };
->o3 : { b: undefined | {    c: string;}; }
+>o3 : { b: undefined | { c: string; }; }
 >b : { c: string; } | undefined
 >c : string
 
@@ -63,8 +63,8 @@ delete (o3.b?.c);
 >c : string | undefined
 
 declare const o4: { b?: { c: { d?: { e: string } } } };
->o4 : { b?: { c: {    d?: {        e: string;    };}; } | undefined; }
->b : { c: {    d?: {        e: string;    };}; } | undefined
+>o4 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
+>b : { c: { d?: { e: string; }; }; } | undefined
 >c : { d?: { e: string; } | undefined; }
 >d : { e: string; } | undefined
 >e : string
@@ -108,8 +108,8 @@ delete (o4.b?.c.d?.e);
 >e : string | undefined
 
 declare const o5: { b?(): { c: { d?: { e: string } } } };
->o5 : { b?(): {    c: {        d?: {            e: string;        };    };}; }
->b : (() => {    c: {        d?: {            e: string;        };    };}) | undefined
+>o5 : { b?(): { c: { d?: { e: string; }; }; }; }
+>b : (() => { c: { d?: { e: string; }; }; }) | undefined
 >c : { d?: { e: string; } | undefined; }
 >d : { e: string; } | undefined
 >e : string
@@ -142,8 +142,8 @@ delete (o5.b?.().c.d?.e);
 >e : string | undefined
 
 declare const o6: { b?: { c: { d?: { e: string } } } };
->o6 : { b?: { c: {    d?: {        e: string;    };}; } | undefined; }
->b : { c: {    d?: {        e: string;    };}; } | undefined
+>o6 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
+>b : { c: { d?: { e: string; }; }; } | undefined
 >c : { d?: { e: string; } | undefined; }
 >d : { e: string; } | undefined
 >e : string

--- a/tests/baselines/reference/dependentDestructuredVariables.types
+++ b/tests/baselines/reference/dependentDestructuredVariables.types
@@ -471,7 +471,7 @@ function unrefined1<T>(ab: AB<T>): void {
 // Repro from #38020
 
 type Action3 =
->Action3 : { type: 'add'; payload: {    toAdd: number;}; } | { type: 'remove'; payload: {    toRemove: number;}; }
+>Action3 : { type: 'add'; payload: { toAdd: number; }; } | { type: 'remove'; payload: { toRemove: number; }; }
 
     | {type: 'add', payload: { toAdd: number } }
 >type : "add"
@@ -1052,7 +1052,7 @@ function fa1(x: [true, number] | [false, string]) {
 }
 
 function fa2(x: { guard: true, value: number } | { guard: false, value: string }) {
->fa2 : (x: {    guard: true;    value: number;} | {    guard: false;    value: string;}) => void
+>fa2 : (x: { guard: true; value: number; } | { guard: false; value: string; }) => void
 >x : { guard: true; value: number; } | { guard: false; value: string; }
 >guard : true
 >true : true

--- a/tests/baselines/reference/derivedInterfaceIncompatibleWithBaseIndexer.types
+++ b/tests/baselines/reference/derivedInterfaceIncompatibleWithBaseIndexer.types
@@ -32,7 +32,7 @@ interface Derived3 extends Base {
 
 interface Derived4 extends Base {
     foo(): { x: number } // error
->foo : () => {    x: number;}
+>foo : () => { x: number; }
 >x : number
 }
 

--- a/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.types
+++ b/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.types
@@ -5,7 +5,7 @@ class Base {
 >Base : Base
 
     foo(x: { a: number }): { a: number } {
->foo : (x: {    a: number;}) => {    a: number;}
+>foo : (x: { a: number; }) => { a: number; }
 >x : { a: number; }
 >a : number
 >a : number
@@ -19,7 +19,7 @@ class Derived extends Base {
 >Base : Base
 
     foo(x: { a: number; b: number }): { a: number; b: number } {
->foo : (x: {    a: number;    b: number;}) => {    a: number;    b: number;}
+>foo : (x: { a: number; b: number; }) => { a: number; b: number; }
 >x : { a: number; b: number; }
 >a : number
 >b : number

--- a/tests/baselines/reference/destructionAssignmentError.types
+++ b/tests/baselines/reference/destructionAssignmentError.types
@@ -2,7 +2,7 @@
 
 === destructionAssignmentError.ts ===
 declare function fn(): { a: 1, b: 2 }
->fn : () => {    a: 1;    b: 2;}
+>fn : () => { a: 1; b: 2; }
 >a : 1
 >b : 2
 

--- a/tests/baselines/reference/destructureOptionalParameter.types
+++ b/tests/baselines/reference/destructureOptionalParameter.types
@@ -2,14 +2,14 @@
 
 === destructureOptionalParameter.ts ===
 declare function f1({ a, b }?: { a: number, b: string }): void;
->f1 : ({ a, b }?: {    a: number;    b: string;}) => void
+>f1 : ({ a, b }?: { a: number; b: string; }) => void
 >a : number
 >b : string
 >a : number
 >b : string
 
 function f2({ a, b }: { a: number, b: number } = { a: 0, b: 0 }) {
->f2 : ({ a, b }?: {    a: number;    b: number;}) => void
+>f2 : ({ a, b }?: { a: number; b: number; }) => void
 >a : number
 >b : number
 >a : number

--- a/tests/baselines/reference/destructuringControlFlow.types
+++ b/tests/baselines/reference/destructuringControlFlow.types
@@ -2,7 +2,7 @@
 
 === destructuringControlFlow.ts ===
 function f1(obj: { a?: string }) {
->f1 : (obj: {    a?: string;}) => void
+>f1 : (obj: { a?: string; }) => void
 >obj : { a?: string | undefined; }
 >a : string | undefined
 
@@ -96,7 +96,7 @@ function f2(obj: [number, string] | null[]) {
 }
 
 function f3(obj: { a?: number, b?: string }) {
->f3 : (obj: {    a?: number;    b?: string;}) => void
+>f3 : (obj: { a?: number; b?: string; }) => void
 >obj : { a?: number | undefined; b?: string | undefined; }
 >a : number | undefined
 >b : string | undefined

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES5.types
@@ -13,13 +13,13 @@ function a1([a, b, [[c]]]: [number, number, string[][]]) { }
 >c : string
 
 function a2(o: { x: number, a: number }) { }
->a2 : (o: {    x: number;    a: number;}) => void
+>a2 : (o: { x: number; a: number; }) => void
 >o : { x: number; a: number; }
 >x : number
 >a : number
 
 function a3({j, k, l: {m, n}, q: [a, b, c]}: { j: number, k: string, l: { m: boolean, n: number }, q: (number|string)[] }) { };
->a3 : ({ j, k, l: { m, n }, q: [a, b, c] }: {    j: number;    k: string;    l: {        m: boolean;        n: number;    };    q: (number | string)[];}) => void
+>a3 : ({ j, k, l: { m, n }, q: [a, b, c] }: { j: number; k: string; l: { m: boolean; n: number; }; q: (number | string)[]; }) => void
 >j : number
 >k : string
 >l : any
@@ -37,7 +37,7 @@ function a3({j, k, l: {m, n}, q: [a, b, c]}: { j: number, k: string, l: { m: boo
 >q : (string | number)[]
 
 function a4({x, a}: { x: number, a: number }) { }
->a4 : ({ x, a }: {    x: number;    a: number;}) => void
+>a4 : ({ x, a }: { x: number; a: number; }) => void
 >x : number
 >a : number
 >x : number
@@ -212,7 +212,7 @@ function c2({z = 10}) { }
 >10 : 10
 
 function c3({b}: { b: number|string} = { b: "hello" }) { }
->c3 : ({ b }?: {    b: number | string;}) => void
+>c3 : ({ b }?: { b: number | string; }) => void
 >b : string | number
 >b : string | number
 >{ b: "hello" } : { b: string; }
@@ -406,12 +406,12 @@ function e1({x: number}) { }  // x has type any NOT number
 >number : any
 
 function e2({x}: { x: number }) { }  // x is type number
->e2 : ({ x }: {    x: number;}) => void
+>e2 : ({ x }: { x: number; }) => void
 >x : number
 >x : number
 
 function e3({x}: { x?: number }) { }  // x is an optional with type number
->e3 : ({ x }: {    x?: number;}) => void
+>e3 : ({ x }: { x?: number; }) => void
 >x : number
 >x : number
 
@@ -423,7 +423,7 @@ function e4({x: [number,string,any] }) { }  // x has type [any, any, any]
 >any : any
 
 function e5({x: [a, b, c]}: { x: [number, number, number] }) { }  // x has type [any, any, any]
->e5 : ({ x: [a, b, c] }: {    x: [number, number, number];}) => void
+>e5 : ({ x: [a, b, c] }: { x: [number, number, number]; }) => void
 >x : any
 >a : number
 >b : number

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES5iterable.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES5iterable.types
@@ -13,13 +13,13 @@ function a1([a, b, [[c]]]: [number, number, string[][]]) { }
 >c : string
 
 function a2(o: { x: number, a: number }) { }
->a2 : (o: {    x: number;    a: number;}) => void
+>a2 : (o: { x: number; a: number; }) => void
 >o : { x: number; a: number; }
 >x : number
 >a : number
 
 function a3({j, k, l: {m, n}, q: [a, b, c]}: { j: number, k: string, l: { m: boolean, n: number }, q: (number|string)[] }) { };
->a3 : ({ j, k, l: { m, n }, q: [a, b, c] }: {    j: number;    k: string;    l: {        m: boolean;        n: number;    };    q: (number | string)[];}) => void
+>a3 : ({ j, k, l: { m, n }, q: [a, b, c] }: { j: number; k: string; l: { m: boolean; n: number; }; q: (number | string)[]; }) => void
 >j : number
 >k : string
 >l : any
@@ -37,7 +37,7 @@ function a3({j, k, l: {m, n}, q: [a, b, c]}: { j: number, k: string, l: { m: boo
 >q : (string | number)[]
 
 function a4({x, a}: { x: number, a: number }) { }
->a4 : ({ x, a }: {    x: number;    a: number;}) => void
+>a4 : ({ x, a }: { x: number; a: number; }) => void
 >x : number
 >a : number
 >x : number
@@ -212,7 +212,7 @@ function c2({z = 10}) { }
 >10 : 10
 
 function c3({b}: { b: number|string} = { b: "hello" }) { }
->c3 : ({ b }?: {    b: number | string;}) => void
+>c3 : ({ b }?: { b: number | string; }) => void
 >b : string | number
 >b : string | number
 >{ b: "hello" } : { b: string; }
@@ -406,12 +406,12 @@ function e1({x: number}) { }  // x has type any NOT number
 >number : any
 
 function e2({x}: { x: number }) { }  // x is type number
->e2 : ({ x }: {    x: number;}) => void
+>e2 : ({ x }: { x: number; }) => void
 >x : number
 >x : number
 
 function e3({x}: { x?: number }) { }  // x is an optional with type number
->e3 : ({ x }: {    x?: number;}) => void
+>e3 : ({ x }: { x?: number; }) => void
 >x : number
 >x : number
 
@@ -423,7 +423,7 @@ function e4({x: [number,string,any] }) { }  // x has type [any, any, any]
 >any : any
 
 function e5({x: [a, b, c]}: { x: [number, number, number] }) { }  // x has type [any, any, any]
->e5 : ({ x: [a, b, c] }: {    x: [number, number, number];}) => void
+>e5 : ({ x: [a, b, c] }: { x: [number, number, number]; }) => void
 >x : any
 >a : number
 >b : number

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES6.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES6.types
@@ -15,13 +15,13 @@ function a1([a, b, [[c]]]: [number, number, string[][]]) { }
 >c : string
 
 function a2(o: { x: number, a: number }) { }
->a2 : (o: {    x: number;    a: number;}) => void
+>a2 : (o: { x: number; a: number; }) => void
 >o : { x: number; a: number; }
 >x : number
 >a : number
 
 function a3({j, k, l: {m, n}, q: [a, b, c]}: { j: number, k: string, l: { m: boolean, n: number }, q: (number|string)[] }) { };
->a3 : ({ j, k, l: { m, n }, q: [a, b, c] }: {    j: number;    k: string;    l: {        m: boolean;        n: number;    };    q: (number | string)[];}) => void
+>a3 : ({ j, k, l: { m, n }, q: [a, b, c] }: { j: number; k: string; l: { m: boolean; n: number; }; q: (number | string)[]; }) => void
 >j : number
 >k : string
 >l : any
@@ -39,7 +39,7 @@ function a3({j, k, l: {m, n}, q: [a, b, c]}: { j: number, k: string, l: { m: boo
 >q : (string | number)[]
 
 function a4({x, a}: { x: number, a: number }) { }
->a4 : ({ x, a }: {    x: number;    a: number;}) => void
+>a4 : ({ x, a }: { x: number; a: number; }) => void
 >x : number
 >a : number
 >x : number
@@ -195,7 +195,7 @@ function c2({z = 10}) { }
 >10 : 10
 
 function c3({b}: { b: number|string} = { b: "hello" }) { }
->c3 : ({ b }?: {    b: number | string;}) => void
+>c3 : ({ b }?: { b: number | string; }) => void
 >b : string | number
 >b : string | number
 >{ b: "hello" } : { b: string; }
@@ -380,12 +380,12 @@ function e1({x: number}) { }  // x has type any NOT number
 >number : any
 
 function e2({x}: { x: number }) { }  // x is type number
->e2 : ({ x }: {    x: number;}) => void
+>e2 : ({ x }: { x: number; }) => void
 >x : number
 >x : number
 
 function e3({x}: { x?: number }) { }  // x is an optional with type number
->e3 : ({ x }: {    x?: number;}) => void
+>e3 : ({ x }: { x?: number; }) => void
 >x : number
 >x : number
 
@@ -397,7 +397,7 @@ function e4({x: [number,string,any] }) { }  // x has type [any, any, any]
 >any : any
 
 function e5({x: [a, b, c]}: { x: [number, number, number] }) { }  // x has type [any, any, any]
->e5 : ({ x: [a, b, c] }: {    x: [number, number, number];}) => void
+>e5 : ({ x: [a, b, c] }: { x: [number, number, number]; }) => void
 >x : any
 >a : number
 >b : number

--- a/tests/baselines/reference/destructuringParameterDeclaration2.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.types
@@ -122,7 +122,7 @@ function c2({z = 10}) { }
 >10 : 10
 
 function c3({b}: { b: number|string } = { b: "hello" }) { }
->c3 : ({ b }?: {    b: number | string;}) => void
+>c3 : ({ b }?: { b: number | string; }) => void
 >b : string | number
 >b : string | number
 >{ b: "hello" } : { b: string; }

--- a/tests/baselines/reference/destructuringParameterDeclaration5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration5.types
@@ -55,17 +55,17 @@ function d0<T extends Class>({x} = { x: new Class() }) { }
 >Class : typeof Class
 
 function d1<T extends F>({x}: { x: F }) { }
->d1 : <T extends F>({ x }: {    x: F;}) => void
+>d1 : <T extends F>({ x }: { x: F; }) => void
 >x : F
 >x : F
 
 function d2<T extends Class>({x}: { x: Class }) { }
->d2 : <T extends Class>({ x }: {    x: Class;}) => void
+>d2 : <T extends Class>({ x }: { x: Class; }) => void
 >x : Class
 >x : Class
 
 function d3<T extends D>({y}: { y: D }) { }
->d3 : <T extends D>({ y }: {    y: D;}) => void
+>d3 : <T extends D>({ y }: { y: D; }) => void
 >y : D
 >y : D
 

--- a/tests/baselines/reference/destructuringParameterDeclaration8.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration8.types
@@ -4,7 +4,7 @@
 // explicit type annotation should cause `method` to have type 'x' | 'y'
 // both inside and outside `test`.
 function test({
->test : ({ method, nested: { p } }: {    method?: 'x' | 'y';    nested?: {        p: 'a' | 'b';    };}) => void
+>test : ({ method, nested: { p } }: { method?: 'x' | 'y'; nested?: { p: 'a' | 'b'; }; }) => void
 
     method = 'z',
 >method : "x" | "y"

--- a/tests/baselines/reference/destructuringPropertyAssignmentNameIsNotAssignmentTarget.types
+++ b/tests/baselines/reference/destructuringPropertyAssignmentNameIsNotAssignmentTarget.types
@@ -3,7 +3,7 @@
 === destructuringPropertyAssignmentNameIsNotAssignmentTarget.ts ===
 // test for #10668
 function qux(bar: { value: number }) {
->qux : (bar: {    value: number;}) => void
+>qux : (bar: { value: number; }) => void
 >bar : { value: number; }
 >value : number
 

--- a/tests/baselines/reference/destructuringTypeGuardFlow.types
+++ b/tests/baselines/reference/destructuringTypeGuardFlow.types
@@ -2,7 +2,7 @@
 
 === destructuringTypeGuardFlow.ts ===
 type foo = {
->foo : { bar: number | null; baz: string; nested: {    a: number;    b: string | null;}; }
+>foo : { bar: number | null; baz: string; nested: { a: number; b: string | null; }; }
 
   bar: number | null;
 >bar : number | null

--- a/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.types
+++ b/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.types
@@ -12,7 +12,7 @@ declare function getNum(): number;
 >getNum : () => number
 
 declare function foo(arg: { x: Bar, y: Date }, item: number, items?: [number, number, number]): void;
->foo : (arg: {    x: Bar;    y: Date;}, item: number, items?: [number, number, number]) => void
+>foo : (arg: { x: Bar; y: Date; }, item: number, items?: [number, number, number]) => void
 >arg : { x: Bar; y: Date; }
 >x : Bar
 >y : Date

--- a/tests/baselines/reference/discriminatedUnionTypes2.types
+++ b/tests/baselines/reference/discriminatedUnionTypes2.types
@@ -2,7 +2,7 @@
 
 === discriminatedUnionTypes2.ts ===
 function f10(x : { kind: false, a: string } | { kind: true, b: string } | { kind: string, c: string }) {
->f10 : (x: {    kind: false;    a: string;} | {    kind: true;    b: string;} | {    kind: string;    c: string;}) => void
+>f10 : (x: { kind: false; a: string; } | { kind: true; b: string; } | { kind: string; c: string; }) => void
 >x : { kind: false; a: string; } | { kind: true; b: string; } | { kind: string; c: string; }
 >kind : false
 >false : false
@@ -46,7 +46,7 @@ function f10(x : { kind: false, a: string } | { kind: true, b: string } | { kind
 }
 
 function f11(x : { kind: false, a: string } | { kind: true, b: string } | { kind: string, c: string }) {
->f11 : (x: {    kind: false;    a: string;} | {    kind: true;    b: string;} | {    kind: string;    c: string;}) => void
+>f11 : (x: { kind: false; a: string; } | { kind: true; b: string; } | { kind: string; c: string; }) => void
 >x : { kind: false; a: string; } | { kind: true; b: string; } | { kind: string; c: string; }
 >kind : false
 >false : false
@@ -89,7 +89,7 @@ function f11(x : { kind: false, a: string } | { kind: true, b: string } | { kind
 }
 
 function f13(x: { a: null; b: string } | { a: string, c: number }) {
->f13 : (x: {    a: null;    b: string;} | {    a: string;    c: number;}) => void
+>f13 : (x: { a: null; b: string; } | { a: string; c: number; }) => void
 >x : { a: null; b: string; } | { a: string; c: number; }
 >a : null
 >b : string
@@ -108,7 +108,7 @@ function f13(x: { a: null; b: string } | { a: string, c: number }) {
 }
 
 function f14<T>(x: { a: 0; b: string } | { a: T, c: number }) {
->f14 : <T>(x: {    a: 0;    b: string;} | {    a: T;    c: number;}) => void
+>f14 : <T>(x: { a: 0; b: string; } | { a: T; c: number; }) => void
 >x : { a: 0; b: string; } | { a: T; c: number; }
 >a : 0
 >b : string
@@ -357,7 +357,7 @@ type RuntimeValue =
 >value : boolean
 
 function foo1(x: RuntimeValue & { type: 'number' }) {
->foo1 : (x: RuntimeValue & {    type: 'number';}) => void
+>foo1 : (x: RuntimeValue & { type: 'number'; }) => void
 >x : { type: "number"; value: number; } & { type: 'number'; }
 >type : "number"
 
@@ -382,7 +382,7 @@ function foo1(x: RuntimeValue & { type: 'number' }) {
 }
 
 function foo2(x: RuntimeValue & ({ type: 'number' } | { type: 'string' })) {
->foo2 : (x: RuntimeValue & ({    type: 'number';} | {    type: 'string';})) => void
+>foo2 : (x: RuntimeValue & ({ type: 'number'; } | { type: 'string'; })) => void
 >x : ({ type: "number"; value: number; } & { type: 'number'; }) | ({ type: "string"; value: string; } & { type: 'string'; })
 >type : "number"
 >type : "string"

--- a/tests/baselines/reference/elaboratedErrorsOnNullableTargets01.types
+++ b/tests/baselines/reference/elaboratedErrorsOnNullableTargets01.types
@@ -2,12 +2,12 @@
 
 === elaboratedErrorsOnNullableTargets01.ts ===
 export declare let x: null | { foo: { bar: string | null } | undefined } | undefined;
->x : { foo: {    bar: string | null;} | undefined; } | null | undefined
+>x : { foo: { bar: string | null; } | undefined; } | null | undefined
 >foo : { bar: string | null; } | undefined
 >bar : string | null
 
 export declare let y: { foo: { bar: number | undefined } };
->y : { foo: {    bar: number | undefined;}; }
+>y : { foo: { bar: number | undefined; }; }
 >foo : { bar: number | undefined; }
 >bar : number | undefined
 

--- a/tests/baselines/reference/elementAccessChain.2.types
+++ b/tests/baselines/reference/elementAccessChain.2.types
@@ -11,7 +11,7 @@ o1?.["b"];
 >"b" : "b"
 
 declare const o2: undefined | { b: { c: string } };
->o2 : { b: {    c: string;}; }
+>o2 : { b: { c: string; }; }
 >b : { c: string; }
 >c : string
 
@@ -30,7 +30,7 @@ o2?.b["c"];
 >"c" : "c"
 
 declare const o3: { b: undefined | { c: string } };
->o3 : { b: undefined | {    c: string;}; }
+>o3 : { b: undefined | { c: string; }; }
 >b : { c: string; }
 >c : string
 

--- a/tests/baselines/reference/elementAccessChain.types
+++ b/tests/baselines/reference/elementAccessChain.types
@@ -11,7 +11,7 @@ o1?.["b"];
 >"b" : "b"
 
 declare const o2: undefined | { b: { c: string } };
->o2 : { b: {    c: string;}; } | undefined
+>o2 : { b: { c: string; }; } | undefined
 >b : { c: string; }
 >c : string
 
@@ -30,7 +30,7 @@ o2?.b["c"];
 >"c" : "c"
 
 declare const o3: { b: undefined | { c: string } };
->o3 : { b: undefined | {    c: string;}; }
+>o3 : { b: undefined | { c: string; }; }
 >b : { c: string; } | undefined
 >c : string
 
@@ -49,8 +49,8 @@ o3.b?.["c"];
 >"c" : "c"
 
 declare const o4: { b?: { c: { d?: { e: string } } } };
->o4 : { b?: { c: {    d?: {        e: string;    };}; } | undefined; }
->b : { c: {    d?: {        e: string;    };}; } | undefined
+>o4 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
+>b : { c: { d?: { e: string; }; }; } | undefined
 >c : { d?: { e: string; } | undefined; }
 >d : { e: string; } | undefined
 >e : string
@@ -78,8 +78,8 @@ o4.b?.["c"].d?.["e"];
 >"e" : "e"
 
 declare const o5: { b?(): { c: { d?: { e: string } } } };
->o5 : { b?(): {    c: {        d?: {            e: string;        };    };}; }
->b : (() => {    c: {        d?: {            e: string;        };    };}) | undefined
+>o5 : { b?(): { c: { d?: { e: string; }; }; }; }
+>b : (() => { c: { d?: { e: string; }; }; }) | undefined
 >c : { d?: { e: string; } | undefined; }
 >d : { e: string; } | undefined
 >e : string
@@ -134,7 +134,7 @@ o5["b"]?.()["c"].d?.["e"];
 
 // GH#33744
 declare const o6: <T>() => undefined | ({ x: number });
->o6 : <T>() => undefined | ({    x: number;})
+>o6 : <T>() => undefined | ({ x: number; })
 >x : number
 
 o6<number>()?.["x"];

--- a/tests/baselines/reference/emptyOptionalBindingPatternInDeclarationSignature.types
+++ b/tests/baselines/reference/emptyOptionalBindingPatternInDeclarationSignature.types
@@ -4,11 +4,11 @@
 // #50791
 
 declare function fn1({}?: { x: string }): void;
->fn1 : ({}?: {    x: string;}) => void
+>fn1 : ({}?: { x: string; }) => void
 >x : string
 
 declare function fn2({ x }?: { x: string }): void;
->fn2 : ({ x }?: {    x: string;}) => void
+>fn2 : ({ x }?: { x: string; }) => void
 >x : string
 >x : string
 
@@ -23,61 +23,61 @@ declare class C1 {
 >C1 : C1
 
     method({}?: { x: string }): void
->method : ({}?: {    x: string;}) => void
+>method : ({}?: { x: string; }) => void
 >x : string
 
     static method2({}?: { x: string }): void
->method2 : ({}?: {    x: string;}) => void
+>method2 : ({}?: { x: string; }) => void
 >x : string
 
     static field: ({}?: { x: string }) => void
->field : ({}?: {    x: string;}) => void
+>field : ({}?: { x: string; }) => void
 >x : string
 
     static field2: ({}?: { x: string }) => void
->field2 : ({}?: {    x: string;}) => void
+>field2 : ({}?: { x: string; }) => void
 >x : string
 }
 
 interface I1 {
     method({}?: { x: string }): void
->method : ({}?: {    x: string;}) => void
+>method : ({}?: { x: string; }) => void
 >x : string
 
     method2: ({}?: { x: string }) => void
->method2 : ({}?: {    x: string;}) => void
+>method2 : ({}?: { x: string; }) => void
 >x : string
 }
 
 type T1 = ({}?: { x: string }) => void
->T1 : ({}?: {    x: string;}) => void
+>T1 : ({}?: { x: string; }) => void
 >x : string
 
 type T2 = {
->T2 : { method({}?: {    x: string;}): void; method2: ({}?: {    x: string;}) => void; }
+>T2 : { method({}?: { x: string; }): void; method2: ({}?: { x: string; }) => void; }
 
     method({}?: { x: string }): void
->method : ({}?: {    x: string;}) => void
+>method : ({}?: { x: string; }) => void
 >x : string
 
     method2: ({}?: { x: string }) => void
->method2 : ({}?: {    x: string;}) => void
+>method2 : ({}?: { x: string; }) => void
 >x : string
 }
 
 declare const val1: ({}?: { x: string }) => void
->val1 : ({}?: {    x: string;}) => void
+>val1 : ({}?: { x: string; }) => void
 >x : string
 
 declare const val2: {
->val2 : { method({}?: {    x: string;}): void; method2: ({}?: {    x: string;}) => void; }
+>val2 : { method({}?: { x: string; }): void; method2: ({}?: { x: string; }) => void; }
 
     method({}?: { x: string }): void
->method : ({}?: {    x: string;}) => void
+>method : ({}?: { x: string; }) => void
 >x : string
 
     method2: ({}?: { x: string }) => void
->method2 : ({}?: {    x: string;}) => void
+>method2 : ({}?: { x: string; }) => void
 >x : string
 }
 

--- a/tests/baselines/reference/enumAssignabilityInInheritance.types
+++ b/tests/baselines/reference/enumAssignabilityInInheritance.types
@@ -114,7 +114,7 @@ var r4 = foo5(E.A);
 >A : E
 
 declare function foo6(x: { bar: number }): { bar: number };
->foo6 : { (x: {    bar: number;}): {    bar: number;}; (x: E): E; }
+>foo6 : { (x: { bar: number; }): { bar: number; }; (x: E): E; }
 >x : { bar: number; }
 >bar : number
 >bar : number

--- a/tests/baselines/reference/equalityStrictNulls.types
+++ b/tests/baselines/reference/equalityStrictNulls.types
@@ -101,7 +101,7 @@ function f2() {
 }
 
 function f3(a: number, b: boolean, c: { x: number }, d: number | string) {
->f3 : (a: number, b: boolean, c: {    x: number;}, d: number | string) => void
+>f3 : (a: number, b: boolean, c: { x: number; }, d: number | string) => void
 >a : number
 >b : boolean
 >c : { x: number; }

--- a/tests/baselines/reference/errorsInGenericTypeReference.types
+++ b/tests/baselines/reference/errorsInGenericTypeReference.types
@@ -43,11 +43,11 @@ class testClass3 {
 >testClass3 : testClass3
 
     testMethod1(): Foo<{ x: V }> { return null; } // error: could not find symbol V
->testMethod1 : () => Foo<{    x: V;}>
+>testMethod1 : () => Foo<{ x: V; }>
 >x : V
 
     static testMethod2(): Foo<{ x: V }> { return null } // error: could not find symbol V
->testMethod2 : () => Foo<{    x: V;}>
+>testMethod2 : () => Foo<{ x: V; }>
 >x : V
 
     set a(value: Foo<{ x: V }>) { } // error: could not find symbol V
@@ -63,13 +63,13 @@ class testClass3 {
 
 // in function return type annotation
 function testFunction1(): Foo<{ x: V }> { return null; } // error: could not find symbol V
->testFunction1 : () => Foo<{    x: V;}>
+>testFunction1 : () => Foo<{ x: V; }>
 >x : V
 
 
 // in paramter types
 function testFunction2(p: Foo<{ x: V }>) { }// error: could not find symbol V
->testFunction2 : (p: Foo<{    x: V;}>) => void
+>testFunction2 : (p: Foo<{ x: V; }>) => void
 >p : Foo<{ x: V; }>
 >x : V
 
@@ -128,7 +128,7 @@ interface testInterface2 {
 >x : V
 
     method(a: Foo<{ x: V }>): Foo<{ x: V }>; //2x: error: could not find symbol V
->method : (a: Foo<{    x: V;}>) => Foo<{    x: V;}>
+>method : (a: Foo<{ x: V; }>) => Foo<{ x: V; }>
 >a : Foo<{ x: V; }>
 >x : V
 >x : V

--- a/tests/baselines/reference/excessPropertiesInOverloads.types
+++ b/tests/baselines/reference/excessPropertiesInOverloads.types
@@ -2,12 +2,12 @@
 
 === excessPropertiesInOverloads.ts ===
 declare function fn(a: { x: string }): void;
->fn : { (a: {    x: string;}): void; (a: { y: string; }): void; }
+>fn : { (a: { x: string; }): void; (a: { y: string; }): void; }
 >a : { x: string; }
 >x : string
 
 declare function fn(a: { y: string }): void;
->fn : { (a: { x: string; }): void; (a: {    y: string;}): void; }
+>fn : { (a: { x: string; }): void; (a: { y: string; }): void; }
 >a : { y: string; }
 >y : string
 

--- a/tests/baselines/reference/excessPropertyCheckIntersectionWithRecursiveType.types
+++ b/tests/baselines/reference/excessPropertyCheckIntersectionWithRecursiveType.types
@@ -4,7 +4,7 @@
 // repro from #44750
 
 type Request = { l1: { l2: boolean } };
->Request : { l1: {    l2: boolean;}; }
+>Request : { l1: { l2: boolean; }; }
 >l1 : { l2: boolean; }
 >l2 : boolean
 

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.types
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.types
@@ -399,7 +399,7 @@ declare const prop2: string | undefined;
 >prop2 : string | undefined
 
 function F1(_arg: { props: Properties }) { }
->F1 : (_arg: {    props: Properties;}) => void
+>F1 : (_arg: { props: Properties; }) => void
 >_arg : { props: Properties; }
 >props : Properties
 

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.types
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.types
@@ -82,7 +82,7 @@ let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // error - y does not exist in typ
 // https://github.com/Microsoft/TypeScript/issues/18075
 
 export type MyType = { id: number; } & { name: string; } & { photo: { id: number; } & { url: string; } }
->MyType : { id: number; } & { name: string; } & { photo: {    id: number;} & {    url: string;}; }
+>MyType : { id: number; } & { name: string; } & { photo: { id: number; } & { url: string; }; }
 >id : number
 >name : string
 >photo : { id: number; } & { url: string; }

--- a/tests/baselines/reference/excessiveStackDepthFlatArray.types
+++ b/tests/baselines/reference/excessiveStackDepthFlatArray.types
@@ -3,7 +3,7 @@
 === index.tsx ===
 interface MiddlewareArray<T> extends Array<T> {}
 declare function configureStore(options: { middleware: MiddlewareArray<any> }): void;
->configureStore : (options: {    middleware: MiddlewareArray<any>;}) => void
+>configureStore : (options: { middleware: MiddlewareArray<any>; }) => void
 >options : { middleware: MiddlewareArray<any>; }
 >middleware : MiddlewareArray<any>
 

--- a/tests/baselines/reference/expandoFunctionContextualTypesJs.types
+++ b/tests/baselines/reference/expandoFunctionContextualTypesJs.types
@@ -59,7 +59,7 @@ const check = MyComponent2;
  * @param {{ props: MyComponentProps }} p 
  */
 function expectLiteral(p) {}
->expectLiteral : (p: {    props: MyComponentProps;}) => void
+>expectLiteral : (p: { props: MyComponentProps; }) => void
 >p : { props: MyComponentProps; }
 
 function foo() {

--- a/tests/baselines/reference/freshLiteralInference.types
+++ b/tests/baselines/reference/freshLiteralInference.types
@@ -16,7 +16,7 @@ let x1 = value;  // regular "1"
 >value : "1"
 
 declare function f2<T extends "1" | "2" | "3">(x: { value: T }): { value: T };
->f2 : <T extends "1" | "2" | "3">(x: {    value: T;}) => {    value: T;}
+>f2 : <T extends "1" | "2" | "3">(x: { value: T; }) => { value: T; }
 >x : { value: T; }
 >value : T
 >value : T

--- a/tests/baselines/reference/functionAssignment.types
+++ b/tests/baselines/reference/functionAssignment.types
@@ -68,7 +68,7 @@ f2(() => {
 });
 
 function f3(a: { a: number; b: number; }) { }
->f3 : (a: {    a: number;    b: number;}) => void
+>f3 : (a: { a: number; b: number; }) => void
 >a : { a: number; b: number; }
 >a : number
 >b : number

--- a/tests/baselines/reference/functionOverloads14.types
+++ b/tests/baselines/reference/functionOverloads14.types
@@ -2,11 +2,11 @@
 
 === functionOverloads14.ts ===
 function foo():{a:number;}
->foo : { (): {    a: number;}; (): { a: string; }; }
+>foo : { (): { a: number; }; (): { a: string; }; }
 >a : number
 
 function foo():{a:string;}
->foo : { (): { a: number; }; (): {    a: string;}; }
+>foo : { (): { a: number; }; (): { a: string; }; }
 >a : string
 
 function foo():{a:any;} { return {a:1} }

--- a/tests/baselines/reference/functionOverloads15.types
+++ b/tests/baselines/reference/functionOverloads15.types
@@ -2,13 +2,13 @@
 
 === functionOverloads15.ts ===
 function foo(foo:{a:string; b:number;}):string;
->foo : { (foo: {    a: string;    b: number;}): string; (foo: { a: string; b: number; }): number; }
+>foo : { (foo: { a: string; b: number; }): string; (foo: { a: string; b: number; }): number; }
 >foo : { a: string; b: number; }
 >a : string
 >b : number
 
 function foo(foo:{a:string; b:number;}):number;
->foo : { (foo: { a: string; b: number; }): string; (foo: {    a: string;    b: number;}): number; }
+>foo : { (foo: { a: string; b: number; }): string; (foo: { a: string; b: number; }): number; }
 >foo : { a: string; b: number; }
 >a : string
 >b : number

--- a/tests/baselines/reference/functionOverloads16.types
+++ b/tests/baselines/reference/functionOverloads16.types
@@ -2,12 +2,12 @@
 
 === functionOverloads16.ts ===
 function foo(foo:{a:string;}):string;
->foo : { (foo: {    a: string;}): string; (foo: { a: string; }): number; }
+>foo : { (foo: { a: string; }): string; (foo: { a: string; }): number; }
 >foo : { a: string; }
 >a : string
 
 function foo(foo:{a:string;}):number;
->foo : { (foo: { a: string; }): string; (foo: {    a: string;}): number; }
+>foo : { (foo: { a: string; }): string; (foo: { a: string; }): number; }
 >foo : { a: string; }
 >a : string
 

--- a/tests/baselines/reference/functionOverloads17.types
+++ b/tests/baselines/reference/functionOverloads17.types
@@ -2,7 +2,7 @@
 
 === functionOverloads17.ts ===
 function foo():{a:number;}
->foo : () => {    a: number;}
+>foo : () => { a: number; }
 >a : number
 
 function foo():{a:string;} { return {a:""} }

--- a/tests/baselines/reference/functionOverloads18.types
+++ b/tests/baselines/reference/functionOverloads18.types
@@ -2,7 +2,7 @@
 
 === functionOverloads18.ts ===
 function foo(bar:{a:number;});
->foo : (bar: {    a: number;}) => any
+>foo : (bar: { a: number; }) => any
 >bar : { a: number; }
 >a : number
 

--- a/tests/baselines/reference/functionOverloads19.types
+++ b/tests/baselines/reference/functionOverloads19.types
@@ -2,12 +2,12 @@
 
 === functionOverloads19.ts ===
 function foo(bar:{b:string;});
->foo : { (bar: {    b: string;}): any; (bar: { a: string; }): any; }
+>foo : { (bar: { b: string; }): any; (bar: { a: string; }): any; }
 >bar : { b: string; }
 >b : string
 
 function foo(bar:{a:string;});
->foo : { (bar: { b: string; }): any; (bar: {    a: string;}): any; }
+>foo : { (bar: { b: string; }): any; (bar: { a: string; }): any; }
 >bar : { a: string; }
 >a : string
 

--- a/tests/baselines/reference/functionOverloads20.types
+++ b/tests/baselines/reference/functionOverloads20.types
@@ -2,12 +2,12 @@
 
 === functionOverloads20.ts ===
 function foo(bar:{a:number;}): number;
->foo : { (bar: {    a: number;}): number; (bar: { a: string; }): string; }
+>foo : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: number; }
 >a : number
 
 function foo(bar:{a:string;}): string;
->foo : { (bar: { a: number; }): number; (bar: {    a: string;}): string; }
+>foo : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: string; }
 >a : string
 

--- a/tests/baselines/reference/functionOverloads21.types
+++ b/tests/baselines/reference/functionOverloads21.types
@@ -2,12 +2,12 @@
 
 === functionOverloads21.ts ===
 function foo(bar:{a:number;}[]);
->foo : { (bar: {    a: number;}[]): any; (bar: { a: number; b: string; }[]): any; }
+>foo : { (bar: { a: number; }[]): any; (bar: { a: number; b: string; }[]): any; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:number; b:string;}[]);
->foo : { (bar: { a: number; }[]): any; (bar: {    a: number;    b: string;}[]): any; }
+>foo : { (bar: { a: number; }[]): any; (bar: { a: number; b: string; }[]): any; }
 >bar : { a: number; b: string; }[]
 >a : number
 >b : string

--- a/tests/baselines/reference/functionOverloads22.types
+++ b/tests/baselines/reference/functionOverloads22.types
@@ -2,12 +2,12 @@
 
 === functionOverloads22.ts ===
 function foo(bar:number):{a:number;}[];
->foo : { (bar: number): {    a: number;}[]; (bar: string): { a: number; b: string; }[]; }
+>foo : { (bar: number): { a: number; }[]; (bar: string): { a: number; b: string; }[]; }
 >bar : number
 >a : number
 
 function foo(bar:string):{a:number; b:string;}[];
->foo : { (bar: number): { a: number; }[]; (bar: string): {    a: number;    b: string;}[]; }
+>foo : { (bar: number): { a: number; }[]; (bar: string): { a: number; b: string; }[]; }
 >bar : string
 >a : number
 >b : string

--- a/tests/baselines/reference/functionOverloads34.types
+++ b/tests/baselines/reference/functionOverloads34.types
@@ -2,12 +2,12 @@
 
 === functionOverloads34.ts ===
 function foo(bar:{a:number;}):string;
->foo : { (bar: {    a: number;}): string; (bar: { a: boolean; }): number; }
+>foo : { (bar: { a: number; }): string; (bar: { a: boolean; }): number; }
 >bar : { a: number; }
 >a : number
 
 function foo(bar:{a:boolean;}):number;
->foo : { (bar: { a: number; }): string; (bar: {    a: boolean;}): number; }
+>foo : { (bar: { a: number; }): string; (bar: { a: boolean; }): number; }
 >bar : { a: boolean; }
 >a : boolean
 

--- a/tests/baselines/reference/functionOverloads35.types
+++ b/tests/baselines/reference/functionOverloads35.types
@@ -2,12 +2,12 @@
 
 === functionOverloads35.ts ===
 function foo(bar:{a:number;}):number;
->foo : { (bar: {    a: number;}): number; (bar: { a: string; }): string; }
+>foo : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: number; }
 >a : number
 
 function foo(bar:{a:string;}):string;
->foo : { (bar: { a: number; }): number; (bar: {    a: string;}): string; }
+>foo : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: string; }
 >a : string
 

--- a/tests/baselines/reference/functionOverloads36.types
+++ b/tests/baselines/reference/functionOverloads36.types
@@ -2,12 +2,12 @@
 
 === functionOverloads36.ts ===
 function foo(bar:{a:number;}):number;
->foo : { (bar: {    a: number;}): number; (bar: { a: string; }): string; }
+>foo : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: number; }
 >a : number
 
 function foo(bar:{a:string;}):string;
->foo : { (bar: { a: number; }): number; (bar: {    a: string;}): string; }
+>foo : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: string; }
 >a : string
 

--- a/tests/baselines/reference/functionOverloads37.types
+++ b/tests/baselines/reference/functionOverloads37.types
@@ -2,12 +2,12 @@
 
 === functionOverloads37.ts ===
 function foo(bar:{a:number;}[]):string;
->foo : { (bar: {    a: number;}[]): string; (bar: { a: boolean; }[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:boolean;}[]):number;
->foo : { (bar: { a: number; }[]): string; (bar: {    a: boolean;}[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: boolean; }[]
 >a : boolean
 

--- a/tests/baselines/reference/functionOverloads38.types
+++ b/tests/baselines/reference/functionOverloads38.types
@@ -2,12 +2,12 @@
 
 === functionOverloads38.ts ===
 function foo(bar:{a:number;}[]):string;
->foo : { (bar: {    a: number;}[]): string; (bar: { a: boolean; }[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:boolean;}[]):number;
->foo : { (bar: { a: number; }[]): string; (bar: {    a: boolean;}[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: boolean; }[]
 >a : boolean
 

--- a/tests/baselines/reference/functionOverloads39.types
+++ b/tests/baselines/reference/functionOverloads39.types
@@ -2,12 +2,12 @@
 
 === functionOverloads39.ts ===
 function foo(bar:{a:number;}[]):string;
->foo : { (bar: {    a: number;}[]): string; (bar: { a: boolean; }[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:boolean;}[]):number;
->foo : { (bar: { a: number; }[]): string; (bar: {    a: boolean;}[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: boolean; }[]
 >a : boolean
 

--- a/tests/baselines/reference/functionOverloads40.types
+++ b/tests/baselines/reference/functionOverloads40.types
@@ -2,12 +2,12 @@
 
 === functionOverloads40.ts ===
 function foo(bar:{a:number;}[]):string;
->foo : { (bar: {    a: number;}[]): string; (bar: { a: boolean; }[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:boolean;}[]):number;
->foo : { (bar: { a: number; }[]): string; (bar: {    a: boolean;}[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: boolean; }[]
 >a : boolean
 

--- a/tests/baselines/reference/functionOverloads41.types
+++ b/tests/baselines/reference/functionOverloads41.types
@@ -2,12 +2,12 @@
 
 === functionOverloads41.ts ===
 function foo(bar:{a:number;}[]):string;
->foo : { (bar: {    a: number;}[]): string; (bar: { a: boolean; }[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:boolean;}[]):number;
->foo : { (bar: { a: number; }[]): string; (bar: {    a: boolean;}[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: boolean; }[]
 >a : boolean
 

--- a/tests/baselines/reference/functionOverloads42.types
+++ b/tests/baselines/reference/functionOverloads42.types
@@ -2,12 +2,12 @@
 
 === functionOverloads42.ts ===
 function foo(bar:{a:number;}[]):string;
->foo : { (bar: {    a: number;}[]): string; (bar: { a: any; }[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: any; }[]): number; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:any;}[]):number;
->foo : { (bar: { a: number; }[]): string; (bar: {    a: any;}[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: any; }[]): number; }
 >bar : { a: any; }[]
 >a : any
 

--- a/tests/baselines/reference/functionOverloads43.types
+++ b/tests/baselines/reference/functionOverloads43.types
@@ -2,12 +2,12 @@
 
 === functionOverloads43.ts ===
 function foo(bar: { a:number }[]): number;
->foo : { (bar: {    a: number;}[]): number; (bar: { a: string; }[]): string; }
+>foo : { (bar: { a: number; }[]): number; (bar: { a: string; }[]): string; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar: { a:string }[]): string;
->foo : { (bar: { a: number; }[]): number; (bar: {    a: string;}[]): string; }
+>foo : { (bar: { a: number; }[]): number; (bar: { a: string; }[]): string; }
 >bar : { a: string; }[]
 >a : string
 

--- a/tests/baselines/reference/functionOverloads44.types
+++ b/tests/baselines/reference/functionOverloads44.types
@@ -11,12 +11,12 @@ interface Cat extends Animal { cat }
 >cat : any
 
 function foo1(bar: { a:number }[]): Dog;
->foo1 : { (bar: {    a: number;}[]): Dog; (bar: { a: string; }[]): Animal; }
+>foo1 : { (bar: { a: number; }[]): Dog; (bar: { a: string; }[]): Animal; }
 >bar : { a: number; }[]
 >a : number
 
 function foo1(bar: { a:string }[]): Animal;
->foo1 : { (bar: { a: number; }[]): Dog; (bar: {    a: string;}[]): Animal; }
+>foo1 : { (bar: { a: number; }[]): Dog; (bar: { a: string; }[]): Animal; }
 >bar : { a: string; }[]
 >a : string
 
@@ -30,12 +30,12 @@ function foo1([x]: { a:number | string }[]): Dog {
 }
 
 function foo2(bar: { a:number }[]): Cat;
->foo2 : { (bar: {    a: number;}[]): Cat; (bar: { a: string; }[]): Dog | Cat; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog | Cat; }
 >bar : { a: number; }[]
 >a : number
 
 function foo2(bar: { a:string }[]): Cat | Dog;
->foo2 : { (bar: { a: number; }[]): Cat; (bar: {    a: string;}[]): Cat | Dog; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Cat | Dog; }
 >bar : { a: string; }[]
 >a : string
 

--- a/tests/baselines/reference/functionOverloads45.types
+++ b/tests/baselines/reference/functionOverloads45.types
@@ -11,12 +11,12 @@ interface Cat extends Animal { cat }
 >cat : any
 
 function foo1(bar: { a:number }[]): Cat;
->foo1 : { (bar: {    a: number;}[]): Cat; (bar: { a: string; }[]): Dog; }
+>foo1 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog; }
 >bar : { a: number; }[]
 >a : number
 
 function foo1(bar: { a:string }[]): Dog;
->foo1 : { (bar: { a: number; }[]): Cat; (bar: {    a: string;}[]): Dog; }
+>foo1 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog; }
 >bar : { a: string; }[]
 >a : string
 
@@ -30,12 +30,12 @@ function foo1([x]: { a:number | string }[]): Animal {
 }
 
 function foo2(bar: { a:number }[]): Cat;
->foo2 : { (bar: {    a: number;}[]): Cat; (bar: { a: string; }[]): Dog; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog; }
 >bar : { a: number; }[]
 >a : number
 
 function foo2(bar: { a:string }[]): Dog;
->foo2 : { (bar: { a: number; }[]): Cat; (bar: {    a: string;}[]): Dog; }
+>foo2 : { (bar: { a: number; }[]): Cat; (bar: { a: string; }[]): Dog; }
 >bar : { a: string; }[]
 >a : string
 

--- a/tests/baselines/reference/functionReturnTypeQuery.types
+++ b/tests/baselines/reference/functionReturnTypeQuery.types
@@ -12,7 +12,7 @@ declare function test1(foo: string, bar: typeof foo): typeof foo;
 >foo : string
 
 declare function test2({foo}: {foo: string}, bar: typeof foo): typeof foo;
->test2 : ({ foo }: {    foo: string;}, bar: typeof foo) => typeof foo
+>test2 : ({ foo }: { foo: string; }, bar: typeof foo) => typeof foo
 >foo : string
 >foo : string
 >bar : string

--- a/tests/baselines/reference/generatedContextualTyping.types
+++ b/tests/baselines/reference/generatedContextualTyping.types
@@ -1054,7 +1054,7 @@ function x123(parm: () => Base[] = function named() { return [d1, d2] }) { }
 >d2 : Derived2
 
 function x124(parm: { (): Base[]; } = () => [d1, d2]) { }
->x124 : (parm?: {    (): Base[];}) => void
+>x124 : (parm?: { (): Base[]; }) => void
 >parm : () => Base[]
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1062,7 +1062,7 @@ function x124(parm: { (): Base[]; } = () => [d1, d2]) { }
 >d2 : Derived2
 
 function x125(parm: { (): Base[]; } = function() { return [d1, d2] }) { }
->x125 : (parm?: {    (): Base[];}) => void
+>x125 : (parm?: { (): Base[]; }) => void
 >parm : () => Base[]
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1070,7 +1070,7 @@ function x125(parm: { (): Base[]; } = function() { return [d1, d2] }) { }
 >d2 : Derived2
 
 function x126(parm: { (): Base[]; } = function named() { return [d1, d2] }) { }
->x126 : (parm?: {    (): Base[];}) => void
+>x126 : (parm?: { (): Base[]; }) => void
 >parm : () => Base[]
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >named : () => (Derived1 | Derived2)[]
@@ -1101,7 +1101,7 @@ function x129(parm: { [n: number]: Base; } = [d1, d2]) { }
 >d2 : Derived2
 
 function x130(parm: {n: Base[]; }  = { n: [d1, d2] }) { }
->x130 : (parm?: {    n: Base[];}) => void
+>x130 : (parm?: { n: Base[]; }) => void
 >parm : { n: Base[]; }
 >n : Base[]
 >{ n: [d1, d2] } : { n: (Derived1 | Derived2)[]; }
@@ -1152,21 +1152,21 @@ function x135(): () => Base[] { return function named() { return [d1, d2] }; }
 >d2 : Derived2
 
 function x136(): { (): Base[]; } { return () => [d1, d2]; }
->x136 : () => {    (): Base[];}
+>x136 : () => { (): Base[]; }
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
 >d1 : Derived1
 >d2 : Derived2
 
 function x137(): { (): Base[]; } { return function() { return [d1, d2] }; }
->x137 : () => {    (): Base[];}
+>x137 : () => { (): Base[]; }
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
 >d1 : Derived1
 >d2 : Derived2
 
 function x138(): { (): Base[]; } { return function named() { return [d1, d2] }; }
->x138 : () => {    (): Base[];}
+>x138 : () => { (): Base[]; }
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >named : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1193,7 +1193,7 @@ function x141(): { [n: number]: Base; } { return [d1, d2]; }
 >d2 : Derived2
 
 function x142(): {n: Base[]; }  { return { n: [d1, d2] }; }
->x142 : () => {    n: Base[];}
+>x142 : () => { n: Base[]; }
 >n : Base[]
 >{ n: [d1, d2] } : { n: (Derived1 | Derived2)[]; }
 >n : (Derived1 | Derived2)[]
@@ -1254,7 +1254,7 @@ function x147(): () => Base[] { return function named() { return [d1, d2] }; ret
 >d2 : Derived2
 
 function x148(): { (): Base[]; } { return () => [d1, d2]; return () => [d1, d2]; }
->x148 : () => {    (): Base[];}
+>x148 : () => { (): Base[]; }
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
 >d1 : Derived1
@@ -1265,7 +1265,7 @@ function x148(): { (): Base[]; } { return () => [d1, d2]; return () => [d1, d2];
 >d2 : Derived2
 
 function x149(): { (): Base[]; } { return function() { return [d1, d2] }; return function() { return [d1, d2] }; }
->x149 : () => {    (): Base[];}
+>x149 : () => { (): Base[]; }
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
 >d1 : Derived1
@@ -1276,7 +1276,7 @@ function x149(): { (): Base[]; } { return function() { return [d1, d2] }; return
 >d2 : Derived2
 
 function x150(): { (): Base[]; } { return function named() { return [d1, d2] }; return function named() { return [d1, d2] }; }
->x150 : () => {    (): Base[];}
+>x150 : () => { (): Base[]; }
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >named : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1317,7 +1317,7 @@ function x153(): { [n: number]: Base; } { return [d1, d2]; return [d1, d2]; }
 >d2 : Derived2
 
 function x154(): {n: Base[]; }  { return { n: [d1, d2] }; return { n: [d1, d2] }; }
->x154 : () => {    n: Base[];}
+>x154 : () => { n: Base[]; }
 >n : Base[]
 >{ n: [d1, d2] } : { n: (Derived1 | Derived2)[]; }
 >n : (Derived1 | Derived2)[]
@@ -1383,7 +1383,7 @@ var x159: () => () => Base[] = () => { return function named() { return [d1, d2]
 >d2 : Derived2
 
 var x160: () => { (): Base[]; } = () => { return () => [d1, d2]; };
->x160 : () => {    (): Base[];}
+>x160 : () => { (): Base[]; }
 >() => { return () => [d1, d2]; } : () => () => (Derived1 | Derived2)[]
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1391,7 +1391,7 @@ var x160: () => { (): Base[]; } = () => { return () => [d1, d2]; };
 >d2 : Derived2
 
 var x161: () => { (): Base[]; } = () => { return function() { return [d1, d2] }; };
->x161 : () => {    (): Base[];}
+>x161 : () => { (): Base[]; }
 >() => { return function() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1399,7 +1399,7 @@ var x161: () => { (): Base[]; } = () => { return function() { return [d1, d2] };
 >d2 : Derived2
 
 var x162: () => { (): Base[]; } = () => { return function named() { return [d1, d2] }; };
->x162 : () => {    (): Base[];}
+>x162 : () => { (): Base[]; }
 >() => { return function named() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >named : () => (Derived1 | Derived2)[]
@@ -1430,7 +1430,7 @@ var x165: () => { [n: number]: Base; } = () => { return [d1, d2]; };
 >d2 : Derived2
 
 var x166: () => {n: Base[]; }  = () => { return { n: [d1, d2] }; };
->x166 : () => {    n: Base[];}
+>x166 : () => { n: Base[]; }
 >n : Base[]
 >() => { return { n: [d1, d2] }; } : () => { n: (Derived1 | Derived2)[]; }
 >{ n: [d1, d2] } : { n: (Derived1 | Derived2)[]; }
@@ -1484,7 +1484,7 @@ var x171: () => () => Base[] = function() { return function named() { return [d1
 >d2 : Derived2
 
 var x172: () => { (): Base[]; } = function() { return () => [d1, d2]; };
->x172 : () => {    (): Base[];}
+>x172 : () => { (): Base[]; }
 >function() { return () => [d1, d2]; } : () => () => (Derived1 | Derived2)[]
 >() => [d1, d2] : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1492,7 +1492,7 @@ var x172: () => { (): Base[]; } = function() { return () => [d1, d2]; };
 >d2 : Derived2
 
 var x173: () => { (): Base[]; } = function() { return function() { return [d1, d2] }; };
->x173 : () => {    (): Base[];}
+>x173 : () => { (): Base[]; }
 >function() { return function() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >[d1, d2] : (Derived1 | Derived2)[]
@@ -1500,7 +1500,7 @@ var x173: () => { (): Base[]; } = function() { return function() { return [d1, d
 >d2 : Derived2
 
 var x174: () => { (): Base[]; } = function() { return function named() { return [d1, d2] }; };
->x174 : () => {    (): Base[];}
+>x174 : () => { (): Base[]; }
 >function() { return function named() { return [d1, d2] }; } : () => () => (Derived1 | Derived2)[]
 >function named() { return [d1, d2] } : () => (Derived1 | Derived2)[]
 >named : () => (Derived1 | Derived2)[]
@@ -1531,7 +1531,7 @@ var x177: () => { [n: number]: Base; } = function() { return [d1, d2]; };
 >d2 : Derived2
 
 var x178: () => {n: Base[]; }  = function() { return { n: [d1, d2] }; };
->x178 : () => {    n: Base[];}
+>x178 : () => { n: Base[]; }
 >n : Base[]
 >function() { return { n: [d1, d2] }; } : () => { n: (Derived1 | Derived2)[]; }
 >{ n: [d1, d2] } : { n: (Derived1 | Derived2)[]; }
@@ -2073,7 +2073,7 @@ var x239: { n: () => Base[]; } = { n: function named() { return [d1, d2] } };
 >d2 : Derived2
 
 var x240: { n: { (): Base[]; }; } = { n: () => [d1, d2] };
->x240 : { n: {    (): Base[];}; }
+>x240 : { n: { (): Base[]; }; }
 >n : () => Base[]
 >{ n: () => [d1, d2] } : { n: () => (Derived1 | Derived2)[]; }
 >n : () => (Derived1 | Derived2)[]
@@ -2083,7 +2083,7 @@ var x240: { n: { (): Base[]; }; } = { n: () => [d1, d2] };
 >d2 : Derived2
 
 var x241: { n: { (): Base[]; }; } = { n: function() { return [d1, d2] } };
->x241 : { n: {    (): Base[];}; }
+>x241 : { n: { (): Base[]; }; }
 >n : () => Base[]
 >{ n: function() { return [d1, d2] } } : { n: () => (Derived1 | Derived2)[]; }
 >n : () => (Derived1 | Derived2)[]
@@ -2093,7 +2093,7 @@ var x241: { n: { (): Base[]; }; } = { n: function() { return [d1, d2] } };
 >d2 : Derived2
 
 var x242: { n: { (): Base[]; }; } = { n: function named() { return [d1, d2] } };
->x242 : { n: {    (): Base[];}; }
+>x242 : { n: { (): Base[]; }; }
 >n : () => Base[]
 >{ n: function named() { return [d1, d2] } } : { n: () => (Derived1 | Derived2)[]; }
 >n : () => (Derived1 | Derived2)[]
@@ -2132,7 +2132,7 @@ var x245: { n: { [n: number]: Base; }; } = { n: [d1, d2] };
 >d2 : Derived2
 
 var x246: { n: {n: Base[]; } ; } = { n: { n: [d1, d2] } };
->x246 : { n: {    n: Base[];}; }
+>x246 : { n: { n: Base[]; }; }
 >n : { n: Base[]; }
 >n : Base[]
 >{ n: { n: [d1, d2] } } : { n: { n: (Derived1 | Derived2)[]; }; }
@@ -2925,7 +2925,7 @@ function x323(n: () => Base[]) { }; x323(function named() { return [d1, d2] });
 >d2 : Derived2
 
 function x324(n: { (): Base[]; }) { }; x324(() => [d1, d2]);
->x324 : (n: {    (): Base[];}) => void
+>x324 : (n: { (): Base[]; }) => void
 >n : () => Base[]
 >x324(() => [d1, d2]) : void
 >x324 : (n: () => Base[]) => void
@@ -2935,7 +2935,7 @@ function x324(n: { (): Base[]; }) { }; x324(() => [d1, d2]);
 >d2 : Derived2
 
 function x325(n: { (): Base[]; }) { }; x325(function() { return [d1, d2] });
->x325 : (n: {    (): Base[];}) => void
+>x325 : (n: { (): Base[]; }) => void
 >n : () => Base[]
 >x325(function() { return [d1, d2] }) : void
 >x325 : (n: () => Base[]) => void
@@ -2945,7 +2945,7 @@ function x325(n: { (): Base[]; }) { }; x325(function() { return [d1, d2] });
 >d2 : Derived2
 
 function x326(n: { (): Base[]; }) { }; x326(function named() { return [d1, d2] });
->x326 : (n: {    (): Base[];}) => void
+>x326 : (n: { (): Base[]; }) => void
 >n : () => Base[]
 >x326(function named() { return [d1, d2] }) : void
 >x326 : (n: () => Base[]) => void
@@ -2984,7 +2984,7 @@ function x329(n: { [n: number]: Base; }) { }; x329([d1, d2]);
 >d2 : Derived2
 
 function x330(n: {n: Base[]; } ) { }; x330({ n: [d1, d2] });
->x330 : (n: {    n: Base[];}) => void
+>x330 : (n: { n: Base[]; }) => void
 >n : { n: Base[]; }
 >n : Base[]
 >x330({ n: [d1, d2] }) : void
@@ -3056,8 +3056,8 @@ var x335 = (n: () => Base[]) => n; x335(function named() { return [d1, d2] });
 >d2 : Derived2
 
 var x336 = (n: { (): Base[]; }) => n; x336(() => [d1, d2]);
->x336 : (n: {    (): Base[];}) => () => Base[]
->(n: { (): Base[]; }) => n : (n: {    (): Base[];}) => () => Base[]
+>x336 : (n: { (): Base[]; }) => () => Base[]
+>(n: { (): Base[]; }) => n : (n: { (): Base[]; }) => () => Base[]
 >n : () => Base[]
 >n : () => Base[]
 >x336(() => [d1, d2]) : () => Base[]
@@ -3068,8 +3068,8 @@ var x336 = (n: { (): Base[]; }) => n; x336(() => [d1, d2]);
 >d2 : Derived2
 
 var x337 = (n: { (): Base[]; }) => n; x337(function() { return [d1, d2] });
->x337 : (n: {    (): Base[];}) => () => Base[]
->(n: { (): Base[]; }) => n : (n: {    (): Base[];}) => () => Base[]
+>x337 : (n: { (): Base[]; }) => () => Base[]
+>(n: { (): Base[]; }) => n : (n: { (): Base[]; }) => () => Base[]
 >n : () => Base[]
 >n : () => Base[]
 >x337(function() { return [d1, d2] }) : () => Base[]
@@ -3080,8 +3080,8 @@ var x337 = (n: { (): Base[]; }) => n; x337(function() { return [d1, d2] });
 >d2 : Derived2
 
 var x338 = (n: { (): Base[]; }) => n; x338(function named() { return [d1, d2] });
->x338 : (n: {    (): Base[];}) => () => Base[]
->(n: { (): Base[]; }) => n : (n: {    (): Base[];}) => () => Base[]
+>x338 : (n: { (): Base[]; }) => () => Base[]
+>(n: { (): Base[]; }) => n : (n: { (): Base[]; }) => () => Base[]
 >n : () => Base[]
 >n : () => Base[]
 >x338(function named() { return [d1, d2] }) : () => Base[]
@@ -3202,8 +3202,8 @@ var x347 = function(n: () => Base[]) { }; x347(function named() { return [d1, d2
 >d2 : Derived2
 
 var x348 = function(n: { (): Base[]; }) { }; x348(() => [d1, d2]);
->x348 : (n: {    (): Base[];}) => void
->function(n: { (): Base[]; }) { } : (n: {    (): Base[];}) => void
+>x348 : (n: { (): Base[]; }) => void
+>function(n: { (): Base[]; }) { } : (n: { (): Base[]; }) => void
 >n : () => Base[]
 >x348(() => [d1, d2]) : void
 >x348 : (n: () => Base[]) => void
@@ -3213,8 +3213,8 @@ var x348 = function(n: { (): Base[]; }) { }; x348(() => [d1, d2]);
 >d2 : Derived2
 
 var x349 = function(n: { (): Base[]; }) { }; x349(function() { return [d1, d2] });
->x349 : (n: {    (): Base[];}) => void
->function(n: { (): Base[]; }) { } : (n: {    (): Base[];}) => void
+>x349 : (n: { (): Base[]; }) => void
+>function(n: { (): Base[]; }) { } : (n: { (): Base[]; }) => void
 >n : () => Base[]
 >x349(function() { return [d1, d2] }) : void
 >x349 : (n: () => Base[]) => void
@@ -3224,8 +3224,8 @@ var x349 = function(n: { (): Base[]; }) { }; x349(function() { return [d1, d2] }
 >d2 : Derived2
 
 var x350 = function(n: { (): Base[]; }) { }; x350(function named() { return [d1, d2] });
->x350 : (n: {    (): Base[];}) => void
->function(n: { (): Base[]; }) { } : (n: {    (): Base[];}) => void
+>x350 : (n: { (): Base[]; }) => void
+>function(n: { (): Base[]; }) { } : (n: { (): Base[]; }) => void
 >n : () => Base[]
 >x350(function named() { return [d1, d2] }) : void
 >x350 : (n: () => Base[]) => void

--- a/tests/baselines/reference/generatorReturnContextualType.types
+++ b/tests/baselines/reference/generatorReturnContextualType.types
@@ -4,7 +4,7 @@
 // #35995
 
 function* f1(): Generator<any, { x: 'x' }, any> {
->f1 : () => Generator<any, {    x: 'x';}, any>
+>f1 : () => Generator<any, { x: 'x'; }, any>
 >x : "x"
 
   return { x: 'x' };
@@ -14,7 +14,7 @@ function* f1(): Generator<any, { x: 'x' }, any> {
 }
 
 function* g1(): Iterator<any, { x: 'x' }, any> {
->g1 : () => Iterator<any, {    x: 'x';}, any>
+>g1 : () => Iterator<any, { x: 'x'; }, any>
 >x : "x"
 
   return { x: 'x' };
@@ -24,7 +24,7 @@ function* g1(): Iterator<any, { x: 'x' }, any> {
 }
 
 async function* f2(): AsyncGenerator<any, { x: 'x' }, any> {
->f2 : () => AsyncGenerator<any, {    x: 'x';}, any>
+>f2 : () => AsyncGenerator<any, { x: 'x'; }, any>
 >x : "x"
 
   return { x: 'x' };
@@ -34,7 +34,7 @@ async function* f2(): AsyncGenerator<any, { x: 'x' }, any> {
 }
 
 async function* g2(): AsyncIterator<any, { x: 'x' }, any> {
->g2 : () => AsyncIterator<any, {    x: 'x';}, any>
+>g2 : () => AsyncIterator<any, { x: 'x'; }, any>
 >x : "x"
 
   return { x: 'x' };
@@ -44,7 +44,7 @@ async function* g2(): AsyncIterator<any, { x: 'x' }, any> {
 }
 
 async function* f3(): AsyncGenerator<any, { x: 'x' }, any> {
->f3 : () => AsyncGenerator<any, {    x: 'x';}, any>
+>f3 : () => AsyncGenerator<any, { x: 'x'; }, any>
 >x : "x"
 
   return Promise.resolve({ x: 'x' });
@@ -58,7 +58,7 @@ async function* f3(): AsyncGenerator<any, { x: 'x' }, any> {
 }
 
 async function* g3(): AsyncIterator<any, { x: 'x' }, any> {
->g3 : () => AsyncIterator<any, {    x: 'x';}, any>
+>g3 : () => AsyncIterator<any, { x: 'x'; }, any>
 >x : "x"
 
   return Promise.resolve({ x: 'x' });
@@ -72,7 +72,7 @@ async function* g3(): AsyncIterator<any, { x: 'x' }, any> {
 }
 
 async function* f4(): AsyncGenerator<any, { x: 'x' }, any> {
->f4 : () => AsyncGenerator<any, {    x: 'x';}, any>
+>f4 : () => AsyncGenerator<any, { x: 'x'; }, any>
 >x : "x"
 
   const ret = { x: 'x' };
@@ -90,7 +90,7 @@ async function* f4(): AsyncGenerator<any, { x: 'x' }, any> {
 }
 
 async function* g4(): AsyncIterator<any, { x: 'x' }, any> {
->g4 : () => AsyncIterator<any, {    x: 'x';}, any>
+>g4 : () => AsyncIterator<any, { x: 'x'; }, any>
 >x : "x"
 
   const ret = { x: 'x' };

--- a/tests/baselines/reference/genericArrayPropertyAssignment.types
+++ b/tests/baselines/reference/genericArrayPropertyAssignment.types
@@ -2,7 +2,7 @@
 
 === genericArrayPropertyAssignment.ts ===
 function isEmpty(list: {length:number;})
->isEmpty : (list: {    length: number;}) => boolean
+>isEmpty : (list: { length: number; }) => boolean
 >list : { length: number; }
 >length : number
 {

--- a/tests/baselines/reference/genericAssignmentCompatWithInterfaces1.types
+++ b/tests/baselines/reference/genericAssignmentCompatWithInterfaces1.types
@@ -37,7 +37,7 @@ var a1: I<string> = { x: new A<number>() };
 var a2: I<string> = function (): { x: A<number> } {
 >a2 : I<string>
 >function (): { x: A<number> } {   var z = { x: new A<number>() }; return z;} () : { x: A<number>; }
->function (): { x: A<number> } {   var z = { x: new A<number>() }; return z;} : () => {    x: A<number>;}
+>function (): { x: A<number> } {   var z = { x: new A<number>() }; return z;} : () => { x: A<number>; }
 >x : A<number>
 
    var z = { x: new A<number>() }; return z;

--- a/tests/baselines/reference/genericCallWithObjectLiteralArgs.types
+++ b/tests/baselines/reference/genericCallWithObjectLiteralArgs.types
@@ -2,7 +2,7 @@
 
 === genericCallWithObjectLiteralArgs.ts ===
 function foo<T>(x: { bar: T; baz: T }) {
->foo : <T>(x: {    bar: T;    baz: T;}) => { bar: T; baz: T; }
+>foo : <T>(x: { bar: T; baz: T; }) => { bar: T; baz: T; }
 >x : { bar: T; baz: T; }
 >bar : T
 >baz : T

--- a/tests/baselines/reference/genericCallWithObjectLiteralArguments1.types
+++ b/tests/baselines/reference/genericCallWithObjectLiteralArguments1.types
@@ -2,7 +2,7 @@
 
 === genericCallWithObjectLiteralArguments1.ts ===
 function foo<T>(n: { x: T; y: T }, m: T) { return m; }
->foo : <T>(n: {    x: T;    y: T;}, m: T) => T
+>foo : <T>(n: { x: T; y: T; }, m: T) => T
 >n : { x: T; y: T; }
 >x : T
 >y : T

--- a/tests/baselines/reference/genericCallWithObjectTypeArgs2.types
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgs2.types
@@ -24,7 +24,7 @@ class Derived2 extends Base {
 
 // returns {}[]
 function f<T extends Base, U extends Base>(a: { x: T; y: U }) {
->f : <T extends Base, U extends Base>(a: {    x: T;    y: U;}) => (T | U)[]
+>f : <T extends Base, U extends Base>(a: { x: T; y: U; }) => (T | U)[]
 >a : { x: T; y: U; }
 >x : T
 >y : U
@@ -65,7 +65,7 @@ var r2 = f({ x: new Base(), y: new Derived2() }); // {}[]
 
 
 function f2<T extends Base, U extends Base>(a: { x: T; y: U }) {
->f2 : <T extends Base, U extends Base>(a: {    x: T;    y: U;}) => (x: T) => U
+>f2 : <T extends Base, U extends Base>(a: { x: T; y: U; }) => (x: T) => U
 >a : { x: T; y: U; }
 >x : T
 >y : U

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints2.types
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints2.types
@@ -19,7 +19,7 @@ class Derived extends Base {
 }
 
 function f<T extends Base>(x: { foo: T; bar: T }) {
->f : <T extends Base>(x: {    foo: T;    bar: T;}) => T
+>f : <T extends Base>(x: { foo: T; bar: T; }) => T
 >x : { foo: T; bar: T; }
 >foo : T
 >bar : T

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints3.types
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints3.types
@@ -25,7 +25,7 @@ class Derived2 extends Base {
 }
 
 function f<T extends Base>(a: { x: T; y: T }) {
->f : <T extends Base>(a: {    x: T;    y: T;}) => T
+>f : <T extends Base>(a: { x: T; y: T; }) => T
 >a : { x: T; y: T; }
 >x : T
 >y : T

--- a/tests/baselines/reference/genericContextualTypes2.types
+++ b/tests/baselines/reference/genericContextualTypes2.types
@@ -78,11 +78,11 @@ createMachine<{ count: number }>({
 >entry : AssignAction<{ count: number; }>
 >assign({    count: (ctx: { count: number }) => ++ctx.count,  }) : AssignAction<{ count: number; }>
 >assign : <TContext>(assignment: PropertyAssigner<LowInfer<TContext>>) => AssignAction<TContext>
->{    count: (ctx: { count: number }) => ++ctx.count,  } : { count: (ctx: {    count: number;}) => number; }
+>{    count: (ctx: { count: number }) => ++ctx.count,  } : { count: (ctx: { count: number; }) => number; }
 
     count: (ctx: { count: number }) => ++ctx.count,
->count : (ctx: {    count: number;}) => number
->(ctx: { count: number }) => ++ctx.count : (ctx: {    count: number;}) => number
+>count : (ctx: { count: number; }) => number
+>(ctx: { count: number }) => ++ctx.count : (ctx: { count: number; }) => number
 >ctx : { count: number; }
 >count : number
 >++ctx.count : number

--- a/tests/baselines/reference/genericContextualTypes3.types
+++ b/tests/baselines/reference/genericContextualTypes3.types
@@ -77,11 +77,11 @@ createMachine<{ count: number }>({
 >entry : AssignAction<{ count: number; }>
 >assign({    count: (ctx: { count: number }) => ++ctx.count,  }) : AssignAction<{ count: number; }>
 >assign : <TContext>(assignment: PropertyAssigner<LowInfer<TContext>>) => AssignAction<TContext>
->{    count: (ctx: { count: number }) => ++ctx.count,  } : { count: (ctx: {    count: number;}) => number; }
+>{    count: (ctx: { count: number }) => ++ctx.count,  } : { count: (ctx: { count: number; }) => number; }
 
     count: (ctx: { count: number }) => ++ctx.count,
->count : (ctx: {    count: number;}) => number
->(ctx: { count: number }) => ++ctx.count : (ctx: {    count: number;}) => number
+>count : (ctx: { count: number; }) => number
+>(ctx: { count: number }) => ++ctx.count : (ctx: { count: number; }) => number
 >ctx : { count: number; }
 >count : number
 >++ctx.count : number

--- a/tests/baselines/reference/genericFunctionInference1.types
+++ b/tests/baselines/reference/genericFunctionInference1.types
@@ -30,7 +30,7 @@ declare function list<T>(a: T): T[];
 >a : T
 
 declare function box<V>(x: V): { value: V };
->box : <V>(x: V) => {    value: V;}
+>box : <V>(x: V) => { value: V; }
 >x : V
 >value : V
 
@@ -167,7 +167,7 @@ const g00: <T>(x: T) => T[] = pipe(list);
 >list : <T>(a: T) => T[]
 
 const g01: <T>(x: T) => { value: T[] } = pipe(list, box);
->g01 : <T>(x: T) => {    value: T[];}
+>g01 : <T>(x: T) => { value: T[]; }
 >x : T
 >value : T[]
 >pipe(list, box) : (a: T) => { value: T[]; }
@@ -176,7 +176,7 @@ const g01: <T>(x: T) => { value: T[] } = pipe(list, box);
 >box : <V>(x: V) => { value: V; }
 
 const g02: <T>(x: T) => { value: T }[] = pipe(box, list);
->g02 : <T>(x: T) => {    value: T;}[]
+>g02 : <T>(x: T) => { value: T; }[]
 >x : T
 >value : T
 >pipe(box, list) : (x: T) => { value: T; }[]
@@ -185,7 +185,7 @@ const g02: <T>(x: T) => { value: T }[] = pipe(box, list);
 >list : <T>(a: T) => T[]
 
 const g03: <T>(x: T) => { value: T[] } = pipe(x => list(x), box);
->g03 : <T>(x: T) => {    value: T[];}
+>g03 : <T>(x: T) => { value: T[]; }
 >x : T
 >value : T[]
 >pipe(x => list(x), box) : (x: T) => { value: T[]; }
@@ -198,7 +198,7 @@ const g03: <T>(x: T) => { value: T[] } = pipe(x => list(x), box);
 >box : <V>(x: V) => { value: V; }
 
 const g04: <T>(x: T) => { value: T[] } = pipe(list, x => box(x));
->g04 : <T>(x: T) => {    value: T[];}
+>g04 : <T>(x: T) => { value: T[]; }
 >x : T
 >value : T[]
 >pipe(list, x => box(x)) : (a: T) => { value: T[]; }
@@ -211,7 +211,7 @@ const g04: <T>(x: T) => { value: T[] } = pipe(list, x => box(x));
 >x : T[]
 
 const g05: <T>(x: T) => { value: T[] } = pipe(x => list(x), x => box(x))
->g05 : <T>(x: T) => {    value: T[];}
+>g05 : <T>(x: T) => { value: T[]; }
 >x : T
 >value : T[]
 >pipe(x => list(x), x => box(x)) : (x: T) => { value: T[]; }
@@ -228,7 +228,7 @@ const g05: <T>(x: T) => { value: T[] } = pipe(x => list(x), x => box(x))
 >x : T[]
 
 const g06: <T>(x: T) => { value: T[] } = pipe(list, pipe(box));
->g06 : <T>(x: T) => {    value: T[];}
+>g06 : <T>(x: T) => { value: T[]; }
 >x : T
 >value : T[]
 >pipe(list, pipe(box)) : (a: T) => { value: T[]; }
@@ -239,7 +239,7 @@ const g06: <T>(x: T) => { value: T[] } = pipe(list, pipe(box));
 >box : <V>(x: V) => { value: V; }
 
 const g07: <T>(x: T) => { value: T[] } = pipe(x => list(x), pipe(box));
->g07 : <T>(x: T) => {    value: T[];}
+>g07 : <T>(x: T) => { value: T[]; }
 >x : T
 >value : T[]
 >pipe(x => list(x), pipe(box)) : (x: T) => { value: T[]; }
@@ -254,7 +254,7 @@ const g07: <T>(x: T) => { value: T[] } = pipe(x => list(x), pipe(box));
 >box : <V>(x: V) => { value: V; }
 
 const g08: <T>(x: T) => { value: T[] } = pipe(x => list(x), pipe(x => box(x)));
->g08 : <T>(x: T) => {    value: T[];}
+>g08 : <T>(x: T) => { value: T[]; }
 >x : T
 >value : T[]
 >pipe(x => list(x), pipe(x => box(x))) : (x: T) => { value: T[]; }
@@ -623,7 +623,7 @@ var z = identityM(x);
 // #3038
 
 export function keyOf<a>(value: { key: a; }): a {
->keyOf : <a>(value: {    key: a;}) => a
+>keyOf : <a>(value: { key: a; }) => a
 >value : { key: a; }
 >key : a
 

--- a/tests/baselines/reference/genericFunctionInference1.types
+++ b/tests/baselines/reference/genericFunctionInference1.types
@@ -167,7 +167,7 @@ const g00: <T>(x: T) => T[] = pipe(list);
 >list : <T>(a: T) => T[]
 
 const g01: <T>(x: T) => { value: T[] } = pipe(list, box);
->g01 : <T>(x: T) => { value: T[]; }
+>g01 : <T>(x: T) => {    value: T[];}
 >x : T
 >value : T[]
 >pipe(list, box) : (a: T) => { value: T[]; }
@@ -176,7 +176,7 @@ const g01: <T>(x: T) => { value: T[] } = pipe(list, box);
 >box : <V>(x: V) => { value: V; }
 
 const g02: <T>(x: T) => { value: T }[] = pipe(box, list);
->g02 : <T>(x: T) => { value: T; }[]
+>g02 : <T>(x: T) => {    value: T;}[]
 >x : T
 >value : T
 >pipe(box, list) : (x: T) => { value: T; }[]
@@ -185,7 +185,7 @@ const g02: <T>(x: T) => { value: T }[] = pipe(box, list);
 >list : <T>(a: T) => T[]
 
 const g03: <T>(x: T) => { value: T[] } = pipe(x => list(x), box);
->g03 : <T>(x: T) => { value: T[]; }
+>g03 : <T>(x: T) => {    value: T[];}
 >x : T
 >value : T[]
 >pipe(x => list(x), box) : (x: T) => { value: T[]; }
@@ -198,7 +198,7 @@ const g03: <T>(x: T) => { value: T[] } = pipe(x => list(x), box);
 >box : <V>(x: V) => { value: V; }
 
 const g04: <T>(x: T) => { value: T[] } = pipe(list, x => box(x));
->g04 : <T>(x: T) => { value: T[]; }
+>g04 : <T>(x: T) => {    value: T[];}
 >x : T
 >value : T[]
 >pipe(list, x => box(x)) : (a: T) => { value: T[]; }
@@ -211,7 +211,7 @@ const g04: <T>(x: T) => { value: T[] } = pipe(list, x => box(x));
 >x : T[]
 
 const g05: <T>(x: T) => { value: T[] } = pipe(x => list(x), x => box(x))
->g05 : <T>(x: T) => { value: T[]; }
+>g05 : <T>(x: T) => {    value: T[];}
 >x : T
 >value : T[]
 >pipe(x => list(x), x => box(x)) : (x: T) => { value: T[]; }
@@ -228,7 +228,7 @@ const g05: <T>(x: T) => { value: T[] } = pipe(x => list(x), x => box(x))
 >x : T[]
 
 const g06: <T>(x: T) => { value: T[] } = pipe(list, pipe(box));
->g06 : <T>(x: T) => { value: T[]; }
+>g06 : <T>(x: T) => {    value: T[];}
 >x : T
 >value : T[]
 >pipe(list, pipe(box)) : (a: T) => { value: T[]; }
@@ -239,7 +239,7 @@ const g06: <T>(x: T) => { value: T[] } = pipe(list, pipe(box));
 >box : <V>(x: V) => { value: V; }
 
 const g07: <T>(x: T) => { value: T[] } = pipe(x => list(x), pipe(box));
->g07 : <T>(x: T) => { value: T[]; }
+>g07 : <T>(x: T) => {    value: T[];}
 >x : T
 >value : T[]
 >pipe(x => list(x), pipe(box)) : (x: T) => { value: T[]; }
@@ -254,7 +254,7 @@ const g07: <T>(x: T) => { value: T[] } = pipe(x => list(x), pipe(box));
 >box : <V>(x: V) => { value: V; }
 
 const g08: <T>(x: T) => { value: T[] } = pipe(x => list(x), pipe(x => box(x)));
->g08 : <T>(x: T) => { value: T[]; }
+>g08 : <T>(x: T) => {    value: T[];}
 >x : T
 >value : T[]
 >pipe(x => list(x), pipe(x => box(x))) : (x: T) => { value: T[]; }

--- a/tests/baselines/reference/genericFunctionInference2.types
+++ b/tests/baselines/reference/genericFunctionInference2.types
@@ -12,7 +12,7 @@ declare function combineReducers<S>(reducers: { [K in keyof S]: Reducer<S[K]> })
 >reducers : { [K in keyof S]: Reducer<S[K]>; }
 
 type MyState = { combined: { foo: number } };
->MyState : { combined: {    foo: number;}; }
+>MyState : { combined: { foo: number; }; }
 >combined : { foo: number; }
 >foo : number
 

--- a/tests/baselines/reference/genericFunctionParameters.types
+++ b/tests/baselines/reference/genericFunctionParameters.types
@@ -44,7 +44,7 @@ let x3 = f3(x => x);  // Array<any>
 
 declare const s: <R>(go: <S>(ops: { init(): S; }) => R) => R;
 >s : <R>(go: <S>(ops: { init(): S; }) => R) => R
->go : <S>(ops: { init(): S; }) => R
+>go : <S>(ops: {    init(): S;}) => R
 >ops : { init(): S; }
 >init : () => S
 

--- a/tests/baselines/reference/genericFunctionParameters.types
+++ b/tests/baselines/reference/genericFunctionParameters.types
@@ -44,7 +44,7 @@ let x3 = f3(x => x);  // Array<any>
 
 declare const s: <R>(go: <S>(ops: { init(): S; }) => R) => R;
 >s : <R>(go: <S>(ops: { init(): S; }) => R) => R
->go : <S>(ops: {    init(): S;}) => R
+>go : <S>(ops: { init(): S; }) => R
 >ops : { init(): S; }
 >init : () => S
 

--- a/tests/baselines/reference/genericFunctionsAndConditionalInference.types
+++ b/tests/baselines/reference/genericFunctionsAndConditionalInference.types
@@ -10,8 +10,8 @@ declare function unboxify<T>(obj: Boxified<T>): T;
 >obj : Boxified<T>
 
 function foo<U, V>(obj: { u: { value: U }, v: { value: V } }) {
->foo : <U, V>(obj: {    u: {        value: U;    };    v: {        value: V;    };}) => { u: U; v: V; }
->obj : { u: {    value: U;}; v: {    value: V;}; }
+>foo : <U, V>(obj: { u: { value: U; }; v: { value: V; }; }) => { u: U; v: V; }
+>obj : { u: { value: U; }; v: { value: V; }; }
 >u : { value: U; }
 >value : U
 >v : { value: V; }

--- a/tests/baselines/reference/genericInstantiationEquivalentToObjectLiteral.types
+++ b/tests/baselines/reference/genericInstantiationEquivalentToObjectLiteral.types
@@ -28,7 +28,7 @@ declare function f<T, U>(x: Pair<T, U>);
 >x : Pair<T, U>
 
 declare function f2<T, U>(x: { first: T; second: U; });
->f2 : <T, U>(x: {    first: T;    second: U;}) => any
+>f2 : <T, U>(x: { first: T; second: U; }) => any
 >x : { first: T; second: U; }
 >first : T
 >second : U

--- a/tests/baselines/reference/genericRestTypes.types
+++ b/tests/baselines/reference/genericRestTypes.types
@@ -78,7 +78,7 @@ function assignmentWithComplexRest3<T extends any[]>() {
 >x : string
 
     const fn2: (...args: {x: "a"} & {x: "b"}) => void = fn1;
->fn2 : (...args: {    x: "a";} & {    x: "b";}) => void
+>fn2 : (...args: { x: "a"; } & { x: "b"; }) => void
 >args : never
 >x : "a"
 >x : "b"

--- a/tests/baselines/reference/genericSpecializationToTypeLiteral1.types
+++ b/tests/baselines/reference/genericSpecializationToTypeLiteral1.types
@@ -89,7 +89,7 @@ interface IEnumerable<T> {
 
 interface IDictionary<TKey, TValue> {
     toEnumerable(): IEnumerable<{ key: TKey; value: TValue }>;
->toEnumerable : () => IEnumerable<{    key: TKey;    value: TValue;}>
+>toEnumerable : () => IEnumerable<{ key: TKey; value: TValue; }>
 >key : TKey
 >value : TValue
 }

--- a/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.types
+++ b/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.types
@@ -3,7 +3,7 @@
 === genericTypeWithNonGenericBaseMisMatch.ts ===
 interface I {
 	f: (a: { a: number }) => void
->f : (a: {    a: number;}) => void
+>f : (a: { a: number; }) => void
 >a : { a: number; }
 >a : number
 }

--- a/tests/baselines/reference/generics2.types
+++ b/tests/baselines/reference/generics2.types
@@ -20,7 +20,7 @@ interface G<T, U extends B> {
 
 
 var v1: {
->v1 : { x: {    a: string;}; y: {    a: string;    b: string;    c: string;}; }
+>v1 : { x: { a: string; }; y: { a: string; b: string; c: string; }; }
 
     x: { a: string; }
 >x : { a: string; }

--- a/tests/baselines/reference/generics2NoError.types
+++ b/tests/baselines/reference/generics2NoError.types
@@ -20,7 +20,7 @@ interface G<T, U extends B> {
 
 
 var v1: {
->v1 : { x: {    a: string;}; y: {    a: string;    b: string;    c: string;}; }
+>v1 : { x: { a: string; }; y: { a: string; b: string; c: string; }; }
 
     x: { a: string; }
 >x : { a: string; }

--- a/tests/baselines/reference/homomorphicMappedTypeIntersectionAssignability.types
+++ b/tests/baselines/reference/homomorphicMappedTypeIntersectionAssignability.types
@@ -2,7 +2,7 @@
 
 === homomorphicMappedTypeIntersectionAssignability.ts ===
 function f<TType>(
->f : <TType>(a: {    weak?: string;} & Readonly<TType> & {    name: "ok";}, b: Readonly<TType & {    name: string;}>, c: Readonly<TType> & {    name: string;}) => void
+>f : <TType>(a: { weak?: string; } & Readonly<TType> & { name: "ok"; }, b: Readonly<TType & { name: string; }>, c: Readonly<TType> & { name: string; }) => void
 
     a: { weak?: string } & Readonly<TType> & { name: "ok" },
 >a : { weak?: string | undefined; } & Readonly<TType> & { name: "ok"; }

--- a/tests/baselines/reference/identityAndDivergentNormalizedTypes.types
+++ b/tests/baselines/reference/identityAndDivergentNormalizedTypes.types
@@ -4,7 +4,7 @@
 // Repros from #53998
 
 type ApiPost =
->ApiPost : { path: "/login"; body: {}; } | { path: "/user"; body: {    name: string;}; }
+>ApiPost : { path: "/login"; body: {}; } | { path: "/user"; body: { name: string; }; }
 
     | {
         path: "/login";
@@ -64,7 +64,7 @@ const tmp = <PATH extends PostPath>(
 }
 
 function fx1<P extends PostPath>(x: { body: PostBody<P> }, y: { body: PostBody<P> }) {
->fx1 : <P extends "/login" | "/user">(x: {    body: PostBody<P>;}, y: {    body: PostBody<P>;}) => void
+>fx1 : <P extends "/login" | "/user">(x: { body: PostBody<P>; }, y: { body: PostBody<P>; }) => void
 >x : { body: PostBody<P>; }
 >body : PostBody<P>
 >y : { body: PostBody<P>; }

--- a/tests/baselines/reference/identityRelationNeverTypes.types
+++ b/tests/baselines/reference/identityRelationNeverTypes.types
@@ -24,7 +24,7 @@ declare class State<TContext> {
 }
 
 function f1(state: State<{ foo: number }>) {
->f1 : (state: State<{    foo: number;}>) => void
+>f1 : (state: State<{ foo: number; }>) => void
 >state : State<{ foo: number; }>
 >foo : number
 

--- a/tests/baselines/reference/illegalGenericWrapping1.types
+++ b/tests/baselines/reference/illegalGenericWrapping1.types
@@ -18,7 +18,7 @@ interface Sequence<T> {
 >value : T
 
     groupBy<K>(keySelector: (value: T) => K): Sequence<{ key: K; items: Sequence<T>; }>;
->groupBy : <K>(keySelector: (value: T) => K) => Sequence<{    key: K;    items: Sequence<T>;}>
+>groupBy : <K>(keySelector: (value: T) => K) => Sequence<{ key: K; items: Sequence<T>; }>
 >keySelector : (value: T) => K
 >value : T
 >key : K

--- a/tests/baselines/reference/implicitAnyFunctionInvocationWithAnyArguements.types
+++ b/tests/baselines/reference/implicitAnyFunctionInvocationWithAnyArguements.types
@@ -36,7 +36,7 @@ function testFunctionExprC2(eq: (v1: any, v2: any) => number) { };
 >v2 : any
 
 function testObjLiteral(objLit: { v: any; w: any }) { }; 
->testObjLiteral : (objLit: {    v: any;    w: any;}) => void
+>testObjLiteral : (objLit: { v: any; w: any; }) => void
 >objLit : { v: any; w: any; }
 >v : any
 >w : any

--- a/tests/baselines/reference/inKeywordAndIntersection.types
+++ b/tests/baselines/reference/inKeywordAndIntersection.types
@@ -12,7 +12,7 @@ class B { b = 0 }
 >0 : 0
 
 function f10(obj: A & { x: string } | B) {
->f10 : (obj: (A & {    x: string;}) | B) => void
+>f10 : (obj: (A & { x: string; }) | B) => void
 >obj : B | (A & { x: string; })
 >x : string
 

--- a/tests/baselines/reference/inKeywordTypeguard(strict=false).types
+++ b/tests/baselines/reference/inKeywordTypeguard(strict=false).types
@@ -301,7 +301,7 @@ class UnreachableCodeDetection {
 }
 
 function positiveIntersectionTest(x: { a: string } & { b: string }) {
->positiveIntersectionTest : (x: {    a: string;} & {    b: string;}) => void
+>positiveIntersectionTest : (x: { a: string; } & { b: string; }) => void
 >x : { a: string; } & { b: string; }
 >a : string
 >b : string
@@ -342,7 +342,7 @@ if ('extra' in error) {
 }
 
 function narrowsToNever(x: { l: number } | { r: number }) {
->narrowsToNever : (x: {    l: number;} | {    r: number;}) => number
+>narrowsToNever : (x: { l: number; } | { r: number; }) => number
 >x : { l: number; } | { r: number; }
 >l : number
 >r : number
@@ -659,7 +659,7 @@ function f3<T>(x: T) {
 }
 
 function f4(x: { a: string }) {
->f4 : (x: {    a: string;}) => void
+>f4 : (x: { a: string; }) => void
 >x : { a: string; }
 >a : string
 
@@ -704,7 +704,7 @@ function f4(x: { a: string }) {
 }
 
 function f5(x: { a: string } | { b: string }) {
->f5 : (x: {    a: string;} | {    b: string;}) => void
+>f5 : (x: { a: string; } | { b: string; }) => void
 >x : { a: string; } | { b: string; }
 >a : string
 >b : string
@@ -732,7 +732,7 @@ function f5(x: { a: string } | { b: string }) {
 }
 
 function f6(x: { a: string } | { b: string }) {
->f6 : (x: {    a: string;} | {    b: string;}) => void
+>f6 : (x: { a: string; } | { b: string; }) => void
 >x : { a: string; } | { b: string; }
 >a : string
 >b : string
@@ -762,7 +762,7 @@ function f6(x: { a: string } | { b: string }) {
 // Object and corresponding intersection should narrow the same
 
 function f7(x: { a: string, b: number }, y: { a: string } & { b: number }) {
->f7 : (x: {    a: string;    b: number;}, y: {    a: string;} & {    b: number;}) => void
+>f7 : (x: { a: string; b: number; }, y: { a: string; } & { b: number; }) => void
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -890,7 +890,7 @@ function f9(x: object) {
 }
 
 function f10(x: { a: unknown }) {
->f10 : (x: {    a: unknown;}) => void
+>f10 : (x: { a: unknown; }) => void
 >x : { a: unknown; }
 >a : unknown
 
@@ -909,7 +909,7 @@ function f10(x: { a: unknown }) {
 }
 
 function f11(x: { a: any }) {
->f11 : (x: {    a: any;}) => void
+>f11 : (x: { a: any; }) => void
 >x : { a: any; }
 >a : any
 
@@ -928,7 +928,7 @@ function f11(x: { a: any }) {
 }
 
 function f12(x: { a: string }) {
->f12 : (x: {    a: string;}) => void
+>f12 : (x: { a: string; }) => void
 >x : { a: string; }
 >a : string
 
@@ -947,7 +947,7 @@ function f12(x: { a: string }) {
 }
 
 function f13(x: { a?: string }) {
->f13 : (x: {    a?: string;}) => void
+>f13 : (x: { a?: string; }) => void
 >x : { a?: string; }
 >a : string
 
@@ -966,7 +966,7 @@ function f13(x: { a?: string }) {
 }
 
 function f14(x: { a: string | undefined }) {
->f14 : (x: {    a: string | undefined;}) => void
+>f14 : (x: { a: string | undefined; }) => void
 >x : { a: string | undefined; }
 >a : string
 
@@ -985,7 +985,7 @@ function f14(x: { a: string | undefined }) {
 }
 
 function f15(x: { a?: string | undefined }) {
->f15 : (x: {    a?: string | undefined;}) => void
+>f15 : (x: { a?: string | undefined; }) => void
 >x : { a?: string | undefined; }
 >a : string
 

--- a/tests/baselines/reference/inKeywordTypeguard(strict=true).types
+++ b/tests/baselines/reference/inKeywordTypeguard(strict=true).types
@@ -301,7 +301,7 @@ class UnreachableCodeDetection {
 }
 
 function positiveIntersectionTest(x: { a: string } & { b: string }) {
->positiveIntersectionTest : (x: {    a: string;} & {    b: string;}) => void
+>positiveIntersectionTest : (x: { a: string; } & { b: string; }) => void
 >x : { a: string; } & { b: string; }
 >a : string
 >b : string
@@ -342,7 +342,7 @@ if ('extra' in error) {
 }
 
 function narrowsToNever(x: { l: number } | { r: number }) {
->narrowsToNever : (x: {    l: number;} | {    r: number;}) => number
+>narrowsToNever : (x: { l: number; } | { r: number; }) => number
 >x : { l: number; } | { r: number; }
 >l : number
 >r : number
@@ -659,7 +659,7 @@ function f3<T>(x: T) {
 }
 
 function f4(x: { a: string }) {
->f4 : (x: {    a: string;}) => void
+>f4 : (x: { a: string; }) => void
 >x : { a: string; }
 >a : string
 
@@ -704,7 +704,7 @@ function f4(x: { a: string }) {
 }
 
 function f5(x: { a: string } | { b: string }) {
->f5 : (x: {    a: string;} | {    b: string;}) => void
+>f5 : (x: { a: string; } | { b: string; }) => void
 >x : { a: string; } | { b: string; }
 >a : string
 >b : string
@@ -732,7 +732,7 @@ function f5(x: { a: string } | { b: string }) {
 }
 
 function f6(x: { a: string } | { b: string }) {
->f6 : (x: {    a: string;} | {    b: string;}) => void
+>f6 : (x: { a: string; } | { b: string; }) => void
 >x : { a: string; } | { b: string; }
 >a : string
 >b : string
@@ -762,7 +762,7 @@ function f6(x: { a: string } | { b: string }) {
 // Object and corresponding intersection should narrow the same
 
 function f7(x: { a: string, b: number }, y: { a: string } & { b: number }) {
->f7 : (x: {    a: string;    b: number;}, y: {    a: string;} & {    b: number;}) => void
+>f7 : (x: { a: string; b: number; }, y: { a: string; } & { b: number; }) => void
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -890,7 +890,7 @@ function f9(x: object) {
 }
 
 function f10(x: { a: unknown }) {
->f10 : (x: {    a: unknown;}) => void
+>f10 : (x: { a: unknown; }) => void
 >x : { a: unknown; }
 >a : unknown
 
@@ -909,7 +909,7 @@ function f10(x: { a: unknown }) {
 }
 
 function f11(x: { a: any }) {
->f11 : (x: {    a: any;}) => void
+>f11 : (x: { a: any; }) => void
 >x : { a: any; }
 >a : any
 
@@ -928,7 +928,7 @@ function f11(x: { a: any }) {
 }
 
 function f12(x: { a: string }) {
->f12 : (x: {    a: string;}) => void
+>f12 : (x: { a: string; }) => void
 >x : { a: string; }
 >a : string
 
@@ -947,7 +947,7 @@ function f12(x: { a: string }) {
 }
 
 function f13(x: { a?: string }) {
->f13 : (x: {    a?: string;}) => void
+>f13 : (x: { a?: string; }) => void
 >x : { a?: string | undefined; }
 >a : string | undefined
 
@@ -966,7 +966,7 @@ function f13(x: { a?: string }) {
 }
 
 function f14(x: { a: string | undefined }) {
->f14 : (x: {    a: string | undefined;}) => void
+>f14 : (x: { a: string | undefined; }) => void
 >x : { a: string | undefined; }
 >a : string | undefined
 
@@ -985,7 +985,7 @@ function f14(x: { a: string | undefined }) {
 }
 
 function f15(x: { a?: string | undefined }) {
->f15 : (x: {    a?: string | undefined;}) => void
+>f15 : (x: { a?: string | undefined; }) => void
 >x : { a?: string | undefined; }
 >a : string | undefined
 

--- a/tests/baselines/reference/incompatibleTypes.types
+++ b/tests/baselines/reference/incompatibleTypes.types
@@ -49,7 +49,7 @@ class C3 implements IFoo3 { // incompatible on the property type
 
 interface IFoo4 {
     p1: { a: { a: string; }; b: string; };
->p1 : { a: {    a: string;}; b: string; }
+>p1 : { a: { a: string; }; b: string; }
 >a : { a: string; }
 >a : string
 >b : string
@@ -59,7 +59,7 @@ class C4 implements IFoo4 { // incompatible on the property type
 >C4 : C4
 
     public p1: { c: { b: string; }; d: string; };
->p1 : { c: {    b: string;}; d: string; }
+>p1 : { c: { b: string; }; d: string; }
 >c : { b: string; }
 >b : string
 >d : string
@@ -90,15 +90,15 @@ if1(c1);
 
 
 function of1(n: { a: { a: string; }; b: string; }): number;
->of1 : { (n: {    a: {        a: string;    };    b: string;}): number; (s: { c: { b: string; }; d: string; }): string; }
->n : { a: {    a: string;}; b: string; }
+>of1 : { (n: { a: { a: string; }; b: string; }): number; (s: { c: { b: string; }; d: string; }): string; }
+>n : { a: { a: string; }; b: string; }
 >a : { a: string; }
 >a : string
 >b : string
 
 function of1(s: { c: { b: string; }; d: string; }): string;
->of1 : { (n: { a: { a: string; }; b: string; }): number; (s: {    c: {        b: string;    };    d: string;}): string; }
->s : { c: {    b: string;}; d: string; }
+>of1 : { (n: { a: { a: string; }; b: string; }): number; (s: { c: { b: string; }; d: string; }): string; }
+>s : { c: { b: string; }; d: string; }
 >c : { b: string; }
 >b : string
 >d : string
@@ -147,7 +147,7 @@ function bar() {
 }
 
 var o1: { a: { a: string; }; b: string; } = { e: 0, f: 0 };
->o1 : { a: {    a: string;}; b: string; }
+>o1 : { a: { a: string; }; b: string; }
 >a : { a: string; }
 >a : string
 >b : string

--- a/tests/baselines/reference/indexSignatureInOtherFile.types
+++ b/tests/baselines/reference/indexSignatureInOtherFile.types
@@ -42,7 +42,7 @@ interface Array1<T> {
    * when they will be absent when used in a 'with' statement.
    */
   [Symbol.unscopables](): {
->[Symbol.unscopables] : () => {    copyWithin: boolean;    entries: boolean;    fill: boolean;    find: boolean;    findIndex: boolean;    keys: boolean;    values: boolean;}
+>[Symbol.unscopables] : () => { copyWithin: boolean; entries: boolean; fill: boolean; find: boolean; findIndex: boolean; keys: boolean; values: boolean; }
 >Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
 >unscopables : unique symbol

--- a/tests/baselines/reference/indexSignatureInOtherFile1.types
+++ b/tests/baselines/reference/indexSignatureInOtherFile1.types
@@ -33,7 +33,7 @@ interface Array1<T> {
    * when they will be absent when used in a 'with' statement.
    */
   [Symbol.unscopables](): {
->[Symbol.unscopables] : () => {    copyWithin: boolean;    entries: boolean;    fill: boolean;    find: boolean;    findIndex: boolean;    keys: boolean;    values: boolean;}
+>[Symbol.unscopables] : () => { copyWithin: boolean; entries: boolean; fill: boolean; find: boolean; findIndex: boolean; keys: boolean; values: boolean; }
 >Symbol.unscopables : unique symbol
 >Symbol : SymbolConstructor
 >unscopables : unique symbol

--- a/tests/baselines/reference/indexSignatures1.types
+++ b/tests/baselines/reference/indexSignatures1.types
@@ -9,7 +9,7 @@ const sym = Symbol();
 >Symbol : SymbolConstructor
 
 function gg3(x: { [key: string]: string }, y: { [key: symbol]: string }, z: { [sym]: number }) {
->gg3 : (x: { [key: string]: string; }, y: { [key: symbol]: string; }, z: {    [sym]: number;}) => void
+>gg3 : (x: { [key: string]: string; }, y: { [key: symbol]: string; }, z: { [sym]: number; }) => void
 >x : { [key: string]: string; }
 >key : string
 >y : { [key: symbol]: string; }

--- a/tests/baselines/reference/indexedAccessNormalization.types
+++ b/tests/baselines/reference/indexedAccessNormalization.types
@@ -34,7 +34,7 @@ function f1<M extends object>(mymap: MyMap<M>, k: keyof M) {
 }
 
 function f2<M extends object>(mymap: MyMap<M>, k: keyof M, z: { x: number }) {
->f2 : <M extends object>(mymap: MyMap<M>, k: keyof M, z: {    x: number;}) => void
+>f2 : <M extends object>(mymap: MyMap<M>, k: keyof M, z: { x: number; }) => void
 >mymap : MyMap<M>
 >k : keyof M
 >z : { x: number; }

--- a/tests/baselines/reference/indirectTypeParameterReferences.types
+++ b/tests/baselines/reference/indirectTypeParameterReferences.types
@@ -82,7 +82,7 @@ combined(comb => {
 // Repro from #19091
 
 declare function f<T>(a: T): { a: typeof a };
->f : <T>(a: T) => {    a: typeof a;}
+>f : <T>(a: T) => { a: typeof a; }
 >a : T
 >a : T
 >a : T

--- a/tests/baselines/reference/inferFromBindingPattern.types
+++ b/tests/baselines/reference/inferFromBindingPattern.types
@@ -8,7 +8,7 @@ declare function f2<T extends string>(): [T];
 >f2 : <T extends string>() => [T]
 
 declare function f3<T extends string>(): { x: T };
->f3 : <T extends string>() => {    x: T;}
+>f3 : <T extends string>() => { x: T; }
 >x : T
 
 let x1 = f1();         // string

--- a/tests/baselines/reference/inferStringLiteralUnionForBindingElement.types
+++ b/tests/baselines/reference/inferStringLiteralUnionForBindingElement.types
@@ -2,7 +2,7 @@
 
 === inferStringLiteralUnionForBindingElement.ts ===
 declare function func<T extends string>(arg: { keys: T[] }): { readonly keys: T[]; readonly firstKey: T; };
->func : <T extends string>(arg: {    keys: T[];}) => {    readonly keys: T[];    readonly firstKey: T;}
+>func : <T extends string>(arg: { keys: T[]; }) => { readonly keys: T[]; readonly firstKey: T; }
 >arg : { keys: T[]; }
 >keys : T[]
 >keys : T[]

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -335,7 +335,7 @@ type Jsonified<T> =
     : "what is this";
 
 type Example = {
->Example : { str: "literalstring"; fn: () => void; date: Date; customClass: MyClass; obj: {    prop: "property";    clz: MyClass;    nested: {        attr: Date;    };}; }
+>Example : { str: "literalstring"; fn: () => void; date: Date; customClass: MyClass; obj: { prop: "property"; clz: MyClass; nested: { attr: Date; }; }; }
 
     str: "literalstring",
 >str : "literalstring"
@@ -350,7 +350,7 @@ type Example = {
 >customClass : MyClass
 
     obj: {
->obj : { prop: "property"; clz: MyClass; nested: {    attr: Date;}; }
+>obj : { prop: "property"; clz: MyClass; nested: { attr: Date; }; }
 
         prop: "property",
 >prop : "property"

--- a/tests/baselines/reference/inferingFromAny.types
+++ b/tests/baselines/reference/inferingFromAny.types
@@ -20,7 +20,7 @@ declare function f3<T, U>(t: [T, U]): [T, U];
 >t : [T, U]
 
 declare function f4<T>(x: { bar: T; baz: T }): T;
->f4 : <T>(x: {    bar: T;    baz: T;}) => T
+>f4 : <T>(x: { bar: T; baz: T; }) => T
 >x : { bar: T; baz: T; }
 >bar : T
 >baz : T
@@ -67,7 +67,7 @@ declare function f13<T, U>(x: T & U): [T, U];
 >x : T & U
 
 declare function f14<T, U>(x: { a: T | U, b: U & T }): [T, U];
->f14 : <T, U>(x: {    a: T | U;    b: U & T;}) => [T, U]
+>f14 : <T, U>(x: { a: T | U; b: U & T; }) => [T, U]
 >x : { a: T | U; b: U & T; }
 >a : T | U
 >b : U & T

--- a/tests/baselines/reference/inferrenceInfiniteLoopWithSubtyping.types
+++ b/tests/baselines/reference/inferrenceInfiniteLoopWithSubtyping.types
@@ -29,7 +29,7 @@ export class ObjectTypeComposer<TSource, TContext> {
 >fields : Readonly<{ [key: string]: Readonly<Resolver>; }>
 
   public addResolver<TResolverSource>(opts: { type?: Thunk<ComposeOutputTypeDefinition> }): this;
->addResolver : <TResolverSource>(opts: {    type?: Thunk<ComposeOutputTypeDefinition>;}) => this
+>addResolver : <TResolverSource>(opts: { type?: Thunk<ComposeOutputTypeDefinition>; }) => this
 >opts : { type?: Thunk<ComposeOutputTypeDefinition>; }
 >type : Thunk<ComposeOutputTypeDefinition>
 }

--- a/tests/baselines/reference/infinitelyGenerativeInheritance1.types
+++ b/tests/baselines/reference/infinitelyGenerativeInheritance1.types
@@ -6,7 +6,7 @@ interface Stack<T> {
 >pop : () => T
 
       zip<S>(a: Stack<S>): Stack<{ x: T; y: S }>
->zip : <S>(a: Stack<S>) => Stack<{    x: T;    y: S;}>
+>zip : <S>(a: Stack<S>) => Stack<{ x: T; y: S; }>
 >a : Stack<S>
 >x : T
 >y : S
@@ -14,7 +14,7 @@ interface Stack<T> {
 
 interface MyStack<T> extends Stack<T> {
       zip<S>(a: Stack<S>): Stack<{ x: T; y: S }>
->zip : <S>(a: Stack<S>) => Stack<{    x: T;    y: S;}>
+>zip : <S>(a: Stack<S>) => Stack<{ x: T; y: S; }>
 >a : Stack<S>
 >x : T
 >y : S

--- a/tests/baselines/reference/initializedParameterBeforeNonoptionalNotOptional.types
+++ b/tests/baselines/reference/initializedParameterBeforeNonoptionalNotOptional.types
@@ -2,7 +2,7 @@
 
 === index.d.ts ===
 export declare function foo({a}?: {
->foo : ({ a }?: {    a?: string;}) => void
+>foo : ({ a }?: { a?: string; }) => void
 >a : string | undefined
 
     a?: string;
@@ -10,7 +10,7 @@ export declare function foo({a}?: {
 
 }): void;
 export declare function foo2({a}: {
->foo2 : ({ a }: {    a?: string | undefined;} | undefined, b: string) => void
+>foo2 : ({ a }: { a?: string | undefined; } | undefined, b: string) => void
 >a : string | undefined
 
     a?: string | undefined;
@@ -20,7 +20,7 @@ export declare function foo2({a}: {
 >b : string
 
 export declare function foo3({a, b: {c}}: {
->foo3 : ({ a, b: { c } }: {    a?: string | undefined;    b?: {        c?: string | undefined;    } | undefined;} | undefined, b: string) => void
+>foo3 : ({ a, b: { c } }: { a?: string | undefined; b?: { c?: string | undefined; } | undefined; } | undefined, b: string) => void
 >a : string | undefined
 >b : any
 >c : string | undefined

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.types
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.types
@@ -76,8 +76,8 @@ import { predom } from "./renderer2"
 >predom : () => predom.JSX.Element
 
 export const MySFC = (props: {x: number, y: number, children?: predom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{...this.props.children}</p>;
->MySFC : (props: {    x: number;    y: number;    children?: predom.JSX.Element[];}) => predom.JSX.Element
->(props: {x: number, y: number, children?: predom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{...this.props.children}</p> : (props: {    x: number;    y: number;    children?: predom.JSX.Element[];}) => predom.JSX.Element
+>MySFC : (props: { x: number; y: number; children?: predom.JSX.Element[]; }) => predom.JSX.Element
+>(props: {x: number, y: number, children?: predom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{...this.props.children}</p> : (props: { x: number; y: number; children?: predom.JSX.Element[]; }) => predom.JSX.Element
 >props : { x: number; y: number; children?: predom.JSX.Element[]; }
 >x : number
 >y : number
@@ -214,8 +214,8 @@ elem = <h></h>; // Expect assignability error here
 >h : any
 
 const DOMSFC = (props: {x: number, y: number, children?: dom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{props.children}</p>;
->DOMSFC : (props: {    x: number;    y: number;    children?: dom.JSX.Element[];}) => dom.JSX.Element
->(props: {x: number, y: number, children?: dom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{props.children}</p> : (props: {    x: number;    y: number;    children?: dom.JSX.Element[];}) => dom.JSX.Element
+>DOMSFC : (props: { x: number; y: number; children?: dom.JSX.Element[]; }) => dom.JSX.Element
+>(props: {x: number, y: number, children?: dom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{props.children}</p> : (props: { x: number; y: number; children?: dom.JSX.Element[]; }) => dom.JSX.Element
 >props : { x: number; y: number; children?: dom.JSX.Element[]; }
 >x : number
 >y : number

--- a/tests/baselines/reference/instanceofOperatorWithInvalidOperands.es2015.types
+++ b/tests/baselines/reference/instanceofOperatorWithInvalidOperands.es2015.types
@@ -170,8 +170,8 @@ var rc1 = '' instanceof {};
 
 // @@hasInstance restricts LHS
 var o4: {[Symbol.hasInstance](value: { x: number }): boolean;};
->o4 : { [Symbol.hasInstance](value: {    x: number;}): boolean; }
->[Symbol.hasInstance] : (value: {    x: number;}) => boolean
+>o4 : { [Symbol.hasInstance](value: { x: number; }): boolean; }
+>[Symbol.hasInstance] : (value: { x: number; }) => boolean
 >Symbol.hasInstance : unique symbol
 >Symbol : SymbolConstructor
 >hasInstance : unique symbol

--- a/tests/baselines/reference/instantiationExpressions.types
+++ b/tests/baselines/reference/instantiationExpressions.types
@@ -459,7 +459,7 @@ type A<U> = InstanceType<typeof Array<U>>;  // U[]
 >Array : ArrayConstructor
 
 declare const g1: {
->g1 : { <T>(a: T): { a: T; }; new <U>(b: U): { b: U; }; }
+>g1 : { <T>(a: T): {    a: T;}; new <U>(b: U): {    b: U;}; }
 
     <T>(a: T): { a: T };
 >a : T

--- a/tests/baselines/reference/instantiationExpressions.types
+++ b/tests/baselines/reference/instantiationExpressions.types
@@ -151,7 +151,7 @@ function f12(f: { <T>(a: T): T, x: string }) {
 }
 
 function f13(f: { x: string, y: string }) {
->f13 : (f: {    x: string;    y: string;}) => void
+>f13 : (f: { x: string; y: string; }) => void
 >f : { x: string; y: string; }
 >x : string
 >y : string
@@ -253,7 +253,7 @@ function f22(f: (<T>(a: T) => T) & { x: string }) {
 }
 
 function f23(f: { x: string } & { y: string }) {
->f23 : (f: {    x: string;} & {    y: string;}) => void
+>f23 : (f: { x: string; } & { y: string; }) => void
 >f : { x: string; } & { y: string; }
 >x : string
 >y : string
@@ -355,7 +355,7 @@ function f32(f: (<T>(a: T) => T) | { x: string }) {
 }
 
 function f33(f: { x: string } | { y: string }) {
->f33 : (f: {    x: string;} | {    y: string;}) => void
+>f33 : (f: { x: string; } | { y: string; }) => void
 >f : { x: string; } | { y: string; }
 >x : string
 >y : string
@@ -459,7 +459,7 @@ type A<U> = InstanceType<typeof Array<U>>;  // U[]
 >Array : ArrayConstructor
 
 declare const g1: {
->g1 : { <T>(a: T): {    a: T;}; new <U>(b: U): {    b: U;}; }
+>g1 : { <T>(a: T): { a: T; }; new <U>(b: U): { b: U; }; }
 
     <T>(a: T): { a: T };
 >a : T

--- a/tests/baselines/reference/interfaceExtendsObjectIntersection.types
+++ b/tests/baselines/reference/interfaceExtendsObjectIntersection.types
@@ -13,7 +13,7 @@ type T3 = () => void;
 >T3 : () => void
 
 type T4 = new () => { a: number };
->T4 : new () => {    a: number;}
+>T4 : new () => { a: number; }
 >a : number
 
 type T5 = number[];

--- a/tests/baselines/reference/interfaceImplementation7.types
+++ b/tests/baselines/reference/interfaceImplementation7.types
@@ -2,16 +2,16 @@
 
 === interfaceImplementation7.ts ===
 interface i1{ name(): { s: string; }; }
->name : () => {    s: string;}
+>name : () => { s: string; }
 >s : string
 
 interface i2{ name(): { n: number; }; }
->name : () => {    n: number;}
+>name : () => { n: number; }
 >n : number
 
 interface i3 extends i1, i2 { }
 interface i4 extends i1, i2 { name(): { s: string; n: number; }; }
->name : () => {    s: string;    n: number;}
+>name : () => { s: string; n: number; }
 >s : string
 >n : number
 

--- a/tests/baselines/reference/interfacePropertiesWithSameName1.types
+++ b/tests/baselines/reference/interfacePropertiesWithSameName1.types
@@ -6,7 +6,7 @@ interface Mover {
 >move : () => void
 
     getStatus(): { speed: number; };
->getStatus : () => {    speed: number;}
+>getStatus : () => { speed: number; }
 >speed : number
 }
 interface Shaker {
@@ -14,13 +14,13 @@ interface Shaker {
 >shake : () => void
 
     getStatus(): { frequency: number; };
->getStatus : () => {    frequency: number;}
+>getStatus : () => { frequency: number; }
 >frequency : number
 }
 
 interface MoverShaker extends Mover, Shaker {
     getStatus(): { speed: number; frequency: number; };
->getStatus : () => {    speed: number;    frequency: number;}
+>getStatus : () => { speed: number; frequency: number; }
 >speed : number
 >frequency : number
 }

--- a/tests/baselines/reference/interfacePropertiesWithSameName2.types
+++ b/tests/baselines/reference/interfacePropertiesWithSameName2.types
@@ -6,7 +6,7 @@ interface Mover {
 >move : () => void
 
     getStatus(): { speed: number; };
->getStatus : () => {    speed: number;}
+>getStatus : () => { speed: number; }
 >speed : number
 }
 interface Shaker {
@@ -14,7 +14,7 @@ interface Shaker {
 >shake : () => void
 
     getStatus(): { frequency: number; };
->getStatus : () => {    frequency: number;}
+>getStatus : () => { frequency: number; }
 >frequency : number
 }
 
@@ -33,7 +33,7 @@ declare module MoversAndShakers {
 >move : () => void
 
         getStatus(): { speed: number; };
->getStatus : () => {    speed: number;}
+>getStatus : () => { speed: number; }
 >speed : number
     }
     export interface Shaker {
@@ -41,7 +41,7 @@ declare module MoversAndShakers {
 >shake : () => void
 
         getStatus(): { frequency: number; };
->getStatus : () => {    frequency: number;}
+>getStatus : () => { frequency: number; }
 >frequency : number
     }
 }
@@ -55,7 +55,7 @@ interface MoverShaker3 extends MoversAndShakers.Mover, MoversAndShakers.Shaker {
 >MoversAndShakers : typeof MoversAndShakers
 
     getStatus(): { speed: number; frequency: number; }; // ok because this getStatus overrides the conflicting ones above
->getStatus : () => {    speed: number;    frequency: number;}
+>getStatus : () => { speed: number; frequency: number; }
 >speed : number
 >frequency : number
 }

--- a/tests/baselines/reference/intersectionOfTypeVariableHasApparentSignatures.types
+++ b/tests/baselines/reference/intersectionOfTypeVariableHasApparentSignatures.types
@@ -9,7 +9,7 @@ interface Component<P> {
 
 interface Props {
     children?: (items: {x: number}) => void
->children : ((items: {    x: number;}) => void) | undefined
+>children : ((items: { x: number; }) => void) | undefined
 >items : { x: number; }
 >x : number
 }

--- a/tests/baselines/reference/intersectionPropertyCheck.types
+++ b/tests/baselines/reference/intersectionPropertyCheck.types
@@ -2,7 +2,7 @@
 
 === intersectionPropertyCheck.ts ===
 let obj: { a: { x: string } } & { c: number } = { a: { x: 'hello', y: 2 }, c: 5 };  // Nested excess property
->obj : { a: {    x: string;}; } & { c: number; }
+>obj : { a: { x: string; }; } & { c: number; }
 >a : { x: string; }
 >x : string
 >c : number
@@ -17,7 +17,7 @@ let obj: { a: { x: string } } & { c: number } = { a: { x: 'hello', y: 2 }, c: 5 
 >5 : 5
 
 declare let wrong: { a: { y: string } };
->wrong : { a: {    y: string;}; }
+>wrong : { a: { y: string; }; }
 >a : { y: string; }
 >y : string
 
@@ -29,7 +29,7 @@ let weak: { a?: { x?: number } } & { c?: string } = wrong;  // Nested weak objec
 >wrong : { a: { y: string; }; }
 
 function foo<T extends object>(x: { a?: string }, y: T & { a: boolean }) {
->foo : <T extends object>(x: {    a?: string;}, y: T & {    a: boolean;}) => void
+>foo : <T extends object>(x: { a?: string; }, y: T & { a: boolean; }) => void
 >x : { a?: string | undefined; }
 >a : string | undefined
 >y : T & { a: boolean; }

--- a/tests/baselines/reference/intersectionReduction.types
+++ b/tests/baselines/reference/intersectionReduction.types
@@ -183,7 +183,7 @@ type E = { kind: 'e', foo: unknown };
 >foo : unknown
 
 declare function f10<T>(x: { foo: T }): T;
->f10 : <T>(x: {    foo: T;}) => T
+>f10 : <T>(x: { foo: T; }) => T
 >x : { foo: T; }
 >foo : T
 
@@ -302,15 +302,15 @@ const f2 = (t: Container<"a"> | (Container<"b"> & Container<"c">)): Container<"a
 >t : Container<"a">
 
 const f3 = (t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t;
->f3 : (t: Container<"a"> | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => Container<"a">
->(t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t : (t: Container<"a"> | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => Container<"a">
+>f3 : (t: Container<"a"> | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => Container<"a">
+>(t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t : (t: Container<"a"> | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => Container<"a">
 >t : Container<"a">
 >dataB : boolean
 >t : Container<"a">
 
 const f4 = (t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t;
->f4 : (t: number | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => number
->(t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t : (t: number | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => number
+>f4 : (t: number | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => number
+>(t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t : (t: number | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => number
 >t : number
 >dataB : boolean
 >t : number

--- a/tests/baselines/reference/intersectionReductionStrict.types
+++ b/tests/baselines/reference/intersectionReductionStrict.types
@@ -269,15 +269,15 @@ const f2 = (t: Container<"a"> | (Container<"b"> & Container<"c">)): Container<"a
 >t : Container<"a">
 
 const f3 = (t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t;
->f3 : (t: Container<"a"> | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => Container<"a">
->(t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t : (t: Container<"a"> | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => Container<"a">
+>f3 : (t: Container<"a"> | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => Container<"a">
+>(t: Container<"a"> | (Container<"b"> & { dataB: boolean } & Container<"a">)): Container<"a"> => t : (t: Container<"a"> | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => Container<"a">
 >t : Container<"a">
 >dataB : boolean
 >t : Container<"a">
 
 const f4 = (t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t;
->f4 : (t: number | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => number
->(t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t : (t: number | (Container<"b"> & {    dataB: boolean;} & Container<"a">)) => number
+>f4 : (t: number | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => number
+>(t: number | (Container<"b"> & { dataB: boolean } & Container<"a">)): number => t : (t: number | (Container<"b"> & { dataB: boolean; } & Container<"a">)) => number
 >t : number
 >dataB : boolean
 >t : number

--- a/tests/baselines/reference/intersectionTypeInference1.types
+++ b/tests/baselines/reference/intersectionTypeInference1.types
@@ -19,8 +19,8 @@ const parameterFn = (props:{store:string}) => alert(props.store)
 >store : string
 
 const brokenFunction = <OwnProps>(f: (p: {dispatch: number} & OwnProps) => void) => (o: OwnProps) => o
->brokenFunction : <OwnProps>(f: (p: { dispatch: number; } & OwnProps) => void) => (o: OwnProps) => OwnProps
-><OwnProps>(f: (p: {dispatch: number} & OwnProps) => void) => (o: OwnProps) => o : <OwnProps>(f: (p: { dispatch: number; } & OwnProps) => void) => (o: OwnProps) => OwnProps
+>brokenFunction : <OwnProps>(f: (p: {    dispatch: number;} & OwnProps) => void) => (o: OwnProps) => OwnProps
+><OwnProps>(f: (p: {dispatch: number} & OwnProps) => void) => (o: OwnProps) => o : <OwnProps>(f: (p: {    dispatch: number;} & OwnProps) => void) => (o: OwnProps) => OwnProps
 >f : (p: {    dispatch: number;} & OwnProps) => void
 >p : { dispatch: number; } & OwnProps
 >dispatch : number

--- a/tests/baselines/reference/intersectionTypeInference1.types
+++ b/tests/baselines/reference/intersectionTypeInference1.types
@@ -8,8 +8,8 @@ function alert(s: string) {}
 >s : string
 
 const parameterFn = (props:{store:string}) => alert(props.store)
->parameterFn : (props: {    store: string;}) => void
->(props:{store:string}) => alert(props.store) : (props: {    store: string;}) => void
+>parameterFn : (props: { store: string; }) => void
+>(props:{store:string}) => alert(props.store) : (props: { store: string; }) => void
 >props : { store: string; }
 >store : string
 >alert(props.store) : void
@@ -19,9 +19,9 @@ const parameterFn = (props:{store:string}) => alert(props.store)
 >store : string
 
 const brokenFunction = <OwnProps>(f: (p: {dispatch: number} & OwnProps) => void) => (o: OwnProps) => o
->brokenFunction : <OwnProps>(f: (p: {    dispatch: number;} & OwnProps) => void) => (o: OwnProps) => OwnProps
-><OwnProps>(f: (p: {dispatch: number} & OwnProps) => void) => (o: OwnProps) => o : <OwnProps>(f: (p: {    dispatch: number;} & OwnProps) => void) => (o: OwnProps) => OwnProps
->f : (p: {    dispatch: number;} & OwnProps) => void
+>brokenFunction : <OwnProps>(f: (p: { dispatch: number; } & OwnProps) => void) => (o: OwnProps) => OwnProps
+><OwnProps>(f: (p: {dispatch: number} & OwnProps) => void) => (o: OwnProps) => o : <OwnProps>(f: (p: { dispatch: number; } & OwnProps) => void) => (o: OwnProps) => OwnProps
+>f : (p: { dispatch: number; } & OwnProps) => void
 >p : { dispatch: number; } & OwnProps
 >dispatch : number
 >(o: OwnProps) => o : (o: OwnProps) => OwnProps

--- a/tests/baselines/reference/intersectionTypeInference2.types
+++ b/tests/baselines/reference/intersectionTypeInference2.types
@@ -2,7 +2,7 @@
 
 === intersectionTypeInference2.ts ===
 declare function f<T>(x: { prop: T }): T;
->f : <T>(x: {    prop: T;}) => T
+>f : <T>(x: { prop: T; }) => T
 >x : { prop: T; }
 >prop : T
 

--- a/tests/baselines/reference/intersectionTypeMembers.types
+++ b/tests/baselines/reference/intersectionTypeMembers.types
@@ -101,7 +101,7 @@ var n = f(42);
 
 interface D {
     nested: { doublyNested: { d: string; }, different: { e: number } };
->nested : { doublyNested: {    d: string;}; different: {    e: number;}; }
+>nested : { doublyNested: { d: string; }; different: { e: number; }; }
 >doublyNested : { d: string; }
 >d : string
 >different : { e: number; }
@@ -109,7 +109,7 @@ interface D {
 }
 interface E {
     nested: { doublyNested: { f: string; }, other: {g: number } };
->nested : { doublyNested: {    f: string;}; other: {    g: number;}; }
+>nested : { doublyNested: { f: string; }; other: { g: number; }; }
 >doublyNested : { f: string; }
 >f : string
 >other : { g: number; }
@@ -153,14 +153,14 @@ const de: D & E = {
 // Additional test case with >2 doubly nested members so fix for #31441 is tested w/ excess props
 interface F {
     nested: { doublyNested: { g: string; } }
->nested : { doublyNested: {    g: string;}; }
+>nested : { doublyNested: { g: string; }; }
 >doublyNested : { g: string; }
 >g : string
 }
 
 interface G {
     nested: { doublyNested: { h: string; } }
->nested : { doublyNested: {    h: string;}; }
+>nested : { doublyNested: { h: string; }; }
 >doublyNested : { h: string; }
 >h : string
 }

--- a/tests/baselines/reference/intersectionType_useDefineForClassFields.types
+++ b/tests/baselines/reference/intersectionType_useDefineForClassFields.types
@@ -8,7 +8,7 @@ type Foo<T> = {
 }
 
 function bar<T>(_p: T): { new(): Foo<T> } {
->bar : <T>(_p: T) => {    new (): Foo<T>;}
+>bar : <T>(_p: T) => { new (): Foo<T>; }
 >_p : T
 
     return null as any;

--- a/tests/baselines/reference/intraExpressionInferences.types
+++ b/tests/baselines/reference/intraExpressionInferences.types
@@ -344,7 +344,7 @@ type MappingComponent<I extends WrappedMap, O extends WrappedMap> = {
 >MappingComponent : MappingComponent<I, O>
 
     setup(): { inputs: I; outputs: O };
->setup : () => {    inputs: I;    outputs: O;}
+>setup : () => { inputs: I; outputs: O; }
 >inputs : I
 >outputs : O
 

--- a/tests/baselines/reference/jsDeclarationsExportDefinePropertyEmit.types
+++ b/tests/baselines/reference/jsDeclarationsExportDefinePropertyEmit.types
@@ -142,7 +142,7 @@ Object.defineProperty(module.exports.f, "self", { value: module.exports.f });
  * @param {{y: typeof module.exports.b}} b
  */
 function g(a, b) {
->g : (a: {    x: string;}, b: { y: () => void; }) => void
+>g : (a: { x: string; }, b: { y: () => void; }) => void
 >a : { x: string; }
 >b : { y: () => void; }
 
@@ -175,7 +175,7 @@ Object.defineProperty(module.exports, "g", { value: g });
  * @param {{y: typeof module.exports.b}} b
  */
 function hh(a, b) {
->hh : (a: {    x: string;}, b: { y: () => void; }) => void
+>hh : (a: { x: string; }, b: { y: () => void; }) => void
 >a : { x: string; }
 >b : { y: () => void; }
 

--- a/tests/baselines/reference/jsDeclarationsFunctions.types
+++ b/tests/baselines/reference/jsDeclarationsFunctions.types
@@ -70,7 +70,7 @@ f.self = f;
  * @param {{y: typeof b}} b
  */
 function g(a, b) {
->g : (a: {    x: string;}, b: { y: typeof import("index").b; }) => void
+>g : (a: { x: string; }, b: { y: typeof import("index").b; }) => void
 >a : { x: string; }
 >b : { y: typeof import("index").b; }
 
@@ -93,7 +93,7 @@ export { g };
  * @param {{y: typeof b}} b
  */
 function hh(a, b) {
->hh : (a: {    x: string;}, b: { y: typeof import("index").b; }) => void
+>hh : (a: { x: string; }, b: { y: typeof import("index").b; }) => void
 >a : { x: string; }
 >b : { y: typeof import("index").b; }
 

--- a/tests/baselines/reference/jsDeclarationsFunctionsCjs.types
+++ b/tests/baselines/reference/jsDeclarationsFunctionsCjs.types
@@ -128,7 +128,7 @@ module.exports.f.self = module.exports.f;
  * @param {{y: typeof module.exports.b}} b
  */
 function g(a, b) {
->g : (a: {    x: string;}, b: { y: { (): void; cat: string; }; }) => void
+>g : (a: { x: string; }, b: { y: { (): void; cat: string; }; }) => void
 >a : { x: string; }
 >b : { y: { (): void; cat: string; }; }
 
@@ -157,7 +157,7 @@ module.exports.g = g;
  * @param {{y: typeof module.exports.b}} b
  */
 function hh(a, b) {
->hh : (a: {    x: string;}, b: { y: { (): void; cat: string; }; }) => void
+>hh : (a: { x: string; }, b: { y: { (): void; cat: string; }; }) => void
 >a : { x: string; }
 >b : { y: { (): void; cat: string; }; }
 

--- a/tests/baselines/reference/jsDeclarationsReactComponents.types
+++ b/tests/baselines/reference/jsDeclarationsReactComponents.types
@@ -145,8 +145,8 @@ import React from "react";
 >React : typeof React
 
 const TabbedShowLayout = (/** @type {{className: string}}*/prop) => {
->TabbedShowLayout : { (prop: {    className: string;}): JSX.Element; defaultProps: { tabs: string; }; }
->(/** @type {{className: string}}*/prop) => {    return (        <div className={prop.className} key="">            ok        </div>    );} : { (prop: {    className: string;}): JSX.Element; defaultProps: { tabs: string; }; }
+>TabbedShowLayout : { (prop: { className: string; }): JSX.Element; defaultProps: { tabs: string; }; }
+>(/** @type {{className: string}}*/prop) => {    return (        <div className={prop.className} key="">            ok        </div>    );} : { (prop: { className: string; }): JSX.Element; defaultProps: { tabs: string; }; }
 >prop : { className: string; }
 
     return (

--- a/tests/baselines/reference/jsdocFunctionType.types
+++ b/tests/baselines/reference/jsdocFunctionType.types
@@ -30,7 +30,7 @@ var x = id1(function (n) { return this.length + n });
  * @return {function(new: { length: number }, number): number}
  */
 function id2(c) {
->id2 : (c: new (arg1: number) => {    length: number;}) => new (arg1: number) => {    length: number;}
+>id2 : (c: new (arg1: number) => { length: number; }) => new (arg1: number) => { length: number; }
 >c : new (arg1: number) => { length: number; }
 
     return c

--- a/tests/baselines/reference/jsdocParamTag2.types
+++ b/tests/baselines/reference/jsdocParamTag2.types
@@ -7,7 +7,7 @@
  * @param {string} x
  */
 function good1({a, b}, x) {}
->good1 : ({ a, b }: {    a: string;    b: string;}, x: string) => void
+>good1 : ({ a, b }: { a: string; b: string; }, x: string) => void
 >a : string
 >b : string
 >x : string
@@ -17,7 +17,7 @@ function good1({a, b}, x) {}
  * @param {{c: number, d: number}} OBJECTION
  */
 function good2({a, b}, {c, d}) {}
->good2 : ({ a, b }: {    a: string;    b: string;}, { c, d }: {    c: number;    d: number;}) => void
+>good2 : ({ a, b }: { a: string; b: string; }, { c, d }: { c: number; d: number; }) => void
 >a : string
 >b : string
 >c : number
@@ -29,7 +29,7 @@ function good2({a, b}, {c, d}) {}
  * @param {string} y
  */
 function good3(x, {a, b}, y) {}
->good3 : (x: number, { a, b }: {    a: string;    b: string;}, y: string) => void
+>good3 : (x: number, { a, b }: { a: string; b: string; }, y: string) => void
 >x : number
 >a : string
 >b : string
@@ -39,7 +39,7 @@ function good3(x, {a, b}, y) {}
  * @param {{a: string, b: string}} obj
  */
 function good4({a, b}) {}
->good4 : ({ a, b }: {    a: string;    b: string;}) => void
+>good4 : ({ a, b }: { a: string; b: string; }) => void
 >a : string
 >b : string
 
@@ -99,7 +99,7 @@ function good8({a, b}) {}
  * @param {{ a: string }} argument
  */
 function good9({ a }) {
->good9 : ({ a }: {    a: string;}, ...args: any[]) => void
+>good9 : ({ a }: { a: string; }, ...args: any[]) => void
 >a : string
 
     console.log(arguments, a);
@@ -128,7 +128,7 @@ function bad1(x, {a, b}) {}
  * @param {{a: string, b: string}} obj
  */
 function bad2(x, {a, b}) {}
->bad2 : (x: any, { a, b }: {    a: string;    b: string;}) => void
+>bad2 : (x: any, { a, b }: { a: string; b: string; }) => void
 >x : any
 >a : string
 >b : string

--- a/tests/baselines/reference/jsxCallbackWithDestructuring.types
+++ b/tests/baselines/reference/jsxCallbackWithDestructuring.types
@@ -40,7 +40,7 @@ declare global {
 
 export interface RouteProps {
     children?: (props: { x: number }) => any;
->children : ((props: {    x: number;}) => any) | undefined
+>children : ((props: { x: number; }) => any) | undefined
 >props : { x: number; }
 >x : number
 }

--- a/tests/baselines/reference/jsxComplexSignatureHasApplicabilityError.types
+++ b/tests/baselines/reference/jsxComplexSignatureHasApplicabilityError.types
@@ -216,7 +216,7 @@ export type IsOptionUniqueHandler<TValue = OptionValues> = (arg: { option: Optio
 >valueKey : string
 
 export type IsValidNewOptionHandler = (arg: { label: string }) => boolean;
->IsValidNewOptionHandler : (arg: {    label: string;}) => boolean
+>IsValidNewOptionHandler : (arg: { label: string; }) => boolean
 >arg : { label: string; }
 >label : string
 
@@ -232,7 +232,7 @@ export type PromptTextCreatorHandler = (filterText: string) => string;
 >filterText : string
 
 export type ShouldKeyDownEventCreateNewOptionHandler = (arg: { keyCode: number }) => boolean;
->ShouldKeyDownEventCreateNewOptionHandler : (arg: {    keyCode: number;}) => boolean
+>ShouldKeyDownEventCreateNewOptionHandler : (arg: { keyCode: number; }) => boolean
 >arg : { keyCode: number; }
 >keyCode : number
 

--- a/tests/baselines/reference/jsxEmitWithAttributes.types
+++ b/tests/baselines/reference/jsxEmitWithAttributes.types
@@ -87,7 +87,7 @@ import { Element} from './Element';
 >Element : typeof Element
 
 let c: {
->c : { a?: {    b: string;}; }
+>c : { a?: { b: string; }; }
 
 	a?: {
 >a : { b: string; }

--- a/tests/baselines/reference/jsxExcessPropsAndAssignability.types
+++ b/tests/baselines/reference/jsxExcessPropsAndAssignability.types
@@ -7,8 +7,8 @@ import * as React from 'react';
 >React : typeof React
 
 const myHoc = <ComposedComponentProps extends any>(
->myHoc : <ComposedComponentProps extends unknown>(ComposedComponent: React.ComponentClass<ComposedComponentProps, any>) => void
-><ComposedComponentProps extends any>(    ComposedComponent: React.ComponentClass<ComposedComponentProps>,) => {    type WrapperComponentProps = ComposedComponentProps & { myProp: string };    const WrapperComponent: React.ComponentClass<WrapperComponentProps> = null as any;    const props: ComposedComponentProps = null as any;    <WrapperComponent {...props} myProp={'1000000'} />;    <WrapperComponent {...props} myProp={1000000} />;} : <ComposedComponentProps extends unknown>(ComposedComponent: React.ComponentClass<ComposedComponentProps, any>) => void
+>myHoc : <ComposedComponentProps extends unknown>(ComposedComponent: React.ComponentClass<ComposedComponentProps>) => void
+><ComposedComponentProps extends any>(    ComposedComponent: React.ComponentClass<ComposedComponentProps>,) => {    type WrapperComponentProps = ComposedComponentProps & { myProp: string };    const WrapperComponent: React.ComponentClass<WrapperComponentProps> = null as any;    const props: ComposedComponentProps = null as any;    <WrapperComponent {...props} myProp={'1000000'} />;    <WrapperComponent {...props} myProp={1000000} />;} : <ComposedComponentProps extends unknown>(ComposedComponent: React.ComponentClass<ComposedComponentProps>) => void
 
     ComposedComponent: React.ComponentClass<ComposedComponentProps>,
 >ComposedComponent : React.ComponentClass<ComposedComponentProps, any>

--- a/tests/baselines/reference/jsxFactoryAndReactNamespace.types
+++ b/tests/baselines/reference/jsxFactoryAndReactNamespace.types
@@ -87,7 +87,7 @@ import { Element} from './Element';
 >Element : typeof Element
 
 let c: {
->c : { a?: {    b: string;}; }
+>c : { a?: { b: string; }; }
 
 	a?: {
 >a : { b: string; }

--- a/tests/baselines/reference/jsxFactoryIdentifier.types
+++ b/tests/baselines/reference/jsxFactoryIdentifier.types
@@ -93,7 +93,7 @@ let createElement = Element.createElement;
 >createElement : (args: any[]) => {}
 
 let c: {
->c : { a?: {    b: string;}; }
+>c : { a?: { b: string; }; }
 
 	a?: {
 >a : { b: string; }

--- a/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName.types
+++ b/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName.types
@@ -87,7 +87,7 @@ import { Element} from './Element';
 >Element : typeof Element
 
 let c: {
->c : { a?: {    b: string;}; }
+>c : { a?: { b: string; }; }
 
 	a?: {
 >a : { b: string; }

--- a/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName2.types
+++ b/tests/baselines/reference/jsxFactoryNotIdentifierOrQualifiedName2.types
@@ -87,7 +87,7 @@ import { Element} from './Element';
 >Element : typeof Element
 
 let c: {
->c : { a?: {    b: string;}; }
+>c : { a?: { b: string; }; }
 
 	a?: {
 >a : { b: string; }

--- a/tests/baselines/reference/jsxFactoryQualifiedName.types
+++ b/tests/baselines/reference/jsxFactoryQualifiedName.types
@@ -87,7 +87,7 @@ import { Element} from './Element';
 >Element : typeof Element
 
 let c: {
->c : { a?: {    b: string;}; }
+>c : { a?: { b: string; }; }
 
 	a?: {
 >a : { b: string; }

--- a/tests/baselines/reference/jsxIntrinsicElementsCompatability.types
+++ b/tests/baselines/reference/jsxIntrinsicElementsCompatability.types
@@ -6,7 +6,7 @@ import * as React from "react";
 >React : typeof React
 
 function SomeComponent<T extends 'button' | 'a'>(props: { element?: T } & JSX.IntrinsicElements[T]): JSX.Element {
->SomeComponent : <T extends "a" | "button">(props: {    element?: T;} & JSX.IntrinsicElements[T]) => JSX.Element
+>SomeComponent : <T extends "a" | "button">(props: { element?: T; } & JSX.IntrinsicElements[T]) => JSX.Element
 >props : { element?: T | undefined; } & JSX.IntrinsicElements[T]
 >element : T | undefined
 >JSX : any

--- a/tests/baselines/reference/jsxLibraryManagedAttributesUnusedGeneric.types
+++ b/tests/baselines/reference/jsxLibraryManagedAttributesUnusedGeneric.types
@@ -20,7 +20,7 @@ namespace jsx {
         export interface IntrinsicAttributes {}
         export interface IntrinsicClassAttributes<T> {}
         export type IntrinsicElements = {
->IntrinsicElements : { div: {    className: string;}; }
+>IntrinsicElements : { div: { className: string; }; }
 
             div: { className: string }
 >div : { className: string; }
@@ -41,7 +41,7 @@ namespace jsx {
 }
 
 declare const Comp: (p: { className?: string }) => null
->Comp : (p: {    className?: string;}) => null
+>Comp : (p: { className?: string; }) => null
 >p : { className?: string; }
 >className : string
 

--- a/tests/baselines/reference/jsxNamespaceGlobalReexport.types
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexport.types
@@ -92,7 +92,7 @@ import { JSXInternal } from '..';
 >JSXInternal : any
 
 export function jsx(
->jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild;}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChild; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -112,7 +112,7 @@ export function jsx(
 
 ): VNode<any>;
 export function jsx<P>(
->jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild;}, key?: string): VNode<any>; }
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChild; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>
@@ -127,7 +127,7 @@ export function jsx<P>(
 ): VNode<any>;
 
 export function jsxs(
->jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild[];}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChild[]; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -147,7 +147,7 @@ export function jsxs(
 
 ): VNode<any>;
 export function jsxs<P>(
->jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild[];}, key?: string): VNode<any>; }
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChild[]; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>
@@ -162,7 +162,7 @@ export function jsxs<P>(
 ): VNode<any>;
 
 export function jsxDEV(
->jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChildren;}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChildren; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -182,7 +182,7 @@ export function jsxDEV(
 
 ): VNode<any>;
 export function jsxDEV<P>(
->jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChildren;}, key?: string): VNode<any>; }
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChildren; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>

--- a/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.types
+++ b/tests/baselines/reference/jsxNamespaceGlobalReexportMissingAliasTarget.types
@@ -92,7 +92,7 @@ import { JSXInternal } from '..';
 >JSXInternal : any
 
 export function jsx(
->jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild;}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChild; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -112,7 +112,7 @@ export function jsx(
 
 ): VNode<any>;
 export function jsx<P>(
->jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild;}, key?: string): VNode<any>; }
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChild; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>
@@ -127,7 +127,7 @@ export function jsx<P>(
 ): VNode<any>;
 
 export function jsxs(
->jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild[];}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChild[]; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -147,7 +147,7 @@ export function jsxs(
 
 ): VNode<any>;
 export function jsxs<P>(
->jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild[];}, key?: string): VNode<any>; }
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChild[]; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>
@@ -162,7 +162,7 @@ export function jsxs<P>(
 ): VNode<any>;
 
 export function jsxDEV(
->jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChildren;}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChildren; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -182,7 +182,7 @@ export function jsxDEV(
 
 ): VNode<any>;
 export function jsxDEV<P>(
->jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChildren;}, key?: string): VNode<any>; }
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChildren; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>

--- a/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.types
+++ b/tests/baselines/reference/jsxNamespaceImplicitImportJSXNamespace.types
@@ -92,7 +92,7 @@ import { JSXInternal } from '..';
 >JSXInternal : any
 
 export function jsx(
->jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild;}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChild; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -112,7 +112,7 @@ export function jsx(
 
 ): VNode<any>;
 export function jsx<P>(
->jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild;}, key?: string): VNode<any>; }
+>jsx : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChild; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>
@@ -128,7 +128,7 @@ export function jsx<P>(
 
 
 export function jsxs(
->jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChild[];}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChild[]; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -148,7 +148,7 @@ export function jsxs(
 
 ): VNode<any>;
 export function jsxs<P>(
->jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChild[];}, key?: string): VNode<any>; }
+>jsxs : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChild[] | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChild[]; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>
@@ -164,7 +164,7 @@ export function jsxs<P>(
 
 
 export function jsxDEV(
->jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & {    children?: ComponentChildren;}, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes & Record<string, any> & { children?: ComponentChildren; }, key?: string): VNode<any>; <P>(type: ComponentType<P>, props: P & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; }
 
     type: string,
 >type : string
@@ -184,7 +184,7 @@ export function jsxDEV(
 
 ): VNode<any>;
 export function jsxDEV<P>(
->jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & {    children?: ComponentChildren;}, key?: string): VNode<any>; }
+>jsxDEV : { (type: string, props: JSXInternal.HTMLAttributes<{}> & JSXInternal.SVGAttributes<{}> & Record<string, any> & { children?: ComponentChildren | undefined; }, key?: string | undefined): VNode<any>; <P>(type: ComponentType<P>, props: Attributes & P & { children?: ComponentChildren; }, key?: string): VNode<any>; }
 
     type: ComponentType<P>,
 >type : ComponentType<P>

--- a/tests/baselines/reference/jsxPartialSpread.types
+++ b/tests/baselines/reference/jsxPartialSpread.types
@@ -3,8 +3,8 @@
 === jsxPartialSpread.tsx ===
 /// <reference path="react16.d.ts" />
 const Select = (p: {value?: unknown}) => <p></p>;
->Select : (p: {    value?: unknown;}) => JSX.Element
->(p: {value?: unknown}) => <p></p> : (p: {    value?: unknown;}) => JSX.Element
+>Select : (p: { value?: unknown; }) => JSX.Element
+>(p: {value?: unknown}) => <p></p> : (p: { value?: unknown; }) => JSX.Element
 >p : { value?: unknown; }
 >value : unknown
 ><p></p> : JSX.Element
@@ -15,7 +15,7 @@ import React from 'react';
 >React : typeof React
 
 export function Repro({ SelectProps = {} }: { SelectProps?: Partial<Parameters<typeof Select>[0]> }) {
->Repro : ({ SelectProps }: {    SelectProps?: Partial<Parameters<typeof Select>[0]>;}) => JSX.Element
+>Repro : ({ SelectProps }: { SelectProps?: Partial<Parameters<typeof Select>[0]>; }) => JSX.Element
 >SelectProps : Partial<{ value?: unknown; }>
 >{} : {}
 >SelectProps : Partial<{ value?: unknown; }> | undefined

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -977,7 +977,7 @@ function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[
 }
 
 function f80<T extends { a: { x: any } }>(obj: T) {
->f80 : <T extends { a: {    x: any;}; }>(obj: T) => void
+>f80 : <T extends { a: { x: any; }; }>(obj: T) => void
 >a : { x: any; }
 >x : any
 >obj : T
@@ -1028,7 +1028,7 @@ function f80<T extends { a: { x: any } }>(obj: T) {
 }
 
 function f81<T extends { a: { x: any } }>(obj: T) {
->f81 : <T extends { a: {    x: any;}; }>(obj: T) => T["a"]["x"]
+>f81 : <T extends { a: { x: any; }; }>(obj: T) => T["a"]["x"]
 >a : { x: any; }
 >x : any
 >obj : T
@@ -1448,7 +1448,7 @@ function path(obj: any, ...keys: (string | number)[]): any {
 }
 
 type Thing = {
->Thing : { a: {    x: number;    y: string;}; b: boolean; }
+>Thing : { a: { x: number; y: string; }; b: boolean; }
 
     a: { x: number, y: string },
 >a : { x: number; y: string; }
@@ -1719,7 +1719,7 @@ type Handler<T> = {
 };
 
 function onChangeGenericFunction<T>(handler: Handler<T & {preset: number}>) {
->onChangeGenericFunction : <T>(handler: Handler<T & {    preset: number;}>) => void
+>onChangeGenericFunction : <T>(handler: Handler<T & { preset: number; }>) => void
 >handler : Handler<T & { preset: number; }>
 >preset : number
 
@@ -1973,7 +1973,7 @@ type Example<T extends { [K in keyof T]: { prop: any } }> = { [K in keyof T]: T[
 >prop : any
 
 type Result = Example<{ a: { prop: string }; b: { prop: number } }>;
->Result : Example<{ a: {    prop: string;}; b: {    prop: number;}; }>
+>Result : Example<{ a: { prop: string; }; b: { prop: number; }; }>
 >a : { prop: string; }
 >prop : string
 >b : { prop: number; }
@@ -1987,7 +1987,7 @@ type Example2<T> = { [K in keyof Helper2<T>]: Helper2<T>[K]["prop"] };
 >Example2 : Example2<T>
 
 type Result2 = Example2<{ 1: { prop: string }; 2: { prop: number } }>;
->Result2 : Example2<{ 1: {    prop: string;}; 2: {    prop: number;}; }>
+>Result2 : Example2<{ 1: { prop: string; }; 2: { prop: number; }; }>
 >1 : { prop: string; }
 >prop : string
 >2 : { prop: number; }

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -765,8 +765,8 @@ function f60<T>(source: T, target: T) {
 }
 
 function f70(func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void) {
->f70 : (func: <T, U>(k1: keyof T & keyof U, k2: keyof T | keyof U) => void) => void
->func : <T, U>(k1: keyof T & keyof U, k2: keyof T | keyof U) => void
+>f70 : (func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void) => void
+>func : <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void
 >k1 : keyof T & keyof U
 >k2 : keyof T | keyof U
 

--- a/tests/baselines/reference/keyofAndIndexedAccess2.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.types
@@ -2,7 +2,7 @@
 
 === keyofAndIndexedAccess2.ts ===
 function f1(obj: { a: number, b: 0 | 1, c: string }, k0: 'a', k1: 'a' | 'b', k2: 'a' | 'b' | 'c') {
->f1 : (obj: {    a: number;    b: 0 | 1;    c: string;}, k0: 'a', k1: 'a' | 'b', k2: 'a' | 'b' | 'c') => void
+>f1 : (obj: { a: number; b: 0 | 1; c: string; }, k0: 'a', k1: 'a' | 'b', k2: 'a' | 'b' | 'c') => void
 >obj : { a: number; b: 0 | 1; c: string; }
 >a : number
 >b : 0 | 1
@@ -76,7 +76,7 @@ function f1(obj: { a: number, b: 0 | 1, c: string }, k0: 'a', k1: 'a' | 'b', k2:
 }
 
 function f2<T extends { [key: string]: number }>(a: { x: number, y: number }, b: { [key: string]: number }, c: T, k: keyof T) {
->f2 : <T extends { [key: string]: number; }>(a: {    x: number;    y: number;}, b: { [key: string]: number; }, c: T, k: keyof T) => void
+>f2 : <T extends { [key: string]: number; }>(a: { x: number; y: number; }, b: { [key: string]: number; }, c: T, k: keyof T) => void
 >key : string
 >a : { x: number; y: number; }
 >x : number

--- a/tests/baselines/reference/logicalAssignment2(target=es2015).types
+++ b/tests/baselines/reference/logicalAssignment2(target=es2015).types
@@ -3,10 +3,10 @@
 === logicalAssignment2.ts ===
 interface A {
     foo: {
->foo : { bar(): {    baz: 0 | 1 | 42 | undefined | '';}; baz: 0 | 1 | 42 | undefined | ''; }
+>foo : { bar(): { baz: 0 | 1 | 42 | undefined | ''; }; baz: 0 | 1 | 42 | undefined | ''; }
 
         bar(): {
->bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
+>bar : () => { baz: 0 | 1 | 42 | undefined | ''; }
 
             baz: 0 | 1 | 42 | undefined | ''
 >baz : "" | 0 | 1 | 42 | undefined

--- a/tests/baselines/reference/logicalAssignment2(target=es2020).types
+++ b/tests/baselines/reference/logicalAssignment2(target=es2020).types
@@ -3,10 +3,10 @@
 === logicalAssignment2.ts ===
 interface A {
     foo: {
->foo : { bar(): {    baz: 0 | 1 | 42 | undefined | '';}; baz: 0 | 1 | 42 | undefined | ''; }
+>foo : { bar(): { baz: 0 | 1 | 42 | undefined | ''; }; baz: 0 | 1 | 42 | undefined | ''; }
 
         bar(): {
->bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
+>bar : () => { baz: 0 | 1 | 42 | undefined | ''; }
 
             baz: 0 | 1 | 42 | undefined | ''
 >baz : "" | 0 | 1 | 42 | undefined

--- a/tests/baselines/reference/logicalAssignment2(target=es2021).types
+++ b/tests/baselines/reference/logicalAssignment2(target=es2021).types
@@ -3,10 +3,10 @@
 === logicalAssignment2.ts ===
 interface A {
     foo: {
->foo : { bar(): {    baz: 0 | 1 | 42 | undefined | '';}; baz: 0 | 1 | 42 | undefined | ''; }
+>foo : { bar(): { baz: 0 | 1 | 42 | undefined | ''; }; baz: 0 | 1 | 42 | undefined | ''; }
 
         bar(): {
->bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
+>bar : () => { baz: 0 | 1 | 42 | undefined | ''; }
 
             baz: 0 | 1 | 42 | undefined | ''
 >baz : "" | 0 | 1 | 42 | undefined

--- a/tests/baselines/reference/logicalAssignment2(target=esnext).types
+++ b/tests/baselines/reference/logicalAssignment2(target=esnext).types
@@ -3,10 +3,10 @@
 === logicalAssignment2.ts ===
 interface A {
     foo: {
->foo : { bar(): {    baz: 0 | 1 | 42 | undefined | '';}; baz: 0 | 1 | 42 | undefined | ''; }
+>foo : { bar(): { baz: 0 | 1 | 42 | undefined | ''; }; baz: 0 | 1 | 42 | undefined | ''; }
 
         bar(): {
->bar : () => {    baz: 0 | 1 | 42 | undefined | '';}
+>bar : () => { baz: 0 | 1 | 42 | undefined | ''; }
 
             baz: 0 | 1 | 42 | undefined | ''
 >baz : "" | 0 | 1 | 42 | undefined

--- a/tests/baselines/reference/mappedTypeAsClauses.types
+++ b/tests/baselines/reference/mappedTypeAsClauses.types
@@ -202,7 +202,7 @@ type Task = {
 };
 
 type Schema = {
->Schema : { root: {    title: string;    task: Task;}; Task: Task; }
+>Schema : { root: { title: string; task: Task; }; Task: Task; }
 
   root: {
 >root : { title: string; task: Task; }

--- a/tests/baselines/reference/mappedTypeGenericIndexedAccess.types
+++ b/tests/baselines/reference/mappedTypeGenericIndexedAccess.types
@@ -4,7 +4,7 @@
 // Repro from #49242
 
 type Types = {
->Types : { first: {    a1: true;}; second: {    a2: true;}; third: {    a3: true;}; }
+>Types : { first: { a1: true; }; second: { a2: true; }; third: { a3: true; }; }
 
     first: { a1: true };
 >first : { a1: true; }
@@ -75,7 +75,7 @@ class Test {
 // Repro from #49338
 
 type TypesMap = {
->TypesMap : { 0: {    foo: 'bar';}; 1: {    a: 'b';}; }
+>TypesMap : { 0: { foo: 'bar'; }; 1: { a: 'b'; }; }
 
     [0]: { foo: 'bar'; };
 >[0] : { foo: 'bar'; }

--- a/tests/baselines/reference/mappedTypeInferenceErrors.types
+++ b/tests/baselines/reference/mappedTypeInferenceErrors.types
@@ -10,7 +10,7 @@ type ComputedOf<T> = {
 }
 
 declare function foo<P, C>(options: { props: P, computed: ComputedOf<C> } & ThisType<P & C>): void;
->foo : <P, C>(options: {    props: P;    computed: ComputedOf<C>;} & ThisType<P & C>) => void
+>foo : <P, C>(options: { props: P; computed: ComputedOf<C>; } & ThisType<P & C>) => void
 >options : { props: P; computed: ComputedOf<C>; } & ThisType<P & C>
 >props : P
 >computed : ComputedOf<C>

--- a/tests/baselines/reference/mappedTypeModifiers.types
+++ b/tests/baselines/reference/mappedTypeModifiers.types
@@ -107,7 +107,7 @@ type Boxified<T> = { [P in keyof T]: { x: T[P] } };
 >x : T[P]
 
 type B = { a: { x: number }, b: { x: string } };
->B : { a: {    x: number;}; b: {    x: string;}; }
+>B : { a: { x: number; }; b: { x: string; }; }
 >a : { x: number; }
 >x : number
 >b : { x: string; }
@@ -121,7 +121,7 @@ type BP = { a?: { x: number }, b?: { x: string } };
 >x : string
 
 type BR = { readonly a: { x: number }, readonly b: { x: string } };
->BR : { readonly a: {    x: number;}; readonly b: {    x: string;}; }
+>BR : { readonly a: { x: number; }; readonly b: { x: string; }; }
 >a : { x: number; }
 >x : number
 >b : { x: string; }

--- a/tests/baselines/reference/mappedTypes4.types
+++ b/tests/baselines/reference/mappedTypes4.types
@@ -112,7 +112,7 @@ type DeepReadonly<T> = {
 };
 
 type Foo = {
->Foo : { x: number; y: {    a: string;    b: number;}; z: boolean; }
+>Foo : { x: number; y: { a: string; b: number; }; z: boolean; }
 
     x: number;
 >x : number
@@ -128,7 +128,7 @@ type Foo = {
 };
 
 type DeepReadonlyFoo = {
->DeepReadonlyFoo : { readonly x: number; readonly y: {    readonly a: string;    readonly b: number;}; readonly z: boolean; }
+>DeepReadonlyFoo : { readonly x: number; readonly y: { readonly a: string; readonly b: number; }; readonly z: boolean; }
 
     readonly x: number;
 >x : number

--- a/tests/baselines/reference/mixinAccessModifiers.types
+++ b/tests/baselines/reference/mixinAccessModifiers.types
@@ -347,7 +347,7 @@ function f7(x: ProtectedGeneric<{}> & ProtectedGeneric<{}>) {
 }
 
 function f8(x: ProtectedGeneric<{a: void;}> & ProtectedGeneric2<{a:void;b:void;}>) {
->f8 : (x: ProtectedGeneric<{    a: void;}> & ProtectedGeneric2<{    a: void;    b: void;}>) => void
+>f8 : (x: ProtectedGeneric<{ a: void; }> & ProtectedGeneric2<{ a: void; b: void; }>) => void
 >x : never
 >a : void
 >a : void
@@ -367,7 +367,7 @@ function f8(x: ProtectedGeneric<{a: void;}> & ProtectedGeneric2<{a:void;b:void;}
 }
 
 function f9(x: ProtectedGeneric<{a: void;}> & ProtectedGeneric<{a:void;b:void;}>) {
->f9 : (x: ProtectedGeneric<{    a: void;}> & ProtectedGeneric<{    a: void;    b: void;}>) => void
+>f9 : (x: ProtectedGeneric<{ a: void; }> & ProtectedGeneric<{ a: void; b: void; }>) => void
 >x : ProtectedGeneric<{ a: void; }> & ProtectedGeneric<{ a: void; b: void; }>
 >a : void
 >a : void

--- a/tests/baselines/reference/mixinClassesAnnotated.types
+++ b/tests/baselines/reference/mixinClassesAnnotated.types
@@ -36,8 +36,8 @@ interface Printable {
 }
 
 const Printable = <T extends Constructor<Base>>(superClass: T): Constructor<Printable> & { message: string } & T =>
->Printable : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & { message: string; } & T
-><T extends Constructor<Base>>(superClass: T): Constructor<Printable> & { message: string } & T =>    class extends superClass {        static message = "hello";        print() {            const output = this.x + "," + this.y;        }    } : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & { message: string; } & T
+>Printable : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & {    message: string;} & T
+><T extends Constructor<Base>>(superClass: T): Constructor<Printable> & { message: string } & T =>    class extends superClass {        static message = "hello";        print() {            const output = this.x + "," + this.y;        }    } : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & {    message: string;} & T
 >superClass : T
 >message : string
 

--- a/tests/baselines/reference/mixinClassesAnnotated.types
+++ b/tests/baselines/reference/mixinClassesAnnotated.types
@@ -36,8 +36,8 @@ interface Printable {
 }
 
 const Printable = <T extends Constructor<Base>>(superClass: T): Constructor<Printable> & { message: string } & T =>
->Printable : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & {    message: string;} & T
-><T extends Constructor<Base>>(superClass: T): Constructor<Printable> & { message: string } & T =>    class extends superClass {        static message = "hello";        print() {            const output = this.x + "," + this.y;        }    } : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & {    message: string;} & T
+>Printable : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & { message: string; } & T
+><T extends Constructor<Base>>(superClass: T): Constructor<Printable> & { message: string } & T =>    class extends superClass {        static message = "hello";        print() {            const output = this.x + "," + this.y;        }    } : <T extends Constructor<Base>>(superClass: T) => Constructor<Printable> & { message: string; } & T
 >superClass : T
 >message : string
 

--- a/tests/baselines/reference/moduleAliasAsFunctionArgument.types
+++ b/tests/baselines/reference/moduleAliasAsFunctionArgument.types
@@ -6,7 +6,7 @@ import a = require('moduleAliasAsFunctionArgument_0');
 >a : typeof a
 
 function fn(arg: { x: number }) {
->fn : (arg: {    x: number;}) => void
+>fn : (arg: { x: number; }) => void
 >arg : { x: number; }
 >x : number
 }

--- a/tests/baselines/reference/multiLineErrors.types
+++ b/tests/baselines/reference/multiLineErrors.types
@@ -6,7 +6,7 @@ var t = 32;
 >32 : 32
 
 function noReturn(): {
->noReturn : () => {    n: string;    y: number;}
+>noReturn : () => { n: string; y: number; }
 
     n: string;
 >n : string

--- a/tests/baselines/reference/multiline.types
+++ b/tests/baselines/reference/multiline.types
@@ -37,7 +37,7 @@ import * as React from "react";
 >React : typeof React
 
 export function MyComponent(props: { foo: string }) {
->MyComponent : (props: {    foo: string;}) => JSX.Element
+>MyComponent : (props: { foo: string; }) => JSX.Element
 >props : { foo: string; }
 >foo : string
 

--- a/tests/baselines/reference/multipleInferenceContexts.types
+++ b/tests/baselines/reference/multipleInferenceContexts.types
@@ -22,7 +22,7 @@ interface Instance<Data> {
 }
 
 declare var Moon: {
->Moon : <Data>(options?: ConstructorOptions<Data> | undefined) => Instance<Data>
+>Moon : <Data>(options?: ConstructorOptions<Data>) => Instance<Data>
 
     <Data>(options?: ConstructorOptions<Data>): Instance<Data>;
 >options : ConstructorOptions<Data> | undefined

--- a/tests/baselines/reference/narrowingConstrainedTypeVariable.types
+++ b/tests/baselines/reference/narrowingConstrainedTypeVariable.types
@@ -54,7 +54,7 @@ class E { x: string | undefined }
 >x : string | undefined
 
 function f3<T extends E>(v: T | { x: string }) {
->f3 : <T extends E>(v: T | {    x: string;}) => void
+>f3 : <T extends E>(v: T | { x: string; }) => void
 >v : T | { x: string; }
 >x : string
 

--- a/tests/baselines/reference/narrowingDestructuring.types
+++ b/tests/baselines/reference/narrowingDestructuring.types
@@ -41,7 +41,7 @@ function func<T extends X>(value: T) {
 }
 
 type Z = { kind: "f", f: { a: number, b: string, c: number } }
->Z : { kind: "f"; f: {    a: number;    b: string;    c: number;}; } | { kind: "g"; g: {    a: string;    b: number;    c: string;}; }
+>Z : { kind: "f"; f: { a: number; b: string; c: number; }; } | { kind: "g"; g: { a: string; b: number; c: string; }; }
 >kind : "f"
 >f : { a: number; b: string; c: number; }
 >a : number

--- a/tests/baselines/reference/narrowingTypeofDiscriminant.types
+++ b/tests/baselines/reference/narrowingTypeofDiscriminant.types
@@ -2,7 +2,7 @@
 
 === narrowingTypeofDiscriminant.ts ===
 function f1(obj: { kind: 'a', data: string } | { kind: 1, data: number }) {
->f1 : (obj: {    kind: 'a';    data: string;} | {    kind: 1;    data: number;}) => void
+>f1 : (obj: { kind: 'a'; data: string; } | { kind: 1; data: number; }) => void
 >obj : { kind: 'a'; data: string; } | { kind: 1; data: number; }
 >kind : "a"
 >data : string
@@ -27,7 +27,7 @@ function f1(obj: { kind: 'a', data: string } | { kind: 1, data: number }) {
 }
 
 function f2(obj: { kind: 'a', data: string } | { kind: 1, data: number } | undefined) {
->f2 : (obj: {    kind: 'a';    data: string;} | {    kind: 1;    data: number;} | undefined) => void
+>f2 : (obj: { kind: 'a'; data: string; } | { kind: 1; data: number; } | undefined) => void
 >obj : { kind: 'a'; data: string; } | { kind: 1; data: number; } | undefined
 >kind : "a"
 >data : string

--- a/tests/baselines/reference/narrowingTypeofFunction.types
+++ b/tests/baselines/reference/narrowingTypeofFunction.types
@@ -46,7 +46,7 @@ function f2<T>(x: (T & F) | T & string) {
 }
 
 function f3(x: { _foo: number } & number) {
->f3 : (x: {    _foo: number;} & number) => void
+>f3 : (x: { _foo: number; } & number) => void
 >x : { _foo: number; } & number
 >_foo : number
 

--- a/tests/baselines/reference/narrowingTypeofObject.types
+++ b/tests/baselines/reference/narrowingTypeofObject.types
@@ -4,7 +4,7 @@
 interface F { (): string }
 
 function test(x: number & { _foo: string }) {
->test : (x: number & {    _foo: string;}) => void
+>test : (x: number & { _foo: string; }) => void
 >x : number & { _foo: string; }
 >_foo : string
 
@@ -20,7 +20,7 @@ function test(x: number & { _foo: string }) {
 }
 
 function f1(x: F & { foo: number }) {
->f1 : (x: F & {    foo: number;}) => void
+>f1 : (x: F & { foo: number; }) => void
 >x : F & { foo: number; }
 >foo : number
 

--- a/tests/baselines/reference/narrowingTypeofUndefined1.types
+++ b/tests/baselines/reference/narrowingTypeofUndefined1.types
@@ -2,7 +2,7 @@
 
 === narrowingTypeofUndefined1.ts ===
 declare const a: { error: { prop: string }, result: undefined } | { error: undefined, result: { prop: number } }
->a : { error: {    prop: string;}; result: undefined; } | { error: undefined; result: {    prop: number;}; }
+>a : { error: { prop: string; }; result: undefined; } | { error: undefined; result: { prop: number; }; }
 >error : { prop: string; }
 >prop : string
 >result : undefined

--- a/tests/baselines/reference/narrowingUnionToUnion.types
+++ b/tests/baselines/reference/narrowingUnionToUnion.types
@@ -59,7 +59,7 @@ declare function isA(obj: unknown): obj is { a: false } | { b: 0 };
 >b : 0
 
 function fx4(obj: { b: number }) {
->fx4 : (obj: {    b: number;}) => void
+>fx4 : (obj: { b: number; }) => void
 >obj : { b: number; }
 >b : number
 

--- a/tests/baselines/reference/nearbyIdenticalGenericLambdasAssignable.types
+++ b/tests/baselines/reference/nearbyIdenticalGenericLambdasAssignable.types
@@ -2,7 +2,7 @@
 
 === nearbyIdenticalGenericLambdasAssignable.ts ===
 declare const fA: <T>() => { v: T };
->fA : <T>() => { v: T; }
+>fA : <T>() => {    v: T;}
 >v : T
 
 const fB = <T>() => {
@@ -43,7 +43,7 @@ type TC = typeof fC;
 >fC : <T>() => { v: T; }
 
 type TL = <T>() => { v: T }; 
->TL : <T>() => { v: T; }
+>TL : <T>() => {    v: T;}
 >v : T
 
 declare function accA(x: TA): void;

--- a/tests/baselines/reference/nearbyIdenticalGenericLambdasAssignable.types
+++ b/tests/baselines/reference/nearbyIdenticalGenericLambdasAssignable.types
@@ -2,7 +2,7 @@
 
 === nearbyIdenticalGenericLambdasAssignable.ts ===
 declare const fA: <T>() => { v: T };
->fA : <T>() => {    v: T;}
+>fA : <T>() => { v: T; }
 >v : T
 
 const fB = <T>() => {
@@ -43,7 +43,7 @@ type TC = typeof fC;
 >fC : <T>() => { v: T; }
 
 type TL = <T>() => { v: T }; 
->TL : <T>() => {    v: T;}
+>TL : <T>() => { v: T; }
 >v : T
 
 declare function accA(x: TA): void;

--- a/tests/baselines/reference/nestedExcessPropertyChecking.types
+++ b/tests/baselines/reference/nestedExcessPropertyChecking.types
@@ -2,17 +2,17 @@
 
 === nestedExcessPropertyChecking.ts ===
 type A1 = { x: { a?: string } };
->A1 : { x: {    a?: string;}; }
+>A1 : { x: { a?: string; }; }
 >x : { a?: string | undefined; }
 >a : string | undefined
 
 type B1 = { x: { b?: string } };
->B1 : { x: {    b?: string;}; }
+>B1 : { x: { b?: string; }; }
 >x : { b?: string | undefined; }
 >b : string | undefined
 
 type C1 = { x: { c: string } };
->C1 : { x: {    c: string;}; }
+>C1 : { x: { c: string; }; }
 >x : { c: string; }
 >c : string
 
@@ -65,7 +65,7 @@ type OverridesInput = {
 }
 
 const foo1: Partial<{ something: any }> & { variables: {
->foo1 : Partial<{ something: any; }> & { variables: {    overrides?: OverridesInput;} & Partial<{    overrides?: OverridesInput;}>; }
+>foo1 : Partial<{ something: any; }> & { variables: { overrides?: OverridesInput; } & Partial<{ overrides?: OverridesInput; }>; }
 >something : any
 >variables : { overrides?: OverridesInput | undefined; } & Partial<{ overrides?: OverridesInput | undefined; }>
 
@@ -111,10 +111,10 @@ const foo2: Unrelated & { variables: VariablesA & VariablesB } = {
 // Simplified repro from #52252
 
 type T1 = {
->T1 : { primary: {    __typename?: 'Feature';} & {    colors: {        light: number;        dark: number;    };}; }
+>T1 : { primary: { __typename?: 'Feature'; } & { colors: { light: number; dark: number; }; }; }
 
     primary: { __typename?: 'Feature' } & { colors: { light: number, dark: number } },
->primary : { __typename?: "Feature" | undefined; } & { colors: {    light: number;    dark: number;}; }
+>primary : { __typename?: "Feature" | undefined; } & { colors: { light: number; dark: number; }; }
 >__typename : "Feature" | undefined
 >colors : { light: number; dark: number; }
 >light : number
@@ -123,10 +123,10 @@ type T1 = {
 };
 
 type T2 = {
->T2 : { primary: {    __typename?: 'Feature';} & {    colors: {        light: number;    };}; }
+>T2 : { primary: { __typename?: 'Feature'; } & { colors: { light: number; }; }; }
 
     primary: { __typename?: 'Feature' } & { colors: { light: number } },
->primary : { __typename?: "Feature" | undefined; } & { colors: {    light: number;}; }
+>primary : { __typename?: "Feature" | undefined; } & { colors: { light: number; }; }
 >__typename : "Feature" | undefined
 >colors : { light: number; }
 >light : number

--- a/tests/baselines/reference/nestedTypeVariableInfersLiteral.types
+++ b/tests/baselines/reference/nestedTypeVariableInfersLiteral.types
@@ -7,12 +7,12 @@ declare function direct<A extends string>(a: A | A[]): Record<A, string>
 >a : A | A[]
 
 declare function nested<A extends string>(a: { fields: A }): Record<A, string>
->nested : <A extends string>(a: {    fields: A;}) => Record<A, string>
+>nested : <A extends string>(a: { fields: A; }) => Record<A, string>
 >a : { fields: A; }
 >fields : A
 
 declare function nestedUnion<A extends string>(a: { fields: A | A[] }): Record<A, string>
->nestedUnion : <A extends string>(a: {    fields: A | A[];}) => Record<A, string>
+>nestedUnion : <A extends string>(a: { fields: A | A[]; }) => Record<A, string>
 >a : { fields: A | A[]; }
 >fields : A | A[]
 
@@ -57,7 +57,7 @@ const nestedUnionArray = nestedUnion({fields: ["z", "y"]})
 >"y" : "y"
 
 declare function hasZField(arg: { z: string }): void
->hasZField : (arg: {    z: string;}) => void
+>hasZField : (arg: { z: string; }) => void
 >arg : { z: string; }
 >z : string
 

--- a/tests/baselines/reference/neverAsDiscriminantType(strict=false).types
+++ b/tests/baselines/reference/neverAsDiscriminantType(strict=false).types
@@ -153,7 +153,7 @@ export interface GatewayEvents {
 }
 
 function assertMessage(event: { a: 1 }) { }
->assertMessage : (event: {    a: 1;}) => void
+>assertMessage : (event: { a: 1; }) => void
 >event : { a: 1; }
 >a : 1
 

--- a/tests/baselines/reference/neverAsDiscriminantType(strict=true).types
+++ b/tests/baselines/reference/neverAsDiscriminantType(strict=true).types
@@ -153,7 +153,7 @@ export interface GatewayEvents {
 }
 
 function assertMessage(event: { a: 1 }) { }
->assertMessage : (event: {    a: 1;}) => void
+>assertMessage : (event: { a: 1; }) => void
 >event : { a: 1; }
 >a : 1
 

--- a/tests/baselines/reference/neverReturningFunctions1.types
+++ b/tests/baselines/reference/neverReturningFunctions1.types
@@ -330,7 +330,7 @@ function f30(x: string | number | undefined) {
 }
 
 function f31(x: { a: string | number }) {
->f31 : (x: {    a: string | number;}) => void
+>f31 : (x: { a: string | number; }) => void
 >x : { a: string | number; }
 >a : string | number
 

--- a/tests/baselines/reference/neverTypeErrors1.types
+++ b/tests/baselines/reference/neverTypeErrors1.types
@@ -92,7 +92,7 @@ type Union = A & B;
 >Union : never
 
 function func(): { value: Union[] } {
->func : () => {    value: Union[];}
+>func : () => { value: Union[]; }
 >value : never[]
 
     return {

--- a/tests/baselines/reference/neverTypeErrors2.types
+++ b/tests/baselines/reference/neverTypeErrors2.types
@@ -92,7 +92,7 @@ type Union = A & B;
 >Union : never
 
 function func(): { value: Union[] } {
->func : () => {    value: Union[];}
+>func : () => { value: Union[]; }
 >value : never[]
 
     return {

--- a/tests/baselines/reference/noImplicitAnyDestructuringParameterDeclaration.types
+++ b/tests/baselines/reference/noImplicitAnyDestructuringParameterDeclaration.types
@@ -18,7 +18,7 @@ function f2([a = undefined], {b = null}, c = undefined, d = null) { // error
 >d : any
 }
 function f3([a]: [any], {b}: { b: any }, c: any, d: any) {
->f3 : ([a]: [any], { b }: {    b: any;}, c: any, d: any) => void
+>f3 : ([a]: [any], { b }: { b: any; }, c: any, d: any) => void
 >a : any
 >b : any
 >b : any
@@ -26,7 +26,7 @@ function f3([a]: [any], {b}: { b: any }, c: any, d: any) {
 >d : any
 }
 function f4({b}: { b }, x: { b }) { // error in type instead
->f4 : ({ b }: {    b;}, x: {    b;}) => void
+>f4 : ({ b }: { b; }, x: { b; }) => void
 >b : any
 >b : any
 >x : { b: any; }

--- a/tests/baselines/reference/nodeModuleReexportFromDottedPath.types
+++ b/tests/baselines/reference/nodeModuleReexportFromDottedPath.types
@@ -22,7 +22,7 @@ import { PrismaClient } from "@prisma/client";
 >PrismaClient : typeof PrismaClient
 
 declare const enhancePrisma: <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown };
->enhancePrisma : <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown; }
+>enhancePrisma : <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & {    enhanced: unknown;}
 >client : TPrismaClientCtor
 >enhanced : unknown
 

--- a/tests/baselines/reference/nodeModuleReexportFromDottedPath.types
+++ b/tests/baselines/reference/nodeModuleReexportFromDottedPath.types
@@ -22,7 +22,7 @@ import { PrismaClient } from "@prisma/client";
 >PrismaClient : typeof PrismaClient
 
 declare const enhancePrisma: <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown };
->enhancePrisma : <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & {    enhanced: unknown;}
+>enhancePrisma : <TPrismaClientCtor>(client: TPrismaClientCtor) => TPrismaClientCtor & { enhanced: unknown; }
 >client : TPrismaClientCtor
 >enhanced : unknown
 

--- a/tests/baselines/reference/nodeModulesImportAttributesTypeModeDeclarationEmitErrors(module=node16).types
+++ b/tests/baselines/reference/nodeModulesImportAttributesTypeModeDeclarationEmitErrors(module=node16).types
@@ -126,12 +126,12 @@ export const b = (null as any as import("pkg", [ {"resolution-mode": "import"} ]
 === /other4.ts ===
 // Indirected attribute objecty-thing - not allowed
 type Attribute1 = { with: {"resolution-mode": "require"} };
->Attribute1 : { with: {    "resolution-mode": "require";}; }
+>Attribute1 : { with: { "resolution-mode": "require"; }; }
 >with : { "resolution-mode": "require"; }
 >"resolution-mode" : "require"
 
 type Attribute2 = { with: {"resolution-mode": "import"} };
->Attribute2 : { with: {    "resolution-mode": "import";}; }
+>Attribute2 : { with: { "resolution-mode": "import"; }; }
 >with : { "resolution-mode": "import"; }
 >"resolution-mode" : "import"
 

--- a/tests/baselines/reference/nodeModulesImportAttributesTypeModeDeclarationEmitErrors(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesImportAttributesTypeModeDeclarationEmitErrors(module=nodenext).types
@@ -126,12 +126,12 @@ export const b = (null as any as import("pkg", [ {"resolution-mode": "import"} ]
 === /other4.ts ===
 // Indirected attribute objecty-thing - not allowed
 type Attribute1 = { with: {"resolution-mode": "require"} };
->Attribute1 : { with: {    "resolution-mode": "require";}; }
+>Attribute1 : { with: { "resolution-mode": "require"; }; }
 >with : { "resolution-mode": "require"; }
 >"resolution-mode" : "require"
 
 type Attribute2 = { with: {"resolution-mode": "import"} };
->Attribute2 : { with: {    "resolution-mode": "import";}; }
+>Attribute2 : { with: { "resolution-mode": "import"; }; }
 >with : { "resolution-mode": "import"; }
 >"resolution-mode" : "import"
 

--- a/tests/baselines/reference/nodeModulesImportTypeModeDeclarationEmitErrors1(module=node16).types
+++ b/tests/baselines/reference/nodeModulesImportTypeModeDeclarationEmitErrors1(module=node16).types
@@ -124,12 +124,12 @@ export const b = (null as any as import("pkg", [ {"resolution-mode": "import"} ]
 === /other4.ts ===
 // Indirected assertion objecty-thing - not allowed
 type Asserts1 = { assert: {"resolution-mode": "require"} };
->Asserts1 : { assert: {    "resolution-mode": "require";}; }
+>Asserts1 : { assert: { "resolution-mode": "require"; }; }
 >assert : { "resolution-mode": "require"; }
 >"resolution-mode" : "require"
 
 type Asserts2 = { assert: {"resolution-mode": "import"} };
->Asserts2 : { assert: {    "resolution-mode": "import";}; }
+>Asserts2 : { assert: { "resolution-mode": "import"; }; }
 >assert : { "resolution-mode": "import"; }
 >"resolution-mode" : "import"
 

--- a/tests/baselines/reference/nodeModulesImportTypeModeDeclarationEmitErrors1(module=nodenext).types
+++ b/tests/baselines/reference/nodeModulesImportTypeModeDeclarationEmitErrors1(module=nodenext).types
@@ -124,12 +124,12 @@ export const b = (null as any as import("pkg", [ {"resolution-mode": "import"} ]
 === /other4.ts ===
 // Indirected assertion objecty-thing - not allowed
 type Asserts1 = { assert: {"resolution-mode": "require"} };
->Asserts1 : { assert: {    "resolution-mode": "require";}; }
+>Asserts1 : { assert: { "resolution-mode": "require"; }; }
 >assert : { "resolution-mode": "require"; }
 >"resolution-mode" : "require"
 
 type Asserts2 = { assert: {"resolution-mode": "import"} };
->Asserts2 : { assert: {    "resolution-mode": "import";}; }
+>Asserts2 : { assert: { "resolution-mode": "import"; }; }
 >assert : { "resolution-mode": "import"; }
 >"resolution-mode" : "import"
 

--- a/tests/baselines/reference/nonInferrableTypePropagation2.types
+++ b/tests/baselines/reference/nonInferrableTypePropagation2.types
@@ -31,7 +31,7 @@ interface Refinement<A, B extends A> {
 }
 
 declare const filter: {
->filter : { <A, B extends A>(refinement: Refinement<A, B>): (as: readonly A[]) => readonly B[]; <A>(predicate: Predicate<A>): <B extends A>(bs: readonly B[]) => readonly B[]; <A>(predicate: Predicate<A>): (as: readonly A[]) => readonly A[]; }
+>filter : { <A, B extends A>(refinement: Refinement<A, B>): (as: ReadonlyArray<A>) => ReadonlyArray<B>; <A>(predicate: Predicate<A>): <B extends A>(bs: readonly B[]) => readonly B[]; <A>(predicate: Predicate<A>): (as: ReadonlyArray<A>) => ReadonlyArray<A>; }
 
     <A, B extends A>(refinement: Refinement<A, B>): (as: ReadonlyArray<A>) => ReadonlyArray<B>
 >refinement : Refinement<A, B>

--- a/tests/baselines/reference/nonInstantiatedModule.types
+++ b/tests/baselines/reference/nonInstantiatedModule.types
@@ -77,8 +77,8 @@ var p: M2.Point;
 >M2 : any
 
 var p2: { Origin() : { x: number; y: number; } };
->p2 : { Origin(): {    x: number;    y: number;}; }
->Origin : () => {    x: number;    y: number;}
+>p2 : { Origin(): { x: number; y: number; }; }
+>Origin : () => { x: number; y: number; }
 >x : number
 >y : number
 

--- a/tests/baselines/reference/objectLitTargetTypeCallSite.types
+++ b/tests/baselines/reference/objectLitTargetTypeCallSite.types
@@ -2,7 +2,7 @@
 
 === objectLitTargetTypeCallSite.ts ===
 function process( x: {a:number; b:string;}) {
->process : (x: {    a: number;    b: string;}) => number
+>process : (x: { a: number; b: string; }) => number
 >x : { a: number; b: string; }
 >a : number
 >b : string

--- a/tests/baselines/reference/objectLiteralContextualTyping.types
+++ b/tests/baselines/reference/objectLiteralContextualTyping.types
@@ -71,7 +71,7 @@ var w: number;
 >w : number
 
 declare function bar<T>(param: { x?: T }): T;
->bar : <T>(param: {    x?: T;}) => T
+>bar : <T>(param: { x?: T; }) => T
 >param : { x?: T; }
 >x : T
 

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignment.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignment.types
@@ -18,7 +18,7 @@ var person: { name: string; id: number } = { name, id };
 >id : number
 
 function foo( obj:{ name: string }): void { };
->foo : (obj: {    name: string;}) => void
+>foo : (obj: { name: string; }) => void
 >obj : { name: string; }
 >name : string
 
@@ -38,7 +38,7 @@ function bar1(name: string, id: number) { return { name }; }
 >name : string
 
 function baz(name: string, id: number): { name: string; id: number } { return { name, id }; }
->baz : (name: string, id: number) => {    name: string;    id: number;}
+>baz : (name: string, id: number) => { name: string; id: number; }
 >name : string
 >id : number
 >name : string

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentES6.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentES6.types
@@ -18,7 +18,7 @@ var person: { name: string; id: number } = { name, id };
 >id : number
 
 function foo(obj: { name: string }): void { };
->foo : (obj: {    name: string;}) => void
+>foo : (obj: { name: string; }) => void
 >obj : { name: string; }
 >name : string
 
@@ -38,7 +38,7 @@ function bar1(name: string, id: number) { return { name }; }
 >name : string
 
 function baz(name: string, id: number): { name: string; id: number } { return { name, id }; }
->baz : (name: string, id: number) => {    name: string;    id: number;}
+>baz : (name: string, id: number) => { name: string; id: number; }
 >name : string
 >id : number
 >name : string

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.types
@@ -23,7 +23,7 @@ var person1: { name, id };  // ok
 >id : any
 
 function foo(name: string, id: number): { id: string, name: number } { return { name, id }; }  // error
->foo : (name: string, id: number) => {    id: string;    name: number;}
+>foo : (name: string, id: number) => { id: string; name: number; }
 >name : string
 >id : number
 >id : string
@@ -33,7 +33,7 @@ function foo(name: string, id: number): { id: string, name: number } { return { 
 >id : number
 
 function bar(obj: { name: string; id: boolean }) { }
->bar : (obj: {    name: string;    id: boolean;}) => void
+>bar : (obj: { name: string; id: boolean; }) => void
 >obj : { name: string; id: boolean; }
 >name : string
 >id : boolean

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.types
@@ -18,7 +18,7 @@ var person: { b: string; id: number } = { name, id };  // error
 >id : number
 
 function bar(name: string, id: number): { name: number, id: string } { return { name, id }; }  // error
->bar : (name: string, id: number) => {    name: number;    id: string;}
+>bar : (name: string, id: number) => { name: number; id: string; }
 >name : string
 >id : number
 >name : number
@@ -28,7 +28,7 @@ function bar(name: string, id: number): { name: number, id: string } { return { 
 >id : number
 
 function foo(name: string, id: number): { name: string, id: number } { return { name, id }; }  // error
->foo : (name: string, id: number) => {    name: string;    id: number;}
+>foo : (name: string, id: number) => { name: string; id: number; }
 >name : string
 >id : number
 >name : string

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesFunctionArgument.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesFunctionArgument.types
@@ -16,7 +16,7 @@ var person = { name, id };
 >id : number
 
 function foo(p: { name: string; id: number }) { }
->foo : (p: {    name: string;    id: number;}) => void
+>foo : (p: { name: string; id: number; }) => void
 >p : { name: string; id: number; }
 >name : string
 >id : number

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesFunctionArgument2.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesFunctionArgument2.types
@@ -16,7 +16,7 @@ var person = { name, id };
 >id : number
 
 function foo(p: { a: string; id: number }) { }
->foo : (p: {    a: string;    id: number;}) => void
+>foo : (p: { a: string; id: number; }) => void
 >p : { a: string; id: number; }
 >a : string
 >id : number

--- a/tests/baselines/reference/objectRest.types
+++ b/tests/baselines/reference/objectRest.types
@@ -58,11 +58,11 @@ var { d: renamed, ...d } = o2;
 >o2 : { c: string; d: string; }
 
 let nestedrest: { x: number, n1: { y: number, n2: { z: number, n3: { n4: number } } }, rest: number, restrest: number };
->nestedrest : { x: number; n1: {    y: number;    n2: {        z: number;        n3: {            n4: number;        };    };}; rest: number; restrest: number; }
+>nestedrest : { x: number; n1: { y: number; n2: { z: number; n3: { n4: number; }; }; }; rest: number; restrest: number; }
 >x : number
->n1 : { y: number; n2: {    z: number;    n3: {        n4: number;    };}; }
+>n1 : { y: number; n2: { z: number; n3: { n4: number; }; }; }
 >y : number
->n2 : { z: number; n3: {    n4: number;}; }
+>n2 : { z: number; n3: { n4: number; }; }
 >z : number
 >n3 : { n4: number; }
 >n4 : number
@@ -81,7 +81,7 @@ var { x, n1: { y, n2: { z, n3: { ...nr } } }, ...restrest } = nestedrest;
 >nestedrest : { x: number; n1: { y: number; n2: { z: number; n3: { n4: number; }; }; }; rest: number; restrest: number; }
 
 let complex: { x: { ka, ki }, y: number };
->complex : { x: {    ka;    ki;}; y: number; }
+>complex : { x: { ka; ki; }; y: number; }
 >x : { ka: any; ki: any; }
 >ka : any
 >ki : any

--- a/tests/baselines/reference/objectRestAssignment.types
+++ b/tests/baselines/reference/objectRestAssignment.types
@@ -15,7 +15,7 @@ let rest: { };
 >rest : {}
 
 let complex: { x: { ka, ki }, y: number };
->complex : { x: {    ka;    ki;}; y: number; }
+>complex : { x: { ka; ki; }; y: number; }
 >x : { ka: any; ki: any; }
 >ka : any
 >ki : any
@@ -36,7 +36,7 @@ let complex: { x: { ka, ki }, y: number };
 
 // should be:
 let overEmit: { a: { ka: string, x: string }[], b: { z: string, ki: string, ku: string }, ke: string, ko: string };
->overEmit : { a: {    ka: string;    x: string;}[]; b: {    z: string;    ki: string;    ku: string;}; ke: string; ko: string; }
+>overEmit : { a: { ka: string; x: string; }[]; b: { z: string; ki: string; ku: string; }; ke: string; ko: string; }
 >a : { ka: string; x: string; }[]
 >ka : string
 >x : string

--- a/tests/baselines/reference/objectRestBindingContextualInference.types
+++ b/tests/baselines/reference/objectRestBindingContextualInference.types
@@ -19,7 +19,7 @@ type SetupImages<K extends string> = SetupImageRefs<K> & {
 >SetupImages : SetupImages<K>
 
   prepare: () => { type: K };
->prepare : () => {    type: K;}
+>prepare : () => { type: K; }
 >type : K
 
 };

--- a/tests/baselines/reference/objectRestNegative.types
+++ b/tests/baselines/reference/objectRestNegative.types
@@ -31,7 +31,7 @@ let notAssignable: { a: string };
 
 
 function stillMustBeLast({ ...mustBeLast, a }: { a: number, b: string }): void {
->stillMustBeLast : ({ ...mustBeLast, a }: {    a: number;    b: string;}) => void
+>stillMustBeLast : ({ ...mustBeLast, a }: { a: number; b: string; }) => void
 >mustBeLast : { b: string; }
 >a : number
 >a : number

--- a/tests/baselines/reference/objectRestParameter.types
+++ b/tests/baselines/reference/objectRestParameter.types
@@ -2,7 +2,7 @@
 
 === objectRestParameter.ts ===
 function cloneAgain({ a, ...clone }: { a: number, b: string }): void {
->cloneAgain : ({ a, ...clone }: {    a: number;    b: string;}) => void
+>cloneAgain : ({ a, ...clone }: { a: number; b: string; }) => void
 >a : number
 >clone : { b: string; }
 >a : number
@@ -10,9 +10,9 @@ function cloneAgain({ a, ...clone }: { a: number, b: string }): void {
 }
 
 declare function suddenly(f: (a: { x: { z, ka }, y: string }) => void);
->suddenly : (f: (a: {    x: {        z;        ka;    };    y: string;}) => void) => any
->f : (a: {    x: {        z;        ka;    };    y: string;}) => void
->a : { x: {    z;    ka;}; y: string; }
+>suddenly : (f: (a: { x: { z; ka; }; y: string; }) => void) => any
+>f : (a: { x: { z; ka; }; y: string; }) => void
+>a : { x: { z; ka; }; y: string; }
 >x : { z: any; ka: any; }
 >z : any
 >ka : any
@@ -59,7 +59,7 @@ class C {
 >C : C
 
     m({ a, ...clone }: { a: number, b: string}): void {
->m : ({ a, ...clone }: {    a: number;    b: string;}) => void
+>m : ({ a, ...clone }: { a: number; b: string; }) => void
 >a : number
 >clone : { b: string; }
 >a : number

--- a/tests/baselines/reference/objectRestParameterES5.types
+++ b/tests/baselines/reference/objectRestParameterES5.types
@@ -2,7 +2,7 @@
 
 === objectRestParameterES5.ts ===
 function cloneAgain({ a, ...clone }: { a: number, b: string }): void {
->cloneAgain : ({ a, ...clone }: {    a: number;    b: string;}) => void
+>cloneAgain : ({ a, ...clone }: { a: number; b: string; }) => void
 >a : number
 >clone : { b: string; }
 >a : number
@@ -10,9 +10,9 @@ function cloneAgain({ a, ...clone }: { a: number, b: string }): void {
 }
 
 declare function suddenly(f: (a: { x: { z, ka }, y: string }) => void);
->suddenly : (f: (a: {    x: {        z;        ka;    };    y: string;}) => void) => any
->f : (a: {    x: {        z;        ka;    };    y: string;}) => void
->a : { x: {    z;    ka;}; y: string; }
+>suddenly : (f: (a: { x: { z; ka; }; y: string; }) => void) => any
+>f : (a: { x: { z; ka; }; y: string; }) => void
+>a : { x: { z; ka; }; y: string; }
 >x : { z: any; ka: any; }
 >z : any
 >ka : any
@@ -59,7 +59,7 @@ class C {
 >C : C
 
     m({ a, ...clone }: { a: number, b: string}): void {
->m : ({ a, ...clone }: {    a: number;    b: string;}) => void
+>m : ({ a, ...clone }: { a: number; b: string; }) => void
 >a : number
 >clone : { b: string; }
 >a : number

--- a/tests/baselines/reference/objectSpread.types
+++ b/tests/baselines/reference/objectSpread.types
@@ -125,7 +125,7 @@ let combinedNestedChangeType: { a: number, b: boolean, c: number } =
 >1 : 1
 
 let propertyNested: { a: { a: number, b: string } } =
->propertyNested : { a: {    a: number;    b: string;}; }
+>propertyNested : { a: { a: number; b: string; }; }
 >a : { a: number; b: string; }
 >a : number
 >b : string
@@ -176,7 +176,7 @@ type Header = { head: string, body: string, authToken: string }
 >authToken : string
 
 function from16326(this: { header: Header }, header: Header, authToken: string): Header {
->from16326 : (this: {    header: Header;}, header: Header, authToken: string) => Header
+>from16326 : (this: { header: Header; }, header: Header, authToken: string) => Header
 >this : { header: Header; }
 >header : Header
 >header : Header
@@ -202,7 +202,7 @@ function from16326(this: { header: Header }, header: Header, authToken: string):
 }
 // boolean && T results in Partial<T>
 function conditionalSpreadBoolean(b: boolean) : { x: number, y: number } {
->conditionalSpreadBoolean : (b: boolean) => {    x: number;    y: number;}
+>conditionalSpreadBoolean : (b: boolean) => { x: number; y: number; }
 >b : boolean
 >x : number
 >y : number
@@ -243,7 +243,7 @@ function conditionalSpreadBoolean(b: boolean) : { x: number, y: number } {
 >o : { x: number; y: number; }
 }
 function conditionalSpreadNumber(nt: number): { x: number, y: number } {
->conditionalSpreadNumber : (nt: number) => {    x: number;    y: number;}
+>conditionalSpreadNumber : (nt: number) => { x: number; y: number; }
 >nt : number
 >x : number
 >y : number
@@ -284,7 +284,7 @@ function conditionalSpreadNumber(nt: number): { x: number, y: number } {
 >o : { x: number; y: number; }
 }
 function conditionalSpreadString(st: string): { x: string, y: number } {
->conditionalSpreadString : (st: string) => {    x: string;    y: number;}
+>conditionalSpreadString : (st: string) => { x: string; y: number; }
 >st : string
 >x : string
 >y : number
@@ -396,7 +396,7 @@ let changeTypeBoth: { a: string, b: number } =
 
 // optional
 function container(
->container : (definiteBoolean: {    sn: boolean;}, definiteString: {    sn: string;}, optionalString: {    sn?: string;}, optionalNumber: {    sn?: number;}) => void
+>container : (definiteBoolean: { sn: boolean; }, definiteString: { sn: string; }, optionalString: { sn?: string; }, optionalNumber: { sn?: number; }) => void
 
     definiteBoolean: { sn: boolean },
 >definiteBoolean : { sn: boolean; }
@@ -581,7 +581,7 @@ let overwriteId: { id: string, a: number, c: number, d: string } =
 >'no' : "no"
 
 function genericSpread<T, U>(t: T, u: U, v: T | U, w: T | { s: string }, obj: { x: number }) {
->genericSpread : <T, U>(t: T, u: U, v: T | U, w: T | {    s: string;}, obj: {    x: number;}) => void
+>genericSpread : <T, U>(t: T, u: U, v: T | U, w: T | { s: string; }, obj: { x: number; }) => void
 >t : T
 >u : U
 >v : T | U

--- a/tests/baselines/reference/objectSpreadStrictNull.types
+++ b/tests/baselines/reference/objectSpreadStrictNull.types
@@ -2,7 +2,7 @@
 
 === objectSpreadStrictNull.ts ===
 function f(
->f : (definiteBoolean: {    sn: boolean;}, definiteString: {    sn: string;}, optionalString: {    sn?: string;}, optionalNumber: {    sn?: number;}, undefinedString: {    sn: string | undefined;}, undefinedNumber: {    sn: number | undefined;}) => void
+>f : (definiteBoolean: { sn: boolean; }, definiteString: { sn: string; }, optionalString: { sn?: string; }, optionalNumber: { sn?: number; }, undefinedString: { sn: string | undefined; }, undefinedNumber: { sn: number | undefined; }) => void
 
     definiteBoolean: { sn: boolean },
 >definiteBoolean : { sn: boolean; }

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.types
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.types
@@ -2,7 +2,7 @@
 
 === operationsAvailableOnPromisedType.ts ===
 async function fn(
->fn : (a: number, b: Promise<number>, c: Promise<string[]>, d: Promise<{    prop: string;}>, e: Promise<() => void>, f: Promise<() => void> | (() => void), g: Promise<{    new (): any;}>) => Promise<void>
+>fn : (a: number, b: Promise<number>, c: Promise<string[]>, d: Promise<{ prop: string; }>, e: Promise<() => void>, f: Promise<() => void> | (() => void), g: Promise<{ new (): any; }>) => Promise<void>
 
     a: number,
 >a : number

--- a/tests/baselines/reference/optionalBindingParameters2.types
+++ b/tests/baselines/reference/optionalBindingParameters2.types
@@ -2,7 +2,7 @@
 
 === optionalBindingParameters2.ts ===
 function foo({ x, y, z }?: { x: string; y: number; z: boolean }) {
->foo : ({ x, y, z }?: {    x: string;    y: number;    z: boolean;}) => void
+>foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => void
 >x : string
 >y : number
 >z : boolean

--- a/tests/baselines/reference/optionalBindingParameters4.types
+++ b/tests/baselines/reference/optionalBindingParameters4.types
@@ -5,7 +5,7 @@
 * @param {{ cause?: string }} [options] 
 */ 
 function foo({ cause } = {}) {
->foo : ({ cause }?: {    cause?: string;}) => string
+>foo : ({ cause }?: { cause?: string; }) => string
 >cause : string
 >{} : {}
 

--- a/tests/baselines/reference/optionalBindingParametersInOverloads2.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads2.types
@@ -2,7 +2,7 @@
 
 === optionalBindingParametersInOverloads2.ts ===
 function foo({ x, y, z }?: { x: string; y: number; z: boolean });
->foo : ({ x, y, z }?: {    x: string;    y: number;    z: boolean;}) => any
+>foo : ({ x, y, z }?: { x: string; y: number; z: boolean; }) => any
 >x : string
 >y : number
 >z : boolean

--- a/tests/baselines/reference/optionalChainingInference.types
+++ b/tests/baselines/reference/optionalChainingInference.types
@@ -3,7 +3,7 @@
 === optionalChainingInference.ts ===
 // https://github.com/microsoft/TypeScript/issues/34579
 declare function unbox<T>(box: { value: T | undefined }): T;
->unbox : <T>(box: {    value: T | undefined;}) => T
+>unbox : <T>(box: { value: T | undefined; }) => T
 >box : { value: T | undefined; }
 >value : T
 

--- a/tests/baselines/reference/optionalParameterInDestructuringWithInitializer.types
+++ b/tests/baselines/reference/optionalParameterInDestructuringWithInitializer.types
@@ -9,7 +9,7 @@ declare function f(a:number,b:number): void;
 >b : number
 
 function func1( {a, b}: {a: number, b?: number} = {a: 1, b: 2} ) {
->func1 : ({ a, b }?: {    a: number;    b?: number;}) => void
+>func1 : ({ a, b }?: { a: number; b?: number; }) => void
 >a : number
 >b : number | undefined
 >a : number
@@ -30,7 +30,7 @@ function func1( {a, b}: {a: number, b?: number} = {a: 1, b: 2} ) {
 }
 
 function func2( {a, b = 3}: {a: number, b?:number} = {a: 1,b: 2} ) {
->func2 : ({ a, b }?: {    a: number;    b?: number;}) => void
+>func2 : ({ a, b }?: { a: number; b?: number; }) => void
 >a : number
 >b : number
 >3 : 3
@@ -52,7 +52,7 @@ function func2( {a, b = 3}: {a: number, b?:number} = {a: 1,b: 2} ) {
 }
 
 function func3( {a, b}: {a: number, b?: number} = {a: 1} ) {
->func3 : ({ a, b }?: {    a: number;    b?: number;}) => void
+>func3 : ({ a, b }?: { a: number; b?: number; }) => void
 >a : number
 >b : number | undefined
 >a : number
@@ -71,7 +71,7 @@ function func3( {a, b}: {a: number, b?: number} = {a: 1} ) {
 }
 
 function func4( {a: {b, c}, d}: {a: {b: number,c?: number},d: number} = {a: {b: 1,c: 2},d: 3} ) {
->func4 : ({ a: { b, c }, d }?: {    a: {        b: number;        c?: number;    };    d: number;}) => void
+>func4 : ({ a: { b, c }, d }?: { a: { b: number; c?: number; }; d: number; }) => void
 >a : any
 >b : number
 >c : number | undefined
@@ -100,7 +100,7 @@ function func4( {a: {b, c}, d}: {a: {b: number,c?: number},d: number} = {a: {b: 
 }
 
 function func5({a: {b, c = 4}, d}: {a: {b: number,c?: number},d: number} = {a: {b: 1,c: 2},d: 3} ) {
->func5 : ({ a: { b, c }, d }?: {    a: {        b: number;        c?: number;    };    d: number;}) => void
+>func5 : ({ a: { b, c }, d }?: { a: { b: number; c?: number; }; d: number; }) => void
 >a : any
 >b : number
 >c : number
@@ -130,7 +130,7 @@ function func5({a: {b, c = 4}, d}: {a: {b: number,c?: number},d: number} = {a: {
 }
 
 function func6( {a: {b, c} = {b: 4, c: 5}, d}: {a: {b: number, c?: number}, d: number} = {a: {b: 1,c: 2}, d: 3} ) {
->func6 : ({ a: { b, c }, d }?: {    a: {        b: number;        c?: number;    };    d: number;}) => void
+>func6 : ({ a: { b, c }, d }?: { a: { b: number; c?: number; }; d: number; }) => void
 >a : any
 >b : number
 >c : number | undefined
@@ -164,7 +164,7 @@ function func6( {a: {b, c} = {b: 4, c: 5}, d}: {a: {b: number, c?: number}, d: n
 }
 
 function func7( {a: {b, c = 6} = {b: 4, c: 5}, d}: {a: {b: number, c?: number}, d: number} = {a: {b: 1, c: 2}, d: 3} ) {
->func7 : ({ a: { b, c }, d }?: {    a: {        b: number;        c?: number;    };    d: number;}) => void
+>func7 : ({ a: { b, c }, d }?: { a: { b: number; c?: number; }; d: number; }) => void
 >a : any
 >b : number
 >c : number

--- a/tests/baselines/reference/optionalParameterRetainsNull.types
+++ b/tests/baselines/reference/optionalParameterRetainsNull.types
@@ -6,8 +6,8 @@ interface Bar {  bar: number; foo: object | null;  }
 >foo : object | null
 
 let a = {
->a : { test<K extends keyof Bar>(a: K, b?: Bar[K] | null | undefined): void; }
->{  test<K extends keyof Bar> (a: K,  b?: Bar[K]  |  null)  { }} : { test<K extends keyof Bar>(a: K, b?: Bar[K] | null | undefined): void; }
+>a : { test<K extends keyof Bar>(a: K, b?: Bar[K] | null): void; }
+>{  test<K extends keyof Bar> (a: K,  b?: Bar[K]  |  null)  { }} : { test<K extends keyof Bar>(a: K, b?: Bar[K] | null): void; }
 
   test<K extends keyof Bar> (a: K,  b?: Bar[K]  |  null)  { }
 >test : <K extends keyof Bar>(a: K, b?: Bar[K] | null) => void

--- a/tests/baselines/reference/optionalPropertiesTest.types
+++ b/tests/baselines/reference/optionalPropertiesTest.types
@@ -2,7 +2,7 @@
 
 === optionalPropertiesTest.ts ===
 var x: {p1:number; p2?:string; p3?:{():number;};};
->x : { p1: number; p2?: string; p3?: {    (): number;}; }
+>x : { p1: number; p2?: string; p3?: { (): number; }; }
 >p1 : number
 >p2 : string
 >p3 : () => number

--- a/tests/baselines/reference/overloadResolutionTest1.types
+++ b/tests/baselines/reference/overloadResolutionTest1.types
@@ -2,12 +2,12 @@
 
 === overloadResolutionTest1.ts ===
 function foo(bar:{a:number;}[]):string;
->foo : { (bar: {    a: number;}[]): string; (bar: { a: boolean; }[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: number; }[]
 >a : number
 
 function foo(bar:{a:boolean;}[]):number;
->foo : { (bar: { a: number; }[]): string; (bar: {    a: boolean;}[]): number; }
+>foo : { (bar: { a: number; }[]): string; (bar: { a: boolean; }[]): number; }
 >bar : { a: boolean; }[]
 >a : boolean
 
@@ -55,12 +55,12 @@ var x1111 = foo([{a:null}]); // works - ambiguous call is resolved to be the fir
 
 
 function foo2(bar:{a:number;}):string;
->foo2 : { (bar: {    a: number;}): string; (bar: { a: boolean; }): number; }
+>foo2 : { (bar: { a: number; }): string; (bar: { a: boolean; }): number; }
 >bar : { a: number; }
 >a : number
 
 function foo2(bar:{a:boolean;}):number;
->foo2 : { (bar: { a: number; }): string; (bar: {    a: boolean;}): number; }
+>foo2 : { (bar: { a: number; }): string; (bar: { a: boolean; }): number; }
 >bar : { a: boolean; }
 >a : boolean
 
@@ -96,12 +96,12 @@ var x4 = foo2({a:"s"}); // error
 
 
 function foo4(bar:{a:number;}):number;
->foo4 : { (bar: {    a: number;}): number; (bar: { a: string; }): string; }
+>foo4 : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: number; }
 >a : number
 
 function foo4(bar:{a:string;}):string;
->foo4 : { (bar: { a: number; }): number; (bar: {    a: string;}): string; }
+>foo4 : { (bar: { a: number; }): number; (bar: { a: string; }): string; }
 >bar : { a: string; }
 >a : string
 

--- a/tests/baselines/reference/overloadedConstructorFixesInferencesAppropriately.types
+++ b/tests/baselines/reference/overloadedConstructorFixesInferencesAppropriately.types
@@ -36,7 +36,7 @@ class AsyncLoader<TResult extends {}> {
 }
 
 function load(): Box<{ success: true } | ErrorResult> {
->load : () => Box<{    success: true;} | ErrorResult>
+>load : () => Box<{ success: true; } | ErrorResult>
 >success : true
 >true : true
 

--- a/tests/baselines/reference/overloadsWithProvisionalErrors.types
+++ b/tests/baselines/reference/overloadsWithProvisionalErrors.types
@@ -2,13 +2,13 @@
 
 === overloadsWithProvisionalErrors.ts ===
 var func: {
->func : { (s: string): number; (lambda: (s: string) => {    a: number;    b: number;}): string; }
+>func : { (s: string): number; (lambda: (s: string) => { a: number; b: number; }): string; }
 
     (s: string): number;
 >s : string
 
     (lambda: (s: string) => { a: number; b: number }): string;
->lambda : (s: string) => {    a: number;    b: number;}
+>lambda : (s: string) => { a: number; b: number; }
 >s : string
 >a : number
 >b : number

--- a/tests/baselines/reference/override19.types
+++ b/tests/baselines/reference/override19.types
@@ -6,7 +6,7 @@ type Foo = abstract new(...args: any) => any;
 >args : any
 
 declare function CreateMixin<C extends Foo, T extends Foo>(Context: C, Base: T): T & {
->CreateMixin : <C extends Foo, T extends Foo>(Context: C, Base: T) => T & (new (...args: any[]) => {    context: InstanceType<C>;})
+>CreateMixin : <C extends Foo, T extends Foo>(Context: C, Base: T) => T & (new (...args: any[]) => { context: InstanceType<C>; })
 >Context : C
 >Base : T
 

--- a/tests/baselines/reference/parameterDestructuringObjectLiteral.types
+++ b/tests/baselines/reference/parameterDestructuringObjectLiteral.types
@@ -4,8 +4,8 @@
 // Repro from #22644
 
 const fn1 = (options: { headers?: {} }) => { };
->fn1 : (options: {    headers?: {};}) => void
->(options: { headers?: {} }) => { } : (options: {    headers?: {};}) => void
+>fn1 : (options: { headers?: {}; }) => void
+>(options: { headers?: {} }) => { } : (options: { headers?: {}; }) => void
 >options : { headers?: {}; }
 >headers : {}
 

--- a/tests/baselines/reference/parameterNamesInTypeParameterList.types
+++ b/tests/baselines/reference/parameterNamesInTypeParameterList.types
@@ -13,7 +13,7 @@ function f0<T extends typeof a>(a: T) {
 }
 
 function f1<T extends typeof a>({a}: {a:T}) {
->f1 : <T extends any>({ a }: {    a: T;}) => void
+>f1 : <T extends any>({ a }: { a: T; }) => void
 >a : any
 >a : T
 >a : T
@@ -49,7 +49,7 @@ class A {
 >b : any
 	}
 	m1<T extends typeof a>({a}: {a:T}) {
->m1 : <T extends any>({ a }: {    a: T;}) => void
+>m1 : <T extends any>({ a }: { a: T; }) => void
 >a : any
 >a : T
 >a : T

--- a/tests/baselines/reference/parseArrowFunctionWithFunctionReturnType.types
+++ b/tests/baselines/reference/parseArrowFunctionWithFunctionReturnType.types
@@ -2,7 +2,7 @@
 
 === parseArrowFunctionWithFunctionReturnType.ts ===
 const fn = <T>(): (() => T) => null as any;
->fn : <T>() => () => T
-><T>(): (() => T) => null as any : <T>() => () => T
+>fn : <T>() => (() => T)
+><T>(): (() => T) => null as any : <T>() => (() => T)
 >null as any : any
 

--- a/tests/baselines/reference/parserShorthandPropertyAssignment1.types
+++ b/tests/baselines/reference/parserShorthandPropertyAssignment1.types
@@ -2,7 +2,7 @@
 
 === parserShorthandPropertyAssignment1.ts ===
 function foo(obj: { name?: string; id: number }) { }
->foo : (obj: {    name?: string;    id: number;}) => void
+>foo : (obj: { name?: string; id: number; }) => void
 >obj : { name?: string; id: number; }
 >name : string
 >id : number

--- a/tests/baselines/reference/parserharness.types
+++ b/tests/baselines/reference/parserharness.types
@@ -2254,7 +2254,7 @@ module Harness {
 >[] : undefined[]
 
         var timeFunction: (
->timeFunction : (benchmark: Benchmark, description?: string, name?: string, f?: (bench?: {    (): void;}) => void) => void
+>timeFunction : (benchmark: Benchmark, description?: string, name?: string, f?: (bench?: { (): void; }) => void) => void
 
             benchmark: Benchmark,
 >benchmark : Benchmark
@@ -2266,7 +2266,7 @@ module Harness {
 >name : string
 
             f?: (bench?: { (): void; }) => void
->f : (bench?: {    (): void;}) => void
+>f : (bench?: { (): void; }) => void
 >bench : () => void
 
         ) => void;
@@ -2721,7 +2721,7 @@ module Harness {
 >{} : {}
 
             public toArray(): { filename: string; file: WriterAggregator; }[] {
->toArray : () => {    filename: string;    file: WriterAggregator;}[]
+>toArray : () => { filename: string; file: WriterAggregator; }[]
 >filename : string
 >file : WriterAggregator
 
@@ -5866,7 +5866,7 @@ module Harness {
 
         /** Given a test file containing // @Filename directives, return an array of named units of code to be added to an existing compiler instance */
         export function makeUnitsFromTest(code: string, filename: string): { settings: CompilerSetting[]; testUnitData: TestUnitData[]; } {
->makeUnitsFromTest : (code: string, filename: string) => {    settings: CompilerSetting[];    testUnitData: TestUnitData[];}
+>makeUnitsFromTest : (code: string, filename: string) => { settings: CompilerSetting[]; testUnitData: TestUnitData[]; }
 >code : string
 >filename : string
 >settings : CompilerSetting[]
@@ -7324,7 +7324,7 @@ module Harness {
 >[] : undefined[]
 
             function mapEdits(edits: Services.TextEdit[]): { edit: Services.TextEdit; index: number; }[] {
->mapEdits : (edits: Services.TextEdit[]) => {    edit: Services.TextEdit;    index: number;}[]
+>mapEdits : (edits: Services.TextEdit[]) => { edit: Services.TextEdit; index: number; }[]
 >edits : Services.TextEdit[]
 >Services : any
 >edit : Services.TextEdit

--- a/tests/baselines/reference/primitiveUnionDetection.types
+++ b/tests/baselines/reference/primitiveUnionDetection.types
@@ -7,7 +7,7 @@ type Kind = "one" | "two" | "three";
 >Kind : "one" | "two" | "three"
 
 declare function getInterfaceFromString<T extends Kind>(options?: { type?: T } & { type?: Kind }): T;
->getInterfaceFromString : <T extends Kind>(options?: {    type?: T;} & {    type?: Kind;}) => T
+>getInterfaceFromString : <T extends Kind>(options?: { type?: T; } & { type?: Kind; }) => T
 >options : ({ type?: T | undefined; } & { type?: Kind | undefined; }) | undefined
 >type : T | undefined
 >type : Kind | undefined

--- a/tests/baselines/reference/privateNameAndPropertySignature.types
+++ b/tests/baselines/reference/privateNameAndPropertySignature.types
@@ -20,7 +20,7 @@ interface B {
 }
 
 declare const x: {
->x : { bar: {    #baz: string;    #taz(): string;}; }
+>x : { bar: { #baz: string; #taz(): string; }; }
 
     #foo: number;
 >#foo : number
@@ -40,7 +40,7 @@ declare const x: {
 };
 
 declare const y: [{ qux: { #quux: 3 } }];
->y : [{ qux: {    #quux: 3;}; }]
+>y : [{ qux: { #quux: 3; }; }]
 >qux : {}
 >#quux : 3
 

--- a/tests/baselines/reference/privateWriteOnlyAccessorRead.types
+++ b/tests/baselines/reference/privateWriteOnlyAccessorRead.types
@@ -5,8 +5,8 @@ class Test {
 >Test : Test
 
   set #value(v: { foo: { bar: number } }) {}
->#value : { foo: {    bar: number;}; }
->v : { foo: {    bar: number;}; }
+>#value : { foo: { bar: number; }; }
+>v : { foo: { bar: number; }; }
 >foo : { bar: number; }
 >bar : number
 

--- a/tests/baselines/reference/promisePermutations.types
+++ b/tests/baselines/reference/promisePermutations.types
@@ -102,11 +102,11 @@ declare function testFunctionP(): Promise<number>;
 >testFunctionP : () => Promise<number>
 
 declare function testFunction2(): IPromise<{ x: number }>;
->testFunction2 : () => IPromise<{    x: number;}>
+>testFunction2 : () => IPromise<{ x: number; }>
 >x : number
 
 declare function testFunction2P(): Promise<{ x: number }>;
->testFunction2P : () => Promise<{    x: number;}>
+>testFunction2P : () => Promise<{ x: number; }>
 >x : number
 
 declare function testFunction3(x: number): IPromise<number>;

--- a/tests/baselines/reference/promisePermutations2.types
+++ b/tests/baselines/reference/promisePermutations2.types
@@ -77,11 +77,11 @@ declare function testFunctionP(): Promise<number>;
 >testFunctionP : () => Promise<number>
 
 declare function testFunction2(): IPromise<{ x: number }>;
->testFunction2 : () => IPromise<{    x: number;}>
+>testFunction2 : () => IPromise<{ x: number; }>
 >x : number
 
 declare function testFunction2P(): Promise<{ x: number }>;
->testFunction2P : () => Promise<{    x: number;}>
+>testFunction2P : () => Promise<{ x: number; }>
 >x : number
 
 declare function testFunction3(x: number): IPromise<number>;

--- a/tests/baselines/reference/promisePermutations3.types
+++ b/tests/baselines/reference/promisePermutations3.types
@@ -77,11 +77,11 @@ declare function testFunctionP(): Promise<number>;
 >testFunctionP : () => Promise<number>
 
 declare function testFunction2(): IPromise<{ x: number }>;
->testFunction2 : () => IPromise<{    x: number;}>
+>testFunction2 : () => IPromise<{ x: number; }>
 >x : number
 
 declare function testFunction2P(): Promise<{ x: number }>;
->testFunction2P : () => Promise<{    x: number;}>
+>testFunction2P : () => Promise<{ x: number; }>
 >x : number
 
 declare function testFunction3(x: number): IPromise<number>;

--- a/tests/baselines/reference/propertyAccessChain.2.types
+++ b/tests/baselines/reference/propertyAccessChain.2.types
@@ -11,7 +11,7 @@ o1?.b;
 >b : string
 
 declare const o2: undefined | { b: { c: string } };
->o2 : { b: {    c: string;}; }
+>o2 : { b: { c: string; }; }
 >b : { c: string; }
 >c : string
 
@@ -23,7 +23,7 @@ o2?.b.c;
 >c : string
 
 declare const o3: { b: undefined | { c: string } };
->o3 : { b: undefined | {    c: string;}; }
+>o3 : { b: undefined | { c: string; }; }
 >b : { c: string; }
 >c : string
 

--- a/tests/baselines/reference/propertyAccessChain.types
+++ b/tests/baselines/reference/propertyAccessChain.types
@@ -11,7 +11,7 @@ o1?.b;
 >b : string | undefined
 
 declare const o2: undefined | { b: { c: string } };
->o2 : { b: {    c: string;}; } | undefined
+>o2 : { b: { c: string; }; } | undefined
 >b : { c: string; }
 >c : string
 
@@ -23,7 +23,7 @@ o2?.b.c;
 >c : string | undefined
 
 declare const o3: { b: undefined | { c: string } };
->o3 : { b: undefined | {    c: string;}; }
+>o3 : { b: undefined | { c: string; }; }
 >b : { c: string; } | undefined
 >c : string
 
@@ -35,8 +35,8 @@ o3.b?.c;
 >c : string | undefined
 
 declare const o4: { b?: { c: { d?: { e: string } } } };
->o4 : { b?: { c: {    d?: {        e: string;    };}; } | undefined; }
->b : { c: {    d?: {        e: string;    };}; } | undefined
+>o4 : { b?: { c: { d?: { e: string; }; }; } | undefined; }
+>b : { c: { d?: { e: string; }; }; } | undefined
 >c : { d?: { e: string; } | undefined; }
 >d : { e: string; } | undefined
 >e : string
@@ -53,8 +53,8 @@ o4.b?.c.d?.e;
 >e : string | undefined
 
 declare const o5: { b?(): { c: { d?: { e: string } } } };
->o5 : { b?(): {    c: {        d?: {            e: string;        };    };}; }
->b : (() => {    c: {        d?: {            e: string;        };    };}) | undefined
+>o5 : { b?(): { c: { d?: { e: string; }; }; }; }
+>b : (() => { c: { d?: { e: string; }; }; }) | undefined
 >c : { d?: { e: string; } | undefined; }
 >d : { e: string; } | undefined
 >e : string
@@ -73,7 +73,7 @@ o5.b?.().c.d?.e;
 
 // GH#33744
 declare const o6: <T>() => undefined | ({ x: number });
->o6 : <T>() => undefined | ({    x: number;})
+>o6 : <T>() => undefined | ({ x: number; })
 >x : number
 
 o6<number>()?.x;

--- a/tests/baselines/reference/propertyAccessWidening.types
+++ b/tests/baselines/reference/propertyAccessWidening.types
@@ -56,7 +56,7 @@ function g2(headerNames: any) {
 // Object in property or element access is widened when target of assignment
 
 function foo(options?: { a: string, b: number }) {
->foo : (options?: {    a: string;    b: number;}) => void
+>foo : (options?: { a: string; b: number; }) => void
 >options : { a: string; b: number; } | undefined
 >a : string
 >b : number

--- a/tests/baselines/reference/ramdaToolsNoInfinite2.types
+++ b/tests/baselines/reference/ramdaToolsNoInfinite2.types
@@ -422,7 +422,7 @@ declare module "Number/_Internal" {
 >NegativeIterationKeys : "-40" | "-39" | "-38" | "-37" | "-36" | "-35" | "-34" | "-33" | "-32" | "-31" | "-30" | "-29" | "-28" | "-27" | "-26" | "-25" | "-24" | "-23" | "-22" | "-21" | "-20" | "-19" | "-18" | "-17" | "-16" | "-15" | "-14" | "-13" | "-12" | "-11" | "-10" | "-9" | "-8" | "-7" | "-6" | "-5" | "-4" | "-3" | "-2" | "-1"
 
     export type Numbers = {
->Numbers : { string: {    'all': Format<IterationMap[KnownIterationMapKeys], 's'>;    '+': Format<IterationMap[PositiveIterationKeys], 's'>;    '-': Format<IterationMap[NegativeIterationKeys], 's'>;    '0': Format<IterationMap['0'], 's'>;}; number: {    'all': Format<IterationMap[KnownIterationMapKeys], 'n'>;    '+': Format<IterationMap[PositiveIterationKeys], 'n'>;    '-': Format<IterationMap[NegativeIterationKeys], 'n'>;    '0': Format<IterationMap['0'], 'n'>;}; }
+>Numbers : { string: { 'all': Format<IterationMap[KnownIterationMapKeys], 's'>; '+': Format<IterationMap[PositiveIterationKeys], 's'>; '-': Format<IterationMap[NegativeIterationKeys], 's'>; '0': Format<IterationMap['0'], 's'>; }; number: { 'all': Format<IterationMap[KnownIterationMapKeys], 'n'>; '+': Format<IterationMap[PositiveIterationKeys], 'n'>; '-': Format<IterationMap[NegativeIterationKeys], 'n'>; '0': Format<IterationMap['0'], 'n'>; }; }
 
         'string': {
 >'string' : { all: Format<IterationMap[KnownIterationMapKeys], 's'>; '+': Format<IterationMap[PositiveIterationKeys], 's'>; '-': Format<IterationMap[NegativeIterationKeys], 's'>; '0': Format<IterationMap['0'], 's'>; }

--- a/tests/baselines/reference/reactReadonlyHOCAssignabilityReal.types
+++ b/tests/baselines/reference/reactReadonlyHOCAssignabilityReal.types
@@ -6,7 +6,7 @@ import * as React from "react";
 >React : typeof React
 
 function myHigherOrderComponent<P>(Inner: React.ComponentClass<P & {name: string}>): React.ComponentClass<P> {
->myHigherOrderComponent : <P>(Inner: React.ComponentClass<P & {    name: string;}>) => React.ComponentClass<P>
+>myHigherOrderComponent : <P>(Inner: React.ComponentClass<P & { name: string; }>) => React.ComponentClass<P>
 >Inner : React.ComponentClass<P & { name: string; }, any>
 >React : any
 >name : string

--- a/tests/baselines/reference/readonlyAssignmentInSubclassOfClassExpression.types
+++ b/tests/baselines/reference/readonlyAssignmentInSubclassOfClassExpression.types
@@ -4,7 +4,7 @@
 class C extends (class {} as new () => Readonly<{ attrib: number }>) {
 >C : C
 >(class {} as new () => Readonly<{ attrib: number }>) : Readonly<{ attrib: number; }>
->class {} as new () => Readonly<{ attrib: number }> : new () => Readonly<{    attrib: number;}>
+>class {} as new () => Readonly<{ attrib: number }> : new () => Readonly<{ attrib: number; }>
 >class {} : typeof (Anonymous class)
 >attrib : number
 

--- a/tests/baselines/reference/recursiveClassBaseType.types
+++ b/tests/baselines/reference/recursiveClassBaseType.types
@@ -8,7 +8,7 @@ declare const p: <T>(fn: () => T) => T;
 >fn : () => T
 
 declare const Base: <T>(val: T) => { new(): T };
->Base : <T>(val: T) => new () => T
+>Base : <T>(val: T) => {    new (): T;}
 >val : T
 
 class C extends Base({ x: p<C[]>(() => []) }) { }

--- a/tests/baselines/reference/recursiveClassBaseType.types
+++ b/tests/baselines/reference/recursiveClassBaseType.types
@@ -8,7 +8,7 @@ declare const p: <T>(fn: () => T) => T;
 >fn : () => T
 
 declare const Base: <T>(val: T) => { new(): T };
->Base : <T>(val: T) => {    new (): T;}
+>Base : <T>(val: T) => { new (): T; }
 >val : T
 
 class C extends Base({ x: p<C[]>(() => []) }) { }

--- a/tests/baselines/reference/recursiveConditionalEvaluationNonInfinite.types
+++ b/tests/baselines/reference/recursiveConditionalEvaluationNonInfinite.types
@@ -10,7 +10,7 @@ declare const x: Test<number[]>;
 >x : { array: { notArray: number; }; }
 
 const y: { array: { notArray: number } } = x; // Error
->y : { array: {    notArray: number;}; }
+>y : { array: { notArray: number; }; }
 >array : { notArray: number; }
 >notArray : number
 >x : { array: { notArray: number; }; }

--- a/tests/baselines/reference/recursiveConditionalTypes.types
+++ b/tests/baselines/reference/recursiveConditionalTypes.types
@@ -179,8 +179,8 @@ declare let b3: InfBox<string>;
 >b3 : InfBox<string>
 
 declare let b4: { value: { value: { value: typeof b4 }}};
->b4 : { value: {    value: {        value: typeof b4;    };}; }
->value : { value: {    value: typeof b4;}; }
+>b4 : { value: { value: { value: typeof b4; }; }; }
+>value : { value: { value: typeof b4; }; }
 >value : { value: typeof b4; }
 >value : { value: { value: { value: typeof b4; }; }; }
 >b4 : { value: { value: { value: any; }; }; }

--- a/tests/baselines/reference/reverseMappedTypeAssignableToIndex.types
+++ b/tests/baselines/reference/reverseMappedTypeAssignableToIndex.types
@@ -21,7 +21,7 @@ type LiteralType = {
 >second : "second"
 }
 type MappedLiteralType = {
->MappedLiteralType : { first: {    name: "first";}; second: {    name: "second";}; }
+>MappedLiteralType : { first: { name: "first"; }; second: { name: "second"; }; }
 
 	first: { name: "first" },
 >first : { name: "first"; }

--- a/tests/baselines/reference/reverseMappedTypePrimitiveConstraintProperty.types
+++ b/tests/baselines/reference/reverseMappedTypePrimitiveConstraintProperty.types
@@ -2,7 +2,7 @@
 
 === reverseMappedTypePrimitiveConstraintProperty.ts ===
 declare function test<
->test : <T extends { prop: string; nested: {    nestedProp: string;}; }>(obj: { [K in keyof T]: T[K]; }) => T
+>test : <T extends { prop: string; nested: { nestedProp: string; }; }>(obj: { [K in keyof T]: T[K]; }) => T
 
   T extends { prop: string; nested: { nestedProp: string } },
 >prop : string

--- a/tests/baselines/reference/slightlyIndirectedDeepObjectLiteralElaborations.types
+++ b/tests/baselines/reference/slightlyIndirectedDeepObjectLiteralElaborations.types
@@ -3,10 +3,10 @@
 === slightlyIndirectedDeepObjectLiteralElaborations.ts ===
 interface Foo {
     a: {
->a : { b: {    c: {        d: string;    };}; }
+>a : { b: { c: { d: string; }; }; }
 
         b: {
->b : { c: {    d: string;}; }
+>b : { c: { d: string; }; }
 
             c: {
 >c : { d: string; }

--- a/tests/baselines/reference/spellingSuggestionJSXAttribute.types
+++ b/tests/baselines/reference/spellingSuggestionJSXAttribute.types
@@ -6,7 +6,7 @@ import * as React from "react";
 >React : typeof React
 
 function MyComp2(props: { className?: string, htmlFor?: string }) {
->MyComp2 : (props: {    className?: string;    htmlFor?: string;}) => any
+>MyComp2 : (props: { className?: string; htmlFor?: string; }) => any
 >props : { className?: string; htmlFor?: string; }
 >className : string
 >htmlFor : string

--- a/tests/baselines/reference/spreadOverwritesProperty.types
+++ b/tests/baselines/reference/spreadOverwritesProperty.types
@@ -33,7 +33,7 @@ var unused3 = { b: 1, ...abq }
 >abq : { a: number; b?: number; }
 
 function g(obj: { x: number | undefined }) {
->g : (obj: {    x: number | undefined;}) => { x: number | undefined; }
+>g : (obj: { x: number | undefined; }) => { x: number | undefined; }
 >obj : { x: number | undefined; }
 >x : number
 
@@ -44,7 +44,7 @@ function g(obj: { x: number | undefined }) {
 >obj : { x: number; }
 }
 function h(obj: { x: number }) {
->h : (obj: {    x: number;}) => { x: number; }
+>h : (obj: { x: number; }) => { x: number; }
 >obj : { x: number; }
 >x : number
 

--- a/tests/baselines/reference/spreadOverwritesPropertyStrict.types
+++ b/tests/baselines/reference/spreadOverwritesPropertyStrict.types
@@ -46,7 +46,7 @@ var unused5 = { ...abq, b: 1 } // ok
 >1 : 1
 
 function g(obj: { x: number | undefined }) {
->g : (obj: {    x: number | undefined;}) => { x: number | undefined; }
+>g : (obj: { x: number | undefined; }) => { x: number | undefined; }
 >obj : { x: number | undefined; }
 >x : number | undefined
 
@@ -57,7 +57,7 @@ function g(obj: { x: number | undefined }) {
 >obj : { x: number | undefined; }
 }
 function f(obj: { x: number } | undefined) {
->f : (obj: {    x: number;} | undefined) => { x: number; }
+>f : (obj: { x: number; } | undefined) => { x: number; }
 >obj : { x: number; } | undefined
 >x : number
 
@@ -68,7 +68,7 @@ function f(obj: { x: number } | undefined) {
 >obj : { x: number; } | undefined
 }
 function h(obj: { x: number } | { x: string }) {
->h : (obj: {    x: number;} | {    x: string;}) => { x: number; } | { x: string; }
+>h : (obj: { x: number; } | { x: string; }) => { x: number; } | { x: string; }
 >obj : { x: number; } | { x: string; }
 >x : number
 >x : string
@@ -80,7 +80,7 @@ function h(obj: { x: number } | { x: string }) {
 >obj : { x: number; } | { x: string; }
 }
 function i(b: boolean, t: { command: string, ok: string }) {
->i : (b: boolean, t: {    command: string;    ok: string;}) => { command: string; ok?: string | undefined; }
+>i : (b: boolean, t: { command: string; ok: string; }) => { command: string; ok?: string | undefined; }
 >b : boolean
 >t : { command: string; ok: string; }
 >command : string
@@ -109,7 +109,7 @@ function j() {
 >"bye" : "bye"
 }
 function k(t: { command: string, ok: string }) {
->k : (t: {    command: string;    ok: string;}) => { command: string; ok: string; spoiler2: boolean; spoiler: boolean; }
+>k : (t: { command: string; ok: string; }) => { command: string; ok: string; spoiler2: boolean; spoiler: boolean; }
 >t : { command: string; ok: string; }
 >command : string
 >ok : string
@@ -127,7 +127,7 @@ function k(t: { command: string, ok: string }) {
 }
 
 function l(anyrequired: { a: any }) {
->l : (anyrequired: {    a: any;}) => { a: any; }
+>l : (anyrequired: { a: any; }) => { a: any; }
 >anyrequired : { a: any; }
 >a : any
 
@@ -138,7 +138,7 @@ function l(anyrequired: { a: any }) {
 >anyrequired : { a: any; }
 }
 function m(anyoptional: { a?: any }) {
->m : (anyoptional: {    a?: any;}) => { a: any; }
+>m : (anyoptional: { a?: any; }) => { a: any; }
 >anyoptional : { a?: any; }
 >a : any
 

--- a/tests/baselines/reference/spreadUnion3.types
+++ b/tests/baselines/reference/spreadUnion3.types
@@ -2,7 +2,7 @@
 
 === spreadUnion3.ts ===
 function f(x: { y: string } | undefined): { y: string } {
->f : (x: {    y: string;} | undefined) => {    y: string;}
+>f : (x: { y: string; } | undefined) => { y: string; }
 >x : { y: string; } | undefined
 >y : string
 >y : string
@@ -20,7 +20,7 @@ f(undefined)
 
 
 function g(t?: { a: number } | null): void {
->g : (t?: {    a: number;} | null) => void
+>g : (t?: { a: number; } | null) => void
 >t : { a: number; } | null | undefined
 >a : number
 

--- a/tests/baselines/reference/staticInheritance.types
+++ b/tests/baselines/reference/staticInheritance.types
@@ -2,7 +2,7 @@
 
 === staticInheritance.ts ===
 function doThing(x: { n: string }) { }
->doThing : (x: {    n: string;}) => void
+>doThing : (x: { n: string; }) => void
 >x : { n: string; }
 >n : string
 

--- a/tests/baselines/reference/strictOptionalProperties1.types
+++ b/tests/baselines/reference/strictOptionalProperties1.types
@@ -49,7 +49,7 @@ function f1(obj: { a?: string, b?: string | undefined }) {
 }
 
 function f2(obj: { a?: string, b?: string | undefined }) {
->f2 : (obj: {    a?: string;    b?: string | undefined;}) => void
+>f2 : (obj: { a?: string; b?: string | undefined; }) => void
 >obj : { a?: string; b?: string | undefined; }
 >a : string | undefined
 >b : string | undefined
@@ -543,7 +543,7 @@ declare let tx4: [(string | undefined)?];
 >tx4 : [(string | undefined)?]
 
 declare function f11<T>(x: { p?: T }): T;
->f11 : <T>(x: {    p?: T;}) => T
+>f11 : <T>(x: { p?: T; }) => T
 >x : { p?: T; }
 >p : T | undefined
 

--- a/tests/baselines/reference/strictSubtypeAndNarrowing.types
+++ b/tests/baselines/reference/strictSubtypeAndNarrowing.types
@@ -279,7 +279,7 @@ function checkD(f: FnTypes) {
 // Type of x = y is y with freshness preserved
 
 function fx10(obj1: { x?: number }, obj2: { x?: number, y?: number }) {
->fx10 : (obj1: {    x?: number;}, obj2: {    x?: number;    y?: number;}) => void
+>fx10 : (obj1: { x?: number; }, obj2: { x?: number; y?: number; }) => void
 >obj1 : { x?: number | undefined; }
 >x : number | undefined
 >obj2 : { x?: number | undefined; y?: number | undefined; }
@@ -310,7 +310,7 @@ function fx10(obj1: { x?: number }, obj2: { x?: number, y?: number }) {
 }
 
 function fx11(): { x?: number } {
->fx11 : () => {    x?: number;}
+>fx11 : () => { x?: number; }
 >x : number | undefined
 
     let obj: { x?: number, y?: number };
@@ -450,7 +450,7 @@ declare function doesValueAtDeepPathSatisfy<
 
 
 type Foo = {value: {type: 'A'}; a?: number} | {value: {type: 'B'}; b?: number};
->Foo : { value: {    type: 'A';}; a?: number | undefined; } | { value: {    type: 'B';}; b?: number | undefined; }
+>Foo : { value: { type: 'A'; }; a?: number | undefined; } | { value: { type: 'B'; }; b?: number | undefined; }
 >value : { type: 'A'; }
 >type : "A"
 >a : number | undefined
@@ -471,7 +471,7 @@ declare function assert(condition: boolean): asserts condition;
 >condition : boolean
 
 function test1(foo: Foo): {value: {type: 'A'}; a?: number} {
->test1 : (foo: Foo) => {    value: {        type: 'A';    };    a?: number;}
+>test1 : (foo: Foo) => { value: { type: 'A'; }; a?: number; }
 >foo : Foo
 >value : { type: 'A'; }
 >type : "A"
@@ -493,7 +493,7 @@ function test1(foo: Foo): {value: {type: 'A'}; a?: number} {
 }
 
 function test2(foo: Foo): {value: {type: 'A'}; a?: number} {
->test2 : (foo: Foo) => {    value: {        type: 'A';    };    a?: number;}
+>test2 : (foo: Foo) => { value: { type: 'A'; }; a?: number; }
 >foo : Foo
 >value : { type: 'A'; }
 >type : "A"

--- a/tests/baselines/reference/strictTypeofUnionNarrowing.types
+++ b/tests/baselines/reference/strictTypeofUnionNarrowing.types
@@ -2,7 +2,7 @@
 
 === strictTypeofUnionNarrowing.ts ===
 function stringify1(anything: { toString(): string } | undefined): string {
->stringify1 : (anything: {    toString(): string;} | undefined) => string
+>stringify1 : (anything: { toString(): string; } | undefined) => string
 >anything : { toString(): string; } | undefined
 >toString : () => string
 
@@ -54,7 +54,7 @@ function stringify3(anything: unknown | undefined): string { // should simplify 
 }
 
 function stringify4(anything: { toString?(): string } | undefined): string {
->stringify4 : (anything: {    toString?(): string;} | undefined) => string
+>stringify4 : (anything: { toString?(): string; } | undefined) => string
 >anything : { toString?(): string; } | undefined
 >toString : (() => string) | undefined
 

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -706,8 +706,8 @@ var r13b = [r13arg2, r13arg1];
 >r13arg1 : <T extends Derived[]>(x: Base[], y: T) => T
 
 var r14arg1 = <T>(x: { a: T; b: T }) => x.a;
->r14arg1 : <T>(x: { a: T; b: T; }) => T
-><T>(x: { a: T; b: T }) => x.a : <T>(x: { a: T; b: T; }) => T
+>r14arg1 : <T>(x: {    a: T;    b: T;}) => T
+><T>(x: { a: T; b: T }) => x.a : <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -136,8 +136,8 @@ declare function foo10(a: any): any;
 >a : any
 
 declare function foo11(a: (x: { foo: string }, y: { foo: string; bar: string }) => Base): typeof a;
->foo11 : { (a: (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base): typeof a; (a: any): any; }
->a : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>foo11 : { (a: (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): typeof a; (a: any): any; }
+>a : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -172,8 +172,8 @@ declare function foo13(a: any): any;
 >a : any
 
 declare function foo14(a: (x: { a: string; b: number }) => Object): typeof a;
->foo14 : { (a: (x: {    a: string;    b: number;}) => Object): typeof a; (a: any): any; }
->a : (x: {    a: string;    b: number;}) => Object
+>foo14 : { (a: (x: { a: string; b: number; }) => Object): typeof a; (a: any): any; }
+>a : (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -533,11 +533,11 @@ var r8b = [r8arg2, r8arg1];
 >r8arg1 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: T) => U) => (r: T) => U
 
 var r9arg1 = <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => <U>null;
->r9arg1 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
-><T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => <U>null : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>r9arg1 : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
+><T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => <U>null : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -614,8 +614,8 @@ var r11arg1 = <T extends Base>(x: T, y: T) => x;
 >x : T
 
 var r11arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>null;
->r11arg2 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
->(x: { foo: string }, y: { foo: string; bar: string }) => <Base>null : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>r11arg2 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
+>(x: { foo: string }, y: { foo: string; bar: string }) => <Base>null : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -706,8 +706,8 @@ var r13b = [r13arg2, r13arg1];
 >r13arg1 : <T extends Derived[]>(x: Base[], y: T) => T
 
 var r14arg1 = <T>(x: { a: T; b: T }) => x.a;
->r14arg1 : <T>(x: {    a: T;    b: T;}) => T
-><T>(x: { a: T; b: T }) => x.a : <T>(x: {    a: T;    b: T;}) => T
+>r14arg1 : <T>(x: { a: T; b: T; }) => T
+><T>(x: { a: T; b: T }) => x.a : <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -716,8 +716,8 @@ var r14arg1 = <T>(x: { a: T; b: T }) => x.a;
 >a : T
 
 var r14arg2 = (x: { a: string; b: number }) => <Object>null;
->r14arg2 : (x: {    a: string;    b: number;}) => Object
->(x: { a: string; b: number }) => <Object>null : (x: {    a: string;    b: number;}) => Object
+>r14arg2 : (x: { a: string; b: number; }) => Object
+>(x: { a: string; b: number }) => <Object>null : (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number

--- a/tests/baselines/reference/subtypingWithCallSignatures3.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.types
@@ -73,8 +73,8 @@ module Errors {
 >a2 : any
 
     declare function foo11(a2: (x: { foo: string }, y: { foo: string; bar: string }) => Base): typeof a2;
->foo11 : { (a2: (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base): (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base; (a2: any): any; }
->a2 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>foo11 : { (a2: (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): (x: { foo: string; }, y: { foo: string; bar: string; }) => Base; (a2: any): any; }
+>a2 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -98,8 +98,8 @@ module Errors {
 >a2 : any
 
     declare function foo15(a2: (x: { a: string; b: number }) => number): typeof a2;
->foo15 : { (a2: (x: {    a: string;    b: number;}) => number): (x: {    a: string;    b: number;}) => number; (a2: any): any; }
->a2 : (x: {    a: string;    b: number;}) => number
+>foo15 : { (a2: (x: { a: string; b: number; }) => number): (x: { a: string; b: number; }) => number; (a2: any): any; }
+>a2 : (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -239,11 +239,11 @@ module Errors {
 >r2arg2 : (x: (arg: Base) => Derived) => (r: Base) => Derived2
 
     var r3arg = <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => <U>null;
->r3arg : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: number;}) => U) => (r: T) => U
-><T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => <U>null : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: number;}) => U) => (r: T) => U
+>r3arg : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U
+><T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => <U>null : <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: number;}) => U
+>y : (arg2: { foo: number; }) => U
 >arg2 : { foo: number; }
 >foo : number
 >(r: T) => <U>null : (r: T) => U
@@ -317,8 +317,8 @@ module Errors {
 ><T>null : T
 
     var r5arg2 = (x: { foo: string }, y: { foo: string; bar: string }) => <Base>null;
->r5arg2 : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
->(x: { foo: string }, y: { foo: string; bar: string }) => <Base>null : (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>r5arg2 : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
+>(x: { foo: string }, y: { foo: string; bar: string }) => <Base>null : (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -377,16 +377,16 @@ module Errors {
 >r6arg2 : <T extends Derived2[]>(x: Base[], y: Base[]) => T
 
     var r7arg = <T>(x: { a: T; b: T }) => <T>null;
->r7arg : <T>(x: {    a: T;    b: T;}) => T
-><T>(x: { a: T; b: T }) => <T>null : <T>(x: {    a: T;    b: T;}) => T
+>r7arg : <T>(x: { a: T; b: T; }) => T
+><T>(x: { a: T; b: T }) => <T>null : <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
 ><T>null : T
 
     var r7arg2 = (x: { a: string; b: number }) => 1;
->r7arg2 : (x: {    a: string;    b: number;}) => number
->(x: { a: string; b: number }) => 1 : (x: {    a: string;    b: number;}) => number
+>r7arg2 : (x: { a: string; b: number; }) => number
+>(x: { a: string; b: number }) => 1 : (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -411,8 +411,8 @@ module Errors {
 >r7arg2 : (x: { a: string; b: number; }) => number
 
     var r7arg3 = <T extends Base>(x: { a: T; b: T }) => 1;
->r7arg3 : <T extends Base>(x: {    a: T;    b: T;}) => number
-><T extends Base>(x: { a: T; b: T }) => 1 : <T extends Base>(x: {    a: T;    b: T;}) => number
+>r7arg3 : <T extends Base>(x: { a: T; b: T; }) => number
+><T extends Base>(x: { a: T; b: T }) => 1 : <T extends Base>(x: { a: T; b: T; }) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithCallSignatures3.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures3.types
@@ -377,8 +377,8 @@ module Errors {
 >r6arg2 : <T extends Derived2[]>(x: Base[], y: Base[]) => T
 
     var r7arg = <T>(x: { a: T; b: T }) => <T>null;
->r7arg : <T>(x: { a: T; b: T; }) => T
-><T>(x: { a: T; b: T }) => <T>null : <T>(x: { a: T; b: T; }) => T
+>r7arg : <T>(x: {    a: T;    b: T;}) => T
+><T>(x: { a: T; b: T }) => <T>null : <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -411,8 +411,8 @@ module Errors {
 >r7arg2 : (x: { a: string; b: number; }) => number
 
     var r7arg3 = <T extends Base>(x: { a: T; b: T }) => 1;
->r7arg3 : <T extends Base>(x: { a: T; b: T; }) => number
-><T extends Base>(x: { a: T; b: T }) => 1 : <T extends Base>(x: { a: T; b: T; }) => number
+>r7arg3 : <T extends Base>(x: {    a: T;    b: T;}) => number
+><T extends Base>(x: { a: T; b: T }) => 1 : <T extends Base>(x: {    a: T;    b: T;}) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithCallSignatures4.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures4.types
@@ -80,8 +80,8 @@ declare function foo6(a: any): any;
 >a : any
 
 declare function foo11(a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base);
->foo11 : { (a11: <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base): any; (a: any): any; }
->a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>foo11 : { (a11: <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base): any; (a: any): any; }
+>a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -93,8 +93,8 @@ declare function foo11(a: any): any;
 >a : any
 
 declare function foo15(a15: <T>(x: { a: T; b: T }) => T[]);
->foo15 : { (a15: <T>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
->a15 : <T>(x: { a: T; b: T; }) => T[]
+>foo15 : { (a15: <T>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
+>a15 : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -104,8 +104,8 @@ declare function foo15(a: any): any;
 >a : any
 
 declare function foo16(a16: <T extends Base>(x: { a: T; b: T }) => T[]);
->foo16 : { (a16: <T extends Base>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
->a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
+>foo16 : { (a16: <T extends Base>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
+>a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -348,8 +348,8 @@ var r6b = [r6arg2, r6arg];
 >r6arg : <T extends Base, U extends Derived>(x: (arg: T) => U) => T
 
 var r11arg = <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null;
->r11arg : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
-><T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>r11arg : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+><T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -358,8 +358,8 @@ var r11arg = <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null;
 ><Base>null : Base
 
 var r11arg2 = <T>(x: { foo: T }, y: { foo: T; bar: T }) => <Base>null;
->r11arg2 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
-><T>(x: { foo: T }, y: { foo: T; bar: T }) => <Base>null : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>r11arg2 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+><T>(x: { foo: T }, y: { foo: T; bar: T }) => <Base>null : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -386,16 +386,16 @@ var r11b = [r11arg2, r11arg];
 >r11arg : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 
 var r15arg = <U, V>(x: { a: U; b: V; }) => <U[]>null;
->r15arg : <U, V>(x: { a: U; b: V; }) => U[]
-><U, V>(x: { a: U; b: V; }) => <U[]>null : <U, V>(x: { a: U; b: V; }) => U[]
+>r15arg : <U, V>(x: {    a: U;    b: V;}) => U[]
+><U, V>(x: { a: U; b: V; }) => <U[]>null : <U, V>(x: {    a: U;    b: V;}) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 ><U[]>null : U[]
 
 var r15arg2 = <T>(x: { a: T; b: T }) => <T[]>null;
->r15arg2 : <T>(x: { a: T; b: T; }) => T[]
-><T>(x: { a: T; b: T }) => <T[]>null : <T>(x: { a: T; b: T; }) => T[]
+>r15arg2 : <T>(x: {    a: T;    b: T;}) => T[]
+><T>(x: { a: T; b: T }) => <T[]>null : <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -420,16 +420,16 @@ var r15b = [r15arg2, r15arg];
 >r15arg : <U, V>(x: { a: U; b: V; }) => U[]
 
 var r16arg = <T extends Base>(x: { a: T; b: T }) => <T[]>null;
->r16arg : <T extends Base>(x: { a: T; b: T; }) => T[]
-><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: { a: T; b: T; }) => T[]
+>r16arg : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 ><T[]>null : T[]
 
 var r16arg2 = <T extends Base>(x: { a: T; b: T }) => <T[]>null;
->r16arg2 : <T extends Base>(x: { a: T; b: T; }) => T[]
-><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: { a: T; b: T; }) => T[]
+>r16arg2 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithCallSignatures4.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures4.types
@@ -80,8 +80,8 @@ declare function foo6(a: any): any;
 >a : any
 
 declare function foo11(a11: <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base);
->foo11 : { (a11: <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base): any; (a: any): any; }
->a11 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>foo11 : { (a11: <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base): any; (a: any): any; }
+>a11 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -93,8 +93,8 @@ declare function foo11(a: any): any;
 >a : any
 
 declare function foo15(a15: <T>(x: { a: T; b: T }) => T[]);
->foo15 : { (a15: <T>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
->a15 : <T>(x: {    a: T;    b: T;}) => T[]
+>foo15 : { (a15: <T>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
+>a15 : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -104,8 +104,8 @@ declare function foo15(a: any): any;
 >a : any
 
 declare function foo16(a16: <T extends Base>(x: { a: T; b: T }) => T[]);
->foo16 : { (a16: <T extends Base>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
->a16 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>foo16 : { (a16: <T extends Base>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
+>a16 : <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -348,8 +348,8 @@ var r6b = [r6arg2, r6arg];
 >r6arg : <T extends Base, U extends Derived>(x: (arg: T) => U) => T
 
 var r11arg = <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null;
->r11arg : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
-><T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null : <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>r11arg : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+><T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -358,8 +358,8 @@ var r11arg = <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => <Base>null;
 ><Base>null : Base
 
 var r11arg2 = <T>(x: { foo: T }, y: { foo: T; bar: T }) => <Base>null;
->r11arg2 : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
-><T>(x: { foo: T }, y: { foo: T; bar: T }) => <Base>null : <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>r11arg2 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+><T>(x: { foo: T }, y: { foo: T; bar: T }) => <Base>null : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -386,16 +386,16 @@ var r11b = [r11arg2, r11arg];
 >r11arg : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 
 var r15arg = <U, V>(x: { a: U; b: V; }) => <U[]>null;
->r15arg : <U, V>(x: {    a: U;    b: V;}) => U[]
-><U, V>(x: { a: U; b: V; }) => <U[]>null : <U, V>(x: {    a: U;    b: V;}) => U[]
+>r15arg : <U, V>(x: { a: U; b: V; }) => U[]
+><U, V>(x: { a: U; b: V; }) => <U[]>null : <U, V>(x: { a: U; b: V; }) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 ><U[]>null : U[]
 
 var r15arg2 = <T>(x: { a: T; b: T }) => <T[]>null;
->r15arg2 : <T>(x: {    a: T;    b: T;}) => T[]
-><T>(x: { a: T; b: T }) => <T[]>null : <T>(x: {    a: T;    b: T;}) => T[]
+>r15arg2 : <T>(x: { a: T; b: T; }) => T[]
+><T>(x: { a: T; b: T }) => <T[]>null : <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -420,16 +420,16 @@ var r15b = [r15arg2, r15arg];
 >r15arg : <U, V>(x: { a: U; b: V; }) => U[]
 
 var r16arg = <T extends Base>(x: { a: T; b: T }) => <T[]>null;
->r16arg : <T extends Base>(x: {    a: T;    b: T;}) => T[]
-><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>r16arg : <T extends Base>(x: { a: T; b: T; }) => T[]
+><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 ><T[]>null : T[]
 
 var r16arg2 = <T extends Base>(x: { a: T; b: T }) => <T[]>null;
->r16arg2 : <T extends Base>(x: {    a: T;    b: T;}) => T[]
-><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>r16arg2 : <T extends Base>(x: { a: T; b: T; }) => T[]
+><T extends Base>(x: { a: T; b: T }) => <T[]>null : <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithConstructSignatures2.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures2.types
@@ -643,7 +643,7 @@ var r13b = [r13arg2, r13arg1];
 >r13arg1 : new <T extends Derived[]>(x: Base[], y: T) => T
 
 var r14arg1: new <T>(x: { a: T; b: T }) => T;
->r14arg1 : new <T>(x: { a: T; b: T; }) => T
+>r14arg1 : new <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithConstructSignatures2.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures2.types
@@ -136,8 +136,8 @@ declare function foo10(a: any): any;
 >a : any
 
 declare function foo11(a: new (x: { foo: string }, y: { foo: string; bar: string }) => Base): typeof a;
->foo11 : { (a: new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base): typeof a; (a: any): any; }
->a : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>foo11 : { (a: new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): typeof a; (a: any): any; }
+>a : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -172,8 +172,8 @@ declare function foo13(a: any): any;
 >a : any
 
 declare function foo14(a: new (x: { a: string; b: number }) => Object): typeof a;
->foo14 : { (a: new (x: {    a: string;    b: number;}) => Object): typeof a; (a: any): any; }
->a : new (x: {    a: string;    b: number;}) => Object
+>foo14 : { (a: new (x: { a: string; b: number; }) => Object): typeof a; (a: any): any; }
+>a : new (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -494,10 +494,10 @@ var r8b = [r8arg2, r8arg1];
 >r8arg1 : new <T extends Base, U extends Derived>(x: new (arg: T) => U, y: new (arg2: T) => U) => new (r: T) => U
 
 var r9arg1: new <T extends Base, U extends Derived>(x: new (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => new (r: T) => U;
->r9arg1 : new <T extends Base, U extends Derived>(x: new (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => new (r: T) => U
+>r9arg1 : new <T extends Base, U extends Derived>(x: new (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => new (r: T) => U
 >x : new (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -561,7 +561,7 @@ var r11arg1: new <T extends Base>(x: T, y: T) => T;
 >y : T
 
 var r11arg2: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->r11arg2 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>r11arg2 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -643,13 +643,13 @@ var r13b = [r13arg2, r13arg1];
 >r13arg1 : new <T extends Derived[]>(x: Base[], y: T) => T
 
 var r14arg1: new <T>(x: { a: T; b: T }) => T;
->r14arg1 : new <T>(x: {    a: T;    b: T;}) => T
+>r14arg1 : new <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
 var r14arg2: new (x: { a: string; b: number }) => Object;
->r14arg2 : new (x: {    a: string;    b: number;}) => Object
+>r14arg2 : new (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number

--- a/tests/baselines/reference/subtypingWithConstructSignatures3.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures3.types
@@ -349,7 +349,7 @@ module Errors {
 >r6arg2 : new <T extends Derived2[]>(x: Base[], y: Base[]) => T
 
     var r7arg1: new <T>(x: { a: T; b: T }) => T;
->r7arg1 : new <T>(x: { a: T; b: T; }) => T
+>r7arg1 : new <T>(x: {    a: T;    b: T;}) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -379,7 +379,7 @@ module Errors {
 >r7arg2 : new (x: { a: string; b: number; }) => number
 
     var r7arg3: new <T extends Base>(x: { a: T; b: T }) => number;
->r7arg3 : new <T extends Base>(x: { a: T; b: T; }) => number
+>r7arg3 : new <T extends Base>(x: {    a: T;    b: T;}) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithConstructSignatures3.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures3.types
@@ -73,8 +73,8 @@ module Errors {
 >a2 : any
 
     declare function foo11(a2: new (x: { foo: string }, y: { foo: string; bar: string }) => Base): typeof a2;
->foo11 : { (a2: new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base): new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base; (a2: any): any; }
->a2 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>foo11 : { (a2: new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base): new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base; (a2: any): any; }
+>a2 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -98,8 +98,8 @@ module Errors {
 >a2 : any
 
     declare function foo15(a2: new (x: { a: string; b: number }) => number): typeof a2;
->foo15 : { (a2: new (x: {    a: string;    b: number;}) => number): new (x: {    a: string;    b: number;}) => number; (a2: any): any; }
->a2 : new (x: {    a: string;    b: number;}) => number
+>foo15 : { (a2: new (x: { a: string; b: number; }) => number): new (x: { a: string; b: number; }) => number; (a2: any): any; }
+>a2 : new (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -229,10 +229,10 @@ module Errors {
 >r2arg2 : new (x: new (arg: Base) => Derived) => new (r: Base) => Derived2
 
     var r3arg1: new <T extends Base, U extends Derived>(x: new (arg: T) => U, y: (arg2: { foo: number; }) => U) => new (r: T) => U;
->r3arg1 : new <T extends Base, U extends Derived>(x: new (arg: T) => U, y: (arg2: {    foo: number;}) => U) => new (r: T) => U
+>r3arg1 : new <T extends Base, U extends Derived>(x: new (arg: T) => U, y: (arg2: { foo: number; }) => U) => new (r: T) => U
 >x : new (arg: T) => U
 >arg : T
->y : (arg2: {    foo: number;}) => U
+>y : (arg2: { foo: number; }) => U
 >arg2 : { foo: number; }
 >foo : number
 >r : T
@@ -295,7 +295,7 @@ module Errors {
 >y : T
 
     var r5arg2: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->r5arg2 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>r5arg2 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -349,13 +349,13 @@ module Errors {
 >r6arg2 : new <T extends Derived2[]>(x: Base[], y: Base[]) => T
 
     var r7arg1: new <T>(x: { a: T; b: T }) => T;
->r7arg1 : new <T>(x: {    a: T;    b: T;}) => T
+>r7arg1 : new <T>(x: { a: T; b: T; }) => T
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     var r7arg2: new (x: { a: string; b: number }) => number;
->r7arg2 : new (x: {    a: string;    b: number;}) => number
+>r7arg2 : new (x: { a: string; b: number; }) => number
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -379,7 +379,7 @@ module Errors {
 >r7arg2 : new (x: { a: string; b: number; }) => number
 
     var r7arg3: new <T extends Base>(x: { a: T; b: T }) => number;
->r7arg3 : new <T extends Base>(x: {    a: T;    b: T;}) => number
+>r7arg3 : new <T extends Base>(x: { a: T; b: T; }) => number
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithConstructSignatures4.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures4.types
@@ -80,8 +80,8 @@ declare function foo6(a: any): any;
 >a : any
 
 declare function foo11(a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base);
->foo11 : { (a11: new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base): any; (a: any): any; }
->a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>foo11 : { (a11: new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base): any; (a: any): any; }
+>a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -93,8 +93,8 @@ declare function foo11(a: any): any;
 >a : any
 
 declare function foo15(a15: new <T>(x: { a: T; b: T }) => T[]);
->foo15 : { (a15: new <T>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
->a15 : new <T>(x: {    a: T;    b: T;}) => T[]
+>foo15 : { (a15: new <T>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
+>a15 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -104,8 +104,8 @@ declare function foo15(a: any): any;
 >a : any
 
 declare function foo16(a16: new <T extends Base>(x: { a: T; b: T }) => T[]);
->foo16 : { (a16: new <T extends Base>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
->a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>foo16 : { (a16: new <T extends Base>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
+>a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -323,7 +323,7 @@ var r6b = [r6arg2, r6arg];
 >r6arg : new <T extends Base, U extends Derived>(x: new (arg: T) => U) => T
 
 var r11arg: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
->r11arg : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>r11arg : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -331,7 +331,7 @@ var r11arg: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
 >bar : U
 
 var r11arg2: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->r11arg2 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>r11arg2 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -357,13 +357,13 @@ var r11b = [r11arg2, r11arg];
 >r11arg : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 
 var r15arg: new <U, V>(x: { a: U; b: V; }) => U[];
->r15arg : new <U, V>(x: {    a: U;    b: V;}) => U[]
+>r15arg : new <U, V>(x: { a: U; b: V; }) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 
 var r15arg2: new <T>(x: { a: T; b: T }) => T[];
->r15arg2 : new <T>(x: {    a: T;    b: T;}) => T[]
+>r15arg2 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -387,13 +387,13 @@ var r15b = [r15arg2, r15arg];
 >r15arg : new <U, V>(x: { a: U; b: V; }) => U[]
 
 var r16arg: new <T extends Base>(x: { a: T; b: T }) => T[];
->r16arg : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>r16arg : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
 var r16arg2: new <T extends Base>(x: { a: T; b: T }) => T[];
->r16arg2 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>r16arg2 : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithConstructSignatures4.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures4.types
@@ -80,8 +80,8 @@ declare function foo6(a: any): any;
 >a : any
 
 declare function foo11(a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base);
->foo11 : { (a11: new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base): any; (a: any): any; }
->a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>foo11 : { (a11: new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base): any; (a: any): any; }
+>a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -93,8 +93,8 @@ declare function foo11(a: any): any;
 >a : any
 
 declare function foo15(a15: new <T>(x: { a: T; b: T }) => T[]);
->foo15 : { (a15: new <T>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
->a15 : new <T>(x: { a: T; b: T; }) => T[]
+>foo15 : { (a15: new <T>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
+>a15 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -104,8 +104,8 @@ declare function foo15(a: any): any;
 >a : any
 
 declare function foo16(a16: new <T extends Base>(x: { a: T; b: T }) => T[]);
->foo16 : { (a16: new <T extends Base>(x: { a: T; b: T; }) => T[]): any; (a: any): any; }
->a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>foo16 : { (a16: new <T extends Base>(x: {    a: T;    b: T;}) => T[]): any; (a: any): any; }
+>a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -323,7 +323,7 @@ var r6b = [r6arg2, r6arg];
 >r6arg : new <T extends Base, U extends Derived>(x: new (arg: T) => U) => T
 
 var r11arg: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
->r11arg : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
+>r11arg : new <T, U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -331,7 +331,7 @@ var r11arg: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base;
 >bar : U
 
 var r11arg2: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->r11arg2 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>r11arg2 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -357,13 +357,13 @@ var r11b = [r11arg2, r11arg];
 >r11arg : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 
 var r15arg: new <U, V>(x: { a: U; b: V; }) => U[];
->r15arg : new <U, V>(x: { a: U; b: V; }) => U[]
+>r15arg : new <U, V>(x: {    a: U;    b: V;}) => U[]
 >x : { a: U; b: V; }
 >a : U
 >b : V
 
 var r15arg2: new <T>(x: { a: T; b: T }) => T[];
->r15arg2 : new <T>(x: { a: T; b: T; }) => T[]
+>r15arg2 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -387,13 +387,13 @@ var r15b = [r15arg2, r15arg];
 >r15arg : new <U, V>(x: { a: U; b: V; }) => U[]
 
 var r16arg: new <T extends Base>(x: { a: T; b: T }) => T[];
->r16arg : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>r16arg : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
 var r16arg2: new <T extends Base>(x: { a: T; b: T }) => T[];
->r16arg2 : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>r16arg2 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/subtypingWithConstructSignatures5.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures5.types
@@ -183,7 +183,7 @@ interface I extends B {
 >y : T
 
     a14: new <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : new <T, U>(x: { a: T; b: U; }) => T
+>a14 : new <T, U>(x: {    a: T;    b: U;}) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/subtypingWithConstructSignatures5.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures5.types
@@ -79,7 +79,7 @@ interface A { // T
 >x : Derived[]
 
     a11: new (x: { foo: string }, y: { foo: string; bar: string }) => Base;
->a11 : new (x: {    foo: string;}, y: {    foo: string;    bar: string;}) => Base
+>a11 : new (x: { foo: string; }, y: { foo: string; bar: string; }) => Base
 >x : { foo: string; }
 >foo : string
 >y : { foo: string; bar: string; }
@@ -97,7 +97,7 @@ interface A { // T
 >y : Derived[]
 
     a14: new (x: { a: string; b: number }) => Object;
->a14 : new (x: {    a: string;    b: number;}) => Object
+>a14 : new (x: { a: string; b: number; }) => Object
 >x : { a: string; b: number; }
 >a : string
 >b : number
@@ -154,10 +154,10 @@ interface I extends B {
 >r : T
 
     a9: new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number }) => U) => (r: T) => U; // ok, same as a8 with compatible object literal
->a9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: {    foo: string;    bing: number;}) => U) => (r: T) => U
+>a9 : new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: string; bing: number; }) => U) => (r: T) => U
 >x : (arg: T) => U
 >arg : T
->y : (arg2: {    foo: string;    bing: number;}) => U
+>y : (arg2: { foo: string; bing: number; }) => U
 >arg2 : { foo: string; bing: number; }
 >foo : string
 >bing : number
@@ -183,7 +183,7 @@ interface I extends B {
 >y : T
 
     a14: new <T, U>(x: { a: T; b: U }) => T; // ok
->a14 : new <T, U>(x: {    a: T;    b: U;}) => T
+>a14 : new <T, U>(x: { a: T; b: U; }) => T
 >x : { a: T; b: U; }
 >a : T
 >b : U

--- a/tests/baselines/reference/subtypingWithConstructSignatures6.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures6.types
@@ -54,7 +54,7 @@ interface A { // T
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
+>a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -62,13 +62,13 @@ interface A { // T
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: { a: T; b: T; }) => T[]
+>a15 : new <T>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
+>a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -109,7 +109,7 @@ interface I5<T> extends A {
 
 interface I7<T> extends A {
     a11: new <U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->a11 : new <U>(x: {    foo: T;}, y: { foo: U; bar: U; }) => Base
+>a11 : new <U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }

--- a/tests/baselines/reference/subtypingWithConstructSignatures6.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures6.types
@@ -54,7 +54,7 @@ interface A { // T
 >arg : T
 
     a11: new <T>(x: { foo: T }, y: { foo: T; bar: T }) => Base;
->a11 : new <T>(x: {    foo: T;}, y: {    foo: T;    bar: T;}) => Base
+>a11 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: T; bar: T; }
@@ -62,13 +62,13 @@ interface A { // T
 >bar : T
 
     a15: new <T>(x: { a: T; b: T }) => T[];
->a15 : new <T>(x: {    a: T;    b: T;}) => T[]
+>a15 : new <T>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
 
     a16: new <T extends Base>(x: { a: T; b: T }) => T[];
->a16 : new <T extends Base>(x: {    a: T;    b: T;}) => T[]
+>a16 : new <T extends Base>(x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T
@@ -109,7 +109,7 @@ interface I5<T> extends A {
 
 interface I7<T> extends A {
     a11: new <U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
->a11 : new <U>(x: {    foo: T;}, y: {    foo: U;    bar: U;}) => Base
+>a11 : new <U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >x : { foo: T; }
 >foo : T
 >y : { foo: U; bar: U; }
@@ -119,7 +119,7 @@ interface I7<T> extends A {
 
 interface I9<T> extends A {
     a16: new (x: { a: T; b: T }) => T[]; 
->a16 : new (x: {    a: T;    b: T;}) => T[]
+>a16 : new (x: { a: T; b: T; }) => T[]
 >x : { a: T; b: T; }
 >a : T
 >b : T

--- a/tests/baselines/reference/switchCaseCircularRefeference.types
+++ b/tests/baselines/reference/switchCaseCircularRefeference.types
@@ -4,7 +4,7 @@
 // Repro from #9507
 
 function f(x: {a: "A", b} | {a: "C", e}) {
->f : (x: {    a: "A";    b;} | {    a: "C";    e;}) => void
+>f : (x: { a: "A"; b; } | { a: "C"; e; }) => void
 >x : { a: "A"; b: any; } | { a: "C"; e: any; }
 >a : "A"
 >b : any

--- a/tests/baselines/reference/symbolProperty21.types
+++ b/tests/baselines/reference/symbolProperty21.types
@@ -16,7 +16,7 @@ interface I<T, U> {
 }
 
 declare function foo<T, U>(p: I<T, U>): { t: T; u: U };
->foo : <T, U>(p: I<T, U>) => {    t: T;    u: U;}
+>foo : <T, U>(p: I<T, U>) => { t: T; u: U; }
 >p : I<T, U>
 >t : T
 >u : U

--- a/tests/baselines/reference/symbolProperty35.types
+++ b/tests/baselines/reference/symbolProperty35.types
@@ -3,7 +3,7 @@
 === symbolProperty35.ts ===
 interface I1 {
     [Symbol.toStringTag](): { x: string }
->[Symbol.toStringTag] : () => {    x: string;}
+>[Symbol.toStringTag] : () => { x: string; }
 >Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
 >toStringTag : unique symbol
@@ -11,7 +11,7 @@ interface I1 {
 }
 interface I2 {
     [Symbol.toStringTag](): { x: number }
->[Symbol.toStringTag] : () => {    x: number;}
+>[Symbol.toStringTag] : () => { x: number; }
 >Symbol.toStringTag : unique symbol
 >Symbol : SymbolConstructor
 >toStringTag : unique symbol

--- a/tests/baselines/reference/symbolProperty41.types
+++ b/tests/baselines/reference/symbolProperty41.types
@@ -5,7 +5,7 @@ class C {
 >C : C
 
     [Symbol.iterator](x: string): { x: string };
->[Symbol.iterator] : { (x: string): {    x: string;}; (x: "hello"): { x: string; hello: string; }; }
+>[Symbol.iterator] : { (x: string): { x: string; }; (x: "hello"): { x: string; hello: string; }; }
 >Symbol.iterator : unique symbol
 >Symbol : SymbolConstructor
 >iterator : unique symbol
@@ -13,7 +13,7 @@ class C {
 >x : string
 
     [Symbol.iterator](x: "hello"): { x: string; hello: string };
->[Symbol.iterator] : { (x: string): { x: string; }; (x: "hello"): {    x: string;    hello: string;}; }
+>[Symbol.iterator] : { (x: string): { x: string; }; (x: "hello"): { x: string; hello: string; }; }
 >Symbol.iterator : unique symbol
 >Symbol : SymbolConstructor
 >iterator : unique symbol

--- a/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressions.types
+++ b/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressions.types
@@ -7,7 +7,7 @@ interface I {
 >subs : number[]
 
     member: {
->member : new (s: string) => new (n: number) => {    new (): boolean;}
+>member : new (s: string) => new (n: number) => { new (): boolean; }
 
         new (s: string): {
 >s : string

--- a/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressionsES6.types
+++ b/tests/baselines/reference/taggedTemplateStringsWithManyCallAndMemberExpressionsES6.types
@@ -7,7 +7,7 @@ interface I {
 >subs : number[]
 
     member: {
->member : new (s: string) => new (n: number) => {    new (): boolean;}
+>member : new (s: string) => new (n: number) => { new (): boolean; }
 
         new (s: string): {
 >s : string

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments1.types
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments1.types
@@ -97,10 +97,10 @@ export const b = g<Stuff, number, string, boolean> `
 `;
 
 declare let obj: {
->obj : { prop: <T>(strs: TemplateStringsArray, x: (input: T) => T) => { returnedObjProp: T; }; }
+>obj : { prop: <T>(strs: TemplateStringsArray, x: (input: T) => T) => {    returnedObjProp: T;}; }
 
     prop: <T>(strs: TemplateStringsArray, x: (input: T) => T) => {
->prop : <T>(strs: TemplateStringsArray, x: (input: T) => T) => { returnedObjProp: T; }
+>prop : <T>(strs: TemplateStringsArray, x: (input: T) => T) => {    returnedObjProp: T;}
 >strs : TemplateStringsArray
 >x : (input: T) => T
 >input : T

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments1.types
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments1.types
@@ -97,10 +97,10 @@ export const b = g<Stuff, number, string, boolean> `
 `;
 
 declare let obj: {
->obj : { prop: <T>(strs: TemplateStringsArray, x: (input: T) => T) => {    returnedObjProp: T;}; }
+>obj : { prop: <T>(strs: TemplateStringsArray, x: (input: T) => T) => { returnedObjProp: T; }; }
 
     prop: <T>(strs: TemplateStringsArray, x: (input: T) => T) => {
->prop : <T>(strs: TemplateStringsArray, x: (input: T) => T) => {    returnedObjProp: T;}
+>prop : <T>(strs: TemplateStringsArray, x: (input: T) => T) => { returnedObjProp: T; }
 >strs : TemplateStringsArray
 >x : (input: T) => T
 >input : T

--- a/tests/baselines/reference/targetTypeCastTest.types
+++ b/tests/baselines/reference/targetTypeCastTest.types
@@ -2,7 +2,7 @@
 
 === targetTypeCastTest.ts ===
 declare var Point: { new(x:number, y:number): {x: number; y: number; }; }
->Point : new (x: number, y: number) => {    x: number;    y: number;}
+>Point : new (x: number, y: number) => { x: number; y: number; }
 >x : number
 >y : number
 >x : number

--- a/tests/baselines/reference/targetTypeVoidFunc.types
+++ b/tests/baselines/reference/targetTypeVoidFunc.types
@@ -2,7 +2,7 @@
 
 === targetTypeVoidFunc.ts ===
 function f1(): { new (): number; } {
->f1 : () => {    new (): number;}
+>f1 : () => { new (): number; }
 
     return function () { return; }
 >function () { return; } : () => void

--- a/tests/baselines/reference/templateLiteralTypes3.types
+++ b/tests/baselines/reference/templateLiteralTypes3.types
@@ -384,8 +384,8 @@ interface ITest<P extends Prefixes, E extends AllPrefixData = PrefixData<P>> {
 // Repro from #45906
 
 type Schema = { a: { b: { c: number } } };
->Schema : { a: {    b: {        c: number;    };}; }
->a : { b: {    c: number;}; }
+>Schema : { a: { b: { c: number; }; }; }
+>a : { b: { c: number; }; }
 >b : { c: number; }
 >c : number
 

--- a/tests/baselines/reference/templateLiteralTypes4.types
+++ b/tests/baselines/reference/templateLiteralTypes4.types
@@ -468,12 +468,12 @@ type TypedObjectOrdinalMembers<TDef extends readonly FieldDefinition[]> = {
 interface TypedObjectMembers<TDef extends readonly FieldDefinition[]> {
     // get/set a field by name
     get<K extends TDef[number]["name"]>(key: K): FieldType<Extract<TDef[number], { readonly name: K }>["type"]>;
->get : <K extends TDef[number]["name"]>(key: K) => FieldType<Extract<TDef[number], {    readonly name: K;}>["type"]>
+>get : <K extends TDef[number]["name"]>(key: K) => FieldType<Extract<TDef[number], { readonly name: K; }>["type"]>
 >key : K
 >name : K
 
     set<K extends TDef[number]["name"]>(key: K, value: FieldType<Extract<TDef[number], { readonly name: K }>["type"]>): void;
->set : <K extends TDef[number]["name"]>(key: K, value: FieldType<Extract<TDef[number], {    readonly name: K;}>["type"]>) => void
+>set : <K extends TDef[number]["name"]>(key: K, value: FieldType<Extract<TDef[number], { readonly name: K; }>["type"]>) => void
 >key : K
 >value : FieldType<Extract<TDef[number], { readonly name: K; }>["type"]>
 >name : K

--- a/tests/baselines/reference/thisInTypeQuery.types
+++ b/tests/baselines/reference/thisInTypeQuery.types
@@ -34,8 +34,8 @@ class MyClass {
 >runTypeFails : () => void
 
         const params = null as any as { a: { key: string } } | null;
->params : { a: {    key: string;}; } | null
->null as any as { a: { key: string } } | null : { a: {    key: string;}; } | null
+>params : { a: { key: string; }; } | null
+>null as any as { a: { key: string } } | null : { a: { key: string; }; } | null
 >null as any : any
 >a : { key: string; }
 >key : string

--- a/tests/baselines/reference/thisTypeInFunctions.types
+++ b/tests/baselines/reference/thisTypeInFunctions.types
@@ -39,7 +39,7 @@ class C {
 >m : number
     }
     explicitProperty(this: {n: number}, m: number): number {
->explicitProperty : (this: {    n: number;}, m: number) => number
+>explicitProperty : (this: { n: number; }, m: number) => number
 >this : { n: number; }
 >n : number
 >m : number
@@ -79,7 +79,7 @@ interface I {
 >this : void
 
     explicitStructural(this: {a: number}): number;
->explicitStructural : (this: {    a: number;}) => number
+>explicitStructural : (this: { a: number; }) => number
 >this : { a: number; }
 >a : number
 
@@ -92,7 +92,7 @@ interface I {
 >this : this
 }
 function explicitStructural(this: { y: number }, x: number): number {
->explicitStructural : (this: {    y: number;}, x: number) => number
+>explicitStructural : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -105,7 +105,7 @@ function explicitStructural(this: { y: number }, x: number): number {
 >y : number
 }
 function justThis(this: { y: number }): number {
->justThis : (this: {    y: number;}) => number
+>justThis : (this: { y: number; }) => number
 >this : { y: number; }
 >y : number
 
@@ -238,9 +238,9 @@ impl.explicitThis = function () { return this.a; };
 
 // parameter checking
 let ok: {y: number, f: (this: { y: number }, x: number) => number} = { y: 12, f: explicitStructural };
->ok : { y: number; f: (this: {    y: number;}, x: number) => number; }
+>ok : { y: number; f: (this: { y: number; }, x: number) => number; }
 >y : number
->f : (this: {    y: number;}, x: number) => number
+>f : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -339,7 +339,7 @@ d.explicitThis(12);
 >12 : 12
 
 let reconstructed: { 
->reconstructed : { n: number; explicitThis(this: C, m: number): number; explicitC(this: C, m: number): number; explicitProperty: (this: {    n: number;}, m: number) => number; explicitVoid(this: void, m: number): number; }
+>reconstructed : { n: number; explicitThis(this: C, m: number): number; explicitC(this: C, m: number): number; explicitProperty: (this: { n: number; }, m: number) => number; explicitVoid(this: void, m: number): number; }
 
     n: number,
 >n : number
@@ -355,7 +355,7 @@ let reconstructed: {
 >m : number
 
     explicitProperty: (this: {n : number}, m: number) => number,
->explicitProperty : (this: {    n: number;}, m: number) => number
+>explicitProperty : (this: { n: number; }, m: number) => number
 >this : { n: number; }
 >n : number
 >m : number
@@ -424,11 +424,11 @@ explicitVoid(12);
 
 // assignment checking
 let unboundToSpecified: (this: { y: number }, x: number) => number = x => x + this.y; // ok, this:any
->unboundToSpecified : (this: {    y: number;}, x: number) => number
+>unboundToSpecified : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
->x => x + this.y : (this: {    y: number;}, x: number) => any
+>x => x + this.y : (this: { y: number; }, x: number) => any
 >x : number
 >x + this.y : any
 >x : number
@@ -437,18 +437,18 @@ let unboundToSpecified: (this: { y: number }, x: number) => number = x => x + th
 >y : any
 
 let specifiedToSpecified: (this: {y: number}, x: number) => number = explicitStructural;
->specifiedToSpecified : (this: {    y: number;}, x: number) => number
+>specifiedToSpecified : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
 >explicitStructural : (this: { y: number; }, x: number) => number
 
 let anyToSpecified: (this: { y: number }, x: number) => number = function(x: number): number { return x + 12; };
->anyToSpecified : (this: {    y: number;}, x: number) => number
+>anyToSpecified : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
->function(x: number): number { return x + 12; } : (this: {    y: number;}, x: number) => number
+>function(x: number): number { return x + 12; } : (this: { y: number; }, x: number) => number
 >x : number
 >x + 12 : number
 >x : number
@@ -474,14 +474,14 @@ let specifiedLambda: (this: void, x: number) => number = x => x + 12;
 >12 : 12
 
 let unspecifiedLambdaToSpecified: (this: {y: number}, x: number) => number = unspecifiedLambda;
->unspecifiedLambdaToSpecified : (this: {    y: number;}, x: number) => number
+>unspecifiedLambdaToSpecified : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
 >unspecifiedLambda : (x: number) => number
 
 let specifiedLambdaToSpecified: (this: {y: number}, x: number) => number = specifiedLambda;
->specifiedLambdaToSpecified : (this: {    y: number;}, x: number) => number
+>specifiedLambdaToSpecified : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -494,7 +494,7 @@ let explicitCFunction: (this: C, m: number) => number;
 >m : number
 
 let explicitPropertyFunction: (this: {n: number}, m: number) => number;
->explicitPropertyFunction : (this: {    n: number;}, m: number) => number
+>explicitPropertyFunction : (this: { n: number; }, m: number) => number
 >this : { n: number; }
 >n : number
 >m : number
@@ -528,11 +528,11 @@ c.explicitProperty = explicitPropertyFunction;
 >explicitPropertyFunction : (this: { n: number; }, m: number) => number
 
 c.explicitProperty = function(this: {n: number}, m: number) { return this.n + m };
->c.explicitProperty = function(this: {n: number}, m: number) { return this.n + m } : (this: {    n: number;}, m: number) => number
+>c.explicitProperty = function(this: {n: number}, m: number) { return this.n + m } : (this: { n: number; }, m: number) => number
 >c.explicitProperty : (this: { n: number; }, m: number) => number
 >c : C
 >explicitProperty : (this: { n: number; }, m: number) => number
->function(this: {n: number}, m: number) { return this.n + m } : (this: {    n: number;}, m: number) => number
+>function(this: {n: number}, m: number) { return this.n + m } : (this: { n: number; }, m: number) => number
 >this : { n: number; }
 >n : number
 >m : number
@@ -876,7 +876,7 @@ function InterfaceThis(this: I) {
 >12 : 12
 }
 function LiteralTypeThis(this: {x: string}) {
->LiteralTypeThis : (this: {    x: string;}) => void
+>LiteralTypeThis : (this: { x: string; }) => void
 >this : { x: string; }
 >x : string
 

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.types
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.types
@@ -43,7 +43,7 @@ class C {
 >m : number
     }
     explicitProperty(this: {n: number}, m: number): number {
->explicitProperty : (this: {    n: number;}, m: number) => number
+>explicitProperty : (this: { n: number; }, m: number) => number
 >this : { n: number; }
 >n : number
 >m : number
@@ -112,7 +112,7 @@ interface I {
 >this : void
 
     explicitStructural(this: {a: number}): number;
->explicitStructural : (this: {    a: number;}) => number
+>explicitStructural : (this: { a: number; }) => number
 >this : { a: number; }
 >a : number
 
@@ -189,7 +189,7 @@ implExplicitInterface(); // error, no 'a' in 'void'
 >implExplicitInterface : (this: I) => number
 
 function explicitStructural(this: { y: number }, x: number): number {
->explicitStructural : (this: {    y: number;}, x: number) => number
+>explicitStructural : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -202,7 +202,7 @@ function explicitStructural(this: { y: number }, x: number): number {
 >y : number
 }
 function propertyName(this: { y: number }, x: number): number {
->propertyName : (this: {    y: number;}, x: number) => number
+>propertyName : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -227,9 +227,9 @@ function voidThisSpecified(this: void, x: number): number {
 >notSpecified : any
 }
 let ok: {y: number, f: (this: { y: number }, x: number) => number} = { y: 12, explicitStructural };
->ok : { y: number; f: (this: {    y: number;}, x: number) => number; }
+>ok : { y: number; f: (this: { y: number; }, x: number) => number; }
 >y : number
->f : (this: {    y: number;}, x: number) => number
+>f : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -239,9 +239,9 @@ let ok: {y: number, f: (this: { y: number }, x: number) => number} = { y: 12, ex
 >explicitStructural : (this: { y: number; }, x: number) => number
 
 let wrongPropertyType: {y: string, f: (this: { y: number }, x: number) => number} = { y: 'foo', explicitStructural };
->wrongPropertyType : { y: string; f: (this: {    y: number;}, x: number) => number; }
+>wrongPropertyType : { y: string; f: (this: { y: number; }, x: number) => number; }
 >y : string
->f : (this: {    y: number;}, x: number) => number
+>f : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -251,9 +251,9 @@ let wrongPropertyType: {y: string, f: (this: { y: number }, x: number) => number
 >explicitStructural : (this: { y: number; }, x: number) => number
 
 let wrongPropertyName: {wrongName: number, f: (this: { y: number }, x: number) => number} = { wrongName: 12, explicitStructural };
->wrongPropertyName : { wrongName: number; f: (this: {    y: number;}, x: number) => number; }
+>wrongPropertyName : { wrongName: number; f: (this: { y: number; }, x: number) => number; }
 >wrongName : number
->f : (this: {    y: number;}, x: number) => number
+>f : (this: { y: number; }, x: number) => number
 >this : { y: number; }
 >y : number
 >x : number
@@ -394,7 +394,7 @@ let specifiedToVoid: (this: void, x: number) => number = explicitStructural;
 >explicitStructural : (this: { y: number; }, x: number) => number
 
 let reconstructed: { 
->reconstructed : { n: number; explicitThis(this: C, m: number): number; explicitC(this: C, m: number): number; explicitProperty: (this: {    n: number;}, m: number) => number; explicitVoid(this: void, m: number): number; }
+>reconstructed : { n: number; explicitThis(this: C, m: number): number; explicitC(this: C, m: number): number; explicitProperty: (this: { n: number; }, m: number) => number; explicitVoid(this: void, m: number): number; }
 
     n: number,
 >n : number
@@ -410,7 +410,7 @@ let reconstructed: {
 >m : number
 
     explicitProperty: (this: {n : number}, m: number) => number,
->explicitProperty : (this: {    n: number;}, m: number) => number
+>explicitProperty : (this: { n: number; }, m: number) => number
 >this : { n: number; }
 >n : number
 >m : number
@@ -460,7 +460,7 @@ let d = new D();
 >D : typeof D
 
 let explicitXProperty: (this: { x: number }, m: number) => number;
->explicitXProperty : (this: {    x: number;}, m: number) => number
+>explicitXProperty : (this: { x: number; }, m: number) => number
 >this : { x: number; }
 >x : number
 >m : number
@@ -770,8 +770,8 @@ c.explicitProperty = (this, m) => m + this.n;
 >n : any
 
 const f2 = <T>(this: {n: number}, m: number) => m + this.n;
->f2 : <T>(this: {    n: number;}, m: number) => any
-><T>(this: {n: number}, m: number) => m + this.n : <T>(this: {    n: number;}, m: number) => any
+>f2 : <T>(this: { n: number; }, m: number) => any
+><T>(this: {n: number}, m: number) => m + this.n : <T>(this: { n: number; }, m: number) => any
 >this : { n: number; }
 >n : number
 >m : number
@@ -782,8 +782,8 @@ const f2 = <T>(this: {n: number}, m: number) => m + this.n;
 >n : any
 
 const f3 = async (this: {n: number}, m: number) => m + this.n;
->f3 : (this: {    n: number;}, m: number) => Promise<any>
->async (this: {n: number}, m: number) => m + this.n : (this: {    n: number;}, m: number) => Promise<any>
+>f3 : (this: { n: number; }, m: number) => Promise<any>
+>async (this: {n: number}, m: number) => m + this.n : (this: { n: number; }, m: number) => Promise<any>
 >this : { n: number; }
 >n : number
 >m : number
@@ -794,8 +794,8 @@ const f3 = async (this: {n: number}, m: number) => m + this.n;
 >n : any
 
 const f4 = async <T>(this: {n: number}, m: number) => m + this.n;
->f4 : <T>(this: {    n: number;}, m: number) => Promise<any>
->async <T>(this: {n: number}, m: number) => m + this.n : <T>(this: {    n: number;}, m: number) => Promise<any>
+>f4 : <T>(this: { n: number; }, m: number) => Promise<any>
+>async <T>(this: {n: number}, m: number) => m + this.n : <T>(this: { n: number; }, m: number) => Promise<any>
 >this : { n: number; }
 >n : number
 >m : number

--- a/tests/baselines/reference/thisTypeSyntacticContext.types
+++ b/tests/baselines/reference/thisTypeSyntacticContext.types
@@ -2,15 +2,15 @@
 
 === thisTypeSyntacticContext.ts ===
 function f(this: { n: number }) {
->f : (this: {    n: number;}) => void
+>f : (this: { n: number; }) => void
 >this : { n: number; }
 >n : number
 }
 
 const o: { n: number, test?: (this: { n: number }) => void } = { n: 1 }
->o : { n: number; test?: (this: {    n: number;}) => void; }
+>o : { n: number; test?: (this: { n: number; }) => void; }
 >n : number
->test : (this: {    n: number;}) => void
+>test : (this: { n: number; }) => void
 >this : { n: number; }
 >n : number
 >{ n: 1 } : { n: number; }

--- a/tests/baselines/reference/tslibReExportHelpers2.types
+++ b/tests/baselines/reference/tslibReExportHelpers2.types
@@ -19,7 +19,7 @@ export declare function __classPrivateFieldGet<T extends object, V>(
 
 ): V;
 export declare function __classPrivateFieldGet<T extends new (...args: any[]) => unknown, V>(
->__classPrivateFieldGet : { <T extends object, V>(receiver: T, state: { has(o: T): boolean; get(o: T): V; }, kind?: "f"): V; <T extends new (...args: any[]) => unknown, V>(receiver: T, state: T, kind: "f", f: {    value: V;}): V; }
+>__classPrivateFieldGet : { <T extends object, V>(receiver: T, state: { has(o: T): boolean; get(o: T): V; }, kind?: "f"): V; <T extends new (...args: any[]) => unknown, V>(receiver: T, state: T, kind: "f", f: { value: V; }): V; }
 >args : any[]
 
   receiver: T,

--- a/tests/baselines/reference/tsxAttributeQuickinfoTypesSameAsObjectLiteral.types
+++ b/tests/baselines/reference/tsxAttributeQuickinfoTypesSameAsObjectLiteral.types
@@ -13,8 +13,8 @@ namespace JSX {
 }
 
 const Foo = (props: { foo: "A" | "B" | "C" }) => <span>{props.foo}</span>;
->Foo : (props: {    foo: "A" | "B" | "C";}) => JSX.Element
->(props: { foo: "A" | "B" | "C" }) => <span>{props.foo}</span> : (props: {    foo: "A" | "B" | "C";}) => JSX.Element
+>Foo : (props: { foo: "A" | "B" | "C"; }) => JSX.Element
+>(props: { foo: "A" | "B" | "C" }) => <span>{props.foo}</span> : (props: { foo: "A" | "B" | "C"; }) => JSX.Element
 >props : { foo: "A" | "B" | "C"; }
 >foo : "A" | "B" | "C"
 ><span>{props.foo}</span> : JSX.Element

--- a/tests/baselines/reference/tsxSfcReturnNull.types
+++ b/tests/baselines/reference/tsxSfcReturnNull.types
@@ -10,7 +10,7 @@ const Foo = (props: any) => null;
 >props : any
 
 function Greet(x: {name?: string}) {
->Greet : (x: {    name?: string;}) => any
+>Greet : (x: { name?: string; }) => any
 >x : { name?: string; }
 >name : string
 

--- a/tests/baselines/reference/tsxSfcReturnNullStrictNullChecks.types
+++ b/tests/baselines/reference/tsxSfcReturnNullStrictNullChecks.types
@@ -10,7 +10,7 @@ const Foo = (props: any) => null;
 >props : any
 
 function Greet(x: {name?: string}) {
->Greet : (x: {    name?: string;}) => null
+>Greet : (x: { name?: string; }) => null
 >x : { name?: string | undefined; }
 >name : string | undefined
 

--- a/tests/baselines/reference/tsxSfcReturnUndefinedStrictNullChecks.types
+++ b/tests/baselines/reference/tsxSfcReturnUndefinedStrictNullChecks.types
@@ -11,7 +11,7 @@ const Foo = (props: any) => undefined;
 >undefined : undefined
 
 function Greet(x: {name?: string}) {
->Greet : (x: {    name?: string;}) => undefined
+>Greet : (x: { name?: string; }) => undefined
 >x : { name?: string | undefined; }
 >name : string | undefined
 

--- a/tests/baselines/reference/tsxSpreadChildren.types
+++ b/tests/baselines/reference/tsxSpreadChildren.types
@@ -23,7 +23,7 @@ interface TodoListProps {
 >todos : TodoProp[]
 }
 function Todo(prop: { key: number, todo: string }) {
->Todo : (prop: {    key: number;    todo: string;}) => JSX.Element
+>Todo : (prop: { key: number; todo: string; }) => JSX.Element
 >prop : { key: number; todo: string; }
 >key : number
 >todo : string

--- a/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react,target=es2015).types
+++ b/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react,target=es2015).types
@@ -23,7 +23,7 @@ interface TodoListProps {
 >todos : TodoProp[]
 }
 function Todo(prop: { key: number, todo: string }) {
->Todo : (prop: {    key: number;    todo: string;}) => JSX.Element
+>Todo : (prop: { key: number; todo: string; }) => JSX.Element
 >prop : { key: number; todo: string; }
 >key : number
 >todo : string

--- a/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react,target=es5).types
+++ b/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react,target=es5).types
@@ -23,7 +23,7 @@ interface TodoListProps {
 >todos : TodoProp[]
 }
 function Todo(prop: { key: number, todo: string }) {
->Todo : (prop: {    key: number;    todo: string;}) => JSX.Element
+>Todo : (prop: { key: number; todo: string; }) => JSX.Element
 >prop : { key: number; todo: string; }
 >key : number
 >todo : string

--- a/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react-jsx,target=es2015).types
+++ b/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react-jsx,target=es2015).types
@@ -23,7 +23,7 @@ interface TodoListProps {
 >todos : TodoProp[]
 }
 function Todo(prop: { key: number, todo: string }) {
->Todo : (prop: {    key: number;    todo: string;}) => any
+>Todo : (prop: { key: number; todo: string; }) => any
 >prop : { key: number; todo: string; }
 >key : number
 >todo : string

--- a/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react-jsx,target=es5).types
+++ b/tests/baselines/reference/tsxSpreadChildrenInvalidType(jsx=react-jsx,target=es5).types
@@ -23,7 +23,7 @@ interface TodoListProps {
 >todos : TodoProp[]
 }
 function Todo(prop: { key: number, todo: string }) {
->Todo : (prop: {    key: number;    todo: string;}) => any
+>Todo : (prop: { key: number; todo: string; }) => any
 >prop : { key: number; todo: string; }
 >key : number
 >todo : string

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload1.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload1.types
@@ -5,27 +5,27 @@ import React = require('react')
 >React : typeof React
 
 declare function OneThing(k: {yxx: string}): JSX.Element;
->OneThing : { (k: {    yxx: string;}): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
+>OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
 >k : { yxx: string; }
 >yxx : string
 >JSX : any
 
 declare function OneThing(k: {yxx1: string, children: string}): JSX.Element;
->OneThing : { (k: { yxx: string; }): JSX.Element; (k: {    yxx1: string;    children: string;}): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
+>OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
 >k : { yxx1: string; children: string; }
 >yxx1 : string
 >children : string
 >JSX : any
 
 declare function OneThing(l: {yy: number, yy1: string}): JSX.Element;
->OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: {    yy: number;    yy1: string;}): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
+>OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
 >l : { yy: number; yy1: string; }
 >yy : number
 >yy1 : string
 >JSX : any
 
 declare function OneThing(l: {yy: number, yy1: string, yy2: boolean}): JSX.Element;
->OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: {    yy: number;    yy1: string;    yy2: boolean;}): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
+>OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
 >l : { yy: number; yy1: string; yy2: boolean; }
 >yy : number
 >yy1 : string
@@ -33,7 +33,7 @@ declare function OneThing(l: {yy: number, yy1: string, yy2: boolean}): JSX.Eleme
 >JSX : any
 
 declare function OneThing(l1: {data: string, "data-prop": boolean}): JSX.Element;
->OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: {    data: string;    "data-prop": boolean;}): JSX.Element; }
+>OneThing : { (k: { yxx: string; }): JSX.Element; (k: { yxx1: string; children: string; }): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; (l: { yy: number; yy1: string; yy2: boolean; }): JSX.Element; (l1: { data: string; "data-prop": boolean; }): JSX.Element; }
 >l1 : { data: string; "data-prop": boolean; }
 >data : string
 >"data-prop" : boolean
@@ -83,21 +83,21 @@ declare function TestingOneThing({y1: string}): JSX.Element;
 >JSX : any
 
 declare function TestingOneThing(j: {"extra-data": string, yy?: string}): JSX.Element;
->TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: {    "extra-data": string;    yy?: string;}): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >j : { "extra-data": string; yy?: string; }
 >"extra-data" : string
 >yy : string
 >JSX : any
 
 declare function TestingOneThing(n: {yy: number, direction?: number}): JSX.Element;
->TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: {    yy: number;    direction?: number;}): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >n : { yy: number; direction?: number; }
 >yy : number
 >direction : number
 >JSX : any
 
 declare function TestingOneThing(n: {yy: string, name: string}): JSX.Element;
->TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: {    yy: string;    name: string;}): JSX.Element; }
+>TestingOneThing : { ({ y1: string }: { y1: any; }): JSX.Element; (j: { "extra-data": string; yy?: string; }): JSX.Element; (n: { yy: number; direction?: number; }): JSX.Element; (n: { yy: string; name: string; }): JSX.Element; }
 >n : { yy: string; name: string; }
 >yy : string
 >name : string
@@ -144,14 +144,14 @@ const d5 = <TestingOneThing extra-data="hello" yy="hello" name="Bob" />;
 
 
 declare function TestingOptional(a: {y1?: string, y2?: number}): JSX.Element;
->TestingOptional : { (a: {    y1?: string;    y2?: number;}): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
+>TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
 >a : { y1?: string; y2?: number; }
 >y1 : string
 >y2 : number
 >JSX : any
 
 declare function TestingOptional(a: {y1: boolean, y2?: number, y3: boolean}): JSX.Element;
->TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: {    y1: boolean;    y2?: number;    y3: boolean;}): JSX.Element; }
+>TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
 >a : { y1: boolean; y2?: number; y3: boolean; }
 >y1 : boolean
 >y2 : number

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload2.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload2.types
@@ -9,7 +9,7 @@ declare function OneThing(): JSX.Element;
 >JSX : any
 
 declare function OneThing(l: {yy: number, yy1: string}): JSX.Element;
->OneThing : { (): JSX.Element; (l: {    yy: number;    yy1: string;}): JSX.Element; }
+>OneThing : { (): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; }
 >l : { yy: number; yy1: string; }
 >yy : number
 >yy1 : string

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload3.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload3.types
@@ -10,7 +10,7 @@ declare function ZeroThingOrTwoThing(): JSX.Element;
 >JSX : any
 
 declare function ZeroThingOrTwoThing(l: {yy: number, yy1: string}, context: Context): JSX.Element;
->ZeroThingOrTwoThing : { (): JSX.Element; (l: {    yy: number;    yy1: string;}, context: Context): JSX.Element; }
+>ZeroThingOrTwoThing : { (): JSX.Element; (l: { yy: number; yy1: string; }, context: Context): JSX.Element; }
 >l : { yy: number; yy1: string; }
 >yy : number
 >yy1 : string
@@ -57,19 +57,19 @@ const two5 = <ZeroThingOrTwoThing  {...obj2} yy={1000} />;  // it is just any so
 >1000 : 1000
 
 declare function ThreeThing(l: {y1: string}): JSX.Element;
->ThreeThing : { (l: {    y1: string;}): JSX.Element; (l: { y2: string; }): JSX.Element; (l: { yy: number; yy1: string; }, context: Context, updater: any): JSX.Element; }
+>ThreeThing : { (l: { y1: string; }): JSX.Element; (l: { y2: string; }): JSX.Element; (l: { yy: number; yy1: string; }, context: Context, updater: any): JSX.Element; }
 >l : { y1: string; }
 >y1 : string
 >JSX : any
 
 declare function ThreeThing(l: {y2: string}): JSX.Element;
->ThreeThing : { (l: { y1: string; }): JSX.Element; (l: {    y2: string;}): JSX.Element; (l: { yy: number; yy1: string; }, context: Context, updater: any): JSX.Element; }
+>ThreeThing : { (l: { y1: string; }): JSX.Element; (l: { y2: string; }): JSX.Element; (l: { yy: number; yy1: string; }, context: Context, updater: any): JSX.Element; }
 >l : { y2: string; }
 >y2 : string
 >JSX : any
 
 declare function ThreeThing(l: {yy: number, yy1: string}, context: Context, updater: any): JSX.Element;
->ThreeThing : { (l: { y1: string; }): JSX.Element; (l: { y2: string; }): JSX.Element; (l: {    yy: number;    yy1: string;}, context: Context, updater: any): JSX.Element; }
+>ThreeThing : { (l: { y1: string; }): JSX.Element; (l: { y2: string; }): JSX.Element; (l: { yy: number; yy1: string; }, context: Context, updater: any): JSX.Element; }
 >l : { yy: number; yy1: string; }
 >yy : number
 >yy1 : string

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.types
@@ -9,7 +9,7 @@ declare function OneThing(): JSX.Element;
 >JSX : any
 
 declare function OneThing(l: {yy: number, yy1: string}): JSX.Element;
->OneThing : { (): JSX.Element; (l: {    yy: number;    yy1: string;}): JSX.Element; }
+>OneThing : { (): JSX.Element; (l: { yy: number; yy1: string; }): JSX.Element; }
 >l : { yy: number; yy1: string; }
 >yy : number
 >yy1 : string
@@ -94,13 +94,13 @@ const c7 = <OneThing {...obj2} yy />;  // Should error as there is extra attribu
 >yy : true
 
 declare function TestingOneThing(j: {"extra-data": string}): JSX.Element;
->TestingOneThing : { (j: {    "extra-data": string;}): JSX.Element; (n: { yy: string; direction?: number; }): JSX.Element; }
+>TestingOneThing : { (j: { "extra-data": string; }): JSX.Element; (n: { yy: string; direction?: number; }): JSX.Element; }
 >j : { "extra-data": string; }
 >"extra-data" : string
 >JSX : any
 
 declare function TestingOneThing(n: {yy: string, direction?: number}): JSX.Element;
->TestingOneThing : { (j: { "extra-data": string; }): JSX.Element; (n: {    yy: string;    direction?: number;}): JSX.Element; }
+>TestingOneThing : { (j: { "extra-data": string; }): JSX.Element; (n: { yy: string; direction?: number; }): JSX.Element; }
 >n : { yy: string; direction?: number; }
 >yy : string
 >direction : number
@@ -121,14 +121,14 @@ const d2 = <TestingOneThing yy="hello" direction="left" />
 >direction : string
 
 declare function TestingOptional(a: {y1?: string, y2?: number}): JSX.Element;
->TestingOptional : { (a: {    y1?: string;    y2?: number;}): JSX.Element; (a: { y1?: string; y2?: number; children: JSX.Element; }): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
+>TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: { y1?: string; y2?: number; children: JSX.Element; }): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
 >a : { y1?: string; y2?: number; }
 >y1 : string
 >y2 : number
 >JSX : any
 
 declare function TestingOptional(a: {y1?: string, y2?: number, children: JSX.Element}): JSX.Element;
->TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: {    y1?: string;    y2?: number;    children: JSX.Element;}): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
+>TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: { y1?: string; y2?: number; children: JSX.Element; }): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
 >a : { y1?: string; y2?: number; children: JSX.Element; }
 >y1 : string
 >y2 : number
@@ -137,7 +137,7 @@ declare function TestingOptional(a: {y1?: string, y2?: number, children: JSX.Ele
 >JSX : any
 
 declare function TestingOptional(a: {y1: boolean, y2?: number, y3: boolean}): JSX.Element;
->TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: { y1?: string; y2?: number; children: JSX.Element; }): JSX.Element; (a: {    y1: boolean;    y2?: number;    y3: boolean;}): JSX.Element; }
+>TestingOptional : { (a: { y1?: string; y2?: number; }): JSX.Element; (a: { y1?: string; y2?: number; children: JSX.Element; }): JSX.Element; (a: { y1: boolean; y2?: number; y3: boolean; }): JSX.Element; }
 >a : { y1: boolean; y2?: number; y3: boolean; }
 >y1 : boolean
 >y2 : number

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.types
@@ -11,7 +11,7 @@ function EmptyPropSFC() {
 }
 
 function Greet(x: {name: string}) {
->Greet : (x: {    name: string;}) => JSX.Element
+>Greet : (x: { name: string; }) => JSX.Element
 >x : { name: string; }
 >name : string
 
@@ -33,7 +33,7 @@ function Meet({name = 'world'}) {
 >div : any
 }
 function MeetAndGreet(k: {"prop-name": string}) {
->MeetAndGreet : (k: {    "prop-name": string;}) => JSX.Element
+>MeetAndGreet : (k: { "prop-name": string; }) => JSX.Element
 >k : { "prop-name": string; }
 >"prop-name" : string
 

--- a/tests/baselines/reference/tsxStatelessFunctionComponents2.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents2.types
@@ -5,7 +5,7 @@ import React = require('react');
 >React : typeof React
 
 function Greet(x: {name?: string}) {
->Greet : (x: {    name?: string;}) => JSX.Element
+>Greet : (x: { name?: string; }) => JSX.Element
 >x : { name?: string; }
 >name : string
 

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments1.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments1.types
@@ -5,7 +5,7 @@ import React = require('react')
 >React : typeof React
 
 declare function ComponentWithTwoAttributes<K,V>(l: {key1: K, value: V}): JSX.Element;
->ComponentWithTwoAttributes : <K, V>(l: {    key1: K;    value: V;}) => JSX.Element
+>ComponentWithTwoAttributes : <K, V>(l: { key1: K; value: V; }) => JSX.Element
 >l : { key1: K; value: V; }
 >key1 : K
 >value : V

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.types
@@ -5,14 +5,14 @@ import React = require('react')
 >React : typeof React
 
 declare function ComponentSpecific1<U>(l: {prop: U, "ignore-prop": string}): JSX.Element;
->ComponentSpecific1 : <U>(l: {    prop: U;    "ignore-prop": string;}) => JSX.Element
+>ComponentSpecific1 : <U>(l: { prop: U; "ignore-prop": string; }) => JSX.Element
 >l : { prop: U; "ignore-prop": string; }
 >prop : U
 >"ignore-prop" : string
 >JSX : any
 
 declare function ComponentSpecific2<U>(l: {prop: U}): JSX.Element;
->ComponentSpecific2 : <U>(l: {    prop: U;}) => JSX.Element
+>ComponentSpecific2 : <U>(l: { prop: U; }) => JSX.Element
 >l : { prop: U; }
 >prop : U
 >JSX : any

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments3.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments3.types
@@ -9,7 +9,7 @@ declare function OverloadComponent<U>(): JSX.Element;
 >JSX : any
 
 declare function OverloadComponent<U>(attr: {b: U, a?: string, "ignore-prop": boolean}): JSX.Element;
->OverloadComponent : { <U>(): JSX.Element; <U>(attr: {    b: U;    a?: string;    "ignore-prop": boolean;}): JSX.Element; <T, U>(attr: { b: U; a: T; }): JSX.Element; }
+>OverloadComponent : { <U>(): JSX.Element; <U>(attr: { b: U; a?: string; "ignore-prop": boolean; }): JSX.Element; <T, U>(attr: { b: U; a: T; }): JSX.Element; }
 >attr : { b: U; a?: string; "ignore-prop": boolean; }
 >b : U
 >a : string
@@ -17,7 +17,7 @@ declare function OverloadComponent<U>(attr: {b: U, a?: string, "ignore-prop": bo
 >JSX : any
 
 declare function OverloadComponent<T, U>(attr: {b: U, a: T}): JSX.Element;
->OverloadComponent : { <U>(): JSX.Element; <U>(attr: { b: U; a?: string; "ignore-prop": boolean; }): JSX.Element; <T, U>(attr: {    b: U;    a: T;}): JSX.Element; }
+>OverloadComponent : { <U>(): JSX.Element; <U>(attr: { b: U; a?: string; "ignore-prop": boolean; }): JSX.Element; <T, U>(attr: { b: U; a: T; }): JSX.Element; }
 >attr : { b: U; a: T; }
 >b : U
 >a : T

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.types
@@ -9,7 +9,7 @@ declare function OverloadComponent<U>(): JSX.Element;
 >JSX : any
 
 declare function OverloadComponent<U>(attr: {b: U, a: string, "ignore-prop": boolean}): JSX.Element;
->OverloadComponent : { <U>(): JSX.Element; <U>(attr: {    b: U;    a: string;    "ignore-prop": boolean;}): JSX.Element; <T, U>(attr: { b: U; a: T; }): JSX.Element; }
+>OverloadComponent : { <U>(): JSX.Element; <U>(attr: { b: U; a: string; "ignore-prop": boolean; }): JSX.Element; <T, U>(attr: { b: U; a: T; }): JSX.Element; }
 >attr : { b: U; a: string; "ignore-prop": boolean; }
 >b : U
 >a : string
@@ -17,7 +17,7 @@ declare function OverloadComponent<U>(attr: {b: U, a: string, "ignore-prop": boo
 >JSX : any
 
 declare function OverloadComponent<T, U>(attr: {b: U, a: T}): JSX.Element;
->OverloadComponent : { <U>(): JSX.Element; <U>(attr: { b: U; a: string; "ignore-prop": boolean; }): JSX.Element; <T, U>(attr: {    b: U;    a: T;}): JSX.Element; }
+>OverloadComponent : { <U>(): JSX.Element; <U>(attr: { b: U; a: string; "ignore-prop": boolean; }): JSX.Element; <T, U>(attr: { b: U; a: T; }): JSX.Element; }
 >attr : { b: U; a: T; }
 >b : U
 >a : T

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments5.types
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments5.types
@@ -29,13 +29,13 @@ function createComponent<T extends { prop: number }>(arg: T) {
 }
 
 declare function ComponentSpecific<U>(l: { prop: U }): JSX.Element;
->ComponentSpecific : <U>(l: {    prop: U;}) => JSX.Element
+>ComponentSpecific : <U>(l: { prop: U; }) => JSX.Element
 >l : { prop: U; }
 >prop : U
 >JSX : any
 
 declare function ComponentSpecific1<U>(l: { prop: U, "ignore-prop": number }): JSX.Element;
->ComponentSpecific1 : <U>(l: {    prop: U;    "ignore-prop": number;}) => JSX.Element
+>ComponentSpecific1 : <U>(l: { prop: U; "ignore-prop": number; }) => JSX.Element
 >l : { prop: U; "ignore-prop": number; }
 >prop : U
 >"ignore-prop" : number

--- a/tests/baselines/reference/tsxTypeErrors.types
+++ b/tests/baselines/reference/tsxTypeErrors.types
@@ -41,7 +41,7 @@ class MyClass {
 >MyClass : MyClass
 
   props: {
->props : { pt?: {    x: number;    y: number;}; name?: string; reqd: boolean; }
+>props : { pt?: { x: number; y: number; }; name?: string; reqd: boolean; }
 
     pt?: { x: number; y: number; };
 >pt : { x: number; y: number; }

--- a/tests/baselines/reference/tsxUnionElementType1.types
+++ b/tests/baselines/reference/tsxUnionElementType1.types
@@ -5,7 +5,7 @@ import React = require('react');
 >React : typeof React
 
 function SFC1(prop: { x: number }) {
->SFC1 : (prop: {    x: number;}) => JSX.Element
+>SFC1 : (prop: { x: number; }) => JSX.Element
 >prop : { x: number; }
 >x : number
 
@@ -17,7 +17,7 @@ function SFC1(prop: { x: number }) {
 };
 
 function SFC2(prop: { x: boolean }) {
->SFC2 : (prop: {    x: boolean;}) => JSX.Element
+>SFC2 : (prop: { x: boolean; }) => JSX.Element
 >prop : { x: boolean; }
 >x : boolean
 

--- a/tests/baselines/reference/tsxUnionElementType2.types
+++ b/tests/baselines/reference/tsxUnionElementType2.types
@@ -5,7 +5,7 @@ import React = require('react');
 >React : typeof React
 
 function SFC1(prop: { x: number }) {
->SFC1 : (prop: {    x: number;}) => JSX.Element
+>SFC1 : (prop: { x: number; }) => JSX.Element
 >prop : { x: number; }
 >x : number
 
@@ -17,7 +17,7 @@ function SFC1(prop: { x: number }) {
 };
 
 function SFC2(prop: { x: boolean }) {
->SFC2 : (prop: {    x: boolean;}) => JSX.Element
+>SFC2 : (prop: { x: boolean; }) => JSX.Element
 >prop : { x: boolean; }
 >x : boolean
 

--- a/tests/baselines/reference/tsxUnionElementType5.types
+++ b/tests/baselines/reference/tsxUnionElementType5.types
@@ -23,7 +23,7 @@ function EmptySFC2() {
 }
 
 function SFC2(prop: { x: boolean }) {
->SFC2 : (prop: {    x: boolean;}) => JSX.Element
+>SFC2 : (prop: { x: boolean; }) => JSX.Element
 >prop : { x: boolean; }
 >x : boolean
 

--- a/tests/baselines/reference/tsxUnionElementType6.types
+++ b/tests/baselines/reference/tsxUnionElementType6.types
@@ -23,7 +23,7 @@ function EmptySFC2() {
 }
 
 function SFC2(prop: { x: boolean }) {
->SFC2 : (prop: {    x: boolean;}) => JSX.Element
+>SFC2 : (prop: { x: boolean; }) => JSX.Element
 >prop : { x: boolean; }
 >x : boolean
 

--- a/tests/baselines/reference/tsxUnionMemberChecksFilterDataProps.types
+++ b/tests/baselines/reference/tsxUnionMemberChecksFilterDataProps.types
@@ -7,13 +7,13 @@ import React, { ReactElement } from "react";
 >ReactElement : any
 
 declare function NotHappy(props: ({ fixed?: boolean } | { value?: number })): ReactElement<any>;
->NotHappy : (props: ({    fixed?: boolean;} | {    value?: number;})) => ReactElement<any>
+>NotHappy : (props: ({ fixed?: boolean; } | { value?: number; })) => ReactElement<any>
 >props : { fixed?: boolean; } | { value?: number; }
 >fixed : boolean
 >value : number
 
 declare function Happy(props: { fixed?: boolean, value?: number }): ReactElement<any>;
->Happy : (props: {    fixed?: boolean;    value?: number;}) => ReactElement<any>
+>Happy : (props: { fixed?: boolean; value?: number; }) => ReactElement<any>
 >props : { fixed?: boolean; value?: number; }
 >fixed : boolean
 >value : number

--- a/tests/baselines/reference/typeArgInference.types
+++ b/tests/baselines/reference/typeArgInference.types
@@ -3,7 +3,7 @@
 === typeArgInference.ts ===
 interface I {
     f<T, U>(a1: { a: T; b: U }[], a2: { a: T; b: U }[]): { c: T; d: U };
->f : <T, U>(a1: {    a: T;    b: U;}[], a2: {    a: T;    b: U;}[]) => {    c: T;    d: U;}
+>f : <T, U>(a1: { a: T; b: U; }[], a2: { a: T; b: U; }[]) => { c: T; d: U; }
 >a1 : { a: T; b: U; }[]
 >a : T
 >b : U
@@ -14,7 +14,7 @@ interface I {
 >d : U
 
     g<T, U>(...arg: { a: T; b: U }[][]): { c: T; d: U };
->g : <T, U>(...arg: {    a: T;    b: U;}[][]) => {    c: T;    d: U;}
+>g : <T, U>(...arg: { a: T; b: U; }[][]) => { c: T; d: U; }
 >arg : { a: T; b: U; }[][]
 >a : T
 >b : U

--- a/tests/baselines/reference/typeArgumentInferenceOrdering.types
+++ b/tests/baselines/reference/typeArgumentInferenceOrdering.types
@@ -19,7 +19,7 @@ interface Goo {
 }
 
 function foo<T>(f: { y: T }): T { return null }
->foo : <T>(f: {    y: T;}) => T
+>foo : <T>(f: { y: T; }) => T
 >f : { y: T; }
 >y : T
 

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty1.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty1.types
@@ -34,10 +34,10 @@ interface Square {
 
 interface Subshape {
     "0": {
->"0" : { sub: {    under: {        shape: Shape;    };}; }
+>"0" : { sub: { under: { shape: Shape; }; }; }
 
         sub: {
->sub : { under: {    shape: Shape;}; }
+>sub : { under: { shape: Shape; }; }
 
             under: {
 >under : { shape: Shape; }

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty5.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty5.types
@@ -31,7 +31,7 @@ if (a[aIndex] && a[aIndex].x) {
 }
 
 const b: { key: { x?: number } } = { key: {} };
->b : { key: {    x?: number;}; }
+>b : { key: { x?: number; }; }
 >key : { x?: number | undefined; }
 >x : number | undefined
 >{ key: {} } : { key: {}; }

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty6.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty6.types
@@ -33,7 +33,7 @@ declare const bIndex: "key";
 >bIndex : "key"
 
 const b: { key: { x?: number } } = { key: {} };
->b : { key: {    x?: number;}; }
+>b : { key: { x?: number; }; }
 >key : { x?: number | undefined; }
 >x : number | undefined
 >{ key: {} } : { key: {}; }

--- a/tests/baselines/reference/typeGuardOfFormTypeOfFunction.types
+++ b/tests/baselines/reference/typeGuardOfFormTypeOfFunction.types
@@ -62,7 +62,7 @@ function f4<T>(x: T) {
 }
 
 function f5(x: { s: string }) {
->f5 : (x: {    s: string;}) => void
+>f5 : (x: { s: string; }) => void
 >x : { s: string; }
 >s : string
 
@@ -112,7 +112,7 @@ function f10(x: string | (() => string)) {
 }
 
 function f11(x: { s: string } | (() => string)) {
->f11 : (x: {    s: string;} | (() => string)) => void
+>f11 : (x: { s: string; } | (() => string)) => void
 >x : { s: string; } | (() => string)
 >s : string
 
@@ -132,7 +132,7 @@ function f11(x: { s: string } | (() => string)) {
 }
 
 function f12(x: { s: string } | { n: number }) {
->f12 : (x: {    s: string;} | {    n: number;}) => void
+>f12 : (x: { s: string; } | { n: number; }) => void
 >x : { s: string; } | { n: number; }
 >s : string
 >n : number

--- a/tests/baselines/reference/typeGuardOfFromPropNameInUnionType.types
+++ b/tests/baselines/reference/typeGuardOfFromPropNameInUnionType.types
@@ -68,7 +68,7 @@ function multipleClasses(x: A | B | C | D) {
 }
 
 function anonymousClasses(x: { a: string; } | { b: number; }) {
->anonymousClasses : (x: {    a: string;} | {    b: number;}) => void
+>anonymousClasses : (x: { a: string; } | { b: number; }) => void
 >x : { a: string; } | { b: number; }
 >a : string
 >b : number

--- a/tests/baselines/reference/typeInferenceWithExcessPropertiesJsx.types
+++ b/tests/baselines/reference/typeInferenceWithExcessPropertiesJsx.types
@@ -13,7 +13,7 @@ type TranslationEntry = {
 >args : [] | [unknown]
 }
 type Translations = {
->Translations : { a: {    args: [string];}; b: {    args: [];}; }
+>Translations : { a: { args: [string]; }; b: { args: []; }; }
 
     a: { args: [string] },
 >a : { args: [string]; }

--- a/tests/baselines/reference/typeName1.types
+++ b/tests/baselines/reference/typeName1.types
@@ -114,7 +114,7 @@ var x12:{z:I;x:boolean;y:(s:string)=>boolean;w:{ z:I;[s:string]:{ x; y; };[n:num
 >3 : 3
 
 var x13:{ new(): number; new(n:number):number; x: string; w: {y: number;}; (): {}; } = 3;
->x13 : { (): {}; new (): number; new (n: number): number; x: string; w: {    y: number;}; }
+>x13 : { (): {}; new (): number; new (n: number): number; x: string; w: { y: number; }; }
 >n : number
 >x : string
 >w : { y: number; }

--- a/tests/baselines/reference/typeParameterConstModifiers.types
+++ b/tests/baselines/reference/typeParameterConstModifiers.types
@@ -126,7 +126,7 @@ const x42 = f4([{ a: 1, b: 'x' }, { a: 2, b: 'y' }]);
 >'y' : "y"
 
 declare function f5<const T>(obj: { x: T, y: T }): T;
->f5 : <const T>(obj: {    x: T;    y: T;}) => T
+>f5 : <const T>(obj: { x: T; y: T; }) => T
 >obj : { x: T; y: T; }
 >x : T
 >y : T
@@ -308,8 +308,8 @@ type T5 = { new <const T>(x: T): T };
 // Corrected repro from #51745
 
 type Obj = { a: { b: { c: "123" } } };
->Obj : { a: {    b: {        c: "123";    };}; }
->a : { b: {    c: "123";}; }
+>Obj : { a: { b: { c: "123"; }; }; }
+>a : { b: { c: "123"; }; }
 >b : { c: "123"; }
 >c : "123"
 
@@ -450,7 +450,7 @@ const t1_55033 = factory_55033((a: { test: number }, b: string) => {})(
 >factory_55033((a: { test: number }, b: string) => {})(    { test: 123 },    "some string") : readonly [{ readonly test: 123; }, "some string"]
 >factory_55033((a: { test: number }, b: string) => {}) : <const K extends readonly [a: { test: number; }, b: string]>(...args: K) => K
 >factory_55033 : <const T extends readonly unknown[]>(cb: (...args: T) => void) => <const K extends T>(...args: K) => K
->(a: { test: number }, b: string) => {} : (a: {    test: number;}, b: string) => void
+>(a: { test: number }, b: string) => {} : (a: { test: number; }, b: string) => void
 >a : { test: number; }
 >test : number
 >b : string
@@ -470,7 +470,7 @@ const t2_55033 = factory_55033((a: { test: number }, b: string) => {})(
 >factory_55033((a: { test: number }, b: string) => {})(    { test: 123 } as const,    "some string") : readonly [{ readonly test: 123; }, "some string"]
 >factory_55033((a: { test: number }, b: string) => {}) : <const K extends readonly [a: { test: number; }, b: string]>(...args: K) => K
 >factory_55033 : <const T extends readonly unknown[]>(cb: (...args: T) => void) => <const K extends T>(...args: K) => K
->(a: { test: number }, b: string) => {} : (a: {    test: number;}, b: string) => void
+>(a: { test: number }, b: string) => {} : (a: { test: number; }, b: string) => void
 >a : { test: number; }
 >test : number
 >b : string
@@ -510,7 +510,7 @@ const t1_55033_2 = factory_55033_2((a: { test: number }, b: string) => {})(
 >factory_55033_2((a: { test: number }, b: string) => {})(    { test: 123 },    "some string") : [{ readonly test: 123; }, "some string"]
 >factory_55033_2((a: { test: number }, b: string) => {}) : <const K extends [a: { test: number; }, b: string]>(...args: K) => K
 >factory_55033_2 : <const T extends unknown[]>(cb: (...args: T) => void) => <const K extends T>(...args: K) => K
->(a: { test: number }, b: string) => {} : (a: {    test: number;}, b: string) => void
+>(a: { test: number }, b: string) => {} : (a: { test: number; }, b: string) => void
 >a : { test: number; }
 >test : number
 >b : string
@@ -530,7 +530,7 @@ const t2_55033_2 = factory_55033_2((a: { test: number }, b: string) => {})(
 >factory_55033_2((a: { test: number }, b: string) => {})(    { test: 123 } as const,    "some string") : [{ readonly test: 123; }, "some string"]
 >factory_55033_2((a: { test: number }, b: string) => {}) : <const K extends [a: { test: number; }, b: string]>(...args: K) => K
 >factory_55033_2 : <const T extends unknown[]>(cb: (...args: T) => void) => <const K extends T>(...args: K) => K
->(a: { test: number }, b: string) => {} : (a: {    test: number;}, b: string) => void
+>(a: { test: number }, b: string) => {} : (a: { test: number; }, b: string) => void
 >a : { test: number; }
 >test : number
 >b : string

--- a/tests/baselines/reference/typeParameterConstModifiersWithIntersection.types
+++ b/tests/baselines/reference/typeParameterConstModifiersWithIntersection.types
@@ -11,7 +11,7 @@ interface Config<T1 extends { type: string }> {
 }
 
 declare function test<
->test : <T1 extends { type: string; }, const TConfig extends Config<T1>>(config: {    produceThing: T1;} & TConfig) => TConfig
+>test : <T1 extends { type: string; }, const TConfig extends Config<T1>>(config: { produceThing: T1; } & TConfig) => TConfig
 
   T1 extends { type: string },
 >type : string

--- a/tests/baselines/reference/typeParametersAvailableInNestedScope3.js
+++ b/tests/baselines/reference/typeParametersAvailableInNestedScope3.js
@@ -5,10 +5,13 @@ function foo<T>(v: T) {
     function a<T>(a: T) { return a; }
     function b(): T { return v; }
 
+    type Alias = T;
     function c<T>(v: T) {
+        type Alias2 = T;
         function a<T>(a: T) { return a; }
         function b(): T { return v; }
-        return { a, b };
+        function c<T>(): [Alias, Alias2, T] { return null as any; }
+        return { a, b, c };
     }
 
     return { a, b, c };
@@ -22,7 +25,8 @@ function foo(v) {
     function c(v) {
         function a(a) { return a; }
         function b() { return v; }
-        return { a: a, b: b };
+        function c() { return null; }
+        return { a: a, b: b, c: c };
     }
     return { a: a, b: b, c: c };
 }
@@ -35,5 +39,6 @@ declare function foo<T>(v: T): {
     c: <T_2>(v: T_2) => {
         a: <T_3>(a: T_3) => T_3;
         b: () => T_2;
+        c: <T_4>() => [T, T_2, T_4];
     };
 };

--- a/tests/baselines/reference/typeParametersAvailableInNestedScope3.symbols
+++ b/tests/baselines/reference/typeParametersAvailableInNestedScope3.symbols
@@ -19,32 +19,48 @@ function foo<T>(v: T) {
 >T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 0, 13))
 >v : Symbol(v, Decl(typeParametersAvailableInNestedScope3.ts, 0, 16))
 
+    type Alias = T;
+>Alias : Symbol(Alias, Decl(typeParametersAvailableInNestedScope3.ts, 2, 33))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 0, 13))
+
     function c<T>(v: T) {
->c : Symbol(c, Decl(typeParametersAvailableInNestedScope3.ts, 2, 33))
->T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 4, 15))
->v : Symbol(v, Decl(typeParametersAvailableInNestedScope3.ts, 4, 18))
->T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 4, 15))
+>c : Symbol(c, Decl(typeParametersAvailableInNestedScope3.ts, 4, 19))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 5, 15))
+>v : Symbol(v, Decl(typeParametersAvailableInNestedScope3.ts, 5, 18))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 5, 15))
+
+        type Alias2 = T;
+>Alias2 : Symbol(Alias2, Decl(typeParametersAvailableInNestedScope3.ts, 5, 25))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 5, 15))
 
         function a<T>(a: T) { return a; }
->a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 4, 25))
->T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 5, 19))
->a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 5, 22))
->T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 5, 19))
->a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 5, 22))
+>a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 6, 24))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 7, 19))
+>a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 7, 22))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 7, 19))
+>a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 7, 22))
 
         function b(): T { return v; }
->b : Symbol(b, Decl(typeParametersAvailableInNestedScope3.ts, 5, 41))
->T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 4, 15))
->v : Symbol(v, Decl(typeParametersAvailableInNestedScope3.ts, 4, 18))
+>b : Symbol(b, Decl(typeParametersAvailableInNestedScope3.ts, 7, 41))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 5, 15))
+>v : Symbol(v, Decl(typeParametersAvailableInNestedScope3.ts, 5, 18))
 
-        return { a, b };
->a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 7, 16))
->b : Symbol(b, Decl(typeParametersAvailableInNestedScope3.ts, 7, 19))
+        function c<T>(): [Alias, Alias2, T] { return null as any; }
+>c : Symbol(c, Decl(typeParametersAvailableInNestedScope3.ts, 8, 37))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 9, 19))
+>Alias : Symbol(Alias, Decl(typeParametersAvailableInNestedScope3.ts, 2, 33))
+>Alias2 : Symbol(Alias2, Decl(typeParametersAvailableInNestedScope3.ts, 5, 25))
+>T : Symbol(T, Decl(typeParametersAvailableInNestedScope3.ts, 9, 19))
+
+        return { a, b, c };
+>a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 10, 16))
+>b : Symbol(b, Decl(typeParametersAvailableInNestedScope3.ts, 10, 19))
+>c : Symbol(c, Decl(typeParametersAvailableInNestedScope3.ts, 10, 22))
     }
 
     return { a, b, c };
->a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 10, 12))
->b : Symbol(b, Decl(typeParametersAvailableInNestedScope3.ts, 10, 15))
->c : Symbol(c, Decl(typeParametersAvailableInNestedScope3.ts, 10, 18))
+>a : Symbol(a, Decl(typeParametersAvailableInNestedScope3.ts, 13, 12))
+>b : Symbol(b, Decl(typeParametersAvailableInNestedScope3.ts, 13, 15))
+>c : Symbol(c, Decl(typeParametersAvailableInNestedScope3.ts, 13, 18))
 }
 

--- a/tests/baselines/reference/typeParametersAvailableInNestedScope3.types
+++ b/tests/baselines/reference/typeParametersAvailableInNestedScope3.types
@@ -2,7 +2,7 @@
 
 === typeParametersAvailableInNestedScope3.ts ===
 function foo<T>(v: T) {
->foo : <T>(v: T) => { a: <T>(a: T) => T; b: () => T; c: <T>(v: T) => { a: <T>(a: T) => T; b: () => T; }; }
+>foo : <T>(v: T) => { a: <T>(a: T) => T; b: () => T; c: <T>(v: T) => { a: <T>(a: T) => T; b: () => T; c: <T>() => [T, T, T]; }; }
 >v : T
 
     function a<T>(a: T) { return a; }
@@ -14,9 +14,15 @@ function foo<T>(v: T) {
 >b : () => T
 >v : T
 
+    type Alias = T;
+>Alias : T
+
     function c<T>(v: T) {
->c : <T>(v: T) => { a: <T>(a: T) => T; b: () => T; }
+>c : <T>(v: T) => { a: <T>(a: T) => T; b: () => T; c: <T>() => [T, T, T]; }
 >v : T
+
+        type Alias2 = T;
+>Alias2 : T
 
         function a<T>(a: T) { return a; }
 >a : <T>(a: T) => T
@@ -27,16 +33,21 @@ function foo<T>(v: T) {
 >b : () => T
 >v : T
 
-        return { a, b };
->{ a, b } : { a: <T>(a: T) => T; b: () => T; }
+        function c<T>(): [Alias, Alias2, T] { return null as any; }
+>c : <T>() => [T, T, T]
+>null as any : any
+
+        return { a, b, c };
+>{ a, b, c } : { a: <T>(a: T) => T; b: () => T; c: <T>() => [T, T, T]; }
 >a : <T>(a: T) => T
 >b : () => T
+>c : <T>() => [T, T, T]
     }
 
     return { a, b, c };
->{ a, b, c } : { a: <T>(a: T) => T; b: () => T; c: <T>(v: T) => { a: <T>(a: T) => T; b: () => T; }; }
+>{ a, b, c } : { a: <T>(a: T) => T; b: () => T; c: <T>(v: T) => { a: <T>(a: T) => T; b: () => T; c: <T>() => [T, T, T]; }; }
 >a : <T>(a: T) => T
 >b : () => T
->c : <T>(v: T) => { a: <T>(a: T) => T; b: () => T; }
+>c : <T>(v: T) => { a: <T>(a: T) => T; b: () => T; c: <T>() => [T, T, T]; }
 }
 

--- a/tests/baselines/reference/typeParametersInStaticMethods.types
+++ b/tests/baselines/reference/typeParametersInStaticMethods.types
@@ -5,8 +5,8 @@ class foo<T> {
 >foo : foo<T>
 
     static M(x: (x: T) => { x: { y: T } }) {
->M : (x: (x: T) => {    x: {        y: T;    };}) => void
->x : (x: T) => {    x: {        y: T;    };}
+>M : (x: (x: T) => { x: { y: T; }; }) => void
+>x : (x: T) => { x: { y: T; }; }
 >x : T
 >x : { y: T; }
 >y : T

--- a/tests/baselines/reference/typePredicateStructuralMatch.types
+++ b/tests/baselines/reference/typePredicateStructuralMatch.types
@@ -35,7 +35,7 @@ type Results = Result[];
 >Results : Result[]
 
 function isResponseInData<T>(value: T | { data: T}): value is { data: T } {
->isResponseInData : <T>(value: T | {    data: T;}) => value is { data: T; }
+>isResponseInData : <T>(value: T | { data: T; }) => value is { data: T; }
 >value : T | { data: T; }
 >data : T
 >data : T
@@ -49,7 +49,7 @@ function isResponseInData<T>(value: T | { data: T}): value is { data: T } {
 }
 
 function getResults1(value: Results | { data: Results }): Results {
->getResults1 : (value: Results | {    data: Results;}) => Results
+>getResults1 : (value: Results | { data: Results; }) => Results
 >value : Results | { data: Results; }
 >data : Results
 
@@ -65,7 +65,7 @@ function getResults1(value: Results | { data: Results }): Results {
 }
 
 function isPlainResponse<T>(value: T | { data: T}): value is T {
->isPlainResponse : <T>(value: T | {    data: T;}) => value is T
+>isPlainResponse : <T>(value: T | { data: T; }) => value is T
 >value : T | { data: T; }
 >data : T
 
@@ -79,7 +79,7 @@ function isPlainResponse<T>(value: T | { data: T}): value is T {
 }
 
 function getResults2(value: Results | { data: Results }): Results {
->getResults2 : (value: Results | {    data: Results;}) => Results
+>getResults2 : (value: Results | { data: Results; }) => Results
 >value : Results | { data: Results; }
 >data : Results
 

--- a/tests/baselines/reference/typeSatisfaction_propertyValueConformance1(nopropertyaccessfromindexsignature=false).types
+++ b/tests/baselines/reference/typeSatisfaction_propertyValueConformance1(nopropertyaccessfromindexsignature=false).types
@@ -10,7 +10,7 @@ declare function checkTruths(x: Facts): void;
 >x : Facts
 
 declare function checkM(x: { m: boolean }): void;
->checkM : (x: {    m: boolean;}) => void
+>checkM : (x: { m: boolean; }) => void
 >x : { m: boolean; }
 >m : boolean
 

--- a/tests/baselines/reference/typeSatisfaction_propertyValueConformance1(nopropertyaccessfromindexsignature=true).types
+++ b/tests/baselines/reference/typeSatisfaction_propertyValueConformance1(nopropertyaccessfromindexsignature=true).types
@@ -10,7 +10,7 @@ declare function checkTruths(x: Facts): void;
 >x : Facts
 
 declare function checkM(x: { m: boolean }): void;
->checkM : (x: {    m: boolean;}) => void
+>checkM : (x: { m: boolean; }) => void
 >x : { m: boolean; }
 >m : boolean
 

--- a/tests/baselines/reference/typeSatisfaction_propertyValueConformance2(nouncheckedindexedaccess=false).types
+++ b/tests/baselines/reference/typeSatisfaction_propertyValueConformance2(nouncheckedindexedaccess=false).types
@@ -10,7 +10,7 @@ declare function checkTruths(x: Facts): void;
 >x : Facts
 
 declare function checkM(x: { m: boolean }): void;
->checkM : (x: {    m: boolean;}) => void
+>checkM : (x: { m: boolean; }) => void
 >x : { m: boolean; }
 >m : boolean
 

--- a/tests/baselines/reference/typeSatisfaction_propertyValueConformance2(nouncheckedindexedaccess=true).types
+++ b/tests/baselines/reference/typeSatisfaction_propertyValueConformance2(nouncheckedindexedaccess=true).types
@@ -10,7 +10,7 @@ declare function checkTruths(x: Facts): void;
 >x : Facts
 
 declare function checkM(x: { m: boolean }): void;
->checkM : (x: {    m: boolean;}) => void
+>checkM : (x: { m: boolean; }) => void
 >x : { m: boolean; }
 >m : boolean
 

--- a/tests/baselines/reference/typeofObjectInference.types
+++ b/tests/baselines/reference/typeofObjectInference.types
@@ -6,8 +6,8 @@ let val = 1
 >1 : 1
 
 function decorateA<O extends any>(fn: (first: {value: typeof val}) => O) {
->decorateA : <O extends unknown>(fn: (first: {    value: typeof val;}) => O) => () => O
->fn : (first: {    value: typeof val;}) => O
+>decorateA : <O extends unknown>(fn: (first: { value: typeof val; }) => O) => () => O
+>fn : (first: { value: typeof val; }) => O
 >first : { value: typeof val; }
 >value : number
 >val : number
@@ -49,8 +49,8 @@ let b = decorateB((value) => 5)
 >5 : 5
 
 function decorateC<O extends any>(fn: (first: {value: number}) => O) {
->decorateC : <O extends unknown>(fn: (first: {    value: number;}) => O) => () => O
->fn : (first: {    value: number;}) => O
+>decorateC : <O extends unknown>(fn: (first: { value: number; }) => O) => () => O
+>fn : (first: { value: number; }) => O
 >first : { value: number; }
 >value : number
 

--- a/tests/baselines/reference/typeofThis.types
+++ b/tests/baselines/reference/typeofThis.types
@@ -83,7 +83,7 @@ function Test2() {
 }
 
 function Test3(this: { no: number }) {
->Test3 : (this: {    no: number;}) => void
+>Test3 : (this: { no: number; }) => void
 >this : { no: number; }
 >no : number
 
@@ -96,7 +96,7 @@ function Test3(this: { no: number }) {
 }
 
 function Test4(this: { no: number } | undefined) {
->Test4 : (this: {    no: number;} | undefined) => void
+>Test4 : (this: { no: number; } | undefined) => void
 >this : { no: number; } | undefined
 >no : number
 

--- a/tests/baselines/reference/undeclaredModuleError.types
+++ b/tests/baselines/reference/undeclaredModuleError.types
@@ -5,13 +5,13 @@ import fs = require('fs');
 >fs : any
 
 function readdir(path: string, accept: (stat: fs.Stats, name: string) => boolean, callback: (error: Error, results: { name: string; stat: fs.Stats; }[]) => void ) {}
->readdir : (path: string, accept: (stat: fs.Stats, name: string) => boolean, callback: (error: Error, results: {    name: string;    stat: fs.Stats;}[]) => void) => void
+>readdir : (path: string, accept: (stat: fs.Stats, name: string) => boolean, callback: (error: Error, results: { name: string; stat: fs.Stats; }[]) => void) => void
 >path : string
 >accept : (stat: fs.Stats, name: string) => boolean
 >stat : fs.Stats
 >fs : any
 >name : string
->callback : (error: Error, results: {    name: string;    stat: fs.Stats;}[]) => void
+>callback : (error: Error, results: { name: string; stat: fs.Stats; }[]) => void
 >error : Error
 >results : { name: string; stat: fs.Stats; }[]
 >name : string

--- a/tests/baselines/reference/undefinedArgumentInference.types
+++ b/tests/baselines/reference/undefinedArgumentInference.types
@@ -2,7 +2,7 @@
 
 === undefinedArgumentInference.ts ===
 function foo1<T>(f1: { x: T; y: T }): T {
->foo1 : <T>(f1: {    x: T;    y: T;}) => T
+>foo1 : <T>(f1: { x: T; y: T; }) => T
 >f1 : { x: T; y: T; }
 >x : T
 >y : T

--- a/tests/baselines/reference/unionAndIntersectionInference2.types
+++ b/tests/baselines/reference/unionAndIntersectionInference2.types
@@ -47,7 +47,7 @@ f1(e1); // number | boolean
 >e1 : string | number | boolean
 
 declare function f2<T>(x: T & { name: string }): T;
->f2 : <T>(x: T & {    name: string;}) => T
+>f2 : <T>(x: T & { name: string; }) => T
 >x : T & { name: string; }
 >name : string
 

--- a/tests/baselines/reference/unionErrorMessageOnMatchingDiscriminant.types
+++ b/tests/baselines/reference/unionErrorMessageOnMatchingDiscriminant.types
@@ -2,7 +2,7 @@
 
 === unionErrorMessageOnMatchingDiscriminant.ts ===
 type A = {
->A : { type: 'a'; data: {    a: string;}; }
+>A : { type: 'a'; data: { a: string; }; }
 
     type: 'a',
 >type : "a"

--- a/tests/baselines/reference/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.types
+++ b/tests/baselines/reference/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.types
@@ -11,9 +11,9 @@ interface INumberDictionary<V> {
 }
 
 declare function forEach<T>(from: IStringDictionary<T> | INumberDictionary<T>, callback: (entry: { key: any; value: T; }, remove: () => void) => any);
->forEach : <T>(from: IStringDictionary<T> | INumberDictionary<T>, callback: (entry: {    key: any;    value: T;}, remove: () => void) => any) => any
+>forEach : <T>(from: IStringDictionary<T> | INumberDictionary<T>, callback: (entry: { key: any; value: T; }, remove: () => void) => any) => any
 >from : IStringDictionary<T> | INumberDictionary<T>
->callback : (entry: {    key: any;    value: T;}, remove: () => void) => any
+>callback : (entry: { key: any; value: T; }, remove: () => void) => any
 >entry : { key: any; value: T; }
 >key : any
 >value : T

--- a/tests/baselines/reference/unionTypeReduction2.types
+++ b/tests/baselines/reference/unionTypeReduction2.types
@@ -2,7 +2,7 @@
 
 === unionTypeReduction2.ts ===
 function f1(x: { f(): void }, y: { f(x?: string): void }) {
->f1 : (x: {    f(): void;}, y: { f(x?: string): void; }) => void
+>f1 : (x: { f(): void; }, y: { f(x?: string): void; }) => void
 >x : { f(): void; }
 >f : () => void
 >y : { f(x?: string): void; }

--- a/tests/baselines/reference/unionTypeWithIndexSignature.types
+++ b/tests/baselines/reference/unionTypeWithIndexSignature.types
@@ -2,7 +2,7 @@
 
 === unionTypeWithIndexSignature.ts ===
 type Two = { foo: { bar: true }, baz: true } | { [s: string]: string };
->Two : { foo: {    bar: true;}; baz: true; } | { [s: string]: string; }
+>Two : { foo: { bar: true; }; baz: true; } | { [s: string]: string; }
 >foo : { bar: true; }
 >bar : true
 >true : true

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -333,7 +333,7 @@ const constInitToIReadonlyTypeWithIndexedAccess: I["readonlyType"] = i.readonlyT
 
 // type literals
 type L = {
->L : { readonly readonlyType: unique symbol; nested: {    readonly readonlyNestedType: unique symbol;}; }
+>L : { readonly readonlyType: unique symbol; nested: { readonly readonlyNestedType: unique symbol; }; }
 
     readonly readonlyType: unique symbol;
 >readonlyType : unique symbol

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.types
@@ -326,7 +326,7 @@ const constInitToIReadonlyTypeWithIndexedAccess: I["readonlyType"] = i.readonlyT
 
 // type literals
 type L = {
->L : { readonly readonlyType: unique symbol; nested: {    readonly readonlyNestedType: unique symbol;}; }
+>L : { readonly readonlyType: unique symbol; nested: { readonly readonlyNestedType: unique symbol; }; }
 
     readonly readonlyType: unique symbol;
 >readonlyType : unique symbol

--- a/tests/baselines/reference/unknownType2.types
+++ b/tests/baselines/reference/unknownType2.types
@@ -520,7 +520,7 @@ function switchTestLiterals(x: unknown) {
 }
 
 function switchTestObjects(x: unknown, y: () => void, z: { prop: number }) {
->switchTestObjects : (x: unknown, y: () => void, z: {    prop: number;}) => void
+>switchTestObjects : (x: unknown, y: () => void, z: { prop: number; }) => void
 >x : unknown
 >y : () => void
 >z : { prop: number; }

--- a/tests/baselines/reference/varArgParamTypeCheck.types
+++ b/tests/baselines/reference/varArgParamTypeCheck.types
@@ -2,7 +2,7 @@
 
 === varArgParamTypeCheck.ts ===
 function sequence(...sequences:{():void;}[]) {
->sequence : (...sequences: {    (): void;}[]) => void
+>sequence : (...sequences: { (): void; }[]) => void
 >sequences : (() => void)[]
 }
 

--- a/tests/baselines/reference/vardecl.types
+++ b/tests/baselines/reference/vardecl.types
@@ -73,10 +73,10 @@ var c : {
     }
 
 var d: {
->d : { foo?(): {    x: number;}; }
+>d : { foo?(): { x: number; }; }
 
     foo? (): {
->foo : () => {    x: number;}
+>foo : () => { x: number; }
 
         x: number;
 >x : number
@@ -85,10 +85,10 @@ var d: {
 }
 
 var d3: {
->d3 : { foo(): {    x: number;    y: number;}; }
+>d3 : { foo(): { x: number; y: number; }; }
 
     foo(): {
->foo : () => {    x: number;    y: number;}
+>foo : () => { x: number; y: number; }
 
         x: number;
 >x : number
@@ -100,10 +100,10 @@ var d3: {
 }
 
 var d2: {
->d2 : { foo(): {    x: number;}; }
+>d2 : { foo(): { x: number; }; }
 
     foo (): {
->foo : () => {    x: number;}
+>foo : () => { x: number; }
 
         x: number;
 >x : number
@@ -123,10 +123,10 @@ var n4: {
 }[];
 
 var d4: {
->d4 : { foo(n: string, x: {    x: number;    y: number;}): {    x: number;    y: number;}; }
+>d4 : { foo(n: string, x: { x: number; y: number; }): { x: number; y: number; }; }
 
     foo(n: string, x: { x: number; y: number; }): {
->foo : (n: string, x: {    x: number;    y: number;}) => {    x: number;    y: number;}
+>foo : (n: string, x: { x: number; y: number; }) => { x: number; y: number; }
 >n : string
 >x : { x: number; y: number; }
 >x : number

--- a/tests/baselines/reference/variadicTuples1.types
+++ b/tests/baselines/reference/variadicTuples1.types
@@ -1386,13 +1386,13 @@ const b = a.bind("", 1);  // Desc<[boolean], object>
 // Repro from #39607
 
 declare function getUser(id: string, options?: { x?: string }): string;
->getUser : (id: string, options?: {    x?: string;}) => string
+>getUser : (id: string, options?: { x?: string; }) => string
 >id : string
 >options : { x?: string | undefined; } | undefined
 >x : string | undefined
 
 declare function getOrgUser(id: string, orgId: number, options?: { y?: number, z?: boolean }): void;
->getOrgUser : (id: string, orgId: number, options?: {    y?: number;    z?: boolean;}) => void
+>getOrgUser : (id: string, orgId: number, options?: { y?: number; z?: boolean; }) => void
 >id : string
 >orgId : number
 >options : { y?: number | undefined; z?: boolean | undefined; } | undefined

--- a/tests/baselines/reference/vueLikeDataAndPropsInference.types
+++ b/tests/baselines/reference/vueLikeDataAndPropsInference.types
@@ -54,7 +54,7 @@ declare function test(fn: Options): void;
 test({
 >test({    props: {        foo: ''    },    data(): { bar: boolean } {        return {            bar: true        }    },    watch: {        foo(newVal: string, oldVal: string): void {            this.bar = false        }    }}) : void
 >test : { <Data, Props>(fn: ThisTypedOptions<Data, Props>): void; (fn: Options<(this: Instance) => object, {}>): void; }
->{    props: {        foo: ''    },    data(): { bar: boolean } {        return {            bar: true        }    },    watch: {        foo(newVal: string, oldVal: string): void {            this.bar = false        }    }} : { props: { foo: string; }; data(this: Readonly<{ foo: string; }> & Instance): {    bar: boolean;}; watch: { foo(newVal: string, oldVal: string): void; }; }
+>{    props: {        foo: ''    },    data(): { bar: boolean } {        return {            bar: true        }    },    watch: {        foo(newVal: string, oldVal: string): void {            this.bar = false        }    }} : { props: { foo: string; }; data(this: Readonly<{ foo: string; }> & Instance): { bar: boolean; }; watch: { foo(newVal: string, oldVal: string): void; }; }
 
     props: {
 >props : { foo: string; }
@@ -67,7 +67,7 @@ test({
     },
 
     data(): { bar: boolean } {
->data : (this: Readonly<{ foo: string; }> & Instance) => {    bar: boolean;}
+>data : (this: Readonly<{ foo: string; }> & Instance) => { bar: boolean; }
 >bar : boolean
 
         return {

--- a/tests/baselines/reference/vueLikeDataAndPropsInference2.types
+++ b/tests/baselines/reference/vueLikeDataAndPropsInference2.types
@@ -55,7 +55,7 @@ declare function test(fn: Options): void;
 test({
 >test({    props: {        foo: ''    },    data(): { bar: boolean } {        return {            bar: true        }    },    watch: {        foo(newVal: string, oldVal: string): void {            this.bar = false        }    }}) : void
 >test : { <Data, Props>(fn: ThisTypedOptions<Data, Props>): void; (fn: Options<object | ((this: Instance) => object), PropsDefinition<Record<string, any>>>): void; }
->{    props: {        foo: ''    },    data(): { bar: boolean } {        return {            bar: true        }    },    watch: {        foo(newVal: string, oldVal: string): void {            this.bar = false        }    }} : { props: { foo: string; }; data(this: Readonly<{ foo: string; }> & Instance): {    bar: boolean;}; watch: { foo(newVal: string, oldVal: string): void; }; }
+>{    props: {        foo: ''    },    data(): { bar: boolean } {        return {            bar: true        }    },    watch: {        foo(newVal: string, oldVal: string): void {            this.bar = false        }    }} : { props: { foo: string; }; data(this: Readonly<{ foo: string; }> & Instance): { bar: boolean; }; watch: { foo(newVal: string, oldVal: string): void; }; }
 
     props: {
 >props : { foo: string; }
@@ -68,7 +68,7 @@ test({
     },
 
     data(): { bar: boolean } {
->data : (this: Readonly<{ foo: string; }> & Instance) => {    bar: boolean;}
+>data : (this: Readonly<{ foo: string; }> & Instance) => { bar: boolean; }
 >bar : boolean
 
         return {

--- a/tests/baselines/reference/weakType.types
+++ b/tests/baselines/reference/weakType.types
@@ -86,7 +86,7 @@ type ChangeOptions = ConfigurableStartEnd & InsertOptions;
 >ChangeOptions : ConfigurableStart & ConfigurableEnd & InsertOptions
 
 function del(options: ConfigurableStartEnd = {},
->del : (options?: ConfigurableStartEnd, error?: {    error?: number;}) => void
+>del : (options?: ConfigurableStartEnd, error?: { error?: number; }) => void
 >options : ConfigurableStartEnd
 >{} : {}
 
@@ -136,7 +136,7 @@ type Spoiler = { nope?: string }
 >nope : string
 
 type Weak = {
->Weak : { a?: number; properties?: {    b?: number;}; }
+>Weak : { a?: number; properties?: { b?: number; }; }
 
     a?: number
 >a : number
@@ -149,7 +149,7 @@ type Weak = {
     }
 }
 declare let propertiesWrong: {
->propertiesWrong : { properties: {    wrong: string;}; }
+>propertiesWrong : { properties: { wrong: string; }; }
 
     properties: {
 >properties : { wrong: string; }

--- a/tests/baselines/reference/widenToAny1.types
+++ b/tests/baselines/reference/widenToAny1.types
@@ -2,7 +2,7 @@
 
 === widenToAny1.ts ===
 function foo1<T>(f1: { x: T; y: T }): T {
->foo1 : <T>(f1: {    x: T;    y: T;}) => T
+>foo1 : <T>(f1: { x: T; y: T; }) => T
 >f1 : { x: T; y: T; }
 >x : T
 >y : T

--- a/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
+++ b/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
@@ -1,0 +1,12 @@
+// @strict: true
+// @declaration: true
+// @module: nodenext
+// @filename: node_modules/react-select/index.d.ts
+export type Whatever = {x: string, y: number};
+export type Props<T, TThing = Whatever> = Omit<TThing, "y"> & Partial<TThing> & T;
+
+// @filename: index.ts
+import { Props } from "react-select";
+
+export const CustomSelect1 = <Option,>(x: Props<Option> & {}) => {}
+export function CustomSelect2<Option,>(x: Props<Option> & {}) {}

--- a/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
+++ b/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
@@ -4,10 +4,13 @@ function foo<T>(v: T) {
     function a<T>(a: T) { return a; }
     function b(): T { return v; }
 
+    type Alias = T;
     function c<T>(v: T) {
+        type Alias2 = T;
         function a<T>(a: T) { return a; }
         function b(): T { return v; }
-        return { a, b };
+        function c<T>(): [Alias, Alias2, T] { return null as any; }
+        return { a, b, c };
     }
 
     return { a, b, c };


### PR DESCRIPTION
Fixes #55575

Mostly, this just required adding local type parameters into the fake scopes we gin up during node building, and then ensuring type parameter node generation always went through the potentially-shadowed-type-parameter-name generation codepath (since we can no longer rely on their global accessibility to determine if their name is OK to use, since while it may be accessible via a fake scope, it might require a different name than it originally had due to shadowing).