### PR TITLE
Pr 50377 redo filter boolean overload

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -34252,7 +34252,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     const arg0Type = getTypeOfExpression(args[0]);
                     // This is safe even if a different BooleanConstructor is defined in a namespace,
                     // because in that case arg0Type.symbol.escapedName will appear as "__type".
-                    if (arg0Type.symbol.escapedName === "BooleanConstructor") {
+                    if (arg0Type.symbol?.escapedName === "BooleanConstructor") {
                         // It is a-priori knowledge the filter returns the same type as the array type
                         // for a signature succeeding when BooleanConstructor is the argument type
                         let returnType = (signature.mapper as undefined | { targets: readonly Type[]; })?.targets[1];

--- a/tests/baselines/reference/arrayFilterBooleanOverload.js
+++ b/tests/baselines/reference/arrayFilterBooleanOverload.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/arrayFilterBooleanOverload.ts] ////
+
+//// [arrayFilterBooleanOverload.ts]
+const nullableValues = ['a', 'b', null]; // expect (string | null)[]
+
+const values1 = nullableValues.filter(Boolean); // expect string[]
+
+// @ts-expect-error
+const values2 = nullableValues.filter(new Boolean);
+
+const arr = [0, 1, "", "foo", null] as const;
+
+const arr2 = arr.filter(Boolean); // expect ("foo" | 1)[]
+
+
+
+//// [arrayFilterBooleanOverload.js]
+"use strict";
+const nullableValues = ['a', 'b', null]; // expect (string | null)[]
+const values1 = nullableValues.filter(Boolean); // expect string[]
+// @ts-expect-error
+const values2 = nullableValues.filter(new Boolean);
+const arr = [0, 1, "", "foo", null];
+const arr2 = arr.filter(Boolean); // expect ("foo" | 1)[]
+
+
+//// [arrayFilterBooleanOverload.d.ts]
+declare const nullableValues: (string | null)[];
+declare const values1: (string | null)[];
+declare const values2: (string | null)[];
+declare const arr: readonly [0, 1, "", "foo", null];
+declare const arr2: ("" | 0 | 1 | "foo" | null)[];

--- a/tests/baselines/reference/arrayFilterBooleanOverload.js
+++ b/tests/baselines/reference/arrayFilterBooleanOverload.js
@@ -26,7 +26,7 @@ const arr2 = arr.filter(Boolean); // expect ("foo" | 1)[]
 
 //// [arrayFilterBooleanOverload.d.ts]
 declare const nullableValues: (string | null)[];
-declare const values1: (string | null)[];
+declare const values1: string[];
 declare const values2: (string | null)[];
 declare const arr: readonly [0, 1, "", "foo", null];
-declare const arr2: ("" | 0 | 1 | "foo" | null)[];
+declare const arr2: (1 | "foo")[];

--- a/tests/baselines/reference/arrayFilterBooleanOverload.symbols
+++ b/tests/baselines/reference/arrayFilterBooleanOverload.symbols
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/arrayFilterBooleanOverload.ts] ////
+
+=== arrayFilterBooleanOverload.ts ===
+const nullableValues = ['a', 'b', null]; // expect (string | null)[]
+>nullableValues : Symbol(nullableValues, Decl(arrayFilterBooleanOverload.ts, 0, 5))
+
+const values1 = nullableValues.filter(Boolean); // expect string[]
+>values1 : Symbol(values1, Decl(arrayFilterBooleanOverload.ts, 2, 5))
+>nullableValues.filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>nullableValues : Symbol(nullableValues, Decl(arrayFilterBooleanOverload.ts, 0, 5))
+>filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Boolean : Symbol(Boolean, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+// @ts-expect-error
+const values2 = nullableValues.filter(new Boolean);
+>values2 : Symbol(values2, Decl(arrayFilterBooleanOverload.ts, 5, 5))
+>nullableValues.filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>nullableValues : Symbol(nullableValues, Decl(arrayFilterBooleanOverload.ts, 0, 5))
+>filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Boolean : Symbol(Boolean, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+const arr = [0, 1, "", "foo", null] as const;
+>arr : Symbol(arr, Decl(arrayFilterBooleanOverload.ts, 7, 5))
+>const : Symbol(const)
+
+const arr2 = arr.filter(Boolean); // expect ("foo" | 1)[]
+>arr2 : Symbol(arr2, Decl(arrayFilterBooleanOverload.ts, 9, 5))
+>arr.filter : Symbol(ReadonlyArray.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(arrayFilterBooleanOverload.ts, 7, 5))
+>filter : Symbol(ReadonlyArray.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Boolean : Symbol(Boolean, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+

--- a/tests/baselines/reference/arrayFilterBooleanOverload.types
+++ b/tests/baselines/reference/arrayFilterBooleanOverload.types
@@ -8,8 +8,8 @@ const nullableValues = ['a', 'b', null]; // expect (string | null)[]
 >'b' : "b"
 
 const values1 = nullableValues.filter(Boolean); // expect string[]
->values1 : (string | null)[]
->nullableValues.filter(Boolean) : (string | null)[]
+>values1 : string[]
+>nullableValues.filter(Boolean) : string[]
 >nullableValues.filter : { <S extends string | null>(predicate: (value: string | null, index: number, array: (string | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: string | null, index: number, array: (string | null)[]) => unknown, thisArg?: any): (string | null)[]; }
 >nullableValues : (string | null)[]
 >filter : { <S extends string | null>(predicate: (value: string | null, index: number, array: (string | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: string | null, index: number, array: (string | null)[]) => unknown, thisArg?: any): (string | null)[]; }
@@ -35,8 +35,8 @@ const arr = [0, 1, "", "foo", null] as const;
 >"foo" : "foo"
 
 const arr2 = arr.filter(Boolean); // expect ("foo" | 1)[]
->arr2 : ("" | 0 | 1 | "foo" | null)[]
->arr.filter(Boolean) : ("" | 0 | 1 | "foo" | null)[]
+>arr2 : (1 | "foo")[]
+>arr.filter(Boolean) : (1 | "foo")[]
 >arr.filter : { <S extends "" | 0 | 1 | "foo" | null>(predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => unknown, thisArg?: any): ("" | 0 | 1 | "foo" | null)[]; }
 >arr : readonly [0, 1, "", "foo", null]
 >filter : { <S extends "" | 0 | 1 | "foo" | null>(predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => unknown, thisArg?: any): ("" | 0 | 1 | "foo" | null)[]; }

--- a/tests/baselines/reference/arrayFilterBooleanOverload.types
+++ b/tests/baselines/reference/arrayFilterBooleanOverload.types
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/arrayFilterBooleanOverload.ts] ////
+
+=== arrayFilterBooleanOverload.ts ===
+const nullableValues = ['a', 'b', null]; // expect (string | null)[]
+>nullableValues : (string | null)[]
+>['a', 'b', null] : (string | null)[]
+>'a' : "a"
+>'b' : "b"
+
+const values1 = nullableValues.filter(Boolean); // expect string[]
+>values1 : (string | null)[]
+>nullableValues.filter(Boolean) : (string | null)[]
+>nullableValues.filter : { <S extends string | null>(predicate: (value: string | null, index: number, array: (string | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: string | null, index: number, array: (string | null)[]) => unknown, thisArg?: any): (string | null)[]; }
+>nullableValues : (string | null)[]
+>filter : { <S extends string | null>(predicate: (value: string | null, index: number, array: (string | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: string | null, index: number, array: (string | null)[]) => unknown, thisArg?: any): (string | null)[]; }
+>Boolean : BooleanConstructor
+
+// @ts-expect-error
+const values2 = nullableValues.filter(new Boolean);
+>values2 : (string | null)[]
+>nullableValues.filter(new Boolean) : (string | null)[]
+>nullableValues.filter : { <S extends string | null>(predicate: (value: string | null, index: number, array: (string | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: string | null, index: number, array: (string | null)[]) => unknown, thisArg?: any): (string | null)[]; }
+>nullableValues : (string | null)[]
+>filter : { <S extends string | null>(predicate: (value: string | null, index: number, array: (string | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: string | null, index: number, array: (string | null)[]) => unknown, thisArg?: any): (string | null)[]; }
+>new Boolean : Boolean
+>Boolean : BooleanConstructor
+
+const arr = [0, 1, "", "foo", null] as const;
+>arr : readonly [0, 1, "", "foo", null]
+>[0, 1, "", "foo", null] as const : readonly [0, 1, "", "foo", null]
+>[0, 1, "", "foo", null] : readonly [0, 1, "", "foo", null]
+>0 : 0
+>1 : 1
+>"" : ""
+>"foo" : "foo"
+
+const arr2 = arr.filter(Boolean); // expect ("foo" | 1)[]
+>arr2 : ("" | 0 | 1 | "foo" | null)[]
+>arr.filter(Boolean) : ("" | 0 | 1 | "foo" | null)[]
+>arr.filter : { <S extends "" | 0 | 1 | "foo" | null>(predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => unknown, thisArg?: any): ("" | 0 | 1 | "foo" | null)[]; }
+>arr : readonly [0, 1, "", "foo", null]
+>filter : { <S extends "" | 0 | 1 | "foo" | null>(predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => value is S, thisArg?: any): S[]; (predicate: (value: "" | 0 | 1 | "foo" | null, index: number, array: readonly ("" | 0 | 1 | "foo" | null)[]) => unknown, thisArg?: any): ("" | 0 | 1 | "foo" | null)[]; }
+>Boolean : BooleanConstructor
+
+

--- a/tests/baselines/reference/unionOfArraysBooleanFilterCall.js
+++ b/tests/baselines/reference/unionOfArraysBooleanFilterCall.js
@@ -1,0 +1,38 @@
+//// [tests/cases/compiler/unionOfArraysBooleanFilterCall.ts] ////
+
+//// [unionOfArraysBooleanFilterCall.ts]
+interface Fizz {
+    id: number;
+    member: number;
+}
+interface Buzz {
+    id: number;
+    member: string;
+}
+type Falsey = "" | 0 | false | null | undefined;
+
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+
+([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+
+([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean); // expect type (Fizz|Buzz)[]
+
+// confirm that the other filter signatures are still available and working
+
+declare function isFizz(x: unknown): x is Fizz;
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isFizz); // expect type Fizz[]
+
+declare function isBuzz(x: unknown): x is Buzz;
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isBuzz); // expect type Buzz[]
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(x => x && typeof x.member === "number"); // expect type (Fizz|Buzz|Falsey)[]
+
+
+//// [unionOfArraysBooleanFilterCall.js]
+[].filter(Boolean); // expect type (Fizz|Buzz)[]
+[].filter(Boolean); // expect type (Fizz|Buzz)[]
+[].filter(Boolean); // expect type (Fizz|Buzz)[]
+[].filter(isFizz); // expect type Fizz[]
+[].filter(isBuzz); // expect type Buzz[]
+[].filter(x => x && typeof x.member === "number"); // expect type (Fizz|Buzz|Falsey)[]

--- a/tests/baselines/reference/unionOfArraysBooleanFilterCall.symbols
+++ b/tests/baselines/reference/unionOfArraysBooleanFilterCall.symbols
@@ -1,0 +1,97 @@
+//// [tests/cases/compiler/unionOfArraysBooleanFilterCall.ts] ////
+
+=== unionOfArraysBooleanFilterCall.ts ===
+interface Fizz {
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+
+    id: number;
+>id : Symbol(Fizz.id, Decl(unionOfArraysBooleanFilterCall.ts, 0, 16))
+
+    member: number;
+>member : Symbol(Fizz.member, Decl(unionOfArraysBooleanFilterCall.ts, 1, 15))
+}
+interface Buzz {
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+
+    id: number;
+>id : Symbol(Buzz.id, Decl(unionOfArraysBooleanFilterCall.ts, 4, 16))
+
+    member: string;
+>member : Symbol(Buzz.member, Decl(unionOfArraysBooleanFilterCall.ts, 5, 15))
+}
+type Falsey = "" | 0 | false | null | undefined;
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Boolean : Symbol(Boolean, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+>([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter : Symbol(filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>filter : Symbol(filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Boolean : Symbol(Boolean, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean); // expect type (Fizz|Buzz)[]
+>([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter : Symbol(filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>filter : Symbol(filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Boolean : Symbol(Boolean, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+// confirm that the other filter signatures are still available and working
+
+declare function isFizz(x: unknown): x is Fizz;
+>isFizz : Symbol(isFizz, Decl(unionOfArraysBooleanFilterCall.ts, 15, 66))
+>x : Symbol(x, Decl(unionOfArraysBooleanFilterCall.ts, 19, 24))
+>x : Symbol(x, Decl(unionOfArraysBooleanFilterCall.ts, 19, 24))
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isFizz); // expect type Fizz[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>isFizz : Symbol(isFizz, Decl(unionOfArraysBooleanFilterCall.ts, 15, 66))
+
+declare function isBuzz(x: unknown): x is Buzz;
+>isBuzz : Symbol(isBuzz, Decl(unionOfArraysBooleanFilterCall.ts, 20, 57))
+>x : Symbol(x, Decl(unionOfArraysBooleanFilterCall.ts, 22, 24))
+>x : Symbol(x, Decl(unionOfArraysBooleanFilterCall.ts, 22, 24))
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isBuzz); // expect type Buzz[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>isBuzz : Symbol(isBuzz, Decl(unionOfArraysBooleanFilterCall.ts, 20, 57))
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(x => x && typeof x.member === "number"); // expect type (Fizz|Buzz|Falsey)[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Fizz : Symbol(Fizz, Decl(unionOfArraysBooleanFilterCall.ts, 0, 0))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>Buzz : Symbol(Buzz, Decl(unionOfArraysBooleanFilterCall.ts, 3, 1))
+>Falsey : Symbol(Falsey, Decl(unionOfArraysBooleanFilterCall.ts, 7, 1))
+>filter : Symbol(Array.filter, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(unionOfArraysBooleanFilterCall.ts, 25, 49))
+>x : Symbol(x, Decl(unionOfArraysBooleanFilterCall.ts, 25, 49))
+>x.member : Symbol(member, Decl(unionOfArraysBooleanFilterCall.ts, 1, 15), Decl(unionOfArraysBooleanFilterCall.ts, 5, 15))
+>x : Symbol(x, Decl(unionOfArraysBooleanFilterCall.ts, 25, 49))
+>member : Symbol(member, Decl(unionOfArraysBooleanFilterCall.ts, 1, 15), Decl(unionOfArraysBooleanFilterCall.ts, 5, 15))
+

--- a/tests/baselines/reference/unionOfArraysBooleanFilterCall.types
+++ b/tests/baselines/reference/unionOfArraysBooleanFilterCall.types
@@ -1,0 +1,95 @@
+//// [tests/cases/compiler/unionOfArraysBooleanFilterCall.ts] ////
+
+=== unionOfArraysBooleanFilterCall.ts ===
+interface Fizz {
+    id: number;
+>id : number
+
+    member: number;
+>member : number
+}
+interface Buzz {
+    id: number;
+>id : number
+
+    member: string;
+>member : string
+}
+type Falsey = "" | 0 | false | null | undefined;
+>Falsey : false | "" | 0
+>false : false
+
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean) : (Fizz | Buzz | Falsey)[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]) : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] as (Fizz|Falsey)[] | (Buzz|Falsey)[] : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] : undefined[]
+>filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>Boolean : BooleanConstructor
+
+([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+>([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean) : (Fizz | Buzz | Falsey)[]
+>([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]) : (Fizz | Falsey)[] | readonly (Buzz | Falsey)[]
+>[] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[] : (Fizz | Falsey)[] | readonly (Buzz | Falsey)[]
+>[] : undefined[]
+>filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>Boolean : BooleanConstructor
+
+([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean); // expect type (Fizz|Buzz)[]
+>([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean) : (Fizz | Buzz | Falsey)[]
+>([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]) : [Fizz | Falsey] | readonly [(Buzz | Falsey)?]
+>[] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?] : [Fizz | Falsey] | readonly [(Buzz | Falsey)?]
+>[] : []
+>filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>Boolean : BooleanConstructor
+
+// confirm that the other filter signatures are still available and working
+
+declare function isFizz(x: unknown): x is Fizz;
+>isFizz : (x: unknown) => x is Fizz
+>x : unknown
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isFizz); // expect type Fizz[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isFizz) : Fizz[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]) : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] as (Fizz|Falsey)[] | (Buzz|Falsey)[] : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] : undefined[]
+>filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>isFizz : (x: unknown) => x is Fizz
+
+declare function isBuzz(x: unknown): x is Buzz;
+>isBuzz : (x: unknown) => x is Buzz
+>x : unknown
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isBuzz); // expect type Buzz[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isBuzz) : Buzz[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]) : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] as (Fizz|Falsey)[] | (Buzz|Falsey)[] : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] : undefined[]
+>filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>isBuzz : (x: unknown) => x is Buzz
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(x => x && typeof x.member === "number"); // expect type (Fizz|Buzz|Falsey)[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(x => x && typeof x.member === "number") : (Fizz | Buzz | Falsey)[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]) : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] as (Fizz|Falsey)[] | (Buzz|Falsey)[] : (Fizz | Falsey)[] | (Buzz | Falsey)[]
+>[] : undefined[]
+>filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
+>x => x && typeof x.member === "number" : (x: Fizz | Buzz | Falsey) => boolean
+>x : Fizz | Buzz | Falsey
+>x && typeof x.member === "number" : boolean
+>x : Fizz | Buzz | Falsey
+>typeof x.member === "number" : boolean
+>typeof x.member : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x.member : string | number
+>x : Fizz | Buzz
+>member : string | number
+>"number" : "number"
+

--- a/tests/baselines/reference/unionOfArraysBooleanFilterCall.types
+++ b/tests/baselines/reference/unionOfArraysBooleanFilterCall.types
@@ -21,7 +21,7 @@ type Falsey = "" | 0 | false | null | undefined;
 
 
 ([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
->([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean) : (Fizz | Buzz | Falsey)[]
+>([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean) : (Fizz | Buzz)[]
 >([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
 >([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]) : (Fizz | Falsey)[] | (Buzz | Falsey)[]
 >[] as (Fizz|Falsey)[] | (Buzz|Falsey)[] : (Fizz | Falsey)[] | (Buzz | Falsey)[]
@@ -30,7 +30,7 @@ type Falsey = "" | 0 | false | null | undefined;
 >Boolean : BooleanConstructor
 
 ([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
->([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean) : (Fizz | Buzz | Falsey)[]
+>([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean) : (Fizz | Buzz)[]
 >([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
 >([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]) : (Fizz | Falsey)[] | readonly (Buzz | Falsey)[]
 >[] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[] : (Fizz | Falsey)[] | readonly (Buzz | Falsey)[]
@@ -39,7 +39,7 @@ type Falsey = "" | 0 | false | null | undefined;
 >Boolean : BooleanConstructor
 
 ([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean); // expect type (Fizz|Buzz)[]
->([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean) : (Fizz | Buzz | Falsey)[]
+>([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean) : (Fizz | Buzz)[]
 >([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter : { <S extends Fizz | Falsey>(predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Fizz | Falsey, index: number, array: (Fizz | Falsey)[]) => unknown, thisArg?: any): (Fizz | Falsey)[]; } | { <S extends Buzz | Falsey>(predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => value is S, thisArg?: any): S[]; (predicate: (value: Buzz | Falsey, index: number, array: readonly (Buzz | Falsey)[]) => unknown, thisArg?: any): (Buzz | Falsey)[]; }
 >([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]) : [Fizz | Falsey] | readonly [(Buzz | Falsey)?]
 >[] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?] : [Fizz | Falsey] | readonly [(Buzz | Falsey)?]

--- a/tests/cases/compiler/arrayFilterBooleanOverload.ts
+++ b/tests/cases/compiler/arrayFilterBooleanOverload.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @declaration: true
+// @target: es6
+
+const nullableValues = ['a', 'b', null]; // expect (string | null)[]
+
+const values1 = nullableValues.filter(Boolean); // expect string[]
+
+// @ts-expect-error
+const values2 = nullableValues.filter(new Boolean);
+
+const arr = [0, 1, "", "foo", null] as const;
+
+const arr2 = arr.filter(Boolean); // expect ("foo" | 1)[]
+

--- a/tests/cases/compiler/unionOfArraysBooleanFilterCall.ts
+++ b/tests/cases/compiler/unionOfArraysBooleanFilterCall.ts
@@ -1,0 +1,27 @@
+// @target: es6
+interface Fizz {
+    id: number;
+    member: number;
+}
+interface Buzz {
+    id: number;
+    member: string;
+}
+type Falsey = "" | 0 | false | null | undefined;
+
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+
+([] as (Fizz|Falsey)[] | readonly (Buzz|Falsey)[]).filter(Boolean); // expect type (Fizz|Buzz)[]
+
+([] as [Fizz|Falsey] | readonly [(Buzz|Falsey)?]).filter(Boolean); // expect type (Fizz|Buzz)[]
+
+// confirm that the other filter signatures are still available and working
+
+declare function isFizz(x: unknown): x is Fizz;
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isFizz); // expect type Fizz[]
+
+declare function isBuzz(x: unknown): x is Buzz;
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(isBuzz); // expect type Buzz[]
+
+([] as (Fizz|Falsey)[] | (Buzz|Falsey)[]).filter(x => x && typeof x.member === "number"); // expect type (Fizz|Buzz|Falsey)[]


### PR DESCRIPTION
It turns out a problem with this idea is that `BooleanConstructor` is not distinguishable from `(x:any)=>boolean`.  Meaning TypeScript doesn't check the interface prototype when the prototype is a TypeScript Symbol for a user variable. I.e., in this case `Boolean`.

Oddly, it does check the interface prototype when the prototype is a unique *ES Symbol*.

If that gets sorted out, it might be worth considering.

--------------------------------------


Fixes #50377 - when `Boolean` is used a predicate to Array.filter falsie types are filtered in the result.
(However, this version doesn't use an overload in `lib/es5.d.ts`)

## Source Files changed:

- `src/compiler/checker.ts`

## Added Test Files

- tests/baselines/reference/unionOfArraysBooleanFilterCall.js
- tests/cases/compiler/arrayFilterBooleanOverload.ts

## Related issues

filter(Boolean)
#50377 Explore adding the Boolean to filter to narrow out null/undefined in array#filter (closed pull)
#50387 Add BooleanConstructor as an overload to .filter to allow for easy type predicate filtering (inDiscussion)
#30621 narrow array type with .filter(Boolean) (marked as duplicate of #16655, although #16655 is more broad than #30621)
#56013 Adding an overload to .filter breaks specific inference with nested functions (related)
#55777

Boolean as falsey check in general
#16655 Boolean() cannot be used to perform a null check (broader than filter(Boolean))
#29955 Allow Boolean() to be used to perform a null check (accepted pull, may have reverted)

#53489 Add fallback logic for generating signatures for unions of array members

## Source code changes


- `checker.ts`
In `chooseOverload`, after `result` is selected, when the argument is of type `BooleanConstructor` and the result signature is `Array.filter`, the result signature is cloned, and its `resolvedReturnType` property is set.


## Regressions

None found with runtests

## Discussion

In this revision, es5.d.ts is not modified at all. Instead, the return type is changed dynamically in `chooseOverload` in checker.ts.
Therefore, the user won't see a completion suggesting Boolean, unlike the last revision. Obviously that is a disadvantage.

The advantage is that there are less changes overall, so the pull is easier to review. (Previously there were ~60 files changes, and that's a lot to review).  

