### PR TITLE
Deprecate ES3 in commandline parser

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -528,6 +528,7 @@ export const targetOptionDeclaration: CommandLineOptionOfCustomType = {
     affectsModuleResolution: true,
     affectsEmit: true,
     affectsBuildInfo: true,
+    deprecatedKeys: new Set(["es3"]),
     paramType: Diagnostics.VERSION,
     showInSimplifiedHelpView: true,
     category: Diagnostics.Language_and_Environment,

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -399,6 +399,7 @@ function generateOptionOutput(sys: System, option: CommandLineOption, rightAlign
                     });
                     return Object.entries(inverted)
                         .map(([, synonyms]) => synonyms.join("/"))
+                        .filter(s => !(option.deprecatedKeys && option.deprecatedKeys.has(s)))
                         .join(", ");
             }
             return possibleValues;

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -395,7 +395,7 @@ function generateOptionOutput(sys: System, option: CommandLineOption, rightAlign
                     // Group synonyms: es6/es2015
                     const inverted: { [value: string]: string[]; } = {};
                     option.type.forEach((value, name) => {
-                        if (!(option.deprecatedKeys && option.deprecatedKeys.has(name))) {
+                        if (!option.deprecatedKeys?.has(name)) {
                             (inverted[value] ||= []).push(name);
                         }
                     });

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -395,11 +395,12 @@ function generateOptionOutput(sys: System, option: CommandLineOption, rightAlign
                     // Group synonyms: es6/es2015
                     const inverted: { [value: string]: string[]; } = {};
                     option.type.forEach((value, name) => {
-                        (inverted[value] ||= []).push(name);
+                        if (!(option.deprecatedKeys && option.deprecatedKeys.has(name))) {
+                            (inverted[value] ||= []).push(name);
+                        }
                     });
                     return Object.entries(inverted)
                         .map(([, synonyms]) => synonyms.join("/"))
-                        .filter(s => !(option.deprecatedKeys && option.deprecatedKeys.has(s)))
                         .join(", ");
             }
             return possibleValues;

--- a/tests/baselines/reference/config/commandLineParsing/parseCommandLine/Parse empty options of --target.js
+++ b/tests/baselines/reference/config/commandLineParsing/parseCommandLine/Parse empty options of --target.js
@@ -7,4 +7,4 @@ FileNames::
 0.ts
 Errors::
 error TS6044: Compiler option 'target' expects an argument.
-error TS6046: Argument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.
+error TS6046: Argument for '--target' option must be: 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.

--- a/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of target to compiler-options with json api.js
+++ b/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of target to compiler-options with json api.js
@@ -23,5 +23,5 @@ CompilerOptions::
   "configFilePath": "tsconfig.json"
 }
 Errors::
-[91merror[0m[90m TS6046: [0mArgument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.
+[91merror[0m[90m TS6046: [0mArgument for '--target' option must be: 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.
 

--- a/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of target to compiler-options with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert incorrect option of target to compiler-options with jsonSourceFile api.js
@@ -23,7 +23,7 @@ CompilerOptions::
   "configFilePath": "tsconfig.json"
 }
 Errors::
-[96mtsconfig.json[0m:[93m3[0m:[93m15[0m - [91merror[0m[90m TS6046: [0mArgument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.
+[96mtsconfig.json[0m:[93m3[0m:[93m15[0m - [91merror[0m[90m TS6046: [0mArgument for '--target' option must be: 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.
 
 [7m3[0m     "target": "",
 [7m [0m [91m              ~~[0m

--- a/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert tsconfig options when there are multiple invalid strings with jsonSourceFile api.js
+++ b/tests/baselines/reference/config/convertCompilerOptionsFromJson/Convert tsconfig options when there are multiple invalid strings with jsonSourceFile api.js
@@ -47,7 +47,7 @@ Errors::
 [7m   [0m [91m~~~[0m
 [7m 19[0m }
 [7m   [0m [91m~[0m
-[96mtsconfig.json[0m:[93m3[0m:[93m15[0m - [91merror[0m[90m TS6046: [0mArgument for '--target' option must be: 'es3', 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.
+[96mtsconfig.json[0m:[93m3[0m:[93m15[0m - [91merror[0m[90m TS6046: [0mArgument for '--target' option must be: 'es5', 'es6', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021', 'es2022', 'esnext'.
 
 [7m3[0m     "target": "<%- options.useTsWithBabel ? 'esnext' : 'es5' %>",
 [7m [0m [91m              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m

--- a/tests/baselines/reference/tsc/runWithoutArgs/does-not-add-color-when-NO_COLOR-is-set.js
+++ b/tests/baselines/reference/tsc/runWithoutArgs/does-not-add-color-when-NO_COLOR-is-set.js
@@ -101,7 +101,7 @@ default: false
 
 --target, -t
 Set the JavaScript language version for emitted JavaScript and include compatible library declarations.
-one of: es3, es5, es6/es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, esnext
+one of: es5, es6/es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, esnext
 default: es5
 
 --module, -m

--- a/tests/baselines/reference/tsc/runWithoutArgs/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped-when-host-can't-provide-terminal-width.js
+++ b/tests/baselines/reference/tsc/runWithoutArgs/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped-when-host-can't-provide-terminal-width.js
@@ -101,7 +101,7 @@ default: false
 
 [94m--target, -t[39m
 Set the JavaScript language version for emitted JavaScript and include compatible library declarations.
-one of: es3, es5, es6/es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, esnext
+one of: es5, es6/es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, esnext
 default: es5
 
 [94m--module, -m[39m

--- a/tests/baselines/reference/tsc/runWithoutArgs/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped.js
+++ b/tests/baselines/reference/tsc/runWithoutArgs/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped.js
@@ -101,7 +101,7 @@ default: false
 
 [94m--target, -t[39m
 Set the JavaScript language version for emitted JavaScript and include compatible library declarations.
-one of: es3, es5, es6/es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, esnext
+one of: es5, es6/es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, esnext
 default: es5
 
 [94m--module, -m[39m


### PR DESCRIPTION
I noticed in #56303 that we didn't remove ES3 (or `moduleResolution: node`) from our help printback