### PR TITLE
ImportAttributes should go through the same emit phases when in an ImportTypeNode

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -223,6 +223,7 @@ import {
     isGeneratedIdentifier,
     isGeneratedPrivateIdentifier,
     isIdentifier,
+    isImportAttributes,
     isIncrementalCompilation,
     isInJsonFile,
     isInternalDeclaration,
@@ -1840,7 +1841,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (hint === EmitHint.IdentifierName) return emitIdentifier(cast(node, isIdentifier));
         if (hint === EmitHint.JsxAttributeValue) return emitLiteral(cast(node, isStringLiteral), /*jsxAttributeEscape*/ true);
         if (hint === EmitHint.MappedTypeParameter) return emitMappedTypeParameter(cast(node, isTypeParameterDeclaration));
-        if (hint === EmitHint.TypeImportAttributes) return emitTypeImportAttributes(cast(node, ts.isImportAttributes));
+        if (hint === EmitHint.TypeImportAttributes) return emitTypeImportAttributes(cast(node, isImportAttributes));
         if (hint === EmitHint.EmbeddedStatement) {
             Debug.assertNode(node, isEmptyStatement);
             return emitEmptyStatement(/*isEmbeddedStatement*/ true);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1841,7 +1841,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (hint === EmitHint.IdentifierName) return emitIdentifier(cast(node, isIdentifier));
         if (hint === EmitHint.JsxAttributeValue) return emitLiteral(cast(node, isStringLiteral), /*jsxAttributeEscape*/ true);
         if (hint === EmitHint.MappedTypeParameter) return emitMappedTypeParameter(cast(node, isTypeParameterDeclaration));
-        if (hint === EmitHint.TypeImportAttributes) return emitTypeImportAttributes(cast(node, isImportAttributes));
+        if (hint === EmitHint.ImportTypeNodeAttributes) return emitImportTypeNodeAttributes(cast(node, isImportAttributes));
         if (hint === EmitHint.EmbeddedStatement) {
             Debug.assertNode(node, isEmptyStatement);
             return emitEmptyStatement(/*isEmbeddedStatement*/ true);
@@ -2946,7 +2946,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (node.attributes) {
             writePunctuation(",");
             writeSpace();
-            pipelineEmit(EmitHint.TypeImportAttributes, node.attributes);
+            pipelineEmit(EmitHint.ImportTypeNodeAttributes, node.attributes);
         }
         writePunctuation(")");
         if (node.qualifier) {
@@ -4071,7 +4071,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         writeTrailingSemicolon();
     }
 
-    function emitTypeImportAttributes(node: ImportAttributes) {
+    function emitImportTypeNodeAttributes(node: ImportAttributes) {
         writePunctuation("{");
         writeSpace();
         writeKeyword(node.token === SyntaxKind.AssertKeyword ? "assert" : "with");

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1840,6 +1840,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (hint === EmitHint.IdentifierName) return emitIdentifier(cast(node, isIdentifier));
         if (hint === EmitHint.JsxAttributeValue) return emitLiteral(cast(node, isStringLiteral), /*jsxAttributeEscape*/ true);
         if (hint === EmitHint.MappedTypeParameter) return emitMappedTypeParameter(cast(node, isTypeParameterDeclaration));
+        if (hint === EmitHint.TypeImportAttributes) return emitTypeImportAttributes(cast(node, ts.isImportAttributes));
         if (hint === EmitHint.EmbeddedStatement) {
             Debug.assertNode(node, isEmptyStatement);
             return emitEmptyStatement(/*isEmbeddedStatement*/ true);
@@ -2944,15 +2945,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
         if (node.attributes) {
             writePunctuation(",");
             writeSpace();
-            writePunctuation("{");
-            writeSpace();
-            writeKeyword(node.attributes.token === SyntaxKind.AssertKeyword ? "assert" : "with");
-            writePunctuation(":");
-            writeSpace();
-            const elements = node.attributes.elements;
-            emitList(node.attributes, elements, ListFormat.ImportAttributes);
-            writeSpace();
-            writePunctuation("}");
+            pipelineEmit(EmitHint.TypeImportAttributes, node.attributes);
         }
         writePunctuation(")");
         if (node.qualifier) {
@@ -4075,6 +4068,18 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
             emitWithLeadingSpace(node.attributes);
         }
         writeTrailingSemicolon();
+    }
+
+    function emitTypeImportAttributes(node: ImportAttributes) {
+        writePunctuation("{");
+        writeSpace();
+        writeKeyword(node.token === SyntaxKind.AssertKeyword ? "assert" : "with");
+        writePunctuation(":");
+        writeSpace();
+        const elements = node.elements;
+        emitList(node, elements, ListFormat.ImportAttributes);
+        writeSpace();
+        writePunctuation("}");
     }
 
     function emitImportAttributes(node: ImportAttributes) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8148,6 +8148,7 @@ export const enum EmitHint {
     Unspecified,         // Emitting an otherwise unspecified node
     EmbeddedStatement,   // Emitting an embedded statement
     JsxAttributeValue,   // Emitting a JSX attribute value
+    TypeImportAttributes,// Emitting attributes as part of an ImportTypeNode
 }
 
 /** @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -8141,14 +8141,14 @@ export const enum ExternalEmitHelpers {
 
 // dprint-ignore
 export const enum EmitHint {
-    SourceFile,          // Emitting a SourceFile
-    Expression,          // Emitting an Expression
-    IdentifierName,      // Emitting an IdentifierName
-    MappedTypeParameter, // Emitting a TypeParameterDeclaration inside of a MappedTypeNode
-    Unspecified,         // Emitting an otherwise unspecified node
-    EmbeddedStatement,   // Emitting an embedded statement
-    JsxAttributeValue,   // Emitting a JSX attribute value
-    TypeImportAttributes,// Emitting attributes as part of an ImportTypeNode
+    SourceFile,              // Emitting a SourceFile
+    Expression,              // Emitting an Expression
+    IdentifierName,          // Emitting an IdentifierName
+    MappedTypeParameter,     // Emitting a TypeParameterDeclaration inside of a MappedTypeNode
+    Unspecified,             // Emitting an otherwise unspecified node
+    EmbeddedStatement,       // Emitting an embedded statement
+    JsxAttributeValue,       // Emitting a JSX attribute value
+    ImportTypeNodeAttributes,// Emitting attributes as part of an ImportTypeNode
 }
 
 /** @internal */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7892,7 +7892,7 @@ declare namespace ts {
         Unspecified = 4,
         EmbeddedStatement = 5,
         JsxAttributeValue = 6,
-        TypeImportAttributes = 7,
+        ImportTypeNodeAttributes = 7,
     }
     enum OuterExpressionKinds {
         Parentheses = 1,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -7892,6 +7892,7 @@ declare namespace ts {
         Unspecified = 4,
         EmbeddedStatement = 5,
         JsxAttributeValue = 6,
+        TypeImportAttributes = 7,
     }
     enum OuterExpressionKinds {
         Parentheses = 1,

--- a/tests/cases/fourslash/refactorToReturnTypeWithImportAssertions.ts
+++ b/tests/cases/fourslash/refactorToReturnTypeWithImportAssertions.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+// @module: NodeNext
+// @traceResolution: true
+
+// @filename: node_modules/inner/index.d.mts
+//// export const esm = true;
+
+// @filename: node_modules/inner/package.json
+//// { "name": "inner", "exports": { "./mjs": "./index.mjs" } }
+
+// @filename: foo.ts
+//// export /*a*/function/*b*/ fn() {
+////     return import("inner/mjs")
+//// }
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Infer function return type",
+    actionName: "Infer function return type",
+    actionDescription: "Infer function return type",
+    newContent:
+`export function fn(): Promise<typeof import("/tests/cases/fourslash/node_modules/inner/index", { with: { "resolution-mode": "import" } })> {
+    return import("inner/mjs")
+}`
+});
+


### PR DESCRIPTION
Fixes #56394
