### PR TITLE
Avoid incorrect narrowings using const variables from binding elemens with literal initializers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26206,7 +26206,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (hasOnlyExpressionInitializer(declaration) && isBlockScopedNameDeclaredBeforeUse(declaration, node)) {
             const initializer = getEffectiveInitializer(declaration);
             if (initializer) {
-                return tryGetNameFromType(getTypeOfExpression(initializer));
+                const initializerType = isBindingPattern(declaration.parent) ? getTypeForBindingElement(declaration as BindingElement) : getTypeOfExpression(initializer);
+                return initializerType && tryGetNameFromType(initializerType);
             }
             if (isEnumMember(declaration)) {
                 return getTextOfPropertyName(declaration.name);

--- a/tests/baselines/reference/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.symbols
+++ b/tests/baselines/reference/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.symbols
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts] ////
+
+=== avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts ===
+declare const foo: ["a", string, number] | ["b", string, boolean];
+>foo : Symbol(foo, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 0, 13))
+
+export function test(arg: { index?: number }) {
+>test : Symbol(test, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 0, 66))
+>arg : Symbol(arg, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 2, 21))
+>index : Symbol(index, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 2, 27))
+
+  const { index = 0 } = arg;
+>index : Symbol(index, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 3, 9))
+>arg : Symbol(arg, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 2, 21))
+
+  if (foo[index] === "a") {
+>foo : Symbol(foo, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 0, 13))
+>index : Symbol(index, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 3, 9))
+
+    foo;
+>foo : Symbol(foo, Decl(avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts, 0, 13))
+  }
+}
+

--- a/tests/baselines/reference/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.types
+++ b/tests/baselines/reference/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.types
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts] ////
+
+=== avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts ===
+declare const foo: ["a", string, number] | ["b", string, boolean];
+>foo : ["a", string, number] | ["b", string, boolean]
+
+export function test(arg: { index?: number }) {
+>test : (arg: { index?: number | undefined; }) => void
+>arg : { index?: number | undefined; }
+>index : number | undefined
+
+  const { index = 0 } = arg;
+>index : number
+>0 : 0
+>arg : { index?: number | undefined; }
+
+  if (foo[index] === "a") {
+>foo[index] === "a" : boolean
+>foo[index] : string | number | boolean
+>foo : ["a", string, number] | ["b", string, boolean]
+>index : number
+>"a" : "a"
+
+    foo;
+>foo : ["a", string, number] | ["b", string, boolean]
+  }
+}
+

--- a/tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts
+++ b/tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts
@@ -1,0 +1,12 @@
+// @strict: true
+// @noEmit: true
+
+declare const foo: ["a", string, number] | ["b", string, boolean];
+
+export function test(arg: { index?: number }) {
+  const { index = 0 } = arg;
+
+  if (foo[index] === "a") {
+    foo;
+  }
+}


### PR DESCRIPTION
spotted this while investigating why https://github.com/microsoft/TypeScript/pull/55193 fixed https://github.com/microsoft/TypeScript/issues/56341
