### PR TITLE
Specialized parsing error for apparent JSX tag in .ts file

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1524,6 +1524,10 @@
         "category": "Error",
         "code": 1464
     },
+    "JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?": {
+        "category": "Error",
+        "code": 1465
+    },
 
     "The 'import.meta' meta-property is not allowed in files which will build into CommonJS output.": {
         "category": "Error",

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.errors.txt
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.errors.txt
@@ -1,0 +1,19 @@
+nonTsxExtensionOpeningClosingTag.ts(2,24): error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+nonTsxExtensionOpeningClosingTag.ts(2,25): error TS2304: Cannot find name 'span'.
+nonTsxExtensionOpeningClosingTag.ts(2,30): error TS2304: Cannot find name 'yippee'.
+nonTsxExtensionOpeningClosingTag.ts(2,38): error TS2304: Cannot find name 'span'.
+
+
+==== nonTsxExtensionOpeningClosingTag.ts (4 errors) ====
+    console.log("before");
+    export const _ = () => <span>yippee</span>;
+                           ~~~~~~~~~~~~~~~~~~~
+!!! error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+                            ~~~~
+!!! error TS2304: Cannot find name 'span'.
+                                 ~~~~~~
+!!! error TS2304: Cannot find name 'yippee'.
+                                         ~~~~
+!!! error TS2304: Cannot find name 'span'.
+    console.log("after");
+    

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.js
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTag.ts] ////
+
+//// [nonTsxExtensionOpeningClosingTag.ts]
+console.log("before");
+export const _ = () => <span>yippee</span>;
+console.log("after");
+
+
+//// [nonTsxExtensionOpeningClosingTag.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports._ = void 0;
+console.log("before");
+var _ = function () { return yippee < span; };
+exports._ = _;
+console.log("after");

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.symbols
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.symbols
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTag.ts] ////
+
+=== nonTsxExtensionOpeningClosingTag.ts ===
+console.log("before");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+export const _ = () => <span>yippee</span>;
+>_ : Symbol(_, Decl(nonTsxExtensionOpeningClosingTag.ts, 1, 12))
+>span : Symbol(span)
+
+console.log("after");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.types
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTag.types
@@ -1,0 +1,25 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTag.ts] ////
+
+=== nonTsxExtensionOpeningClosingTag.ts ===
+console.log("before");
+>console.log("before") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"before" : "before"
+
+export const _ = () => <span>yippee</span>;
+>_ : () => boolean
+>() => <span>yippee</span> : () => boolean
+><span>yippee</span> : boolean
+><span>yippee : span
+>yippee : any
+>span : any
+
+console.log("after");
+>console.log("after") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"after" : "after"
+

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.errors.txt
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.errors.txt
@@ -1,0 +1,48 @@
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,25): error TS2304: Cannot find name 'span'.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,30): error TS1005: '>' expected.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,30): error TS2304: Cannot find name 'aria'.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,35): error TS2304: Cannot find name 'disabled'.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,44): error TS1005: ',' expected.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,52): error TS2349: This expression is not callable.
+  Type '{}' has no call signatures.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,53): error TS1136: Property assignment expected.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,56): error TS1005: ';' expected.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,61): error TS1128: Declaration or statement expected.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,62): error TS1109: Expression expected.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,62): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'RegExp'.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,63): error TS2304: Cannot find name 'yippee'.
+nonTsxExtensionOpeningClosingTagAttributes.ts(2,71): error TS1161: Unterminated regular expression literal.
+
+
+==== nonTsxExtensionOpeningClosingTagAttributes.ts (13 errors) ====
+    console.log("before");
+    export const _ = () => <span aria-disabled onClick={() => {}}>yippee</span>;
+                            ~~~~
+!!! error TS2304: Cannot find name 'span'.
+                                 ~~~~
+!!! error TS1005: '>' expected.
+                                 ~~~~
+!!! error TS2304: Cannot find name 'aria'.
+                                      ~~~~~~~~
+!!! error TS2304: Cannot find name 'disabled'.
+                                               ~~~~~~~
+!!! error TS1005: ',' expected.
+                                                       ~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type '{}' has no call signatures.
+                                                        ~
+!!! error TS1136: Property assignment expected.
+                                                           ~~
+!!! error TS1005: ';' expected.
+                                                                ~
+!!! error TS1128: Declaration or statement expected.
+                                                                 ~
+!!! error TS1109: Expression expected.
+                                                                 ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'RegExp'.
+                                                                  ~~~~~~
+!!! error TS2304: Cannot find name 'yippee'.
+                                                                          
+!!! error TS1161: Unterminated regular expression literal.
+    console.log("after");
+    

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.js
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.js
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagAttributes.ts] ////
+
+//// [nonTsxExtensionOpeningClosingTagAttributes.ts]
+console.log("before");
+export const _ = () => <span aria-disabled onClick={() => {}}>yippee</span>;
+console.log("after");
+
+
+//// [nonTsxExtensionOpeningClosingTagAttributes.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.onClick = exports._ = void 0;
+console.log("before");
+var _ = function () { return aria - disabled; };
+exports._ = _, exports.onClick = {}();
+{ }
+ > yippee < /span>;;
+console.log("after");

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.symbols
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagAttributes.ts] ////
+
+=== nonTsxExtensionOpeningClosingTagAttributes.ts ===
+console.log("before");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+export const _ = () => <span aria-disabled onClick={() => {}}>yippee</span>;
+>_ : Symbol(_, Decl(nonTsxExtensionOpeningClosingTagAttributes.ts, 1, 12))
+>span : Symbol(span)
+>onClick : Symbol(onClick, Decl(nonTsxExtensionOpeningClosingTagAttributes.ts, 1, 42))
+
+console.log("after");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.types
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagAttributes.types
@@ -1,0 +1,33 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagAttributes.ts] ////
+
+=== nonTsxExtensionOpeningClosingTagAttributes.ts ===
+console.log("before");
+>console.log("before") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"before" : "before"
+
+export const _ = () => <span aria-disabled onClick={() => {}}>yippee</span>;
+>_ : () => number
+>() => <span aria-disabled : () => number
+><span aria-disabled : number
+><span aria : span
+>aria : any
+>disabled : any
+>onClick : any
+>{() : any
+>{ : {}
+>>yippee</span>; : boolean
+>>yippee : boolean
+> : any
+>yippee : any
+>/span>; : RegExp
+
+console.log("after");
+>console.log("after") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"after" : "after"
+

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.errors.txt
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.errors.txt
@@ -1,0 +1,23 @@
+nonTsxExtensionOpeningClosingTagMultiline.ts(2,24): error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+nonTsxExtensionOpeningClosingTagMultiline.ts(2,25): error TS2304: Cannot find name 'span'.
+nonTsxExtensionOpeningClosingTagMultiline.ts(3,5): error TS2304: Cannot find name 'yippee'.
+nonTsxExtensionOpeningClosingTagMultiline.ts(4,3): error TS2304: Cannot find name 'span'.
+
+
+==== nonTsxExtensionOpeningClosingTagMultiline.ts (4 errors) ====
+    console.log("before");
+    export const _ = () => <span>
+                           ~~~~~~
+                            ~~~~
+!!! error TS2304: Cannot find name 'span'.
+        yippee
+    ~~~~~~~~~~
+        ~~~~~~
+!!! error TS2304: Cannot find name 'yippee'.
+    </span>;
+    ~~~~~~~
+!!! error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+      ~~~~
+!!! error TS2304: Cannot find name 'span'.
+    console.log("after");
+    

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.js
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.js
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagMultiline.ts] ////
+
+//// [nonTsxExtensionOpeningClosingTagMultiline.ts]
+console.log("before");
+export const _ = () => <span>
+    yippee
+</span>;
+console.log("after");
+
+
+//// [nonTsxExtensionOpeningClosingTagMultiline.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports._ = void 0;
+console.log("before");
+var _ = function () { return yippee
+    < span; };
+exports._ = _;
+console.log("after");

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.symbols
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagMultiline.ts] ////
+
+=== nonTsxExtensionOpeningClosingTagMultiline.ts ===
+console.log("before");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+export const _ = () => <span>
+>_ : Symbol(_, Decl(nonTsxExtensionOpeningClosingTagMultiline.ts, 1, 12))
+>span : Symbol(span)
+
+    yippee
+</span>;
+console.log("after");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+

--- a/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.types
+++ b/tests/baselines/reference/nonTsxExtensionOpeningClosingTagMultiline.types
@@ -1,0 +1,29 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagMultiline.ts] ////
+
+=== nonTsxExtensionOpeningClosingTagMultiline.ts ===
+console.log("before");
+>console.log("before") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"before" : "before"
+
+export const _ = () => <span>
+>_ : () => boolean
+>() => <span>    yippee</span> : () => boolean
+><span>    yippee</span> : boolean
+><span>    yippee : span
+
+    yippee
+>yippee : any
+
+</span>;
+>span : any
+
+console.log("after");
+>console.log("after") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"after" : "after"
+

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTag.errors.txt
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTag.errors.txt
@@ -1,0 +1,13 @@
+nonTsxExtensionSelfClosingTag.ts(2,24): error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+nonTsxExtensionSelfClosingTag.ts(2,25): error TS2304: Cannot find name 'span'.
+
+
+==== nonTsxExtensionSelfClosingTag.ts (2 errors) ====
+    console.log("before");
+    export const _ = () => <span />;
+                           ~~~~~~~~
+!!! error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+                            ~~~~
+!!! error TS2304: Cannot find name 'span'.
+    console.log("after");
+    

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTag.js
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTag.js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTag.ts] ////
+
+//// [nonTsxExtensionSelfClosingTag.ts]
+console.log("before");
+export const _ = () => <span />;
+console.log("after");
+
+
+//// [nonTsxExtensionSelfClosingTag.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports._ = void 0;
+console.log("before");
+var _ = function () { return ; };
+exports._ = _;
+console.log("after");

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTag.symbols
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTag.symbols
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTag.ts] ////
+
+=== nonTsxExtensionSelfClosingTag.ts ===
+console.log("before");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+export const _ = () => <span />;
+>_ : Symbol(_, Decl(nonTsxExtensionSelfClosingTag.ts, 1, 12))
+>span : Symbol(span)
+
+console.log("after");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTag.types
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTag.types
@@ -1,0 +1,26 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTag.ts] ////
+
+=== nonTsxExtensionSelfClosingTag.ts ===
+console.log("before");
+>console.log("before") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"before" : "before"
+
+export const _ = () => <span />;
+>_ : () => span
+>() => <span /> : () => span
+><span /> : span
+
+
+> : any
+
+export const _ = () => <span />;
+console.log("after");
+>console.log("after") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"after" : "after"
+

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.errors.txt
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.errors.txt
@@ -1,0 +1,15 @@
+nonTsxExtensionSelfClosingTagMultiline.ts(2,24): error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+nonTsxExtensionSelfClosingTagMultiline.ts(2,25): error TS2304: Cannot find name 'span'.
+
+
+==== nonTsxExtensionSelfClosingTagMultiline.ts (2 errors) ====
+    console.log("before");
+    export const _ = () => <span
+                           ~~~~~
+                            ~~~~
+!!! error TS2304: Cannot find name 'span'.
+    />;
+    ~~
+!!! error TS1465: JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
+    console.log("after");
+    

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.js
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.js
@@ -1,0 +1,17 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTagMultiline.ts] ////
+
+//// [nonTsxExtensionSelfClosingTagMultiline.ts]
+console.log("before");
+export const _ = () => <span
+/>;
+console.log("after");
+
+
+//// [nonTsxExtensionSelfClosingTagMultiline.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports._ = void 0;
+console.log("before");
+var _ = function () { return ; };
+exports._ = _;
+console.log("after");

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.symbols
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTagMultiline.ts] ////
+
+=== nonTsxExtensionSelfClosingTagMultiline.ts ===
+console.log("before");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+export const _ = () => <span
+>_ : Symbol(_, Decl(nonTsxExtensionSelfClosingTagMultiline.ts, 1, 12))
+>span : Symbol(span)
+
+/>;
+console.log("after");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+

--- a/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.types
+++ b/tests/baselines/reference/nonTsxExtensionSelfClosingTagMultiline.types
@@ -1,0 +1,27 @@
+//// [tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTagMultiline.ts] ////
+
+=== nonTsxExtensionSelfClosingTagMultiline.ts ===
+console.log("before");
+>console.log("before") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"before" : "before"
+
+export const _ = () => <span
+>_ : () => span
+>() => <span/> : () => span
+><span/> : span
+
+
+> : any
+
+export const _ = () => <span
+/>;
+console.log("after");
+>console.log("after") : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>"after" : "after"
+

--- a/tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTag.ts
+++ b/tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTag.ts
@@ -1,0 +1,3 @@
+console.log("before");
+export const _ = () => <span>yippee</span>;
+console.log("after");

--- a/tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagAttributes.ts
+++ b/tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagAttributes.ts
@@ -1,0 +1,3 @@
+console.log("before");
+export const _ = () => <span aria-disabled onClick={() => {}}>yippee</span>;
+console.log("after");

--- a/tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagMultiline.ts
+++ b/tests/cases/conformance/jsx/nonTsxExtensionOpeningClosingTagMultiline.ts
@@ -1,0 +1,5 @@
+console.log("before");
+export const _ = () => <span>
+    yippee
+</span>;
+console.log("after");

--- a/tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTag.ts
+++ b/tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTag.ts
@@ -1,0 +1,3 @@
+console.log("before");
+export const _ = () => <span />;
+console.log("after");

--- a/tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTagMultiline.ts
+++ b/tests/cases/conformance/jsx/nonTsxExtensionSelfClosingTagMultiline.ts
@@ -1,0 +1,4 @@
+console.log("before");
+export const _ = () => <span
+/>;
+console.log("after");


### PR DESCRIPTION
Adds a specialized diagnostic for the case of a `/>` (slash and greater-than-sigh) after an identifier in a non-JSX-mode file.

```plaintext
JSX tags are not permitted in `.ts` files. Did you mean to change the file extension to `.tsx`?
```

I'm not at all confident in this PR's approach. It feels _weird_ to work with a "`previousNode`" and then skip through tokens. Would love to know if there's a cleaner way of doing things, please!

This also doesn't capture every possible syntax variant that could appear to be from JSX syntax in a non-JSX file. I couldn't figure out any clean way to get more cases that came to mind.

Fixes #29375