### PR TITLE
Make "extract to constant" find and replace all similar expressions

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -170,7 +170,7 @@ import {
     visitEachChild,
     visitNode,
     visitNodes,
-    VisitResult
+    VisitResult,
 } from "../_namespaces/ts";
 import {
     refactorKindBeginsWith,
@@ -1477,7 +1477,7 @@ function extractConstantInScope(
                 if (isLiteralExpression(a) && isLiteralExpression(b)) {
                     return a.text === b.text;
                 }
-                else if(isBooleanLiteral(a) && isBooleanLiteral(b)){
+                else if (isBooleanLiteral(a) && isBooleanLiteral(b)) {
                     // must be true here, since we check if a.kind !== b.kind above
                     return true;
                 }
@@ -1485,20 +1485,20 @@ function extractConstantInScope(
                     if (a.elements.length !== b.elements.length) return false;
                     return a.elements.every((a, i) => isSameNode(a, b.elements[i]));
                 }
-                else if(isObjectLiteralExpression(a) && isObjectLiteralExpression(b)){
-                    if(a.properties.length !== b.properties.length) return false;
+                else if (isObjectLiteralExpression(a) && isObjectLiteralExpression(b)) {
+                    if (a.properties.length !== b.properties.length) return false;
                     return a.properties.every((a, i) => isSameNode(a, b.properties[i]));
                 }
-                else if(isPropertyAssignment(a) && isPropertyAssignment(b)){
+                else if (isPropertyAssignment(a) && isPropertyAssignment(b)) {
                     return isSameNode(a.name, b.name) && isSameNode(a.initializer, b.initializer);
                 }
-                else if(isShorthandPropertyAssignment(a) && isShorthandPropertyAssignment(b)){
+                else if (isShorthandPropertyAssignment(a) && isShorthandPropertyAssignment(b)) {
                     return isSameNode(a.name, b.name);
                 }
-                else if(isComputedPropertyName(a) && isComputedPropertyName(b)){
+                else if (isComputedPropertyName(a) && isComputedPropertyName(b)) {
                     return isSameNode(a.expression, b.expression);
                 }
-                else if(isSpreadAssignment(a) && isSpreadAssignment(b) || isSpreadElement(a) && isSpreadElement(b)){
+                else if (isSpreadAssignment(a) && isSpreadAssignment(b) || isSpreadElement(a) && isSpreadElement(b)) {
                     return isSameNode(a.expression, b.expression);
                 }
                 else if (isIdentifier(a) && isIdentifier(b)) {
@@ -1509,7 +1509,7 @@ function extractConstantInScope(
                 else if (isPropertyAccessExpression(a) && isPropertyAccessExpression(b)) {
                     return isSameNode(a.expression, b.expression) && isSameNode(a.name, b.name) && a.questionDotToken?.kind === b.questionDotToken?.kind;
                 }
-                else if(isElementAccessExpression(a) && isElementAccessExpression(b)){
+                else if (isElementAccessExpression(a) && isElementAccessExpression(b)) {
                     return isSameNode(a.expression, b.expression) && isSameNode(a.argumentExpression, b.argumentExpression) && a.questionDotToken?.kind === b.questionDotToken?.kind;
                 }
                 else if (isBinaryExpression(a) && isBinaryExpression(b)) {
@@ -1518,12 +1518,12 @@ function extractConstantInScope(
                 else if (isConditionalExpression(a) && isConditionalExpression(b)) {
                     return isSameNode(a.condition, b.condition) && isSameNode(a.whenTrue, b.whenTrue) && isSameNode(a.whenFalse, b.whenFalse);
                 }
-                else if(isCallExpression(a) && isCallExpression(b)){
-                    if(isSameNode(a.expression, b.expression) && a.questionDotToken?.kind === b.questionDotToken?.kind && a.arguments.length === b.arguments.length && a.typeArguments?.length === b.typeArguments?.length){
+                else if (isCallExpression(a) && isCallExpression(b)) {
+                    if (isSameNode(a.expression, b.expression) && a.questionDotToken?.kind === b.questionDotToken?.kind && a.arguments.length === b.arguments.length && a.typeArguments?.length === b.typeArguments?.length) {
                         return a.arguments.every((a, i) => isSameNode(a, b.arguments[i])) && (a.typeArguments?.every((a, i) => isSameNode(a, b.typeArguments![i])) ?? true);
                     }
                 }
-                else if(isPrefixUnaryExpression(a) && isPrefixUnaryExpression(b) || isPostfixUnaryExpression(a) && isPostfixUnaryExpression(b)){
+                else if (isPrefixUnaryExpression(a) && isPrefixUnaryExpression(b) || isPostfixUnaryExpression(a) && isPostfixUnaryExpression(b)) {
                     return a.operator === b.operator && isSameNode(a.operand, b.operand);
                 }
 

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -63,18 +63,13 @@ import {
     Identifier,
     identifierToKeywordKind,
     isArray,
-    isArrayLiteralExpression,
     isArrowFunction,
     isAssignmentExpression,
     isBinaryExpression,
     isBlock,
     isBlockScope,
-    isBooleanLiteral,
-    isCallExpression,
     isCaseClause,
     isClassLike,
-    isComputedPropertyName,
-    isConditionalExpression,
     isConstructorDeclaration,
     isDeclaration,
     isDeclarationWithTypeParameters,
@@ -93,23 +88,16 @@ import {
     isJsxElement,
     isJsxFragment,
     isJsxSelfClosingElement,
-    isLiteralExpression,
     isModuleBlock,
-    isObjectLiteralExpression,
     isParenthesizedTypeNode,
     isPartOfTypeNode,
-    isPostfixUnaryExpression,
-    isPrefixUnaryExpression,
     isPrivateIdentifier,
     isPropertyAccessExpression,
-    isPropertyAssignment,
     isPropertyDeclaration,
     isQualifiedName,
     isReturnStatement,
     isShorthandPropertyAssignment,
     isSourceFile,
-    isSpreadAssignment,
-    isSpreadElement,
     isStatement,
     isStatic,
     isStringLiteral,
@@ -176,6 +164,9 @@ import {
     refactorKindBeginsWith,
     registerRefactor,
 } from "../_namespaces/ts.refactor";
+import {
+    isSameNode,
+} from "./isSameNode";
 
 const refactorName = "Extract Symbol";
 
@@ -1470,64 +1461,6 @@ function extractConstantInScope(
             }
             else {
                 changeTracker.insertNodeBefore(context.file, nodeToInsertBefore, newVariableStatement, /*blankLineBetween*/ false);
-            }
-
-            function isSameNode(a: Node, b: Node): boolean {
-                if (a.kind !== b.kind) return false;
-                if (isLiteralExpression(a) && isLiteralExpression(b)) {
-                    return a.text === b.text;
-                }
-                else if (isBooleanLiteral(a) && isBooleanLiteral(b)) {
-                    // must be true here, since we check if a.kind !== b.kind above
-                    return true;
-                }
-                else if (isArrayLiteralExpression(a) && isArrayLiteralExpression(b)) {
-                    if (a.elements.length !== b.elements.length) return false;
-                    return a.elements.every((a, i) => isSameNode(a, b.elements[i]));
-                }
-                else if (isObjectLiteralExpression(a) && isObjectLiteralExpression(b)) {
-                    if (a.properties.length !== b.properties.length) return false;
-                    return a.properties.every((a, i) => isSameNode(a, b.properties[i]));
-                }
-                else if (isPropertyAssignment(a) && isPropertyAssignment(b)) {
-                    return isSameNode(a.name, b.name) && isSameNode(a.initializer, b.initializer);
-                }
-                else if (isShorthandPropertyAssignment(a) && isShorthandPropertyAssignment(b)) {
-                    return isSameNode(a.name, b.name);
-                }
-                else if (isComputedPropertyName(a) && isComputedPropertyName(b)) {
-                    return isSameNode(a.expression, b.expression);
-                }
-                else if (isSpreadAssignment(a) && isSpreadAssignment(b) || isSpreadElement(a) && isSpreadElement(b)) {
-                    return isSameNode(a.expression, b.expression);
-                }
-                else if (isIdentifier(a) && isIdentifier(b)) {
-                    return a.symbol
-                        ? a.symbol === b.symbol
-                        : a.text === b.text;
-                }
-                else if (isPropertyAccessExpression(a) && isPropertyAccessExpression(b)) {
-                    return isSameNode(a.expression, b.expression) && isSameNode(a.name, b.name) && a.questionDotToken?.kind === b.questionDotToken?.kind;
-                }
-                else if (isElementAccessExpression(a) && isElementAccessExpression(b)) {
-                    return isSameNode(a.expression, b.expression) && isSameNode(a.argumentExpression, b.argumentExpression) && a.questionDotToken?.kind === b.questionDotToken?.kind;
-                }
-                else if (isBinaryExpression(a) && isBinaryExpression(b)) {
-                    return a.operatorToken.kind === b.operatorToken.kind && isSameNode(a.left, b.left) && isSameNode(a.right, b.right);
-                }
-                else if (isConditionalExpression(a) && isConditionalExpression(b)) {
-                    return isSameNode(a.condition, b.condition) && isSameNode(a.whenTrue, b.whenTrue) && isSameNode(a.whenFalse, b.whenFalse);
-                }
-                else if (isCallExpression(a) && isCallExpression(b)) {
-                    if (isSameNode(a.expression, b.expression) && a.questionDotToken?.kind === b.questionDotToken?.kind && a.arguments.length === b.arguments.length && a.typeArguments?.length === b.typeArguments?.length) {
-                        return a.arguments.every((a, i) => isSameNode(a, b.arguments[i])) && (a.typeArguments?.every((a, i) => isSameNode(a, b.typeArguments![i])) ?? true);
-                    }
-                }
-                else if (isPrefixUnaryExpression(a) && isPrefixUnaryExpression(b) || isPostfixUnaryExpression(a) && isPostfixUnaryExpression(b)) {
-                    return a.operator === b.operator && isSameNode(a.operand, b.operand);
-                }
-
-                return false;
             }
 
             function visitor(potentialNode: Node) {

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -161,7 +161,7 @@ import {
     visitEachChild,
     visitNode,
     visitNodes,
-    VisitResult
+    VisitResult,
 } from "../_namespaces/ts";
 import {
     refactorKindBeginsWith,
@@ -923,8 +923,8 @@ function getPossibleExtractions(targetRange: TargetRange, context: RefactorConte
         const scopeDescription = isFunctionLikeDeclaration(scope)
             ? getDescriptionForFunctionLikeDeclaration(scope)
             : isClassLike(scope)
-                ? getDescriptionForClassLikeDeclaration(scope)
-                : getDescriptionForModuleLikeDeclaration(scope);
+            ? getDescriptionForClassLikeDeclaration(scope)
+            : getDescriptionForModuleLikeDeclaration(scope);
 
         let functionDescription: string;
         let constantDescription: string;
@@ -980,8 +980,8 @@ function getDescriptionForFunctionInScope(scope: Scope): string {
     return isFunctionLikeDeclaration(scope)
         ? "inner function"
         : isClassLike(scope)
-            ? "method"
-            : "function";
+        ? "method"
+        : "function";
 }
 function getDescriptionForConstantInScope(scope: Scope): string {
     return isClassLike(scope)
@@ -1467,29 +1467,30 @@ function extractConstantInScope(
                 if (a.kind !== b.kind) return false;
                 if (isLiteralExpression(a) && isLiteralExpression(b)) {
                     return a.text === b.text;
-                } else if (isArrayLiteralExpression(a) && isArrayLiteralExpression(b)) {
+                }
+                else if (isArrayLiteralExpression(a) && isArrayLiteralExpression(b)) {
                     if (a.elements.length !== b.elements.length) return false;
                     return a.elements.every((a, i) => isSameNode(a, b.elements[i]));
-                } else if (isIdentifier(a) && isIdentifier(b)) {
+                }
+                else if (isIdentifier(a) && isIdentifier(b)) {
                     return a.symbol === b.symbol;
-                } else if (isPropertyAccessExpression(a) && isPropertyAccessExpression(b)) {
+                }
+                else if (isPropertyAccessExpression(a) && isPropertyAccessExpression(b)) {
                     return a.symbol === b.symbol;
-                } else if (isBinaryExpression(a) && isBinaryExpression(b)) {
+                }
+                else if (isBinaryExpression(a) && isBinaryExpression(b)) {
                     return a.operatorToken.kind === b.operatorToken.kind && isSameNode(a.left, b.left) && isSameNode(a.right, b.right);
-                } else if (isConditionalExpression(a) && isConditionalExpression(b)) {
+                }
+                else if (isConditionalExpression(a) && isConditionalExpression(b)) {
                     return isSameNode(a.condition, b.condition) && isSameNode(a.whenTrue, b.whenTrue) && isSameNode(a.whenFalse, b.whenFalse);
                 }
 
                 return false;
             }
 
-            function visitor(potentialNode: Node): VisitResult<Node | undefined> {
+            function visitor(potentialNode: Node) {
                 // Don't handle the actual node here, it wil be handled below using the old code
                 if (potentialNode === node) {
-                    return potentialNode;
-                }
-
-                if (potentialNode === newVariableDeclaration) {
                     return potentialNode;
                 }
 
@@ -1507,7 +1508,7 @@ function extractConstantInScope(
                     return potentialNode;
                 }
 
-                return visitEachChild(potentialNode, visitor, nullTransformationContext)
+                return visitEachChild(potentialNode, visitor, nullTransformationContext);
             }
 
             visitEachChild(scope, visitor, nullTransformationContext);
@@ -1782,7 +1783,7 @@ function getNodeToInsertConstantBefore(node: Node, scope: Scope): Statement {
         }
     }
 
-    for (let curr = (prevScope || node).parent; ; curr = curr.parent) {
+    for (let curr = (prevScope || node).parent;; curr = curr.parent) {
         if (isBlockLike(curr)) {
             let prevStatement: Statement | undefined;
             for (const statement of curr.statements) {
@@ -1817,8 +1818,8 @@ function getPropertyAssignmentsForWritesAndVariableDeclarations(
     return variableAssignments === undefined
         ? writeAssignments!
         : writeAssignments === undefined
-            ? variableAssignments
-            : variableAssignments.concat(writeAssignments);
+        ? variableAssignments
+        : variableAssignments.concat(writeAssignments);
 }
 
 function isReadonlyArray(v: any): v is readonly any[] {
@@ -1887,8 +1888,8 @@ function collectReadsAndWrites(
     const expression = !isReadonlyArray(targetRange.range)
         ? targetRange.range
         : targetRange.range.length === 1 && isExpressionStatement(targetRange.range[0])
-            ? targetRange.range[0].expression
-            : undefined;
+        ? targetRange.range[0].expression
+        : undefined;
 
     let expressionDiagnostic: Diagnostic | undefined;
     if (expression === undefined) {

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1473,10 +1473,10 @@ function extractConstantInScope(
                     return a.elements.every((a, i) => isSameNode(a, b.elements[i]));
                 }
                 else if (isIdentifier(a) && isIdentifier(b)) {
-                    return a.symbol === b.symbol;
+                    return a.symbol ? a.symbol === b.symbol : a.text === b.text;
                 }
                 else if (isPropertyAccessExpression(a) && isPropertyAccessExpression(b)) {
-                    return a.symbol === b.symbol;
+                    return a.symbol ? a.symbol === b.symbol : isSameNode(a.expression, b.expression) && isSameNode(a.name, b.name);
                 }
                 else if (isBinaryExpression(a) && isBinaryExpression(b)) {
                     return a.operatorToken.kind === b.operatorToken.kind && isSameNode(a.left, b.left) && isSameNode(a.right, b.right);

--- a/src/services/refactors/isSameNode.ts
+++ b/src/services/refactors/isSameNode.ts
@@ -1,0 +1,134 @@
+import {
+    ArrayLiteralExpression,
+    BigIntLiteral,
+    BinaryExpression,
+    CallExpression,
+    ComputedPropertyName,
+    ConditionalExpression,
+    ElementAccessExpression,
+    FalseLiteral,
+    Identifier,
+    JsxText,
+    Node,
+    NoSubstitutionTemplateLiteral,
+    NullLiteral,
+    NumericLiteral,
+    ObjectLiteralExpression,
+    PostfixUnaryExpression,
+    PrefixUnaryExpression,
+    PropertyAccessExpression,
+    PropertyAssignment,
+    RegularExpressionLiteral,
+    ShorthandPropertyAssignment,
+    SpreadAssignment,
+    SpreadElement,
+    StringLiteral,
+    SyntaxKind,
+    ThisExpression,
+    TrueLiteral,
+} from "../_namespaces/ts";
+
+export function isSameNode(a: Node, b: Node): boolean {
+    if (a.kind !== b.kind) return false;
+
+    return isSameNodeTable[a.kind]?.(a, b) ?? false;
+}
+
+const isSameNodeTable: Partial<Record<SyntaxKind, (a: any, b: any) => boolean>> = {
+    [SyntaxKind.NumericLiteral](a: NumericLiteral, b: NumericLiteral) {
+        return a.text === b.text;
+    },
+    [SyntaxKind.BigIntLiteral](a: BigIntLiteral, b: BigIntLiteral) {
+        return a.text === b.text;
+    },
+    [SyntaxKind.StringLiteral](a: StringLiteral, b: StringLiteral) {
+        return a.text === b.text;
+    },
+    [SyntaxKind.JsxText](a: JsxText, b: JsxText) {
+        return a.text === b.text;
+    },
+    [SyntaxKind.JsxTextAllWhiteSpaces](a: JsxText, b: JsxText) {
+        return a.text === b.text;
+    },
+    [SyntaxKind.RegularExpressionLiteral](a: RegularExpressionLiteral, b: RegularExpressionLiteral) {
+        return a.text === b.text;
+    },
+    [SyntaxKind.NoSubstitutionTemplateLiteral](a: NoSubstitutionTemplateLiteral, b: NoSubstitutionTemplateLiteral) {
+        return a.text === b.text;
+    },
+    [SyntaxKind.TrueKeyword](_a: TrueLiteral, _b: TrueLiteral) {
+        return true;
+    },
+    [SyntaxKind.FalseKeyword](_a: FalseLiteral, _b: FalseLiteral) {
+        return true;
+    },
+    [SyntaxKind.NullKeyword](_a: NullLiteral, _b: NullLiteral) {
+        return true;
+    },
+    [SyntaxKind.ThisKeyword](_a: ThisExpression, _b: ThisExpression) {
+        return true; // TODO: figure out why a.symbol doesn't exist
+    },
+    [SyntaxKind.ArrayLiteralExpression](a: ArrayLiteralExpression, b: ArrayLiteralExpression) {
+        if (a.elements.length !== b.elements.length) return false;
+        return a.elements.every((a, i) => isSameNode(a, b.elements[i]));
+    },
+    [SyntaxKind.ObjectLiteralExpression](a: ObjectLiteralExpression, b: ObjectLiteralExpression) {
+        if (a.properties.length !== b.properties.length) return false;
+        return a.properties.every((a, i) => isSameNode(a, b.properties[i]));
+    },
+    [SyntaxKind.PropertyAssignment](a: PropertyAssignment, b: PropertyAssignment) {
+        return isSameNode(a.name, b.name)
+            && isSameNode(a.initializer, b.initializer);
+    },
+    [SyntaxKind.ShorthandPropertyAssignment](a: ShorthandPropertyAssignment, b: ShorthandPropertyAssignment) {
+        return isSameNode(a.name, b.name);
+    },
+    [SyntaxKind.ComputedPropertyName](a: ComputedPropertyName, b: ComputedPropertyName) {
+        return isSameNode(a.expression, b.expression);
+    },
+    [SyntaxKind.SpreadAssignment](a: SpreadAssignment, b: SpreadAssignment) {
+        return isSameNode(a.expression, b.expression);
+    },
+    [SyntaxKind.SpreadElement](a: SpreadElement, b: SpreadElement) {
+        return isSameNode(a.expression, b.expression);
+    },
+    [SyntaxKind.Identifier](a: Identifier, b: Identifier) {
+        return a.symbol
+            ? a.symbol === b.symbol
+            : a.text === b.text;
+    },
+    [SyntaxKind.PropertyAccessExpression](a: PropertyAccessExpression, b: PropertyAccessExpression) {
+        return isSameNode(a.expression, b.expression)
+            && isSameNode(a.name, b.name)
+            && a.questionDotToken?.kind === b.questionDotToken?.kind;
+    },
+    [SyntaxKind.ElementAccessExpression](a: ElementAccessExpression, b: ElementAccessExpression) {
+        return isSameNode(a.expression, b.expression)
+            && isSameNode(a.argumentExpression, b.argumentExpression)
+            && a.questionDotToken?.kind === b.questionDotToken?.kind;
+    },
+    [SyntaxKind.BinaryExpression](a: BinaryExpression, b: BinaryExpression) {
+        return a.operatorToken.kind === b.operatorToken.kind
+            && isSameNode(a.left, b.left)
+            && isSameNode(a.right, b.right);
+    },
+    [SyntaxKind.ConditionalExpression](a: ConditionalExpression, b: ConditionalExpression) {
+        return isSameNode(a.condition, b.condition)
+            && isSameNode(a.whenTrue, b.whenTrue)
+            && isSameNode(a.whenFalse, b.whenFalse);
+    },
+    [SyntaxKind.CallExpression](a: CallExpression, b: CallExpression) {
+        return isSameNode(a.expression, b.expression)
+            && a.questionDotToken?.kind === b.questionDotToken?.kind
+            && a.arguments.length === b.arguments.length
+            && a.typeArguments?.length === b.typeArguments?.length
+            && a.arguments.every((a, i) => isSameNode(a, b.arguments[i]))
+            && (a.typeArguments?.every((a, i) => isSameNode(a, b.typeArguments![i])) ?? true);
+    },
+    [SyntaxKind.PrefixUnaryExpression](a: PrefixUnaryExpression, b: PrefixUnaryExpression) {
+        return a.operator === b.operator && isSameNode(a.operand, b.operand);
+    },
+    [SyntaxKind.PostfixUnaryExpression](a: PostfixUnaryExpression, b: PostfixUnaryExpression) {
+        return a.operator === b.operator && isSameNode(a.operand, b.operand);
+    },
+};

--- a/src/services/refactors/isSameNode.ts
+++ b/src/services/refactors/isSameNode.ts
@@ -29,6 +29,8 @@ import {
 } from "../_namespaces/ts";
 
 export function isSameNode(a: Node, b: Node): boolean {
+    if(a === b) return true;
+
     if (a.kind !== b.kind) return false;
 
     return isSameNodeTable[a.kind]?.(a, b) ?? false;

--- a/src/services/refactors/isSameNode.ts
+++ b/src/services/refactors/isSameNode.ts
@@ -29,7 +29,7 @@ import {
 } from "../_namespaces/ts";
 
 export function isSameNode(a: Node, b: Node): boolean {
-    if(a === b) return true;
+    if (a === b) return true;
 
     if (a.kind !== b.kind) return false;
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3278,9 +3278,14 @@ export function getUniqueName(baseName: string, sourceFile: SourceFile): string 
  *
  * @internal
  */
-export function getRenameLocation(edits: readonly FileTextChanges[], renameFilename: string, name: string, preferLastLocation: boolean): number {
+export function getRenameLocation(edits: readonly FileTextChanges[], renameFilename: string, name: string, preferLastLocation: boolean): number;
+/** @internal */
+export function getRenameLocation(edits: readonly FileTextChanges[], renameFilename: string, name: string, preferredLocation: number): number;
+export function getRenameLocation(edits: readonly FileTextChanges[], renameFilename: string, name: string, preferredLocation: number | boolean): number {
     let delta = 0;
     let lastPos = -1;
+    let location = 0;
+    const preferFirstLocation = preferredLocation === false;
     for (const { fileName, textChanges } of edits) {
         Debug.assert(fileName === renameFilename);
         for (const change of textChanges) {
@@ -3290,16 +3295,19 @@ export function getRenameLocation(edits: readonly FileTextChanges[], renameFilen
                 lastPos = span.start + delta + index;
 
                 // If the reference comes first, return immediately.
-                if (!preferLastLocation) {
+                if (preferFirstLocation) {
                     return lastPos;
                 }
+                else if (preferredLocation === location) {
+                    return lastPos;
+                }
+                location++;
             }
             delta += newText.length - span.length;
         }
     }
 
     // If the declaration comes first, return the position of the last occurrence.
-    Debug.assert(preferLastLocation);
     Debug.assert(lastPos >= 0);
     return lastPos;
 }

--- a/src/testRunner/unittests/services/extract/constants.ts
+++ b/src/testRunner/unittests/services/extract/constants.ts
@@ -78,7 +78,7 @@ function F() {
     M1() { }
     M2() { }
     M3() {
-        let x = [#|1|];
+        let x = [#|3|];
     }
 }`,
     );
@@ -91,7 +91,7 @@ function F() {
     b = 2;
     M2() { }
     M3() {
-        let x = [#|1|];
+        let x = [#|3|];
     }
 }`,
     );
@@ -104,7 +104,7 @@ function F() {
     b = 2;
     M2() { }
     M3() {
-        let x = [#|1|];
+        let x = [#|3|];
     }
 }`,
     );
@@ -372,7 +372,7 @@ const myObj: { member(x: number, y: string): void } = {
         "extractConstant_CaseClauseExpression",
         `
 switch (1) {
-    case [#|1|]:
+    case [#|2|]:
         break;
 }
 `,

--- a/tests/baselines/reference/extractConstant/extractConstant_CaseClauseExpression.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_CaseClauseExpression.js
@@ -1,12 +1,12 @@
 // ==ORIGINAL==
 
 switch (1) {
-    case /*[#|*/1/*|]*/:
+    case /*[#|*/2/*|]*/:
         break;
 }
 
 // ==SCOPE::Extract to constant in enclosing scope==
-const newLocal = 1;
+const newLocal = 2;
 switch (1) {
     case /*RENAME*/newLocal:
         break;

--- a/tests/baselines/reference/extractConstant/extractConstant_CaseClauseExpression.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_CaseClauseExpression.ts
@@ -1,12 +1,12 @@
 // ==ORIGINAL==
 
 switch (1) {
-    case /*[#|*/1/*|]*/:
+    case /*[#|*/2/*|]*/:
         break;
 }
 
 // ==SCOPE::Extract to constant in enclosing scope==
-const newLocal = 1;
+const newLocal = 2;
 switch (1) {
     case /*RENAME*/newLocal:
         break;

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.js
@@ -5,7 +5,7 @@ class C {
     M1() { }
     M2() { }
     M3() {
-        let x = /*[#|*/1/*|]*/;
+        let x = /*[#|*/3/*|]*/;
     }
 }
 // ==SCOPE::Extract to constant in enclosing scope==
@@ -15,12 +15,12 @@ class C {
     M1() { }
     M2() { }
     M3() {
-        const newLocal = 1;
+        const newLocal = 3;
         let x = /*RENAME*/newLocal;
     }
 }
 // ==SCOPE::Extract to constant in global scope==
-const newLocal = 1;
+const newLocal = 3;
 class C {
     a = 1;
     b = 2;

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition1.ts
@@ -5,7 +5,7 @@ class C {
     M1() { }
     M2() { }
     M3() {
-        let x = /*[#|*/1/*|]*/;
+        let x = /*[#|*/3/*|]*/;
     }
 }
 // ==SCOPE::Extract to constant in enclosing scope==
@@ -15,7 +15,7 @@ class C {
     M1() { }
     M2() { }
     M3() {
-        const newLocal = 1;
+        const newLocal = 3;
         let x = /*RENAME*/newLocal;
     }
 }
@@ -23,7 +23,7 @@ class C {
 class C {
     a = 1;
     b = 2;
-    private readonly newProperty = 1;
+    private readonly newProperty = 3;
 
     M1() { }
     M2() { }
@@ -32,7 +32,7 @@ class C {
     }
 }
 // ==SCOPE::Extract to constant in global scope==
-const newLocal = 1;
+const newLocal = 3;
 class C {
     a = 1;
     b = 2;

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.js
@@ -5,7 +5,7 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        let x = /*[#|*/1/*|]*/;
+        let x = /*[#|*/3/*|]*/;
     }
 }
 // ==SCOPE::Extract to constant in enclosing scope==
@@ -15,12 +15,12 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        const newLocal = 1;
+        const newLocal = 3;
         let x = /*RENAME*/newLocal;
     }
 }
 // ==SCOPE::Extract to constant in global scope==
-const newLocal = 1;
+const newLocal = 3;
 class C {
     a = 1;
     M1() { }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition2.ts
@@ -5,7 +5,7 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        let x = /*[#|*/1/*|]*/;
+        let x = /*[#|*/3/*|]*/;
     }
 }
 // ==SCOPE::Extract to constant in enclosing scope==
@@ -15,14 +15,14 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        const newLocal = 1;
+        const newLocal = 3;
         let x = /*RENAME*/newLocal;
     }
 }
 // ==SCOPE::Extract to readonly field in class 'C'==
 class C {
     a = 1;
-    private readonly newProperty = 1;
+    private readonly newProperty = 3;
 
     M1() { }
     b = 2;
@@ -32,7 +32,7 @@ class C {
     }
 }
 // ==SCOPE::Extract to constant in global scope==
-const newLocal = 1;
+const newLocal = 3;
 class C {
     a = 1;
     M1() { }

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.js
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.js
@@ -5,7 +5,7 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        let x = /*[#|*/1/*|]*/;
+        let x = /*[#|*/3/*|]*/;
     }
 }
 // ==SCOPE::Extract to constant in enclosing scope==
@@ -15,12 +15,12 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        const newLocal = 1;
+        const newLocal = 3;
         let x = /*RENAME*/newLocal;
     }
 }
 // ==SCOPE::Extract to constant in global scope==
-const newLocal = 1;
+const newLocal = 3;
 class C {
     M1() { }
     a = 1;

--- a/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.ts
+++ b/tests/baselines/reference/extractConstant/extractConstant_ClassInsertionPosition3.ts
@@ -5,7 +5,7 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        let x = /*[#|*/1/*|]*/;
+        let x = /*[#|*/3/*|]*/;
     }
 }
 // ==SCOPE::Extract to constant in enclosing scope==
@@ -15,7 +15,7 @@ class C {
     b = 2;
     M2() { }
     M3() {
-        const newLocal = 1;
+        const newLocal = 3;
         let x = /*RENAME*/newLocal;
     }
 }
@@ -25,14 +25,14 @@ class C {
     a = 1;
     b = 2;
     M2() { }
-    private readonly newProperty = 1;
+    private readonly newProperty = 3;
 
     M3() {
         let x = this./*RENAME*/newProperty;
     }
 }
 // ==SCOPE::Extract to constant in global scope==
-const newLocal = 1;
+const newLocal = 3;
 class C {
     M1() { }
     a = 1;

--- a/tests/cases/fourslash/extract-const_multiple_array.ts
+++ b/tests/cases/fourslash/extract-const_multiple_array.ts
@@ -15,8 +15,8 @@ edit.applyRefactor({
     newContent:
         `const newLocal = [1, 2];
 function foo() {
-    const a = newLocal;
-    const b = /*RENAME*/newLocal;
+    const a = /*RENAME*/newLocal;
+    const b = newLocal;
     return a;
 }`
 });

--- a/tests/cases/fourslash/extract-const_multiple_array.ts
+++ b/tests/cases/fourslash/extract-const_multiple_array.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    /*a*/const a = [1, 2]/*b*/;
+////    const b = [1, 2];
+////    return a;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const newLocal = [1, 2];
+function foo() {
+    const a = newLocal;
+    const b = /*RENAME*/newLocal;
+    return a;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_binaryExpression.ts
+++ b/tests/cases/fourslash/extract-const_multiple_binaryExpression.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    const /*a*/a = 1 + "test"/*b*/;
+////    const b = 1 + "test";
+////    return a + b;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const newLocal = 1 + "test";
+function foo() {
+    const a = newLocal;
+    const b = /*RENAME*/newLocal;
+    return a + b;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_binaryExpression.ts
+++ b/tests/cases/fourslash/extract-const_multiple_binaryExpression.ts
@@ -15,8 +15,8 @@ edit.applyRefactor({
     newContent:
         `const newLocal = 1 + "test";
 function foo() {
-    const a = newLocal;
-    const b = /*RENAME*/newLocal;
+    const a = /*RENAME*/newLocal;
+    const b = newLocal;
     return a + b;
 }`
 });

--- a/tests/cases/fourslash/extract-const_multiple_call.ts
+++ b/tests/cases/fourslash/extract-const_multiple_call.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo(i, b) {
+////    const bar = (...a) => a;
+////    /*a*/const a = bar("test", i++, !b, ...[1, 2, 3])/*b*/;
+////    const b = bar("test", i++, !b, ...[1, 2, 3]);
+////    return a + b;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_0",
+    actionDescription: "Extract to constant in enclosing scope",
+    newContent:
+        `function foo(i, b) {
+    const bar = (...a) => a;
+    const newLocal = bar("test", i++, !b, ...[1, 2, 3]);
+    const a = /*RENAME*/newLocal;
+    const b = newLocal;
+    return a + b;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_conditionalExpression.ts
+++ b/tests/cases/fourslash/extract-const_multiple_conditionalExpression.ts
@@ -17,8 +17,8 @@ edit.applyRefactor({
         `const t = true;
 const newLocal = t ? 1 : "test";
 function foo() {
-    const a = newLocal;
-    const b = /*RENAME*/newLocal;
+    const a = /*RENAME*/newLocal;
+    const b = newLocal;
     return a + b;
 }`
 });

--- a/tests/cases/fourslash/extract-const_multiple_conditionalExpression.ts
+++ b/tests/cases/fourslash/extract-const_multiple_conditionalExpression.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////const t = true;
+////function foo() {
+////    const /*a*/a = t ? 1 : "test"/*b*/;
+////    const b = t ? 1 : "test";
+////    return a + b;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const t = true;
+const newLocal = t ? 1 : "test";
+function foo() {
+    const a = newLocal;
+    const b = /*RENAME*/newLocal;
+    return a + b;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_numeric.ts
+++ b/tests/cases/fourslash/extract-const_multiple_numeric.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    /*a*/const a = 1/*b*/;
+////    const b = 1;
+////    return a;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const newLocal = 1;
+function foo() {
+    const a = newLocal;
+    const b = /*RENAME*/newLocal;
+    return a;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_numeric.ts
+++ b/tests/cases/fourslash/extract-const_multiple_numeric.ts
@@ -15,8 +15,8 @@ edit.applyRefactor({
     newContent:
         `const newLocal = 1;
 function foo() {
-    const a = newLocal;
-    const b = /*RENAME*/newLocal;
+    const a = /*RENAME*/newLocal;
+    const b = newLocal;
     return a;
 }`
 });

--- a/tests/cases/fourslash/extract-const_multiple_numeric2.ts
+++ b/tests/cases/fourslash/extract-const_multiple_numeric2.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    const b = 1;
+////    /*a*/const a = 1/*b*/;
+////    return a;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const newLocal = 1;
+function foo() {
+    const b = newLocal;
+    const a = /*RENAME*/newLocal;
+    return a;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_object.ts
+++ b/tests/cases/fourslash/extract-const_multiple_object.ts
@@ -15,8 +15,8 @@ edit.applyRefactor({
     newContent:
         `const newLocal = { ...x, y, z: false, ['a']: true };
 function foo() {
-    const a = newLocal;
-    const b = /*RENAME*/newLocal;
+    const a = /*RENAME*/newLocal;
+    const b = newLocal;
     return a+b;
 }`
 });

--- a/tests/cases/fourslash/extract-const_multiple_object.ts
+++ b/tests/cases/fourslash/extract-const_multiple_object.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    /*a*/const a = { ...x, y, z: false, ['a']: true }/*b*/;
+////    const b = { ...x, y, z: false, ['a']: true };
+////    return a+b;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const newLocal = { ...x, y, z: false, ['a']: true };
+function foo() {
+    const a = newLocal;
+    const b = /*RENAME*/newLocal;
+    return a+b;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_propertyAccess.ts
+++ b/tests/cases/fourslash/extract-const_multiple_propertyAccess.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    return /*a*/foo.name.length/*b*/ + foo.name.length;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const length = foo.name.length;
+function foo() {
+    return length + /*RENAME*/length;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_propertyAccess.ts
+++ b/tests/cases/fourslash/extract-const_multiple_propertyAccess.ts
@@ -13,6 +13,6 @@ edit.applyRefactor({
     newContent:
         `const length = foo.name.length;
 function foo() {
-    return length + /*RENAME*/length;
+    return /*RENAME*/length + length;
 }`
 });

--- a/tests/cases/fourslash/extract-const_multiple_string.ts
+++ b/tests/cases/fourslash/extract-const_multiple_string.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: foo.ts
+////function foo() {
+////    /*a*/const a = "test"/*b*/;
+////    const b = "test";
+////    return a+b;
+////}
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_1",
+    actionDescription: "Extract to constant in global scope",
+    newContent:
+        `const newLocal = "test";
+function foo() {
+    const a = newLocal;
+    const b = /*RENAME*/newLocal;
+    return a+b;
+}`
+});

--- a/tests/cases/fourslash/extract-const_multiple_string.ts
+++ b/tests/cases/fourslash/extract-const_multiple_string.ts
@@ -15,8 +15,8 @@ edit.applyRefactor({
     newContent:
         `const newLocal = "test";
 function foo() {
-    const a = newLocal;
-    const b = /*RENAME*/newLocal;
+    const a = /*RENAME*/newLocal;
+    const b = newLocal;
     return a+b;
 }`
 });


### PR DESCRIPTION
The goal of this pull-request is for "extract ..." refactoring to find all similar expressions and replaces them all with the new variable created.

For example, it would be nice to turn the following:

```ts
function topFiveSomething(a: SomeObject){
  if(a.something.something.length < 5){
    return a.something.something;
  } else {
    return a.something.something.slice(0, 5);
  }
}
```

Into this:

```ts
function topFiveSomething(a: SomeObject){
  const something = a.something.something;
  if(something.length < 5){
    return something;
  } else {
    return something.slice(0, 5);
  }
}
```

But the current "extract to constant in enclosing scope" will only find and replace on instance of `a.something.something`. This PR makes it find all of them and replace all of them. 

This pr makes the extract constant refactorings replace all matching values, as long as they are fairly simple expressions. 

Fixes #35349
