### PR TITLE
Explicitly declare type=commonjs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "type": "git",
         "url": "https://github.com/Microsoft/TypeScript.git"
     },
+    "type": "commonjs",
     "main": "./lib/typescript.js",
     "typings": "./lib/typescript.d.ts",
     "bin": {


### PR DESCRIPTION
Node.js is experimenting with `.js` files having detection applied to them when `package.json` doesn't list a type; this detection appears to have a performance impact for bundles as large as ours, so it may be best to just explicitly declare that our package treats `.js` files as `commonjs`.