### PR TITLE
Fixed accidental possibility to create `Infinity`/`-Infinity` number literal types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37259,6 +37259,9 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         }
         switch (node.operand.kind) {
             case SyntaxKind.NumericLiteral:
+                if (operandType === numberType) {
+                    return numberType;
+                }
                 switch (node.operator) {
                     case SyntaxKind.MinusToken:
                         return getFreshTypeOfLiteralType(getNumberLiteralType(-(node.operand as NumericLiteral).text));

--- a/tests/baselines/reference/noInfinityNumberLiterals.symbols
+++ b/tests/baselines/reference/noInfinityNumberLiterals.symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/noInfinityNumberLiterals.ts] ////
+
+=== noInfinityNumberLiterals.ts ===
+type PositiveInfinity = 1e999;
+>PositiveInfinity : Symbol(PositiveInfinity, Decl(noInfinityNumberLiterals.ts, 0, 0))
+
+type NegativeInfinity = -1e999;
+>NegativeInfinity : Symbol(NegativeInfinity, Decl(noInfinityNumberLiterals.ts, 0, 30), Decl(noInfinityNumberLiterals.ts, 5, 5))
+
+const positiveInfinity = 1e999;
+>positiveInfinity : Symbol(positiveInfinity, Decl(noInfinityNumberLiterals.ts, 3, 5))
+
+const positiveInfinity2 = +1e999;
+>positiveInfinity2 : Symbol(positiveInfinity2, Decl(noInfinityNumberLiterals.ts, 4, 5))
+
+const NegativeInfinity = -1e999;
+>NegativeInfinity : Symbol(NegativeInfinity, Decl(noInfinityNumberLiterals.ts, 0, 30), Decl(noInfinityNumberLiterals.ts, 5, 5))
+

--- a/tests/baselines/reference/noInfinityNumberLiterals.types
+++ b/tests/baselines/reference/noInfinityNumberLiterals.types
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/noInfinityNumberLiterals.ts] ////
+
+=== noInfinityNumberLiterals.ts ===
+type PositiveInfinity = 1e999;
+>PositiveInfinity : number
+
+type NegativeInfinity = -1e999;
+>NegativeInfinity : number
+>-1e999 : number
+>1e999 : number
+
+const positiveInfinity = 1e999;
+>positiveInfinity : number
+>1e999 : number
+
+const positiveInfinity2 = +1e999;
+>positiveInfinity2 : number
+>+1e999 : number
+>1e999 : number
+
+const NegativeInfinity = -1e999;
+>NegativeInfinity : number
+>-1e999 : number
+>1e999 : number
+

--- a/tests/cases/compiler/noInfinityNumberLiterals.ts
+++ b/tests/cases/compiler/noInfinityNumberLiterals.ts
@@ -1,0 +1,9 @@
+// @strict: true
+// @noEmit: true
+
+type PositiveInfinity = 1e999;
+type NegativeInfinity = -1e999;
+
+const positiveInfinity = 1e999;
+const positiveInfinity2 = +1e999;
+const NegativeInfinity = -1e999;


### PR DESCRIPTION
closes https://github.com/microsoft/TypeScript/issues/56272

While there are some issues open about allowing those in some form, I think that - for the time being - the fact that they can be constructed (somewhat) should be considered a bug.