### PR TITLE
Expose TypeChecker.getMergedSymbol to public (#56192)

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5043,7 +5043,7 @@ export interface TypeChecker {
     isUndefinedSymbol(symbol: Symbol): boolean;
     isArgumentsSymbol(symbol: Symbol): boolean;
     isUnknownSymbol(symbol: Symbol): boolean;
-    /** @internal */ getMergedSymbol(symbol: Symbol): Symbol;
+    getMergedSymbol(symbol: Symbol): Symbol;
 
     getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): string | number | undefined;
     isValidPropertyAccess(node: PropertyAccessExpression | QualifiedName | ImportTypeNode, propertyName: string): boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6778,6 +6778,7 @@ declare namespace ts {
         isUndefinedSymbol(symbol: Symbol): boolean;
         isArgumentsSymbol(symbol: Symbol): boolean;
         isUnknownSymbol(symbol: Symbol): boolean;
+        getMergedSymbol(symbol: Symbol): Symbol;
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): string | number | undefined;
         isValidPropertyAccess(node: PropertyAccessExpression | QualifiedName | ImportTypeNode, propertyName: string): boolean;
         /** Follow all aliases to get the original symbol. */


### PR DESCRIPTION
Fixes #56192

I haven't updated [dtsBundler.mjs](https://github.com/microsoft/TypeScript/blob/d9d027d0c4f5044631a0c078166b8d01f41d28b5/scripts/dtsBundler.mjs#L260-L262) as it seems relies on the compiler from npm rather than local - but please let me know if you want me to update it as well.