### PR TITLE
fix(54268): Renaming JSDoc @param symbol only renames the first instance

### DIFF
--- a/tests/baselines/reference/renameJsDocTypeLiteral.baseline.jsonc
+++ b/tests/baselines/reference/renameJsDocTypeLiteral.baseline.jsonc
@@ -1,0 +1,8 @@
+// === findRenameLocations ===
+// === /a.js ===
+// /**
+//  * @param {Object} [|optionsRENAME|]
+//  * @param {string} [|optionsRENAME|].foo
+//  * @param {number} [|optionsRENAME|].bar
+//  */
+// function foo(/*RENAME*/[|optionsRENAME|]) {}

--- a/tests/cases/fourslash/renameJsDocTypeLiteral.ts
+++ b/tests/cases/fourslash/renameJsDocTypeLiteral.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+// @filename: /a.js
+/////**
+//// * @param {Object} options
+//// * @param {string} options.foo
+//// * @param {number} options.bar
+//// */
+////function foo(/**/options) {}
+
+goTo.file("/a.js");
+verify.baselineRename("", { });


### PR DESCRIPTION
Fixes #54268