### PR TITLE
Remove old references to deprecated assertion node types

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -7,7 +7,6 @@ import {
     arrayFrom,
     arrayIsEqualTo,
     AsExpression,
-    AssertClause,
     BuilderProgram,
     CancellationToken,
     canHaveDecorators,
@@ -918,7 +917,7 @@ export function getModeForUsageLocation(file: { impliedNodeFormat?: ResolutionMo
 }
 
 /** @internal */
-export function getResolutionModeOverride(node: AssertClause | ImportAttributes | undefined, grammarErrorOnNode?: (node: Node, diagnostic: DiagnosticMessage) => void) {
+export function getResolutionModeOverride(node: ImportAttributes | undefined, grammarErrorOnNode?: (node: Node, diagnostic: DiagnosticMessage) => void) {
     if (!node) return undefined;
     if (length(node.elements) !== 1) {
         grammarErrorOnNode?.(

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -1,6 +1,5 @@
 import {
     ArrowFunction,
-    AssertClause,
     Block,
     CallExpression,
     CancellationToken,
@@ -302,11 +301,10 @@ function getOutliningSpanForNode(n: Node, sourceFile: SourceFile): OutliningSpan
         case SyntaxKind.NamedImports:
         case SyntaxKind.NamedExports:
         case SyntaxKind.ImportAttributes:
-        case SyntaxKind.AssertClause:
-            return spanForImportExportElements(n as NamedImports | NamedExports | AssertClause | ImportAttributes);
+            return spanForImportExportElements(n as NamedImports | NamedExports | ImportAttributes);
     }
 
-    function spanForImportExportElements(node: NamedImports | NamedExports | AssertClause | ImportAttributes) {
+    function spanForImportExportElements(node: NamedImports | NamedExports | ImportAttributes) {
         if (!node.elements.length) {
             return undefined;
         }


### PR DESCRIPTION
I noticed this in the monaco build logs:

```
src/language/typescript/lib/typescriptServices.js:165729:6:
      165729 │       case 300 /* AssertClause */:
             ╵       ~~~~

  The earlier case clause is here:

    src/language/typescript/lib/typescriptServices.js:165728:6:
      165728 │       case 300 /* ImportAttributes */:
             ╵       ~~~~

Warning: G] This case clause will never be evaluated because it duplicates an earlier case clause [duplicate-case]

    src/language/typescript/lib/typescriptServices.js:165729:6:
      165729 │       case 300 /* AssertClause */:
             ╵       ~~~~

  The earlier case clause is here:

    src/language/typescript/lib/typescriptServices.js:165728:6:
      165728 │       case 300 /* ImportAttributes */:
             ╵       ~~~~

Warning: G] This case clause will never be evaluated because it duplicates an earlier case clause [duplicate-case]

    src/language/typescript/lib/typescriptServices.js:165729:6:
      165729 │       case 300 /* AssertClause */:
             ╵       ~~~~

  The earlier case clause is here:

    src/language/typescript/lib/typescriptServices.js:165728:6:
      165728 │       case 300 /* ImportAttributes */:
             ╵       ~~~~
```

Generally when we deprecate something and point it at something new, we also remove its use as much as possible (see other deprecated JSDoc stuff), but that wasn't done in this case. This has a visible effect on downstream users as tools like bundlers sometimes detect dead code that looks wrong, like the above switch case where it lists `300` twice.































