### PR TITLE
Fix(55658): Move to file and new file syntax errors with overload functions

### DIFF
--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -348,7 +348,7 @@ function getTargetFileImportsAndAddExportInOldFile(
                 if (hasSyntacticModifier(decl, ModifierFlags.Default)) {
                     oldFileDefault = name;
                 }
-                else {
+                else if (!oldFileNamedImports.includes (name.text)) {
                     oldFileNamedImports.push(name.text);
                 }
             }

--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -348,7 +348,7 @@ function getTargetFileImportsAndAddExportInOldFile(
                 if (hasSyntacticModifier(decl, ModifierFlags.Default)) {
                     oldFileDefault = name;
                 }
-                else if (!oldFileNamedImports.includes (name.text)) {
+                else if (!oldFileNamedImports.includes(name.text)) {
                     oldFileNamedImports.push(name.text);
                 }
             }

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -176,7 +176,7 @@ function getNewFileImportsAndAddExportInOldFile(
             if (hasSyntacticModifier(decl, ModifierFlags.Default)) {
                 oldFileDefault = name;
             }
-            else if (!oldFileNamedImports.includes (name.text)) {
+            else if (!oldFileNamedImports.includes(name.text)) {
                 oldFileNamedImports.push(name.text);
             }
         }

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -176,7 +176,7 @@ function getNewFileImportsAndAddExportInOldFile(
             if (hasSyntacticModifier(decl, ModifierFlags.Default)) {
                 oldFileDefault = name;
             }
-            else {
+            else if (!oldFileNamedImports.includes (name.text)) {
                 oldFileNamedImports.push(name.text);
             }
         }

--- a/tests/cases/fourslash/moveToFile_overloads6.ts
+++ b/tests/cases/fourslash/moveToFile_overloads6.ts
@@ -1,0 +1,42 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /add.ts
+////const x = 20;
+
+// @Filename: /a.ts
+//// [|export function add(a: number, b: number): number;
+//// export function add(a: string, b: string): string;
+//// export function add(a: any, b: any): any {
+////     multiply(2,3);
+////   return a + b;
+//// }|]
+//
+//// function multiply(x: number, y: number): number;
+//// function multiply(x: string, y: string): string;
+//// function multiply(x: any, y: any) {
+////    return x + y;
+//// }
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts":
+`export function multiply(x: number, y: number): number;
+export function multiply(x: string, y: string): string;
+export function multiply(x: any, y: any) {
+   return x + y;
+}`,
+
+        "/add.ts":
+`import { multiply } from "./a";
+
+const x = 20;
+export function add(a: number, b: number): number;
+export function add(a: string, b: string): string;
+export function add(a: any, b: any): any {
+    multiply(2, 3);
+    return a + b;
+}
+`
+    },
+    interactiveRefactorArguments: { targetFile: "/add.ts" },
+});

--- a/tests/cases/fourslash/moveToNewFile_overloads5.ts
+++ b/tests/cases/fourslash/moveToNewFile_overloads5.ts
@@ -1,0 +1,36 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+//// [|export function add(a: number, b: number): number;
+//// export function add(a: string, b: string): string;
+//// export function add(a: any, b: any): any {
+////     multiply(2,3);
+////   return a + b;
+//// }|]
+//
+//// function multiply(x: number, y: number): number;
+//// function multiply(x: string, y: string): string;
+//// function multiply(x: any, y: any) {
+////    return x + y;
+//// }
+
+verify.moveToNewFile({
+    newFileContents: {
+        "/a.ts":
+         `export function multiply(x: number, y: number): number;
+export function multiply(x: string, y: string): string;
+export function multiply(x: any, y: any) {
+   return x + y;
+}`,
+        "/add.ts":
+`import { multiply } from "./a";
+
+export function add(a: number, b: number): number;
+export function add(a: string, b: string): string;
+export function add(a: any, b: any): any {
+    multiply(2, 3);
+    return a + b;
+}
+`
+    },
+});


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/55658
Importing overload functions caused this issue. Fixed it by ensuring that a symbol's declaration for an overload function was being imported only once.
