### PR TITLE
pass 'detached:true' for diff tool

### DIFF
--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -52,6 +52,7 @@ export async function exec(cmd, args, options = {}) {
         }
         else {
             proc.unref();
+            resolve({ exitCode: undefined });
         }
     }));
 }

--- a/scripts/build/utils.mjs
+++ b/scripts/build/utils.mjs
@@ -28,7 +28,7 @@ export async function exec(cmd, args, options = {}) {
         const { ignoreExitCode, waitForExit = true, ignoreStdout } = options;
 
         if (!options.hidePrompt) console.log(`> ${chalk.green(cmd)} ${args.join(" ")}`);
-        const proc = spawn(which.sync(cmd), args, { stdio: waitForExit ? ignoreStdout ? ["inherit", "ignore", "inherit"] : "inherit" : "ignore" });
+        const proc = spawn(which.sync(cmd), args, { stdio: waitForExit ? ignoreStdout ? ["inherit", "ignore", "inherit"] : "inherit" : "ignore", detached: !waitForExit });
         if (waitForExit) {
             const onCanceled = () => {
                 proc.kill();
@@ -52,8 +52,6 @@ export async function exec(cmd, args, options = {}) {
         }
         else {
             proc.unref();
-            // wait a short period in order to allow the process to start successfully before Node exits.
-            setTimeout(() => resolve({ exitCode: undefined }), 100);
         }
     }));
 }


### PR DESCRIPTION
Properly detach subprocess when spawning diff tool for `hereby diff` so that it doesn't terminate immediately when the NodeJS process terminates.
