### PR TITLE
Fix bug template line breaks, which do not follow normal markdown behavior

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,14 +26,11 @@ body:
       description: |
         When did you start seeing this bug occur?
 
-        "Bugs" that have existed in TS for a long time are very likely to be FAQs; please refer to the
-        [FAQ wiki page](https://github.com/Microsoft/TypeScript/wiki/FAQ#common-bugs-that-arent-bugs).
+        "Bugs" that have existed in TS for a long time are very likely to be FAQs; please refer to the [FAQ wiki page](https://github.com/Microsoft/TypeScript/wiki/FAQ#common-bugs-that-arent-bugs).
 
-        Please try the nightly version of TS to see if it's already been fixed.
-        Install `typescript@next` or use the [Playground](http://www.typescriptlang.org/play/?ts=Nightly).
+        Please try the nightly version of TS to see if it's already been fixed. Install `typescript@next` or use the [Playground](http://www.typescriptlang.org/play/?ts=Nightly).
 
-        If possible, try bisecting the issue using [every-ts](https://www.npmjs.com/package/every-ts#bisecting),
-        which should narrow down the problem to a specific change.
+        If possible, try bisecting the issue using [every-ts](https://www.npmjs.com/package/every-ts#bisecting), which should narrow down the problem to a specific change.
 
         The Playground also supports versions of TypeScript back to TypeScript 3.3.
 


### PR DESCRIPTION
I didn't realize it, but the markdown used in the bug template is apparently rendered using the same markdown processing as issues, which is to say that newlines are preserved even if they are part of the same paragraph. This is different than regular markdown files where paragraphs are joined. Annoying difference.

Anyway, I didn't intend for it to look like this:

![image](https://github.com/microsoft/TypeScript/assets/5341706/0d922792-b4c9-4214-92b6-1b05e553f182)

The lines were supposed to join.