### PR TITLE
Add perf_hooks to the package.json browser list

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
         "buffer": false,
         "@microsoft/typescript-etw": false,
         "source-map-support": false,
-        "inspector": false
+        "inspector": false,
+        "perf_hooks": false
     },
     "packageManager": "npm@8.19.4",
     "volta": {


### PR DESCRIPTION
Not having this causes bundlers to get mad because they can't resolve `perf_hooks`, but it's an optional dep. See: https://github.com/microsoft/TypeScript/issues/39436#issuecomment-1756167264