### PR TITLE
Fixed a crash when inferring return type of an accessor with errors in its return statement

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7312,7 +7312,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             if (propertySymbol.flags & SymbolFlags.Accessor) {
                 const writeType = getWriteTypeOfSymbol(propertySymbol);
-                if (propertyType !== writeType) {
+                if (propertyType !== writeType && !isErrorType(propertyType) && !isErrorType(writeType)) {
                     const getterDeclaration = getDeclarationOfKind<GetAccessorDeclaration>(propertySymbol, SyntaxKind.GetAccessor)!;
                     const getterSignature = getSignatureFromDeclaration(getterDeclaration);
                     typeElements.push(

--- a/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.errors.txt
+++ b/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.errors.txt
@@ -1,0 +1,16 @@
+accessorInferredReturnTypeErrorInReturnStatement.ts(2,7): error TS7023: 'primaryPath' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+accessorInferredReturnTypeErrorInReturnStatement.ts(4,18): error TS2339: Property 'collection' does not exist on type '{ readonly primaryPath: any; }'.
+
+
+==== accessorInferredReturnTypeErrorInReturnStatement.ts (2 errors) ====
+    export var basePrototype = {
+      get primaryPath() {
+          ~~~~~~~~~~~
+!!! error TS7023: 'primaryPath' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+        var _this = this;
+        return _this.collection.schema.primaryPath;
+                     ~~~~~~~~~~
+!!! error TS2339: Property 'collection' does not exist on type '{ readonly primaryPath: any; }'.
+      },  
+    };
+    

--- a/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.js
+++ b/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.js
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts] ////
+
+//// [accessorInferredReturnTypeErrorInReturnStatement.ts]
+export var basePrototype = {
+  get primaryPath() {
+    var _this = this;
+    return _this.collection.schema.primaryPath;
+  },  
+};
+
+
+//// [accessorInferredReturnTypeErrorInReturnStatement.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.basePrototype = void 0;
+exports.basePrototype = {
+    get primaryPath() {
+        var _this = this;
+        return _this.collection.schema.primaryPath;
+    },
+};
+
+
+//// [accessorInferredReturnTypeErrorInReturnStatement.d.ts]
+export declare var basePrototype: {
+    readonly primaryPath: any;
+};

--- a/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.symbols
+++ b/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.symbols
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts] ////
+
+=== accessorInferredReturnTypeErrorInReturnStatement.ts ===
+export var basePrototype = {
+>basePrototype : Symbol(basePrototype, Decl(accessorInferredReturnTypeErrorInReturnStatement.ts, 0, 10))
+
+  get primaryPath() {
+>primaryPath : Symbol(primaryPath, Decl(accessorInferredReturnTypeErrorInReturnStatement.ts, 0, 28))
+
+    var _this = this;
+>_this : Symbol(_this, Decl(accessorInferredReturnTypeErrorInReturnStatement.ts, 2, 7))
+>this : Symbol(basePrototype, Decl(accessorInferredReturnTypeErrorInReturnStatement.ts, 0, 26))
+
+    return _this.collection.schema.primaryPath;
+>_this : Symbol(_this, Decl(accessorInferredReturnTypeErrorInReturnStatement.ts, 2, 7))
+
+  },  
+};
+

--- a/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.types
+++ b/tests/baselines/reference/accessorInferredReturnTypeErrorInReturnStatement.types
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts] ////
+
+=== accessorInferredReturnTypeErrorInReturnStatement.ts ===
+export var basePrototype = {
+>basePrototype : { readonly primaryPath: any; }
+>{  get primaryPath() {    var _this = this;    return _this.collection.schema.primaryPath;  },  } : { readonly primaryPath: any; }
+
+  get primaryPath() {
+>primaryPath : any
+
+    var _this = this;
+>_this : { readonly primaryPath: any; }
+>this : { readonly primaryPath: any; }
+
+    return _this.collection.schema.primaryPath;
+>_this.collection.schema.primaryPath : any
+>_this.collection.schema : any
+>_this.collection : any
+>_this : { readonly primaryPath: any; }
+>collection : any
+>schema : any
+>primaryPath : any
+
+  },  
+};
+

--- a/tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts
+++ b/tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts
@@ -1,0 +1,9 @@
+// @strict: true
+// @declaration: true
+
+export var basePrototype = {
+  get primaryPath() {
+    var _this = this;
+    return _this.collection.schema.primaryPath;
+  },  
+};


### PR DESCRIPTION
fixes what has been reported [here](https://github.com/microsoft/TypeScript/issues/56253#issuecomment-1784234294)