### PR TITLE
[Experiment] treat js resolutions like ts if they are from referenced project

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5015,7 +5015,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
 
             if (sourceFile.symbol) {
-                if (resolvedModule.isExternalLibraryImport && !resolutionExtensionIsTSOrJson(resolvedModule.extension)) {
+                if (resolvedModule.isExternalLibraryImport && !resolutionExtensionIsTSOrJson(resolvedModule.extension) && !host.getProjectReferenceRedirect(resolvedModule.resolvedFileName)) {
                     errorOnImplicitAnyModule(/*isError*/ false, errorNode, currentSourceFile, mode, resolvedModule, moduleReference);
                 }
                 if (moduleResolutionKind === ModuleResolutionKind.Node16 || moduleResolutionKind === ModuleResolutionKind.NodeNext) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -4036,10 +4036,11 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                     continue;
                 }
 
-                const isFromNodeModulesSearch = resolution.isExternalLibraryImport;
-                const isJsFile = !resolutionExtensionIsTSOrJson(resolution.extension);
-                const isJsFileFromNodeModules = isFromNodeModulesSearch && isJsFile;
                 const resolvedFileName = resolution.resolvedFileName;
+                const isFromNodeModulesSearch = resolution.isExternalLibraryImport;
+                // Consider the resolution as to "js" file only if its not from referenced project
+                const isJsFile = !resolutionExtensionIsTSOrJson(resolution.extension) && !getProjectReferenceRedirect(resolvedFileName);
+                const isJsFileFromNodeModules = isFromNodeModulesSearch && isJsFile;
 
                 if (isFromNodeModulesSearch) {
                     currentNodeModulesDepth++;

--- a/src/testRunner/unittests/helpers/referencedProjectWithJs.ts
+++ b/src/testRunner/unittests/helpers/referencedProjectWithJs.ts
@@ -1,0 +1,61 @@
+import {
+    dedent,
+} from "../../_namespaces/Utils";
+import {
+    jsonToReadableText,
+} from "../helpers";
+import {
+    libContent,
+} from "./contents";
+import {
+    FileOrFolderOrSymLinkMap,
+    libFile,
+} from "./virtualFileSystemWithWatch";
+
+function tsconfig(additional?: object) {
+    return jsonToReadableText({
+        compilerOptions: {
+            outDir: "./dist",
+            declarationDir: "./dist/types",
+        },
+        extends: "../../tsconfig.base.json",
+        include: ["./src"],
+        ...additional,
+    });
+}
+export function getFsContentsForReferencedProjectWithJs(): FileOrFolderOrSymLinkMap {
+    return {
+        "/home/src/projects/myproject/packages/a/src/lib.js": `export const magicString = "12";`,
+        "/home/src/projects/myproject/packages/a/src/util.ts": `export const magicNumber = 12;`,
+        "/home/src/projects/myproject/packages/a/tsconfig.json": tsconfig(),
+        "/home/src/projects/myproject/packages/a/package.json": jsonToReadableText({
+            name: "@my-package/a",
+            version: "1.0.0",
+            main: "index.js",
+        }),
+        "/home/src/projects/myproject/packages/b/src/index.ts": dedent`
+            import { magicString } from "@my-package/a/src/lib";
+            import { magicNumber } from "@my-package/a/src/util";
+            const a: number = magicNumber;
+            const b: string = magicString;
+            console.log({ a });
+            console.log({ b });
+        `,
+        "/home/src/projects/myproject/packages/b/tsconfig.json": tsconfig({
+            references: [{ path: "../a/tsconfig.json" }],
+        }),
+        "/home/src/projects/myproject/tsconfig.base.json": jsonToReadableText({
+            compilerOptions: {
+                composite: true,
+                allowJs: true,
+                emitDeclarationOnly: true,
+                traceResolution: true,
+                strict: true,
+            },
+        }),
+        "/home/src/projects/myproject/node_modules/@my-package/a": {
+            symLink: "/home/src/projects/myproject/packages/a",
+        },
+        [libFile.path]: libContent,
+    };
+}

--- a/src/testRunner/unittests/tsbuild/javascriptProjectEmit.ts
+++ b/src/testRunner/unittests/tsbuild/javascriptProjectEmit.ts
@@ -3,12 +3,21 @@ import {
     symbolLibContent,
 } from "../helpers/contents";
 import {
+    getFsContentsForReferencedProjectWithJs,
+} from "../helpers/referencedProjectWithJs";
+import {
     verifyTsc,
 } from "../helpers/tsc";
+import {
+    verifyTscWatch,
+} from "../helpers/tscWatch";
 import {
     loadProjectFromFiles,
     replaceText,
 } from "../helpers/vfs";
+import {
+    createWatchedSystem,
+} from "../helpers/virtualFileSystemWithWatch";
 
 describe("unittests:: tsbuild:: javascriptProjectEmit::", () => {
     verifyTsc({
@@ -284,5 +293,18 @@ describe("unittests:: tsbuild:: javascriptProjectEmit::", () => {
                     }`,
             }, symbolLibContent),
         commandLineArgs: ["-b", "/src"],
+    });
+
+    verifyTscWatch({
+        scenario: "javascriptProjectEmit",
+        subScenario: "handles js source files from referenced project",
+        sys: () =>
+            createWatchedSystem(
+                getFsContentsForReferencedProjectWithJs(),
+                {
+                    currentDirectory: "/home/src/projects/myproject",
+                },
+            ),
+        commandLineArgs: ["--b", "packages/b", "-v", "--explainFiles"],
     });
 });

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -9,6 +9,9 @@ import {
     jsonToReadableText,
 } from "../helpers";
 import {
+    getFsContentsForReferencedProjectWithJs,
+} from "../helpers/referencedProjectWithJs";
+import {
     solutionBuildWithBaseline,
 } from "../helpers/solutionBuilder";
 import {
@@ -1692,5 +1695,18 @@ const b: B = new B();`,
             baselineDisableReferencedProjectLoad(false,       false,   false,   false); // Loaded     | Via redirect | index.ts, helper.ts |
         }
         /* eslint-enable local/argument-trivia */
+    });
+
+    it("handles js source files from referenced project", () => {
+        const host = createServerHost(getFsContentsForReferencedProjectWithJs());
+        const session = createSession(host, { canUseEvents: true, logger: createLoggerWithInMemoryLogs(host) });
+
+        openFilesForSession(["/home/src/projects/myproject/packages/b/src/index.ts"], session);
+        verifyGetErrRequest({
+            session,
+            files: ["/home/src/projects/myproject/packages/b/src/index.ts"],
+        });
+
+        baselineTsserverLogs("projectReferences", "handles js source files from referenced project", session);
     });
 });

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/handles-js-source-files-from-referenced-project.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/handles-js-source-files-from-referenced-project.js
@@ -1,0 +1,414 @@
+currentDirectory:: /home/src/projects/myproject useCaseSensitiveFileNames: false
+Input::
+//// [/home/src/projects/myproject/packages/a/src/lib.js]
+export const magicString = "12";
+
+//// [/home/src/projects/myproject/packages/a/src/util.ts]
+export const magicNumber = 12;
+
+//// [/home/src/projects/myproject/packages/a/tsconfig.json]
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declarationDir": "./dist/types"
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "./src"
+  ]
+}
+
+//// [/home/src/projects/myproject/packages/a/package.json]
+{
+  "name": "@my-package/a",
+  "version": "1.0.0",
+  "main": "index.js"
+}
+
+//// [/home/src/projects/myproject/packages/b/src/index.ts]
+import { magicString } from "@my-package/a/src/lib";
+import { magicNumber } from "@my-package/a/src/util";
+const a: number = magicNumber;
+const b: string = magicString;
+console.log({ a });
+console.log({ b });
+
+
+//// [/home/src/projects/myproject/packages/b/tsconfig.json]
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declarationDir": "./dist/types"
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "./src"
+  ],
+  "references": [
+    {
+      "path": "../a/tsconfig.json"
+    }
+  ]
+}
+
+//// [/home/src/projects/myproject/tsconfig.base.json]
+{
+  "compilerOptions": {
+    "composite": true,
+    "allowJs": true,
+    "emitDeclarationOnly": true,
+    "traceResolution": true,
+    "strict": true
+  }
+}
+
+//// [/home/src/projects/myproject/node_modules/@my-package/a] symlink(/home/src/projects/myproject/packages/a)
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+
+/a/lib/tsc.js --b packages/b -v --explainFiles
+Output::
+[[90m12:00:47 AM[0m] Projects in this build: 
+    * packages/a/tsconfig.json
+    * packages/b/tsconfig.json
+
+[[90m12:00:48 AM[0m] Project 'packages/a/tsconfig.json' is out of date because output file 'packages/a/dist/tsconfig.tsbuildinfo' does not exist
+
+[[90m12:00:49 AM[0m] Building project '/home/src/projects/myproject/packages/a/tsconfig.json'...
+
+../../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+packages/a/src/lib.js
+  Matched by include pattern './src' in 'packages/a/tsconfig.json'
+packages/a/src/util.ts
+  Matched by include pattern './src' in 'packages/a/tsconfig.json'
+[[90m12:01:06 AM[0m] Project 'packages/b/tsconfig.json' is out of date because output file 'packages/b/dist/tsconfig.tsbuildinfo' does not exist
+
+[[90m12:01:07 AM[0m] Building project '/home/src/projects/myproject/packages/b/tsconfig.json'...
+
+======== Resolving module '@my-package/a/src/lib' from '/home/src/projects/myproject/packages/b/src/index.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module '@my-package/a/src/lib' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Directory '/home/src/projects/myproject/packages/b/src/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Directory '/home/src/projects/myproject/packages/b/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Directory '/home/src/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Found 'package.json' at '/home/src/projects/myproject/node_modules/@my-package/a/package.json'.
+'package.json' does not have a 'typesVersions' field.
+File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.ts' does not exist.
+File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.tsx' does not exist.
+File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.d.ts' does not exist.
+'package.json' does not have a 'typings' field.
+'package.json' does not have a 'types' field.
+'package.json' has 'main' field 'index.js' that references '/home/src/projects/myproject/node_modules/@my-package/a/src/lib/index.js'.
+Loading module as file / folder, candidate module location '/home/src/projects/myproject/node_modules/@my-package/a/src/lib/index.js', target file types: TypeScript, Declaration.
+File name '/home/src/projects/myproject/node_modules/@my-package/a/src/lib/index.js' has a '.js' extension - stripping it.
+Directory '/home/src/projects/myproject/node_modules/@types' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Directory '/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/lib'
+Loading module '@my-package/a/src/lib' from 'node_modules' folder, target file types: JavaScript.
+Searching all ancestor node_modules directories for fallback extensions: JavaScript.
+Directory '/home/src/projects/myproject/packages/b/src/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/projects/myproject/packages/b/node_modules' does not exist, skipping all lookups in it.
+Directory '/home/src/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+File '/home/src/projects/myproject/node_modules/@my-package/a/package.json' exists according to earlier cached lookups.
+File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.js' exists - use it as a name resolution result.
+Resolving real path for '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.js', result '/home/src/projects/myproject/packages/a/src/lib.js'.
+======== Module name '@my-package/a/src/lib' was successfully resolved to '/home/src/projects/myproject/packages/a/src/lib.js' with Package ID '@my-package/a/src/lib.js@1.0.0'. ========
+======== Resolving module '@my-package/a/src/util' from '/home/src/projects/myproject/packages/b/src/index.ts'. ========
+Module resolution kind is not specified, using 'Node10'.
+Loading module '@my-package/a/src/util' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Directory '/home/src/projects/myproject/packages/b/src/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/util'
+Directory '/home/src/projects/myproject/packages/b/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/util'
+Directory '/home/src/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Scoped package detected, looking in 'my-package__a/src/util'
+File '/home/src/projects/myproject/node_modules/@my-package/a/package.json' exists according to earlier cached lookups.
+File '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts' exists - use it as a name resolution result.
+Resolving real path for '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts', result '/home/src/projects/myproject/packages/a/src/util.ts'.
+======== Module name '@my-package/a/src/util' was successfully resolved to '/home/src/projects/myproject/packages/a/src/util.ts' with Package ID '@my-package/a/src/util.ts@1.0.0'. ========
+[96mpackages/b/src/index.ts[0m:[93m1[0m:[93m29[0m - [91merror[0m[90m TS7016: [0mCould not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.
+  Try `npm i --save-dev @types/my-package__a` if it exists or add a new declaration (.d.ts) file containing `declare module '@my-package/a/src/lib';`
+
+[7m1[0m import { magicString } from "@my-package/a/src/lib";
+[7m [0m [91m                            ~~~~~~~~~~~~~~~~~~~~~~~[0m
+
+../../../../a/lib/lib.d.ts
+  Default library for target 'es5'
+packages/a/dist/types/src/util.d.ts
+  Imported via "@my-package/a/src/util" from file 'packages/b/src/index.ts' with packageId '@my-package/a/src/util.ts@1.0.0'
+  File is output of project reference source 'packages/a/src/util.ts'
+packages/b/src/index.ts
+  Matched by include pattern './src' in 'packages/b/tsconfig.json'
+
+Found 1 error.
+
+
+
+Program root files: [
+  "/home/src/projects/myproject/packages/a/src/lib.js",
+  "/home/src/projects/myproject/packages/a/src/util.ts"
+]
+Program options: {
+  "composite": true,
+  "allowJs": true,
+  "emitDeclarationOnly": true,
+  "traceResolution": true,
+  "strict": true,
+  "outDir": "/home/src/projects/myproject/packages/a/dist",
+  "declarationDir": "/home/src/projects/myproject/packages/a/dist/types",
+  "explainFiles": true,
+  "configFilePath": "/home/src/projects/myproject/packages/a/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/home/src/projects/myproject/packages/a/src/lib.js
+/home/src/projects/myproject/packages/a/src/util.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/home/src/projects/myproject/packages/a/src/lib.js
+/home/src/projects/myproject/packages/a/src/util.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/home/src/projects/myproject/packages/a/src/lib.js (computed .d.ts during emit)
+/home/src/projects/myproject/packages/a/src/util.ts (computed .d.ts during emit)
+
+Program root files: [
+  "/home/src/projects/myproject/packages/b/src/index.ts"
+]
+Program options: {
+  "composite": true,
+  "allowJs": true,
+  "emitDeclarationOnly": true,
+  "traceResolution": true,
+  "strict": true,
+  "outDir": "/home/src/projects/myproject/packages/b/dist",
+  "declarationDir": "/home/src/projects/myproject/packages/b/dist/types",
+  "explainFiles": true,
+  "configFilePath": "/home/src/projects/myproject/packages/b/tsconfig.json"
+}
+Program structureReused: Not
+Program files::
+/a/lib/lib.d.ts
+/home/src/projects/myproject/packages/a/dist/types/src/util.d.ts
+/home/src/projects/myproject/packages/b/src/index.ts
+
+Semantic diagnostics in builder refreshed for::
+/a/lib/lib.d.ts
+/home/src/projects/myproject/packages/a/dist/types/src/util.d.ts
+/home/src/projects/myproject/packages/b/src/index.ts
+
+Shape signatures in builder refreshed for::
+/a/lib/lib.d.ts (used version)
+/home/src/projects/myproject/packages/a/dist/types/src/util.d.ts (used version)
+/home/src/projects/myproject/packages/b/src/index.ts (used version)
+
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+//// [/home/src/projects/myproject/packages/a/dist/types/src/lib.d.ts]
+export const magicString: "12";
+
+
+//// [/home/src/projects/myproject/packages/a/dist/types/src/util.d.ts]
+export declare const magicNumber = 12;
+
+
+//// [/home/src/projects/myproject/packages/a/dist/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../../../a/lib/lib.d.ts","../src/lib.js","../src/util.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},{"version":"-8339786491-export const magicString = \"12\";","signature":"-7063618004-export const magicString: \"12\";\n"},{"version":"-13202486157-export const magicNumber = 12;","signature":"-7610027667-export declare const magicNumber = 12;\n"}],"root":[2,3],"options":{"allowJs":true,"composite":true,"declarationDir":"./types","emitDeclarationOnly":true,"outDir":"./","strict":true},"referencedMap":[],"exportedModulesMap":[],"semanticDiagnosticsPerFile":[1,2,3],"latestChangedDtsFile":"./types/src/util.d.ts"},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/myproject/packages/a/dist/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../../../a/lib/lib.d.ts",
+      "../src/lib.js",
+      "../src/util.ts"
+    ],
+    "fileInfos": {
+      "../../../../../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "../src/lib.js": {
+        "original": {
+          "version": "-8339786491-export const magicString = \"12\";",
+          "signature": "-7063618004-export const magicString: \"12\";\n"
+        },
+        "version": "-8339786491-export const magicString = \"12\";",
+        "signature": "-7063618004-export const magicString: \"12\";\n"
+      },
+      "../src/util.ts": {
+        "original": {
+          "version": "-13202486157-export const magicNumber = 12;",
+          "signature": "-7610027667-export declare const magicNumber = 12;\n"
+        },
+        "version": "-13202486157-export const magicNumber = 12;",
+        "signature": "-7610027667-export declare const magicNumber = 12;\n"
+      }
+    },
+    "root": [
+      [
+        2,
+        "../src/lib.js"
+      ],
+      [
+        3,
+        "../src/util.ts"
+      ]
+    ],
+    "options": {
+      "allowJs": true,
+      "composite": true,
+      "declarationDir": "./types",
+      "emitDeclarationOnly": true,
+      "outDir": "./",
+      "strict": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../../../../../../a/lib/lib.d.ts",
+      "../src/lib.js",
+      "../src/util.ts"
+    ],
+    "latestChangedDtsFile": "./types/src/util.d.ts"
+  },
+  "version": "FakeTSVersion",
+  "size": 1131
+}
+
+//// [/home/src/projects/myproject/packages/b/dist/tsconfig.tsbuildinfo]
+{"program":{"fileNames":["../../../../../../../a/lib/lib.d.ts","../../a/dist/types/src/util.d.ts","../src/index.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-7610027667-export declare const magicNumber = 12;\n","-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n"],"root":[3],"options":{"allowJs":true,"composite":true,"declarationDir":"./types","emitDeclarationOnly":true,"outDir":"./","strict":true},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,[3,[{"file":"../src/index.ts","start":28,"length":23,"code":7016,"category":1,"messageText":{"messageText":"Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.","category":1,"code":7016,"next":[{"info":{"moduleReference":"@my-package/a/src/lib","packageName":"@my-package/a"}}]}}]]],"affectedFilesPendingEmit":[3],"emitSignatures":[3]},"version":"FakeTSVersion"}
+
+//// [/home/src/projects/myproject/packages/b/dist/tsconfig.tsbuildinfo.readable.baseline.txt]
+{
+  "program": {
+    "fileNames": [
+      "../../../../../../../a/lib/lib.d.ts",
+      "../../a/dist/types/src/util.d.ts",
+      "../src/index.ts"
+    ],
+    "fileNamesList": [
+      [
+        "../../a/dist/types/src/util.d.ts"
+      ]
+    ],
+    "fileInfos": {
+      "../../../../../../../a/lib/lib.d.ts": {
+        "original": {
+          "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+          "affectsGlobalScope": true
+        },
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "affectsGlobalScope": true
+      },
+      "../../a/dist/types/src/util.d.ts": {
+        "version": "-7610027667-export declare const magicNumber = 12;\n",
+        "signature": "-7610027667-export declare const magicNumber = 12;\n"
+      },
+      "../src/index.ts": {
+        "version": "-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n",
+        "signature": "-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n"
+      }
+    },
+    "root": [
+      [
+        3,
+        "../src/index.ts"
+      ]
+    ],
+    "options": {
+      "allowJs": true,
+      "composite": true,
+      "declarationDir": "./types",
+      "emitDeclarationOnly": true,
+      "outDir": "./",
+      "strict": true
+    },
+    "referencedMap": {
+      "../src/index.ts": [
+        "../../a/dist/types/src/util.d.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "../src/index.ts": [
+        "../../a/dist/types/src/util.d.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../../../../../../a/lib/lib.d.ts",
+      "../../a/dist/types/src/util.d.ts",
+      [
+        "../src/index.ts",
+        [
+          {
+            "file": "../src/index.ts",
+            "start": 28,
+            "length": 23,
+            "code": 7016,
+            "category": 1,
+            "messageText": {
+              "messageText": "Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.",
+              "category": 1,
+              "code": 7016,
+              "next": [
+                {
+                  "info": {
+                    "moduleReference": "@my-package/a/src/lib",
+                    "packageName": "@my-package/a"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      ]
+    ],
+    "affectedFilesPendingEmit": [
+      [
+        "../src/index.ts",
+        "Dts"
+      ]
+    ],
+    "emitSignatures": [
+      "../src/index.ts"
+    ]
+  },
+  "version": "FakeTSVersion",
+  "size": 1606
+}
+

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/handles-js-source-files-from-referenced-project.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/handles-js-source-files-from-referenced-project.js
@@ -152,22 +152,16 @@ File '/home/src/projects/myproject/node_modules/@my-package/a/package.json' exis
 File '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts' exists - use it as a name resolution result.
 Resolving real path for '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts', result '/home/src/projects/myproject/packages/a/src/util.ts'.
 ======== Module name '@my-package/a/src/util' was successfully resolved to '/home/src/projects/myproject/packages/a/src/util.ts' with Package ID '@my-package/a/src/util.ts@1.0.0'. ========
-[96mpackages/b/src/index.ts[0m:[93m1[0m:[93m29[0m - [91merror[0m[90m TS7016: [0mCould not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.
-  Try `npm i --save-dev @types/my-package__a` if it exists or add a new declaration (.d.ts) file containing `declare module '@my-package/a/src/lib';`
-
-[7m1[0m import { magicString } from "@my-package/a/src/lib";
-[7m [0m [91m                            ~~~~~~~~~~~~~~~~~~~~~~~[0m
-
 ../../../../a/lib/lib.d.ts
   Default library for target 'es5'
+packages/a/dist/types/src/lib.d.ts
+  Imported via "@my-package/a/src/lib" from file 'packages/b/src/index.ts' with packageId '@my-package/a/src/lib.js@1.0.0'
+  File is output of project reference source 'packages/a/src/lib.js'
 packages/a/dist/types/src/util.d.ts
   Imported via "@my-package/a/src/util" from file 'packages/b/src/index.ts' with packageId '@my-package/a/src/util.ts@1.0.0'
   File is output of project reference source 'packages/a/src/util.ts'
 packages/b/src/index.ts
   Matched by include pattern './src' in 'packages/b/tsconfig.json'
-
-Found 1 error.
-
 
 
 Program root files: [
@@ -218,20 +212,23 @@ Program options: {
 Program structureReused: Not
 Program files::
 /a/lib/lib.d.ts
+/home/src/projects/myproject/packages/a/dist/types/src/lib.d.ts
 /home/src/projects/myproject/packages/a/dist/types/src/util.d.ts
 /home/src/projects/myproject/packages/b/src/index.ts
 
 Semantic diagnostics in builder refreshed for::
 /a/lib/lib.d.ts
+/home/src/projects/myproject/packages/a/dist/types/src/lib.d.ts
 /home/src/projects/myproject/packages/a/dist/types/src/util.d.ts
 /home/src/projects/myproject/packages/b/src/index.ts
 
 Shape signatures in builder refreshed for::
 /a/lib/lib.d.ts (used version)
+/home/src/projects/myproject/packages/a/dist/types/src/lib.d.ts (used version)
 /home/src/projects/myproject/packages/a/dist/types/src/util.d.ts (used version)
-/home/src/projects/myproject/packages/b/src/index.ts (used version)
+/home/src/projects/myproject/packages/b/src/index.ts (computed .d.ts during emit)
 
-exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+exitCode:: ExitStatus.Success
 
 //// [/home/src/projects/myproject/packages/a/dist/types/src/lib.d.ts]
 export const magicString: "12";
@@ -310,19 +307,25 @@ export declare const magicNumber = 12;
   "size": 1131
 }
 
+//// [/home/src/projects/myproject/packages/b/dist/types/src/index.d.ts]
+export {};
+
+
 //// [/home/src/projects/myproject/packages/b/dist/tsconfig.tsbuildinfo]
-{"program":{"fileNames":["../../../../../../../a/lib/lib.d.ts","../../a/dist/types/src/util.d.ts","../src/index.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-7610027667-export declare const magicNumber = 12;\n","-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n"],"root":[3],"options":{"allowJs":true,"composite":true,"declarationDir":"./types","emitDeclarationOnly":true,"outDir":"./","strict":true},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,2,[3,[{"file":"../src/index.ts","start":28,"length":23,"code":7016,"category":1,"messageText":{"messageText":"Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.","category":1,"code":7016,"next":[{"info":{"moduleReference":"@my-package/a/src/lib","packageName":"@my-package/a"}}]}}]]],"affectedFilesPendingEmit":[3],"emitSignatures":[3]},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../../../../../../../a/lib/lib.d.ts","../../a/dist/types/src/lib.d.ts","../../a/dist/types/src/util.d.ts","../src/index.ts"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-7063618004-export const magicString: \"12\";\n","-7610027667-export declare const magicNumber = 12;\n",{"version":"-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n","signature":"-3531856636-export {};\n"}],"root":[4],"options":{"allowJs":true,"composite":true,"declarationDir":"./types","emitDeclarationOnly":true,"outDir":"./","strict":true},"fileIdsList":[[2,3]],"referencedMap":[[4,1]],"exportedModulesMap":[],"semanticDiagnosticsPerFile":[1,2,3,4],"latestChangedDtsFile":"./types/src/index.d.ts"},"version":"FakeTSVersion"}
 
 //// [/home/src/projects/myproject/packages/b/dist/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
   "program": {
     "fileNames": [
       "../../../../../../../a/lib/lib.d.ts",
+      "../../a/dist/types/src/lib.d.ts",
       "../../a/dist/types/src/util.d.ts",
       "../src/index.ts"
     ],
     "fileNamesList": [
       [
+        "../../a/dist/types/src/lib.d.ts",
         "../../a/dist/types/src/util.d.ts"
       ]
     ],
@@ -336,18 +339,26 @@ export declare const magicNumber = 12;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
         "affectsGlobalScope": true
       },
+      "../../a/dist/types/src/lib.d.ts": {
+        "version": "-7063618004-export const magicString: \"12\";\n",
+        "signature": "-7063618004-export const magicString: \"12\";\n"
+      },
       "../../a/dist/types/src/util.d.ts": {
         "version": "-7610027667-export declare const magicNumber = 12;\n",
         "signature": "-7610027667-export declare const magicNumber = 12;\n"
       },
       "../src/index.ts": {
+        "original": {
+          "version": "-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n",
+          "signature": "-3531856636-export {};\n"
+        },
         "version": "-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n",
-        "signature": "-5849137514-import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n"
+        "signature": "-3531856636-export {};\n"
       }
     },
     "root": [
       [
-        3,
+        4,
         "../src/index.ts"
       ]
     ],
@@ -361,54 +372,20 @@ export declare const magicNumber = 12;
     },
     "referencedMap": {
       "../src/index.ts": [
+        "../../a/dist/types/src/lib.d.ts",
         "../../a/dist/types/src/util.d.ts"
       ]
     },
-    "exportedModulesMap": {
-      "../src/index.ts": [
-        "../../a/dist/types/src/util.d.ts"
-      ]
-    },
+    "exportedModulesMap": {},
     "semanticDiagnosticsPerFile": [
       "../../../../../../../a/lib/lib.d.ts",
+      "../../a/dist/types/src/lib.d.ts",
       "../../a/dist/types/src/util.d.ts",
-      [
-        "../src/index.ts",
-        [
-          {
-            "file": "../src/index.ts",
-            "start": 28,
-            "length": 23,
-            "code": 7016,
-            "category": 1,
-            "messageText": {
-              "messageText": "Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.",
-              "category": 1,
-              "code": 7016,
-              "next": [
-                {
-                  "info": {
-                    "moduleReference": "@my-package/a/src/lib",
-                    "packageName": "@my-package/a"
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      ]
-    ],
-    "affectedFilesPendingEmit": [
-      [
-        "../src/index.ts",
-        "Dts"
-      ]
-    ],
-    "emitSignatures": [
       "../src/index.ts"
-    ]
+    ],
+    "latestChangedDtsFile": "./types/src/index.d.ts"
   },
   "version": "FakeTSVersion",
-  "size": 1606
+  "size": 1355
 }
 

--- a/tests/baselines/reference/tsserver/projectReferences/handles-js-source-files-from-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/handles-js-source-files-from-referenced-project.js
@@ -200,6 +200,7 @@ Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-pac
 Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts' exists - use it as a name resolution result.
 Info seq  [hh:mm:ss:mss] Resolving real path for '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts', result '/home/src/projects/myproject/packages/a/src/util.ts'.
 Info seq  [hh:mm:ss:mss] ======== Module name '@my-package/a/src/util' was successfully resolved to '/home/src/projects/myproject/packages/a/src/util.ts' with Package ID '@my-package/a/src/util.ts@1.0.0'. ========
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/a/src/lib.js 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/a/src/util.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/src 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
@@ -223,14 +224,17 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/project
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/projects/myproject/packages/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
 Info seq  [hh:mm:ss:mss] Project '/home/src/projects/myproject/packages/b/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (3)
+Info seq  [hh:mm:ss:mss] 	Files (4)
 	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/projects/myproject/packages/a/src/lib.js Text-1 "export const magicString = \"12\";"
 	/home/src/projects/myproject/packages/a/src/util.ts Text-1 "export const magicNumber = 12;"
 	/home/src/projects/myproject/packages/b/src/index.ts SVC-1-0 "import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n"
 
 
 	../../../../../../a/lib/lib.d.ts
 	  Default library for target 'es5'
+	../a/src/lib.js
+	  Imported via "@my-package/a/src/lib" from file 'src/index.ts' with packageId '@my-package/a/src/lib.js@1.0.0'
 	../a/src/util.ts
 	  Imported via "@my-package/a/src/util" from file 'src/index.ts' with packageId '@my-package/a/src/util.ts@1.0.0'
 	src/index.ts
@@ -256,8 +260,8 @@ Info seq  [hh:mm:ss:mss] event:
         "payload": {
           "projectId": "19de839b42336600c9ca4cf032699347534b5f43e7b3767eb2c8cf4e2a04e53f",
           "fileStats": {
-            "js": 0,
-            "jsSize": 0,
+            "js": 1,
+            "jsSize": 32,
             "jsx": 0,
             "jsxSize": 0,
             "ts": 2,
@@ -309,7 +313,7 @@ Info seq  [hh:mm:ss:mss] event:
 Info seq  [hh:mm:ss:mss] Search path: /home/src/projects/myproject/packages/b
 Info seq  [hh:mm:ss:mss] For info: /home/src/projects/myproject/packages/b/tsconfig.json :: No config files found.
 Info seq  [hh:mm:ss:mss] Project '/home/src/projects/myproject/packages/b/tsconfig.json' (Configured)
-Info seq  [hh:mm:ss:mss] 	Files (3)
+Info seq  [hh:mm:ss:mss] 	Files (4)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
@@ -341,6 +345,8 @@ FsWatches::
 /a/lib/lib.d.ts: *new*
   {}
 /home/src/projects/myproject/packages/a/package.json: *new*
+  {}
+/home/src/projects/myproject/packages/a/src/lib.js: *new*
   {}
 /home/src/projects/myproject/packages/a/src/util.ts: *new*
   {}
@@ -404,21 +410,7 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "semanticDiag",
       "body": {
         "file": "/home/src/projects/myproject/packages/b/src/index.ts",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 1,
-              "offset": 29
-            },
-            "end": {
-              "line": 1,
-              "offset": 52
-            },
-            "text": "Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.\n  Try `npm i --save-dev @types/my-package__a` if it exists or add a new declaration (.d.ts) file containing `declare module '@my-package/a/src/lib';`",
-            "code": 7016,
-            "category": "error"
-          }
-        ]
+        "diagnostics": []
       }
     }
 After running Immedidate callback:: count: 1
@@ -434,21 +426,7 @@ Info seq  [hh:mm:ss:mss] event:
       "event": "suggestionDiag",
       "body": {
         "file": "/home/src/projects/myproject/packages/b/src/index.ts",
-        "diagnostics": [
-          {
-            "start": {
-              "line": 1,
-              "offset": 29
-            },
-            "end": {
-              "line": 1,
-              "offset": 52
-            },
-            "text": "Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.\n  Try `npm i --save-dev @types/my-package__a` if it exists or add a new declaration (.d.ts) file containing `declare module '@my-package/a/src/lib';`",
-            "code": 7016,
-            "category": "suggestion"
-          }
-        ]
+        "diagnostics": []
       }
     }
 Info seq  [hh:mm:ss:mss] event:

--- a/tests/baselines/reference/tsserver/projectReferences/handles-js-source-files-from-referenced-project.js
+++ b/tests/baselines/reference/tsserver/projectReferences/handles-js-source-files-from-referenced-project.js
@@ -1,0 +1,463 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/a/lib/typesMap.json" doesn't exist
+Before request
+//// [/home/src/projects/myproject/packages/a/src/lib.js]
+export const magicString = "12";
+
+//// [/home/src/projects/myproject/packages/a/src/util.ts]
+export const magicNumber = 12;
+
+//// [/home/src/projects/myproject/packages/a/tsconfig.json]
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declarationDir": "./dist/types"
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "./src"
+  ]
+}
+
+//// [/home/src/projects/myproject/packages/a/package.json]
+{
+  "name": "@my-package/a",
+  "version": "1.0.0",
+  "main": "index.js"
+}
+
+//// [/home/src/projects/myproject/packages/b/src/index.ts]
+import { magicString } from "@my-package/a/src/lib";
+import { magicNumber } from "@my-package/a/src/util";
+const a: number = magicNumber;
+const b: string = magicString;
+console.log({ a });
+console.log({ b });
+
+
+//// [/home/src/projects/myproject/packages/b/tsconfig.json]
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declarationDir": "./dist/types"
+  },
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "./src"
+  ],
+  "references": [
+    {
+      "path": "../a/tsconfig.json"
+    }
+  ]
+}
+
+//// [/home/src/projects/myproject/tsconfig.base.json]
+{
+  "compilerOptions": {
+    "composite": true,
+    "allowJs": true,
+    "emitDeclarationOnly": true,
+    "traceResolution": true,
+    "strict": true
+  }
+}
+
+//// [/home/src/projects/myproject/node_modules/@my-package/a] symlink(/home/src/projects/myproject/packages/a)
+//// [/a/lib/lib.d.ts]
+/// <reference no-default-lib="true"/>
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number { toExponential: any; }
+interface Object {}
+interface RegExp {}
+interface String { charAt: any; }
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> {}
+declare const console: { log(msg: any): void; };
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "open",
+      "arguments": {
+        "file": "/home/src/projects/myproject/packages/b/src/index.ts"
+      },
+      "seq": 1,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] Search path: /home/src/projects/myproject/packages/b/src
+Info seq  [hh:mm:ss:mss] For info: /home/src/projects/myproject/packages/b/src/index.ts :: Config file name: /home/src/projects/myproject/packages/b/tsconfig.json
+Info seq  [hh:mm:ss:mss] Creating configuration project /home/src/projects/myproject/packages/b/tsconfig.json
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/tsconfig.json 2000 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingStart",
+      "body": {
+        "projectName": "/home/src/projects/myproject/packages/b/tsconfig.json",
+        "reason": "Creating possible configured project for /home/src/projects/myproject/packages/b/src/index.ts to open"
+      }
+    }
+Info seq  [hh:mm:ss:mss] Config: /home/src/projects/myproject/packages/b/tsconfig.json : {
+ "rootNames": [
+  "/home/src/projects/myproject/packages/b/src/index.ts"
+ ],
+ "options": {
+  "composite": true,
+  "allowJs": true,
+  "emitDeclarationOnly": true,
+  "traceResolution": true,
+  "strict": true,
+  "outDir": "/home/src/projects/myproject/packages/b/dist",
+  "declarationDir": "/home/src/projects/myproject/packages/b/dist/types",
+  "configFilePath": "/home/src/projects/myproject/packages/b/tsconfig.json"
+ },
+ "projectReferences": [
+  {
+   "path": "/home/src/projects/myproject/packages/a/tsconfig.json",
+   "originalPath": "../a/tsconfig.json"
+  }
+ ]
+}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/myproject/tsconfig.base.json 2000 undefined Config: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Extended config file
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/src 1 undefined Config: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/src 1 undefined Config: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /home/src/projects/myproject/packages/b/tsconfig.json
+Info seq  [hh:mm:ss:mss] Config: /home/src/projects/myproject/packages/a/tsconfig.json : {
+ "rootNames": [
+  "/home/src/projects/myproject/packages/a/src/lib.js",
+  "/home/src/projects/myproject/packages/a/src/util.ts"
+ ],
+ "options": {
+  "composite": true,
+  "allowJs": true,
+  "emitDeclarationOnly": true,
+  "traceResolution": true,
+  "strict": true,
+  "outDir": "/home/src/projects/myproject/packages/a/dist",
+  "declarationDir": "/home/src/projects/myproject/packages/a/dist/types",
+  "configFilePath": "/home/src/projects/myproject/packages/a/tsconfig.json"
+ }
+}
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/a/tsconfig.json 2000 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/a/src 1 undefined Config: /home/src/projects/myproject/packages/a/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/a/src 1 undefined Config: /home/src/projects/myproject/packages/a/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] ======== Resolving module '@my-package/a/src/lib' from '/home/src/projects/myproject/packages/b/src/index.ts'. ========
+Info seq  [hh:mm:ss:mss] Module resolution kind is not specified, using 'Node10'.
+Info seq  [hh:mm:ss:mss] Loading module '@my-package/a/src/lib' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Info seq  [hh:mm:ss:mss] Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/b/src/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/b/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Found 'package.json' at '/home/src/projects/myproject/node_modules/@my-package/a/package.json'.
+Info seq  [hh:mm:ss:mss] 'package.json' does not have a 'typesVersions' field.
+Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.ts' does not exist.
+Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.tsx' does not exist.
+Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.d.ts' does not exist.
+Info seq  [hh:mm:ss:mss] 'package.json' does not have a 'typings' field.
+Info seq  [hh:mm:ss:mss] 'package.json' does not have a 'types' field.
+Info seq  [hh:mm:ss:mss] 'package.json' has 'main' field 'index.js' that references '/home/src/projects/myproject/node_modules/@my-package/a/src/lib/index.js'.
+Info seq  [hh:mm:ss:mss] Loading module as file / folder, candidate module location '/home/src/projects/myproject/node_modules/@my-package/a/src/lib/index.js', target file types: TypeScript, Declaration.
+Info seq  [hh:mm:ss:mss] File name '/home/src/projects/myproject/node_modules/@my-package/a/src/lib/index.js' has a '.js' extension - stripping it.
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/node_modules/@types' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Directory '/home/src/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Directory '/home/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Directory '/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/lib'
+Info seq  [hh:mm:ss:mss] Loading module '@my-package/a/src/lib' from 'node_modules' folder, target file types: JavaScript.
+Info seq  [hh:mm:ss:mss] Searching all ancestor node_modules directories for fallback extensions: JavaScript.
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/b/src/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/b/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/package.json' exists according to earlier cached lookups.
+Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.js' exists - use it as a name resolution result.
+Info seq  [hh:mm:ss:mss] Resolving real path for '/home/src/projects/myproject/node_modules/@my-package/a/src/lib.js', result '/home/src/projects/myproject/packages/a/src/lib.js'.
+Info seq  [hh:mm:ss:mss] ======== Module name '@my-package/a/src/lib' was successfully resolved to '/home/src/projects/myproject/packages/a/src/lib.js' with Package ID '@my-package/a/src/lib.js@1.0.0'. ========
+Info seq  [hh:mm:ss:mss] ======== Resolving module '@my-package/a/src/util' from '/home/src/projects/myproject/packages/b/src/index.ts'. ========
+Info seq  [hh:mm:ss:mss] Module resolution kind is not specified, using 'Node10'.
+Info seq  [hh:mm:ss:mss] Loading module '@my-package/a/src/util' from 'node_modules' folder, target file types: TypeScript, Declaration.
+Info seq  [hh:mm:ss:mss] Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/b/src/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/util'
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/b/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/util'
+Info seq  [hh:mm:ss:mss] Directory '/home/src/projects/myproject/packages/node_modules' does not exist, skipping all lookups in it.
+Info seq  [hh:mm:ss:mss] Scoped package detected, looking in 'my-package__a/src/util'
+Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/package.json' exists according to earlier cached lookups.
+Info seq  [hh:mm:ss:mss] File '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts' exists - use it as a name resolution result.
+Info seq  [hh:mm:ss:mss] Resolving real path for '/home/src/projects/myproject/node_modules/@my-package/a/src/util.ts', result '/home/src/projects/myproject/packages/a/src/util.ts'.
+Info seq  [hh:mm:ss:mss] ======== Module name '@my-package/a/src/util' was successfully resolved to '/home/src/projects/myproject/packages/a/src/util.ts' with Package ID '@my-package/a/src/util.ts@1.0.0'. ========
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/a/src/util.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/lib/lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/src 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/src 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/a/package.json 2000 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/b/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/packages/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/myproject/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /home/src/projects/node_modules/@types 1 undefined Project: /home/src/projects/myproject/packages/b/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /home/src/projects/myproject/packages/b/tsconfig.json Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/myproject/packages/b/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+	/a/lib/lib.d.ts Text-1 "/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+	/home/src/projects/myproject/packages/a/src/util.ts Text-1 "export const magicNumber = 12;"
+	/home/src/projects/myproject/packages/b/src/index.ts SVC-1-0 "import { magicString } from \"@my-package/a/src/lib\";\nimport { magicNumber } from \"@my-package/a/src/util\";\nconst a: number = magicNumber;\nconst b: string = magicString;\nconsole.log({ a });\nconsole.log({ b });\n"
+
+
+	../../../../../../a/lib/lib.d.ts
+	  Default library for target 'es5'
+	../a/src/util.ts
+	  Imported via "@my-package/a/src/util" from file 'src/index.ts' with packageId '@my-package/a/src/util.ts@1.0.0'
+	src/index.ts
+	  Matched by include pattern './src' in 'tsconfig.json'
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "projectLoadingFinish",
+      "body": {
+        "projectName": "/home/src/projects/myproject/packages/b/tsconfig.json"
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "telemetry",
+      "body": {
+        "telemetryEventName": "projectInfo",
+        "payload": {
+          "projectId": "19de839b42336600c9ca4cf032699347534b5f43e7b3767eb2c8cf4e2a04e53f",
+          "fileStats": {
+            "js": 0,
+            "jsSize": 0,
+            "jsx": 0,
+            "jsxSize": 0,
+            "ts": 2,
+            "tsSize": 239,
+            "tsx": 0,
+            "tsxSize": 0,
+            "dts": 1,
+            "dtsSize": 413,
+            "deferred": 0,
+            "deferredSize": 0
+          },
+          "compilerOptions": {
+            "composite": true,
+            "allowJs": true,
+            "emitDeclarationOnly": true,
+            "traceResolution": true,
+            "strict": true,
+            "outDir": "",
+            "declarationDir": ""
+          },
+          "typeAcquisition": {
+            "enable": false,
+            "include": false,
+            "exclude": false
+          },
+          "extends": true,
+          "files": false,
+          "include": true,
+          "exclude": false,
+          "compileOnSave": false,
+          "configFileName": "tsconfig.json",
+          "projectType": "configured",
+          "languageServiceEnabled": true,
+          "version": "FakeVersion"
+        }
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "configFileDiag",
+      "body": {
+        "triggerFile": "/home/src/projects/myproject/packages/b/src/index.ts",
+        "configFile": "/home/src/projects/myproject/packages/b/tsconfig.json",
+        "diagnostics": []
+      }
+    }
+Info seq  [hh:mm:ss:mss] Search path: /home/src/projects/myproject/packages/b
+Info seq  [hh:mm:ss:mss] For info: /home/src/projects/myproject/packages/b/tsconfig.json :: No config files found.
+Info seq  [hh:mm:ss:mss] Project '/home/src/projects/myproject/packages/b/tsconfig.json' (Configured)
+Info seq  [hh:mm:ss:mss] 	Files (3)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /home/src/projects/myproject/packages/b/src/index.ts ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /home/src/projects/myproject/packages/b/tsconfig.json
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+PolledWatches::
+/home/src/projects/myproject/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/myproject/packages/b/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/projects/myproject/packages/b/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/myproject/packages/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/projects/myproject/packages/node_modules/@types: *new*
+  {"pollingInterval":500}
+/home/src/projects/node_modules: *new*
+  {"pollingInterval":500}
+/home/src/projects/node_modules/@types: *new*
+  {"pollingInterval":500}
+
+FsWatches::
+/a/lib/lib.d.ts: *new*
+  {}
+/home/src/projects/myproject/packages/a/package.json: *new*
+  {}
+/home/src/projects/myproject/packages/a/src/util.ts: *new*
+  {}
+/home/src/projects/myproject/packages/a/tsconfig.json: *new*
+  {}
+/home/src/projects/myproject/packages/b/tsconfig.json: *new*
+  {}
+/home/src/projects/myproject/tsconfig.base.json: *new*
+  {}
+
+FsWatchesRecursive::
+/home/src/projects/myproject/node_modules: *new*
+  {}
+/home/src/projects/myproject/packages/a/src: *new*
+  {}
+/home/src/projects/myproject/packages/b/src: *new*
+  {}
+
+Before request
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "command": "geterr",
+      "arguments": {
+        "delay": 0,
+        "files": [
+          "/home/src/projects/myproject/packages/b/src/index.ts"
+        ]
+      },
+      "seq": 2,
+      "type": "request"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "responseRequired": false
+    }
+After request
+
+Before running Timeout callback:: count: 1
+1: checkOne
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "syntaxDiag",
+      "body": {
+        "file": "/home/src/projects/myproject/packages/b/src/index.ts",
+        "diagnostics": []
+      }
+    }
+After running Timeout callback:: count: 0
+
+Before running Immedidate callback:: count: 1
+1: semanticCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "semanticDiag",
+      "body": {
+        "file": "/home/src/projects/myproject/packages/b/src/index.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 1,
+              "offset": 29
+            },
+            "end": {
+              "line": 1,
+              "offset": 52
+            },
+            "text": "Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.\n  Try `npm i --save-dev @types/my-package__a` if it exists or add a new declaration (.d.ts) file containing `declare module '@my-package/a/src/lib';`",
+            "code": 7016,
+            "category": "error"
+          }
+        ]
+      }
+    }
+After running Immedidate callback:: count: 1
+2: suggestionCheck
+
+Before running Immedidate callback:: count: 1
+2: suggestionCheck
+
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "suggestionDiag",
+      "body": {
+        "file": "/home/src/projects/myproject/packages/b/src/index.ts",
+        "diagnostics": [
+          {
+            "start": {
+              "line": 1,
+              "offset": 29
+            },
+            "end": {
+              "line": 1,
+              "offset": 52
+            },
+            "text": "Could not find a declaration file for module '@my-package/a/src/lib'. '/home/src/projects/myproject/packages/a/src/lib.js' implicitly has an 'any' type.\n  Try `npm i --save-dev @types/my-package__a` if it exists or add a new declaration (.d.ts) file containing `declare module '@my-package/a/src/lib';`",
+            "code": 7016,
+            "category": "suggestion"
+          }
+        ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] event:
+    {
+      "seq": 0,
+      "type": "event",
+      "event": "requestCompleted",
+      "body": {
+        "request_seq": 2
+      }
+    }
+After running Immedidate callback:: count: 0


### PR DESCRIPTION
TODO:: Another place where we check for resolution extension is ts is "typing acquisition" and probably good candidate if we go for this path.

Will fix: #56191