### PR TITLE
fix(47327): Inlay Hint for TypeScript broken for spread operation

### DIFF
--- a/tests/baselines/reference/inlayHintsInteractiveRestParameters3.baseline
+++ b/tests/baselines/reference/inlayHintsInteractiveRestParameters3.baseline
@@ -1,0 +1,27 @@
+// === Inlay Hints ===
+fn(...foo, 3, 4);
+   ^
+{
+  "text": "x:",
+  "position": 133,
+  "kind": "Parameter",
+  "whitespaceAfter": true
+}
+
+fn(...foo, 3, 4);
+           ^
+{
+  "text": "a:",
+  "position": 141,
+  "kind": "Parameter",
+  "whitespaceAfter": true
+}
+
+fn(...foo, 3, 4);
+              ^
+{
+  "text": "b:",
+  "position": 144,
+  "kind": "Parameter",
+  "whitespaceAfter": true
+}

--- a/tests/cases/fourslash/inlayHintsInteractiveRestParameters3.ts
+++ b/tests/cases/fourslash/inlayHintsInteractiveRestParameters3.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+////function fn(x: number, y: number, a: number, b: number) {
+////    return x + y + a + b;
+////}
+////const foo: [x: number, y: number] = [1, 2];
+////fn(...foo, 3, 4);
+
+verify.baselineInlayHints(undefined, {
+    includeInlayParameterNameHints: "all",
+});


### PR DESCRIPTION
Fixes #47327

This issue was fixed by https://github.com/microsoft/TypeScript/pull/54503., This PR adds an additional test to cover the case from https://github.com/microsoft/TypeScript/issues/47327