### PR TITLE
Defer checking expressions in void expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37085,7 +37085,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function checkVoidExpression(node: VoidExpression): Type {
-        checkExpression(node.expression);
+        if (node.parent.kind === SyntaxKind.ArrowFunction && (node.parent as ArrowFunction).body === node) {
+            checkNodeDeferred(node.expression);
+        }
+        else {
+            checkExpression(node.expression);
+        }
         return undefinedWideningType;
     }
 

--- a/tests/baselines/reference/avoidCycleWithVoidExpressionReturnedFromArrow.symbols
+++ b/tests/baselines/reference/avoidCycleWithVoidExpressionReturnedFromArrow.symbols
@@ -1,0 +1,49 @@
+//// [tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts] ////
+
+=== avoidCycleWithVoidExpressionReturnedFromArrow.ts ===
+type HowlErrorCallback = (soundId: number, error: unknown) => void;
+>HowlErrorCallback : Symbol(HowlErrorCallback, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 0, 0))
+>soundId : Symbol(soundId, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 0, 26))
+>error : Symbol(error, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 0, 42))
+
+interface HowlOptions {
+>HowlOptions : Symbol(HowlOptions, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 0, 67))
+
+  onplayerror?: HowlErrorCallback | undefined;
+>onplayerror : Symbol(HowlOptions.onplayerror, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 2, 23))
+>HowlErrorCallback : Symbol(HowlErrorCallback, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 0, 0))
+}
+
+class Howl {
+>Howl : Symbol(Howl, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 4, 1))
+
+  constructor(public readonly options: HowlOptions) {}
+>options : Symbol(Howl.options, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 7, 14))
+>HowlOptions : Symbol(HowlOptions, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 0, 67))
+
+  once(name: "unlock", fn: () => void) {
+>once : Symbol(Howl.once, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 7, 54))
+>name : Symbol(name, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 8, 7))
+>fn : Symbol(fn, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 8, 22))
+
+    console.log(name, fn);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>name : Symbol(name, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 8, 7))
+>fn : Symbol(fn, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 8, 22))
+  }
+}
+
+const instance = new Howl({
+>instance : Symbol(instance, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 13, 5))
+>Howl : Symbol(Howl, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 4, 1))
+
+  onplayerror: () => void instance.once("unlock", () => {}),
+>onplayerror : Symbol(onplayerror, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 13, 27))
+>instance.once : Symbol(Howl.once, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 7, 54))
+>instance : Symbol(instance, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 13, 5))
+>once : Symbol(Howl.once, Decl(avoidCycleWithVoidExpressionReturnedFromArrow.ts, 7, 54))
+
+});
+

--- a/tests/baselines/reference/avoidCycleWithVoidExpressionReturnedFromArrow.types
+++ b/tests/baselines/reference/avoidCycleWithVoidExpressionReturnedFromArrow.types
@@ -1,0 +1,53 @@
+//// [tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts] ////
+
+=== avoidCycleWithVoidExpressionReturnedFromArrow.ts ===
+type HowlErrorCallback = (soundId: number, error: unknown) => void;
+>HowlErrorCallback : (soundId: number, error: unknown) => void
+>soundId : number
+>error : unknown
+
+interface HowlOptions {
+  onplayerror?: HowlErrorCallback | undefined;
+>onplayerror : HowlErrorCallback | undefined
+}
+
+class Howl {
+>Howl : Howl
+
+  constructor(public readonly options: HowlOptions) {}
+>options : HowlOptions
+
+  once(name: "unlock", fn: () => void) {
+>once : (name: "unlock", fn: () => void) => void
+>name : "unlock"
+>fn : () => void
+
+    console.log(name, fn);
+>console.log(name, fn) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>name : "unlock"
+>fn : () => void
+  }
+}
+
+const instance = new Howl({
+>instance : Howl
+>new Howl({  onplayerror: () => void instance.once("unlock", () => {}),}) : Howl
+>Howl : typeof Howl
+>{  onplayerror: () => void instance.once("unlock", () => {}),} : { onplayerror: () => undefined; }
+
+  onplayerror: () => void instance.once("unlock", () => {}),
+>onplayerror : () => undefined
+>() => void instance.once("unlock", () => {}) : () => undefined
+>void instance.once("unlock", () => {}) : undefined
+>instance.once("unlock", () => {}) : void
+>instance.once : (name: "unlock", fn: () => void) => void
+>instance : Howl
+>once : (name: "unlock", fn: () => void) => void
+>"unlock" : "unlock"
+>() => {} : () => void
+
+});
+

--- a/tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts
+++ b/tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts
@@ -1,0 +1,19 @@
+// @strict: true
+// @noEmit: true
+
+type HowlErrorCallback = (soundId: number, error: unknown) => void;
+
+interface HowlOptions {
+  onplayerror?: HowlErrorCallback | undefined;
+}
+
+class Howl {
+  constructor(public readonly options: HowlOptions) {}
+  once(name: "unlock", fn: () => void) {
+    console.log(name, fn);
+  }
+}
+
+const instance = new Howl({
+  onplayerror: () => void instance.once("unlock", () => {}),
+});


### PR DESCRIPTION
This helps to avoid redundant cycles: [TS playground](https://www.typescriptlang.org/play?ts=5.3.0-dev.20231016#code/C4TwDgpgBAEg9gdwDYFEBOa5oMIEMlIBGuAxgNZQC8UAFAM5wCuAdgCYCSrAXFM4wLaEIaADRRhmNDxZlmiZgEoqAPigA3OAEtWAbgBQezc2DCAZqWjxkAeTDBNcZnSgBvPVCiOwSXCAlYAfh4rVAwsPAJicigAHygWVghTIwhdPQBfAxIfOmcQ13coEkc6YDRGEmAsGjBGQiRNEig0CFxWRyQQTzsHJ2DEJFt7EqUXTI9HEggaZlx+CB4AIhYkOHJFsVNmHholSlUNbVHCj2KnOCQIADpVgHMZuYhNxX0PTMy9M9KoI1LcZimVF4EAQsAGNDcE2Y3l8-iktD2By0rB+TmA-ymV0m02WzFW6zEuxUrnSChEGQU+iAA)