### PR TITLE
Revert "Explicitly declare type=commonjs in package.json (#56190)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "type": "git",
         "url": "https://github.com/Microsoft/TypeScript.git"
     },
-    "type": "commonjs",
     "main": "./lib/typescript.js",
     "typings": "./lib/typescript.d.ts",
     "bin": {


### PR DESCRIPTION
This apparently had an effect on esbuild's behavior. I didn't notice it in the package size report:

|  | Before | After | Diff | Diff (percent) |
| - | - | - | - | - |
| Packed | 5.49 MiB | 5.56 MiB | +71.00 KiB | +1.26% |
| Unpacked | 30.49 MiB | 31.03 MiB | +546.64 KiB | +1.75% |

|  | Before | After | Diff | Diff (percent) |
| - | - | - | - | - |
| `lib/tsc.js` | 5.55 MiB | 5.55 MiB | +75.00 B | +0.00% |
| `lib/tsserver.js` | 8.12 MiB | 8.52 MiB | +407.05 KiB | +4.89% |
| `lib/typescript.js` | 8.59 MiB | 8.72 MiB | +139.49 KiB | +1.59% |
| `package.json` | 3.44 KiB | 3.46 KiB | +24.00 B | +0.68% |

I haven't investigated exactly why this happens, other than that some export objects are getting duplicated. But, I did not intend this at all, just to maybe make our package more explicit / faster before the release.