### PR TITLE
Consistently return `errorType` when detecting circularities

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7315,7 +7315,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
             if (propertySymbol.flags & SymbolFlags.Accessor) {
                 const writeType = getWriteTypeOfSymbol(propertySymbol);
-                if (propertyType !== writeType && !isErrorType(propertyType) && !isErrorType(writeType)) {
+                if (propertyType !== writeType) {
                     const getterDeclaration = getDeclarationOfKind<GetAccessorDeclaration>(propertySymbol, SyntaxKind.GetAccessor)!;
                     const getterSignature = getSignatureFromDeclaration(getterDeclaration);
                     typeElements.push(
@@ -11769,7 +11769,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 else if (getter && noImplicitAny) {
                     error(getter, Diagnostics._0_implicitly_has_return_type_any_because_it_does_not_have_a_return_type_annotation_and_is_referenced_directly_or_indirectly_in_one_of_its_return_expressions, symbolToString(symbol));
                 }
-                type = anyType;
+                type = errorType;
             }
             links.type = type;
         }
@@ -11790,7 +11790,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 if (getAnnotatedAccessorTypeNode(setter)) {
                     error(setter, Diagnostics._0_is_referenced_directly_or_indirectly_in_its_own_type_annotation, symbolToString(symbol));
                 }
-                writeType = anyType;
+                writeType = errorType;
             }
             // Absent an explicit setter type annotation we use the read type of the accessor.
             links.writeType = writeType || getTypeOfAccessors(symbol);
@@ -11886,8 +11886,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 : errorType;
 
             if (!popTypeResolution()) {
-                reportCircularityError(exportSymbol ?? symbol);
-                return links.type = errorType;
+                return links.type = reportCircularityError(exportSymbol ?? symbol);
             }
         }
         return links.type;
@@ -11925,7 +11924,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Circularities could also result from parameters in function expressions that end up
         // having themselves as contextual types following type argument inference. In those cases
         // we have already reported an implicit any error so we don't report anything here.
-        return anyType;
+        return errorType;
     }
 
     function getTypeOfSymbolWithDeferredType(symbol: Symbol) {
@@ -15328,7 +15327,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                         }
                     }
                 }
-                type = anyType;
+                type = errorType;
             }
             signature.resolvedReturnType = type;
         }

--- a/tests/baselines/reference/assignmentCompatWithObjectMembers.types
+++ b/tests/baselines/reference/assignmentCompatWithObjectMembers.types
@@ -189,16 +189,16 @@ module ObjectTypes {
 >b : { foo: any; }
 
     var a2 = { foo: a2 };
->a2 : any
+>a2 : error
 >{ foo: a2 } : { foo: any; }
->foo : any
->a2 : any
+>foo : error
+>a2 : error
 
     var b2 = { foo: b2 };
->b2 : any
+>b2 : error
 >{ foo: b2 } : { foo: any; }
->foo : any
->b2 : any
+>foo : error
+>b2 : error
 
     s = t;
 >s = t : T
@@ -216,9 +216,9 @@ module ObjectTypes {
 >s2 : S2
 
     s = a2;
->s = a2 : any
+>s = a2 : error
 >s : S
->a2 : any
+>a2 : error
 
     s2 = t2;
 >s2 = t2 : T2
@@ -241,9 +241,9 @@ module ObjectTypes {
 >b : { foo: any; }
 
     s2 = a2;
->s2 = a2 : any
+>s2 = a2 : error
 >s2 : S2
->a2 : any
+>a2 : error
 
     a = b;
 >a = b : { foo: any; }
@@ -266,33 +266,33 @@ module ObjectTypes {
 >s2 : S2
 
     a = a2;
->a = a2 : any
+>a = a2 : error
 >a : { foo: any; }
->a2 : any
+>a2 : error
 
     a2 = b2;
->a2 = b2 : any
->a2 : any
->b2 : any
+>a2 = b2 : error
+>a2 : error
+>b2 : error
 
     b2 = a2;
->b2 = a2 : any
->b2 : any
->a2 : any
+>b2 = a2 : error
+>b2 : error
+>a2 : error
 
     a2 = b;
 >a2 = b : { foo: any; }
->a2 : any
+>a2 : error
 >b : { foo: any; }
 
     a2 = t2;
 >a2 = t2 : T2
->a2 : any
+>a2 : error
 >t2 : T2
 
     a2 = t;
 >a2 = t : T
->a2 : any
+>a2 : error
 >t : T
 
 }

--- a/tests/baselines/reference/binderUninitializedModuleExportsAssignment.types
+++ b/tests/baselines/reference/binderUninitializedModuleExportsAssignment.types
@@ -2,17 +2,17 @@
 
 === loop.js ===
 var loop1 = loop2;
->loop1 : any
->loop2 : any
+>loop1 : error
+>loop2 : error
 
 var loop2 = loop1;
->loop2 : any
->loop1 : any
+>loop2 : error
+>loop1 : error
 
 module.exports = loop2;
->module.exports = loop2 : any
->module.exports : any
+>module.exports = loop2 : error
+>module.exports : error
 >module : { exports: any; }
 >exports : any
->loop2 : any
+>loop2 : error
 

--- a/tests/baselines/reference/circularMultipleAssignmentDeclaration.types
+++ b/tests/baselines/reference/circularMultipleAssignmentDeclaration.types
@@ -3,11 +3,11 @@
 === circularMultipleAssignmentDeclaration.js ===
 ns.next = ns.next || { shared: {} };
 >ns.next = ns.next || { shared: {} } : any
->ns.next : any
+>ns.next : error
 >ns : typeof ns
 >next : any
 >ns.next || { shared: {} } : any
->ns.next : any
+>ns.next : error
 >ns : typeof ns
 >next : any
 >{ shared: {} } : { shared: {}; }
@@ -16,7 +16,7 @@ ns.next = ns.next || { shared: {} };
 
 ns.next.shared.mymethod = {};
 >ns.next.shared.mymethod = {} : {}
->ns.next.shared.mymethod : any
+>ns.next.shared.mymethod : error
 >ns.next.shared : any
 >ns.next : any
 >ns : typeof ns

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES5.types
@@ -54,7 +54,7 @@ var {b5: { b52 }  } = { b5: { b52 } };
 >{ b5: { b52 } } : { b5: { b52: any; }; }
 >b5 : { b52: any; }
 >{ b52 } : { b52: any; }
->b52 : any
+>b52 : error
 
 // V is an object assignment pattern and, for each assignment property P in V,
 //      P specifies a numeric property name and S has a numeric index signature

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment1ES6.types
@@ -54,7 +54,7 @@ var {b5: { b52 }  } = { b5: { b52 } };
 >{ b5: { b52 } } : { b5: { b52: any; }; }
 >b5 : { b52: any; }
 >{ b52 } : { b52: any; }
->b52 : any
+>b52 : error
 
 // V is an object assignment pattern and, for each assignment property P in V,
 //      P specifies a numeric property name and S has a numeric index signature

--- a/tests/baselines/reference/exportAssignmentCircularModules.types
+++ b/tests/baselines/reference/exportAssignmentCircularModules.types
@@ -8,8 +8,8 @@ module Foo {
 >Foo : typeof Foo
 
 	export var x = foo0.x;
->x : any
->foo0.x : any
+>x : error
+>foo0.x : error
 >foo0 : typeof foo0
 >x : any
 }
@@ -24,8 +24,8 @@ module Foo {
 >Foo : typeof Foo
 
 	export var x = foo1.x;
->x : any
->foo1.x : any
+>x : error
+>foo1.x : error
 >foo1 : typeof foo1
 >x : any
 }
@@ -40,8 +40,8 @@ module Foo {
 >Foo : typeof Foo
 
 	export var x = foo2.x;
->x : any
->foo2.x : any
+>x : error
+>foo2.x : error
 >foo2 : typeof foo2
 >x : any
 }

--- a/tests/baselines/reference/jsDeclarationsExportDoubleAssignmentInClosure.types
+++ b/tests/baselines/reference/jsDeclarationsExportDoubleAssignmentInClosure.types
@@ -11,7 +11,7 @@ function foo() {
 >module : { exports: { (o: any): any; methods: () => void; }; }
 >exports : { (o: any): any; methods: () => void; }
 >exports = function (o) {        return (o == null) ? create(base) : defineProperties(Object(o), descriptors);    } : (o: any) => any
->exports : any
+>exports : error
 >function (o) {        return (o == null) ? create(base) : defineProperties(Object(o), descriptors);    } : (o: any) => any
 >o : any
 
@@ -39,7 +39,7 @@ function foo() {
     }
     exports.methods = m;
 >exports.methods = m : () => void
->exports.methods : any
+>exports.methods : error
 >exports : any
 >methods : any
 >m : () => void

--- a/tests/baselines/reference/moduleExportAssignment4.types
+++ b/tests/baselines/reference/moduleExportAssignment4.types
@@ -3,7 +3,7 @@
 === async.js ===
 exports.default = { m: 1, a: 1 }
 >exports.default = { m: 1, a: 1 } : { m: number; a: number; }
->exports.default : any
+>exports.default : error
 >exports : any
 >default : any
 >{ m: 1, a: 1 } : { m: number; a: number; }
@@ -17,7 +17,7 @@ module.exports = exports['default'];
 >module.exports : error
 >module : { exports: any; }
 >exports : any
->exports['default'] : any
->exports : any
+>exports['default'] : error
+>exports : error
 >'default' : "default"
 

--- a/tests/baselines/reference/noUsedBeforeDefinedErrorInTypeContext.types
+++ b/tests/baselines/reference/noUsedBeforeDefinedErrorInTypeContext.types
@@ -9,14 +9,14 @@ interface IThing<T> {
 }
 
 var foo = {
->foo : any
+>foo : error
 >{    one: {} as IThing<typeof foo>,} : { one: IThing<any>; }
 
     one: {} as IThing<typeof foo>,
 >one : IThing<any>
 >{} as IThing<typeof foo> : IThing<any>
 >{} : {}
->foo : any
+>foo : error
 }
 
 let baz = {
@@ -27,28 +27,28 @@ let baz = {
 >two : IThing<any>
 >{} as IThing<typeof bar> : IThing<any>
 >{} : {}
->bar : any
+>bar : error
 }
 
 let bar = {
->bar : any
+>bar : error
 >{    three: {} as IThing<typeof bar>,} : { three: IThing<any>; }
 
     three: {} as IThing<typeof bar>,
 >three : IThing<any>
 >{} as IThing<typeof bar> : IThing<any>
 >{} : {}
->bar : any
+>bar : error
 }
 
 const qwe = {
->qwe : any
+>qwe : error
 >{    four: {} as IThing<typeof qwe>,} : { four: IThing<any>; }
 
     four: {} as IThing<typeof qwe>,
 >four : IThing<any>
 >{} as IThing<typeof qwe> : IThing<any>
 >{} : {}
->qwe : any
+>qwe : error
 }
 

--- a/tests/baselines/reference/objectLiteralShorthandProperties.types
+++ b/tests/baselines/reference/objectLiteralShorthandProperties.types
@@ -24,7 +24,7 @@ var x2 = {
 }
 
 var x3 = {
->x3 : any
+>x3 : error
 >{    a: 0,    b,    c,    d() { },    x3,    parent: x3} : { a: number; b: any; c: any; d(): void; x3: any; parent: any; }
 
     a: 0,
@@ -41,11 +41,11 @@ var x3 = {
 >d : () => void
 
     x3,
->x3 : any
+>x3 : error
 
     parent: x3
->parent : any
->x3 : any
+>parent : error
+>x3 : error
 
 };
 

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesES6.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesES6.types
@@ -24,7 +24,7 @@ var x2 = {
 }
 
 var x3 = {
->x3 : any
+>x3 : error
 >{    a: 0,    b,    c,    d() { },    x3,    parent: x3} : { a: number; b: any; c: any; d(): void; x3: any; parent: any; }
 
     a: 0,
@@ -41,11 +41,11 @@ var x3 = {
 >d : () => void
 
     x3,
->x3 : any
+>x3 : error
 
     parent: x3
->parent : any
->x3 : any
+>parent : error
+>x3 : error
 
 };
 

--- a/tests/baselines/reference/parserES5ForOfStatement18.types
+++ b/tests/baselines/reference/parserES5ForOfStatement18.types
@@ -2,6 +2,6 @@
 
 === parserES5ForOfStatement18.ts ===
 for (var of of of) { }
->of : any
->of : any
+>of : error
+>of : error
 

--- a/tests/baselines/reference/parserES5ForOfStatement19.types
+++ b/tests/baselines/reference/parserES5ForOfStatement19.types
@@ -2,6 +2,6 @@
 
 === parserES5ForOfStatement19.ts ===
 for (var of in of) { }
->of : any
->of : any
+>of : error
+>of : error
 

--- a/tests/baselines/reference/parserForOfStatement18.types
+++ b/tests/baselines/reference/parserForOfStatement18.types
@@ -2,6 +2,6 @@
 
 === parserForOfStatement18.ts ===
 for (var of of of) { }
->of : any
->of : any
+>of : error
+>of : error
 

--- a/tests/baselines/reference/parserForOfStatement19.types
+++ b/tests/baselines/reference/parserForOfStatement19.types
@@ -2,6 +2,6 @@
 
 === parserForOfStatement19.ts ===
 for (var of in of) { }
->of : any
->of : any
+>of : error
+>of : error
 

--- a/tests/baselines/reference/recur1.types
+++ b/tests/baselines/reference/recur1.types
@@ -16,15 +16,15 @@ salt.pepper = function() {}
 >function() {} : () => void
 
 var cobalt = new cobalt.pitch();   
->cobalt : any
->new cobalt.pitch() : any
->cobalt.pitch : any
+>cobalt : error
+>new cobalt.pitch() : error
+>cobalt.pitch : error
 >cobalt : any
 >pitch : any
 
 cobalt.pitch = function() {}
 >cobalt.pitch = function() {} : () => void
->cobalt.pitch : any
+>cobalt.pitch : error
 >cobalt : any
 >pitch : any
 >function() {} : () => void

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
@@ -15,7 +15,7 @@ import self = require("recursiveExportAssignmentAndFindAliasedType7_moduleD");
 >self : any
 
 var selfVar = self;
->selfVar : any
+>selfVar : error
 >self : error
 
 export = selfVar;

--- a/tests/baselines/reference/recursiveGetterAccess.types
+++ b/tests/baselines/reference/recursiveGetterAccess.types
@@ -5,8 +5,8 @@ class MyClass {
 >MyClass : MyClass
 
 get testProp() { return this.testProp; }
->testProp : any
->this.testProp : any
+>testProp : error
+>this.testProp : error
 >this : this
 >testProp : any
 }

--- a/tests/baselines/reference/recursiveInference1.types
+++ b/tests/baselines/reference/recursiveInference1.types
@@ -9,21 +9,21 @@ function fib(x:number) { return x <= 1 ? x : fib(x - 1) + fib(x - 2); }
 >x : number
 >1 : 1
 >x : number
->fib(x - 1) + fib(x - 2) : any
->fib(x - 1) : any
+>fib(x - 1) + fib(x - 2) : error
+>fib(x - 1) : error
 >fib : (x: number) => any
 >x - 1 : number
 >x : number
 >1 : 1
->fib(x - 2) : any
+>fib(x - 2) : error
 >fib : (x: number) => any
 >x - 2 : number
 >x : number
 >2 : 2
 
 var result = fib(5);
->result : any
->fib(5) : any
+>result : error
+>fib(5) : error
 >fib : (x: number) => any
 >5 : 5
 

--- a/tests/baselines/reference/recursiveInitializer.types
+++ b/tests/baselines/reference/recursiveInitializer.types
@@ -3,9 +3,9 @@
 === recursiveInitializer.ts ===
 // number unless otherwise specified
 var n1 = n1++;
->n1 : any
+>n1 : error
 >n1++ : number
->n1 : any
+>n1 : error
 
 var n2: number = n2 + n2;
 >n2 : number
@@ -14,23 +14,23 @@ var n2: number = n2 + n2;
 >n2 : number
 
 var n3 /* any */ = n3 + n3;
->n3 : any
->n3 + n3 : any
->n3 : any
->n3 : any
+>n3 : error
+>n3 + n3 : error
+>n3 : error
+>n3 : error
 
 // string unless otherwise specified
 var s1 = s1 + '';
->s1 : any
+>s1 : error
 >s1 + '' : string
->s1 : any
+>s1 : error
 >'' : ""
 
 var s2 /* any */ = s2 + s2;
->s2 : any
->s2 + s2 : any
->s2 : any
->s2 : any
+>s2 : error
+>s2 + s2 : error
+>s2 : error
+>s2 : error
 
 var s3 : string = s3 + s3;
 >s3 : string
@@ -39,44 +39,44 @@ var s3 : string = s3 + s3;
 >s3 : string
 
 var s4 = '' + s4;
->s4 : any
+>s4 : error
 >'' + s4 : string
 >'' : ""
->s4 : any
+>s4 : error
 
 // boolean unless otherwise specified
 var b1 = !b1;
->b1 : any
+>b1 : error
 >!b1 : boolean
->b1 : any
+>b1 : error
 
 var b2 = !!b2;
->b2 : any
+>b2 : error
 >!!b2 : boolean
 >!b2 : boolean
->b2 : any
+>b2 : error
 
 var b3 = !b3 || b3; // expected boolean here. actually 'any'
->b3 : any
+>b3 : error
 >!b3 || b3 : any
 >!b3 : boolean
->b3 : any
->b3 : any
+>b3 : error
+>b3 : error
 
 var b4 = (!b4) && b4; // expected boolean here. actually 'any'
->b4 : any
+>b4 : error
 >(!b4) && b4 : any
 >(!b4) : boolean
 >!b4 : boolean
->b4 : any
->b4 : any
+>b4 : error
+>b4 : error
 
 // (x:string) => any
 var f = (x: string) => f(x);
 >f : (x: string) => any
 >(x: string) => f(x) : (x: string) => any
 >x : string
->f(x) : any
+>f(x) : error
 >f : (x: string) => any
 >x : string
 

--- a/tests/baselines/reference/recursiveObjectLiteral.types
+++ b/tests/baselines/reference/recursiveObjectLiteral.types
@@ -2,8 +2,8 @@
 
 === recursiveObjectLiteral.ts ===
 var a = { f: a };
->a : any
+>a : error
 >{ f: a } : { f: any; }
->f : any
->a : any
+>f : error
+>a : error
 

--- a/tests/baselines/reference/recursiveProperties.types
+++ b/tests/baselines/reference/recursiveProperties.types
@@ -5,8 +5,8 @@ class A {
 >A : A
 
     get testProp() { return this.testProp; }
->testProp : any
->this.testProp : any
+>testProp : error
+>this.testProp : error
 >this : this
 >testProp : any
 }

--- a/tests/baselines/reference/templateStringInYieldKeyword.types
+++ b/tests/baselines/reference/templateStringInYieldKeyword.types
@@ -6,9 +6,9 @@ function* gen() {
 
     // Once this is supported, the inner expression does not need to be parenthesized.
     var x = yield `abc${ x }def`;
->x : any
+>x : error
 >yield `abc${ x }def` : any
 >`abc${ x }def` : string
->x : any
+>x : error
 }
 

--- a/tests/baselines/reference/wellKnownSymbolExpando.types
+++ b/tests/baselines/reference/wellKnownSymbolExpando.types
@@ -6,7 +6,7 @@ function f() {}
 
 f[Symbol.iterator] = function() {}
 >f[Symbol.iterator] = function() {} : () => void
->f[Symbol.iterator] : any
+>f[Symbol.iterator] : error
 >f : typeof f
 >Symbol.iterator : unique symbol
 >Symbol : SymbolConstructor

--- a/tests/baselines/reference/witness.errors.txt
+++ b/tests/baselines/reference/witness.errors.txt
@@ -2,24 +2,17 @@ witness.ts(4,21): error TS2372: Parameter 'pInit' cannot reference itself.
 witness.ts(8,14): error TS2729: Property 'x' is used before its initialization.
 witness.ts(20,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'a' must be of type 'any', but here has type 'never'.
 witness.ts(28,12): error TS2695: Left side of comma operator is unused and has no side effects.
-witness.ts(29,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'co1' must be of type 'any', but here has type 'number'.
 witness.ts(30,12): error TS2695: Left side of comma operator is unused and has no side effects.
 witness.ts(30,12): error TS2695: Left side of comma operator is unused and has no side effects.
 witness.ts(32,12): error TS2695: Left side of comma operator is unused and has no side effects.
 witness.ts(32,12): error TS2695: Left side of comma operator is unused and has no side effects.
 witness.ts(32,12): error TS2695: Left side of comma operator is unused and has no side effects.
-witness.ts(33,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'co3' must be of type 'any', but here has type 'number'.
-witness.ts(37,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'as1' must be of type 'any', but here has type 'number'.
-witness.ts(39,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'as2' must be of type 'any', but here has type 'number'.
-witness.ts(43,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'cnd1' must be of type 'any', but here has type 'number'.
-witness.ts(57,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'and1' must be of type 'any', but here has type 'string'.
 witness.ts(68,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'fnCallResult' must be of type 'never', but here has type 'any'.
-witness.ts(110,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'propAcc1' must be of type 'any', but here has type '{ m: any; }'.
 witness.ts(121,14): error TS2729: Property 'n' is used before its initialization.
 witness.ts(128,19): error TS2729: Property 'q' is used before its initialization.
 
 
-==== witness.ts (19 errors) ====
+==== witness.ts (12 errors) ====
     // Initializers
     var varInit = varInit; // any
     var pInit: any;
@@ -59,9 +52,6 @@ witness.ts(128,19): error TS2729: Property 'q' is used before its initialization
                ~~~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
     var co1: number;
-        ~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'co1' must be of type 'any', but here has type 'number'.
-!!! related TS6203 witness.ts:28:5: 'co1' was also declared here.
     var co2 = (3, 4, co2);
                ~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
@@ -76,28 +66,16 @@ witness.ts(128,19): error TS2729: Property 'q' is used before its initialization
                ~~~~~~~~~~~~~
 !!! error TS2695: Left side of comma operator is unused and has no side effects.
     var co3: number;
-        ~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'co3' must be of type 'any', but here has type 'number'.
-!!! related TS6203 witness.ts:32:5: 'co3' was also declared here.
     
     // Assignment
     var as1 = (as1 = 2);
     var as1: number;
-        ~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'as1' must be of type 'any', but here has type 'number'.
-!!! related TS6203 witness.ts:36:5: 'as1' was also declared here.
     var as2 = (as2 = as2 = 2);
     var as2: number;
-        ~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'as2' must be of type 'any', but here has type 'number'.
-!!! related TS6203 witness.ts:38:5: 'as2' was also declared here.
     
     // Conditional
     var cnd1 = cnd1 ? 0 : 1;
     var cnd1: number;
-        ~~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'cnd1' must be of type 'any', but here has type 'number'.
-!!! related TS6203 witness.ts:42:5: 'cnd1' was also declared here.
     var cnd2 = cnd1 ? cnd1 ? '' : "" : '';
     var cnd2: string;
     
@@ -112,9 +90,6 @@ witness.ts(128,19): error TS2729: Property 'q' is used before its initialization
     // &&
     var and1 = and1 && '';
     var and1: string;
-        ~~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'and1' must be of type 'any', but here has type 'string'.
-!!! related TS6203 witness.ts:56:5: 'and1' was also declared here.
     var and2 = '' && and2;
     var and2: any;
     var and3 = and3 && and3;
@@ -171,9 +146,6 @@ witness.ts(128,19): error TS2729: Property 'q' is used before its initialization
         m: propAcc1.m
     };
     var propAcc1: { m: any; }
-        ~~~~~~~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'propAcc1' must be of type 'any', but here has type '{ m: any; }'.
-!!! related TS6203 witness.ts:107:5: 'propAcc1' was also declared here.
     
     // Property access of module member
     module M2 {


### PR DESCRIPTION
a quick experiment based on discussion/observations we had here: https://github.com/microsoft/TypeScript/pull/56258/files#r1393385776