### PR TITLE
Add dependabot to pr_owners

### DIFF
--- a/.github/pr_owners.txt
+++ b/.github/pr_owners.txt
@@ -13,3 +13,4 @@ jakebailey
 DanielRosenwasser
 navya9singh
 iisaduan
+dependabot


### PR DESCRIPTION
Makes the _other_ bots happy now that we are using dependabot to manage GHA pinning. See #56255.