### PR TITLE
feat(55737): JSDoc {@link} support all 4 types of links

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2977,7 +2977,8 @@ export function buildLinkParts(link: JSDocLink | JSDocLinkCode | JSDocLinkPlain,
             if (text) parts.push(linkTextPart(text));
         }
         else {
-            parts.push(linkTextPart(name + (suffix ? "" : " ") + text));
+            const separator = suffix === 0 || (link.text.charCodeAt(suffix) === CharacterCodes.bar && name.charCodeAt(name.length - 1) !== CharacterCodes.space) ? " " : "";
+            parts.push(linkTextPart(name + separator + text));
         }
     }
     parts.push(linkPart("}"));

--- a/tests/baselines/reference/quickInfoLink11.baseline
+++ b/tests/baselines/reference/quickInfoLink11.baseline
@@ -1,0 +1,121 @@
+// === QuickInfo ===
+=== /tests/cases/fourslash/quickInfoLink11.ts ===
+// /**
+//  * {@link https://vscode.dev}
+//  * [link text]{https://vscode.dev}
+//  * {@link https://vscode.dev|link text}
+//  * {@link https://vscode.dev link text}
+//  */
+// function f() {}
+// 
+// f();
+// ^
+// | ----------------------------------------------------------------------
+// | function f(): void
+// | {@link https://vscode.dev}
+// | [link text]{https://vscode.dev}
+// | {@link https://vscode.dev link text}
+// | {@link https://vscode.dev link text}
+// | ----------------------------------------------------------------------
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoLink11.ts",
+      "position": 170,
+      "name": ""
+    },
+    "item": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 170,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "f",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "https://vscode.dev",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": "\n[link text]{https://vscode.dev}\n",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "https://vscode.dev link text",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": "\n",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "https://vscode.dev link text",
+          "kind": "linkText"
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/quickInfoLink11.ts
+++ b/tests/cases/fourslash/quickInfoLink11.ts
@@ -1,0 +1,13 @@
+///<reference path="fourslash.ts" />
+
+/////**
+//// * {@link https://vscode.dev}
+//// * [link text]{https://vscode.dev}
+//// * {@link https://vscode.dev|link text}
+//// * {@link https://vscode.dev link text}
+//// */
+////function f() {}
+////
+/////**/f();
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #55737