### PR TITLE
Avoid reporting a cycle when contextual return type is `any`, `unknown` or `void`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -36874,7 +36874,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     }
                 }
                 if (contextualSignature && !getReturnTypeFromAnnotation(node) && !signature.resolvedReturnType) {
-                    const returnType = getReturnTypeFromBody(node, checkMode);
+                    const contextualReturnType = getContextualReturnType(node, /*contextFlags*/ undefined);
+                    const returnType = contextualReturnType && contextualReturnType.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void) ? contextualReturnType : getReturnTypeFromBody(node, checkMode);
                     if (!signature.resolvedReturnType) {
                         signature.resolvedReturnType = returnType;
                     }

--- a/tests/baselines/reference/noCycleOnContextualReturnTypeVoid.symbols
+++ b/tests/baselines/reference/noCycleOnContextualReturnTypeVoid.symbols
@@ -1,0 +1,64 @@
+//// [tests/cases/compiler/noCycleOnContextualReturnTypeVoid.ts] ////
+
+=== noCycleOnContextualReturnTypeVoid.ts ===
+type HowlErrorCallback = (soundId: number, error: unknown) => void;
+>HowlErrorCallback : Symbol(HowlErrorCallback, Decl(noCycleOnContextualReturnTypeVoid.ts, 0, 0))
+>soundId : Symbol(soundId, Decl(noCycleOnContextualReturnTypeVoid.ts, 0, 26))
+>error : Symbol(error, Decl(noCycleOnContextualReturnTypeVoid.ts, 0, 42))
+
+interface HowlOptions {
+>HowlOptions : Symbol(HowlOptions, Decl(noCycleOnContextualReturnTypeVoid.ts, 0, 67))
+
+  onplayerror?: HowlErrorCallback | undefined;
+>onplayerror : Symbol(HowlOptions.onplayerror, Decl(noCycleOnContextualReturnTypeVoid.ts, 2, 23))
+>HowlErrorCallback : Symbol(HowlErrorCallback, Decl(noCycleOnContextualReturnTypeVoid.ts, 0, 0))
+}
+
+class Howl {
+>Howl : Symbol(Howl, Decl(noCycleOnContextualReturnTypeVoid.ts, 4, 1))
+
+  constructor(public readonly options: HowlOptions) {}
+>options : Symbol(Howl.options, Decl(noCycleOnContextualReturnTypeVoid.ts, 7, 14))
+>HowlOptions : Symbol(HowlOptions, Decl(noCycleOnContextualReturnTypeVoid.ts, 0, 67))
+
+  once(name: "unlock", fn: () => void) {
+>once : Symbol(Howl.once, Decl(noCycleOnContextualReturnTypeVoid.ts, 7, 54))
+>name : Symbol(name, Decl(noCycleOnContextualReturnTypeVoid.ts, 8, 7))
+>fn : Symbol(fn, Decl(noCycleOnContextualReturnTypeVoid.ts, 8, 22))
+
+    console.log(name, fn);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>name : Symbol(name, Decl(noCycleOnContextualReturnTypeVoid.ts, 8, 7))
+>fn : Symbol(fn, Decl(noCycleOnContextualReturnTypeVoid.ts, 8, 22))
+  }
+}
+
+const instance = new Howl({
+>instance : Symbol(instance, Decl(noCycleOnContextualReturnTypeVoid.ts, 13, 5))
+>Howl : Symbol(Howl, Decl(noCycleOnContextualReturnTypeVoid.ts, 4, 1))
+
+  onplayerror: () => instance.once("unlock", () => {}),
+>onplayerror : Symbol(onplayerror, Decl(noCycleOnContextualReturnTypeVoid.ts, 13, 27))
+>instance.once : Symbol(Howl.once, Decl(noCycleOnContextualReturnTypeVoid.ts, 7, 54))
+>instance : Symbol(instance, Decl(noCycleOnContextualReturnTypeVoid.ts, 13, 5))
+>once : Symbol(Howl.once, Decl(noCycleOnContextualReturnTypeVoid.ts, 7, 54))
+
+});
+
+const instance2 = new Howl({
+>instance2 : Symbol(instance2, Decl(noCycleOnContextualReturnTypeVoid.ts, 17, 5))
+>Howl : Symbol(Howl, Decl(noCycleOnContextualReturnTypeVoid.ts, 4, 1))
+
+  onplayerror: () => {
+>onplayerror : Symbol(onplayerror, Decl(noCycleOnContextualReturnTypeVoid.ts, 17, 28))
+
+    return instance2.once("unlock", () => {});
+>instance2.once : Symbol(Howl.once, Decl(noCycleOnContextualReturnTypeVoid.ts, 7, 54))
+>instance2 : Symbol(instance2, Decl(noCycleOnContextualReturnTypeVoid.ts, 17, 5))
+>once : Symbol(Howl.once, Decl(noCycleOnContextualReturnTypeVoid.ts, 7, 54))
+
+  },
+});
+

--- a/tests/baselines/reference/noCycleOnContextualReturnTypeVoid.types
+++ b/tests/baselines/reference/noCycleOnContextualReturnTypeVoid.types
@@ -1,0 +1,73 @@
+//// [tests/cases/compiler/noCycleOnContextualReturnTypeVoid.ts] ////
+
+=== noCycleOnContextualReturnTypeVoid.ts ===
+type HowlErrorCallback = (soundId: number, error: unknown) => void;
+>HowlErrorCallback : (soundId: number, error: unknown) => void
+>soundId : number
+>error : unknown
+
+interface HowlOptions {
+  onplayerror?: HowlErrorCallback | undefined;
+>onplayerror : HowlErrorCallback | undefined
+}
+
+class Howl {
+>Howl : Howl
+
+  constructor(public readonly options: HowlOptions) {}
+>options : HowlOptions
+
+  once(name: "unlock", fn: () => void) {
+>once : (name: "unlock", fn: () => void) => void
+>name : "unlock"
+>fn : () => void
+
+    console.log(name, fn);
+>console.log(name, fn) : void
+>console.log : (...data: any[]) => void
+>console : Console
+>log : (...data: any[]) => void
+>name : "unlock"
+>fn : () => void
+  }
+}
+
+const instance = new Howl({
+>instance : Howl
+>new Howl({  onplayerror: () => instance.once("unlock", () => {}),}) : Howl
+>Howl : typeof Howl
+>{  onplayerror: () => instance.once("unlock", () => {}),} : { onplayerror: () => void; }
+
+  onplayerror: () => instance.once("unlock", () => {}),
+>onplayerror : () => void
+>() => instance.once("unlock", () => {}) : () => void
+>instance.once("unlock", () => {}) : void
+>instance.once : (name: "unlock", fn: () => void) => void
+>instance : Howl
+>once : (name: "unlock", fn: () => void) => void
+>"unlock" : "unlock"
+>() => {} : () => void
+
+});
+
+const instance2 = new Howl({
+>instance2 : Howl
+>new Howl({  onplayerror: () => {    return instance2.once("unlock", () => {});  },}) : Howl
+>Howl : typeof Howl
+>{  onplayerror: () => {    return instance2.once("unlock", () => {});  },} : { onplayerror: () => void; }
+
+  onplayerror: () => {
+>onplayerror : () => void
+>() => {    return instance2.once("unlock", () => {});  } : () => void
+
+    return instance2.once("unlock", () => {});
+>instance2.once("unlock", () => {}) : void
+>instance2.once : (name: "unlock", fn: () => void) => void
+>instance2 : Howl
+>once : (name: "unlock", fn: () => void) => void
+>"unlock" : "unlock"
+>() => {} : () => void
+
+  },
+});
+

--- a/tests/cases/compiler/noCycleOnContextualReturnTypeVoid.ts
+++ b/tests/cases/compiler/noCycleOnContextualReturnTypeVoid.ts
@@ -1,0 +1,25 @@
+// @strict: true
+// @noEmit: true
+
+type HowlErrorCallback = (soundId: number, error: unknown) => void;
+
+interface HowlOptions {
+  onplayerror?: HowlErrorCallback | undefined;
+}
+
+class Howl {
+  constructor(public readonly options: HowlOptions) {}
+  once(name: "unlock", fn: () => void) {
+    console.log(name, fn);
+  }
+}
+
+const instance = new Howl({
+  onplayerror: () => instance.once("unlock", () => {}),
+});
+
+const instance2 = new Howl({
+  onplayerror: () => {
+    return instance2.once("unlock", () => {});
+  },
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/56121