### PR TITLE
fix(55237): TypeScript 5.2 "move to file" results in duplicate imports

### DIFF
--- a/tests/cases/fourslash/moveToFile_existingImports1.ts
+++ b/tests/cases/fourslash/moveToFile_existingImports1.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: /common.ts
+////export const x = 1;
+
+// @filename: /a.ts
+////import { x } from "./common";
+////[|export const bar = x;|]
+
+// @filename: /b.ts
+////import { x } from "./common";
+////export const foo = x;
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts": "",
+        "/b.ts":
+`import { x } from "./common";
+export const foo = x;
+export const bar = x;
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/b.ts" },
+});

--- a/tests/cases/fourslash/moveToFile_existingImports2.ts
+++ b/tests/cases/fourslash/moveToFile_existingImports2.ts
@@ -1,0 +1,28 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: /common.ts
+////export const x = 1;
+
+// @filename: /a.ts
+////import { x } from "./common";
+////export const a = x;
+////[|export const b = x;|]
+
+// @filename: /b.ts
+////import { x } from "./common";
+////export const a = x;
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts":
+`import { x } from "./common";
+export const a = x;
+`,
+        "/b.ts":
+`import { x } from "./common";
+export const a = x;
+export const b = x;
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/b.ts" },
+});

--- a/tests/cases/fourslash/moveToFile_existingImports3.ts
+++ b/tests/cases/fourslash/moveToFile_existingImports3.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @module: commonjs
+// @filename: /common.js
+////export const x = 1;
+
+// @filename: /a.js
+////const { x } = require("./common");
+////[|module.exports.b = x;|]
+
+// @filename: /b.js
+////const { x } = require("./common");
+////module.exports.a = x;
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.js": "",
+        "/b.js":
+`const { x } = require("./common");
+module.exports.a = x;
+module.exports.b = x;
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/b.js" },
+});

--- a/tests/cases/fourslash/moveToFile_existingImports4.ts
+++ b/tests/cases/fourslash/moveToFile_existingImports4.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @module: commonjs
+// @filename: /common.js
+////export const x = 1;
+
+// @filename: /a.js
+////const { x } = require("./common");
+////module.exports.a = x;
+////[|module.exports.b = x;|]
+
+// @filename: /b.js
+////const { x } = require("./common");
+////module.exports.a = x;
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.js":
+`const { x } = require("./common");
+module.exports.a = x;
+`,
+        "/b.js":
+`const { x } = require("./common");
+module.exports.a = x;
+module.exports.b = x;
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/b.js" },
+});


### PR DESCRIPTION
Fixes #55237