### PR TITLE
Fixed a crash when getting document highlights on `out` variance annotation

### DIFF
--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -178,6 +178,7 @@ export namespace DocumentHighlights {
             case SyntaxKind.YieldKeyword:
                 return highlightSpans(getYieldOccurrences(node));
             case SyntaxKind.InKeyword:
+            case SyntaxKind.OutKeyword:
                 return undefined;
             default:
                 return isModifierKind(node.kind) && (isDeclaration(node.parent) || isVariableStatement(node.parent))

--- a/tests/baselines/reference/documentHighlightVarianceModifiers.baseline.jsonc
+++ b/tests/baselines/reference/documentHighlightVarianceModifiers.baseline.jsonc
@@ -1,0 +1,11 @@
+// === documentHighlights ===
+// === /tests/cases/fourslash/documentHighlightVarianceModifiers.ts ===
+// type TFoo<Value> = { value: Value };
+// type TBar</*HIGHLIGHTS*/in out Value> = TFoo<Value>;
+
+
+
+// === documentHighlights ===
+// === /tests/cases/fourslash/documentHighlightVarianceModifiers.ts ===
+// type TFoo<Value> = { value: Value };
+// type TBar<in /*HIGHLIGHTS*/out Value> = TFoo<Value>;

--- a/tests/cases/fourslash/documentHighlightVarianceModifiers.ts
+++ b/tests/cases/fourslash/documentHighlightVarianceModifiers.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts'/>
+
+//// type TFoo<Value> = { value: Value };
+//// type TBar<[|in|] [|out|] Value> = TFoo<Value>;
+
+verify.baselineDocumentHighlights();


### PR DESCRIPTION
Maybe there is something better to be returned here as per Daniel's comment [here](https://github.com/microsoft/TypeScript/pull/48853#issuecomment-1111619730) but this PR doesn't attempt to implement any new feature. It's just a small bug/rare crash that I noticed when investigating https://github.com/microsoft/TypeScript/issues/56390