### PR TITLE
Add user preference for preferring type-only auto imports

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -10014,6 +10014,7 @@ export interface UserPreferences {
     readonly interactiveInlayHints?: boolean;
     readonly allowRenameOfImportPath?: boolean;
     readonly autoImportFileExcludePatterns?: string[];
+    readonly preferTypeOnlyAutoImports?: boolean;
     readonly organizeImportsIgnoreCase?: "auto" | boolean;
     readonly organizeImportsCollation?: "ordinal" | "unicode";
     readonly organizeImportsLocale?: string;

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3323,12 +3323,16 @@ export class TestState {
         this.verifyRangeIs(expectedText, includeWhiteSpace);
     }
 
-    public verifyCodeFixAll({ fixId, fixAllDescription, newFileContent, commands: expectedCommands }: FourSlashInterface.VerifyCodeFixAllOptions): void {
-        const fixWithId = ts.find(this.getCodeFixes(this.activeFile.fileName), a => a.fixId === fixId);
+    public verifyCodeFixAll({ fixId, fixAllDescription, newFileContent, commands: expectedCommands, preferences }: FourSlashInterface.VerifyCodeFixAllOptions): void {
+        if (this.testType === FourSlashTestType.Server && preferences) {
+            this.configure(preferences);
+        }
+
+        const fixWithId = ts.find(this.getCodeFixes(this.activeFile.fileName, /*errorCode*/ undefined, preferences), a => a.fixId === fixId);
         ts.Debug.assert(fixWithId !== undefined, "No available code fix has the expected id. Fix All is not available if there is only one potentially fixable diagnostic present.", () => `Expected '${fixId}'. Available actions:\n${ts.mapDefined(this.getCodeFixes(this.activeFile.fileName), a => `${a.fixName} (${a.fixId || "no fix id"})`).join("\n")}`);
         ts.Debug.assertEqual(fixWithId.fixAllDescription, fixAllDescription);
 
-        const { changes, commands } = this.languageService.getCombinedCodeFix({ type: "file", fileName: this.activeFile.fileName }, fixId, this.formatCodeSettings, ts.emptyOptions);
+        const { changes, commands } = this.languageService.getCombinedCodeFix({ type: "file", fileName: this.activeFile.fileName }, fixId, this.formatCodeSettings, preferences || ts.emptyOptions);
         assert.deepEqual<readonly {}[] | undefined>(commands, expectedCommands);
         this.verifyNewContent({ newFileContent }, changes);
     }

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1873,6 +1873,7 @@ export interface VerifyCodeFixAllOptions {
     fixAllDescription: string;
     newFileContent: NewFileContent;
     commands: readonly {}[];
+    preferences?: ts.UserPreferences;
 }
 
 export interface VerifyRefactorOptions {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -8743,6 +8743,7 @@ declare namespace ts {
         readonly interactiveInlayHints?: boolean;
         readonly allowRenameOfImportPath?: boolean;
         readonly autoImportFileExcludePatterns?: string[];
+        readonly preferTypeOnlyAutoImports?: boolean;
         readonly organizeImportsIgnoreCase?: "auto" | boolean;
         readonly organizeImportsCollation?: "ordinal" | "unicode";
         readonly organizeImportsLocale?: string;

--- a/tests/cases/fourslash/autoImportTypeOnlyPreferred3.ts
+++ b/tests/cases/fourslash/autoImportTypeOnlyPreferred3.ts
@@ -1,0 +1,71 @@
+// @module: esnext
+// @moduleResolution: bundler
+
+// @Filename: /a.ts
+//// export class A {}
+//// export class B {}
+
+// @Filename: /b.ts
+//// let x: A/*b*/;
+
+// @Filename: /c.ts
+//// import { A } from "./a";
+//// new A();
+//// let x: B/*c*/;
+
+// @Filename: /d.ts
+//// new A();
+//// let x: B;
+
+// @Filename: /ns.ts
+//// export * as default from "./a";
+
+// @Filename: /e.ts
+//// let x: /*e*/ns.A;
+
+goTo.marker("b");
+verify.importFixAtPosition([
+`import type { A } from "./a";
+
+let x: A;`],
+  /*errorCode*/ undefined,
+  {
+    preferTypeOnlyAutoImports: true,
+  }
+);
+
+goTo.marker("c");
+verify.importFixAtPosition([
+`import { A, type B } from "./a";
+new A();
+let x: B;`],
+  /*errorCode*/ undefined,
+  {
+    preferTypeOnlyAutoImports: true,
+  }
+);
+
+goTo.file("/d.ts");
+verify.codeFixAll({
+  fixId: "fixMissingImport",
+  fixAllDescription: "Add all missing imports",
+  newFileContent:
+`import { A, type B } from "./a";
+
+new A();
+let x: B;`,
+  preferences: {
+    preferTypeOnlyAutoImports: true,
+  },
+});
+
+goTo.marker("e");
+verify.importFixAtPosition([
+`import type ns from "./ns";
+
+let x: ns.A;`],
+  /*errorCode*/ undefined,
+  {
+    preferTypeOnlyAutoImports: true,
+  }
+);

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -364,7 +364,7 @@ declare namespace FourSlashInterface {
         docCommentTemplateAt(markerName: string | FourSlashInterface.Marker, expectedOffset: number, expectedText: string, options?: VerifyDocCommentTemplateOptions): void;
         noDocCommentTemplateAt(markerName: string | FourSlashInterface.Marker): void;
         rangeAfterCodeFix(expectedText: string, includeWhiteSpace?: boolean, errorCode?: number, index?: number): void;
-        codeFixAll(options: { fixId: string, fixAllDescription: string, newFileContent: NewFileContent, commands?: {}[] }): void;
+        codeFixAll(options: { fixId: string, fixAllDescription: string, newFileContent: NewFileContent, commands?: {}[], preferences?: UserPreferences }): void;
         fileAfterApplyingRefactorAtMarker(markerName: string, expectedContent: string, refactorNameToApply: string, actionName: string, formattingOptions?: FormatCodeOptions): void;
         rangeIs(expectedText: string, includeWhiteSpace?: boolean): void;
         fileAfterApplyingRefactorAtMarker(markerName: string, expectedContent: string, refactorNameToApply: string, formattingOptions?: FormatCodeOptions): void;
@@ -664,6 +664,7 @@ declare namespace FourSlashInterface {
         readonly providePrefixAndSuffixTextForRename?: boolean;
         readonly allowRenameOfImportPath?: boolean;
         readonly autoImportFileExcludePatterns?: readonly string[];
+        readonly preferTypeOnlyAutoImports?: boolean;
         readonly organizeImportsIgnoreCase?: "auto" | boolean;
         readonly organizeImportsCollation?: "unicode" | "ordinal";
         readonly organizeImportsLocale?: string;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Closes #55675

This makes the auto-imports behavior of `verbatimModuleSyntax` available as an editor preference, independent of compiler options. Stylistic preference for type-only imports has been a popular demand since the syntax was introduced, and compiler options which may or may not be appropriate for a user’s actual compilation have long been adopted for their side effects on auto-import behavior. This setting allows users to separate their stylistic preference from picking the right compiler options for their actual use case.