### PR TITLE
Up timeout on cherry-pick branch push

### DIFF
--- a/scripts/open-cherry-pick-pr.mjs
+++ b/scripts/open-cherry-pick-pr.mjs
@@ -84,7 +84,7 @@ ${logText.trim()}`;
     runSequence([
         ["git", ["remote", "add", "fork", remoteUrl]], // Add the remote fork
         ["git", ["push", "--set-upstream", "fork", branchName, "-f"]], // push the branch
-    ]);
+    ], { timeout: 1000000 });
 
     const r = await gh.pulls.create({
         owner: "Microsoft",

--- a/scripts/run-sequence.mjs
+++ b/scripts/run-sequence.mjs
@@ -7,7 +7,7 @@ import cp from "child_process";
  * @returns {string}
  */
 export function runSequence(tasks, opts) {
-    opts = { timeout: 100000, shell: true, ...opts}
+    opts = { timeout: 100000, shell: true, ...opts };
     let lastResult;
     for (const task of tasks) {
         console.log(`${task[0]} ${task[1].join(" ")}`);

--- a/scripts/run-sequence.mjs
+++ b/scripts/run-sequence.mjs
@@ -3,10 +3,11 @@ import cp from "child_process";
 
 /**
  * @param {[string, string[]][]} tasks
- * @param {cp.SpawnSyncOptions} opts
+ * @param {cp.SpawnSyncOptions} [opts]
  * @returns {string}
  */
-export function runSequence(tasks, opts = { timeout: 100000, shell: true }) {
+export function runSequence(tasks, opts) {
+    opts = { timeout: 100000, shell: true, ...opts}
     let lastResult;
     for (const task of tasks) {
         console.log(`${task[0]} ${task[1].join(" ")}`);


### PR DESCRIPTION
Reading https://typescript.visualstudio.com/TypeScript/_build/results?buildId=158633&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=08d41a1b-6013-5b01-b962-661a2fb402c0 I suspect that the push is timing out or something.

The branches _do_ exist: https://github.com/typescript-bot/TypeScript/branches

Given this fork doesn't get regular updates, I suspect that pushing to it pushes a bunch of data?

Maybe this is fine as a temporary workaround until I can shift this to GHA.