### PR TITLE
Experiment: Produce wide index signatures from the spread of an index signature

### DIFF
--- a/tests/baselines/reference/constAssertions.js
+++ b/tests/baselines/reference/constAssertions.js
@@ -258,6 +258,7 @@ declare let o2: {
     readonly d: () => void;
 };
 declare let o3: {
+    readonly [x: string]: 10 | 1 | 2 | 3 | 20 | (() => void) | 4;
     readonly a: 1;
     readonly b: 2;
     readonly c: 3;

--- a/tests/baselines/reference/constAssertions.types
+++ b/tests/baselines/reference/constAssertions.types
@@ -202,9 +202,9 @@ let o2 = { a: 1, 'b': 2, ['c']: 3, d() {}, ['e' + '']: 4 } as const;
 >4 : 4
 
 let o3 = { ...o1, ...o2 } as const;
->o3 : { readonly a: 1; readonly b: 2; readonly c: 3; readonly d: () => void; readonly x: 10; readonly y: 20; }
->{ ...o1, ...o2 } as const : { readonly a: 1; readonly b: 2; readonly c: 3; readonly d: () => void; readonly x: 10; readonly y: 20; }
->{ ...o1, ...o2 } : { readonly a: 1; readonly b: 2; readonly c: 3; readonly d: () => void; readonly x: 10; readonly y: 20; }
+>o3 : { readonly [x: string]: 10 | 1 | 2 | 3 | 20 | (() => void) | 4; readonly a: 1; readonly b: 2; readonly c: 3; readonly d: () => void; readonly x: 10; readonly y: 20; }
+>{ ...o1, ...o2 } as const : { readonly [x: string]: 10 | 1 | 2 | 3 | 20 | (() => void) | 4; readonly a: 1; readonly b: 2; readonly c: 3; readonly d: () => void; readonly x: 10; readonly y: 20; }
+>{ ...o1, ...o2 } : { readonly [x: string]: 10 | 1 | 2 | 3 | 20 | (() => void) | 4; readonly a: 1; readonly b: 2; readonly c: 3; readonly d: () => void; readonly x: 10; readonly y: 20; }
 >o1 : { readonly x: 10; readonly y: 20; }
 >o2 : { readonly [x: string]: 1 | 2 | 3 | (() => void) | 4; readonly a: 1; readonly b: 2; readonly c: 3; readonly d: () => void; }
 

--- a/tests/baselines/reference/objectSpreadComputedProperty.types
+++ b/tests/baselines/reference/objectSpreadComputedProperty.types
@@ -17,24 +17,24 @@ function f() {
 >a : any
 
     const o1 = { ...{}, [n]: n };
->o1 : {}
->{ ...{}, [n]: n } : {}
+>o1 : { [x: number]: number; }
+>{ ...{}, [n]: n } : { [x: number]: number; }
 >{} : {}
 >[n] : number
 >n : number
 >n : number
 
     const o2 = { ...{}, [a]: n };
->o2 : {}
->{ ...{}, [a]: n } : {}
+>o2 : { [x: number]: number; }
+>{ ...{}, [a]: n } : { [x: number]: number; }
 >{} : {}
 >[a] : number
 >a : any
 >n : number
 
     const o3 = { [a]: n, ...{}, [n]: n, ...{}, [m]: m };
->o3 : {}
->{ [a]: n, ...{}, [n]: n, ...{}, [m]: m } : {}
+>o3 : { [x: number]: number; }
+>{ [a]: n, ...{}, [n]: n, ...{}, [m]: m } : { [x: number]: number; }
 >[a] : number
 >a : any
 >n : number

--- a/tests/baselines/reference/spreadIndexSignature.js
+++ b/tests/baselines/reference/spreadIndexSignature.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/spreadIndexSignature.ts] ////
+
+//// [spreadIndexSignature.ts]
+declare const strings: Record<string, string>;
+declare const symbols: Record<symbol, string>;
+
+const o1 = { a: 1, ...strings };
+const o2 = { [Symbol.iterator]: 1, ...strings };
+const o3 = { [Symbol.iterator]: 1, ...symbols };
+
+
+//// [spreadIndexSignature.js]
+const o1 = { a: 1, ...strings };
+const o2 = { [Symbol.iterator]: 1, ...strings };
+const o3 = { [Symbol.iterator]: 1, ...symbols };

--- a/tests/baselines/reference/spreadIndexSignature.symbols
+++ b/tests/baselines/reference/spreadIndexSignature.symbols
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/spreadIndexSignature.ts] ////
+
+=== spreadIndexSignature.ts ===
+declare const strings: Record<string, string>;
+>strings : Symbol(strings, Decl(spreadIndexSignature.ts, 0, 13))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+declare const symbols: Record<symbol, string>;
+>symbols : Symbol(symbols, Decl(spreadIndexSignature.ts, 1, 13))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+
+const o1 = { a: 1, ...strings };
+>o1 : Symbol(o1, Decl(spreadIndexSignature.ts, 3, 5))
+>a : Symbol(a, Decl(spreadIndexSignature.ts, 3, 12))
+>strings : Symbol(strings, Decl(spreadIndexSignature.ts, 0, 13))
+
+const o2 = { [Symbol.iterator]: 1, ...strings };
+>o2 : Symbol(o2, Decl(spreadIndexSignature.ts, 4, 5))
+>[Symbol.iterator] : Symbol([Symbol.iterator], Decl(spreadIndexSignature.ts, 4, 12))
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>strings : Symbol(strings, Decl(spreadIndexSignature.ts, 0, 13))
+
+const o3 = { [Symbol.iterator]: 1, ...symbols };
+>o3 : Symbol(o3, Decl(spreadIndexSignature.ts, 5, 5))
+>[Symbol.iterator] : Symbol([Symbol.iterator], Decl(spreadIndexSignature.ts, 5, 12))
+>Symbol.iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2019.symbol.d.ts, --, --))
+>iterator : Symbol(SymbolConstructor.iterator, Decl(lib.es2015.iterable.d.ts, --, --))
+>symbols : Symbol(symbols, Decl(spreadIndexSignature.ts, 1, 13))
+

--- a/tests/baselines/reference/spreadIndexSignature.types
+++ b/tests/baselines/reference/spreadIndexSignature.types
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/spreadIndexSignature.ts] ////
+
+=== spreadIndexSignature.ts ===
+declare const strings: Record<string, string>;
+>strings : Record<string, string>
+
+declare const symbols: Record<symbol, string>;
+>symbols : Record<symbol, string>
+
+const o1 = { a: 1, ...strings };
+>o1 : { [x: string]: string | number; a: number; }
+>{ a: 1, ...strings } : { [x: string]: string | number; a: number; }
+>a : number
+>1 : 1
+>strings : Record<string, string>
+
+const o2 = { [Symbol.iterator]: 1, ...strings };
+>o2 : { [x: string]: string; [Symbol.iterator]: number; }
+>{ [Symbol.iterator]: 1, ...strings } : { [x: string]: string; [Symbol.iterator]: number; }
+>[Symbol.iterator] : number
+>Symbol.iterator : unique symbol
+>Symbol : SymbolConstructor
+>iterator : unique symbol
+>1 : 1
+>strings : Record<string, string>
+
+const o3 = { [Symbol.iterator]: 1, ...symbols };
+>o3 : { [x: symbol]: string | number; [Symbol.iterator]: number; }
+>{ [Symbol.iterator]: 1, ...symbols } : { [x: symbol]: string | number; [Symbol.iterator]: number; }
+>[Symbol.iterator] : number
+>Symbol.iterator : unique symbol
+>Symbol : SymbolConstructor
+>iterator : unique symbol
+>1 : 1
+>symbols : Record<symbol, string>
+

--- a/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.types
+++ b/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.types
@@ -5,8 +5,8 @@ export class C {
 >C : C
 
     public a =  { b: this.b, ...this.c, [this.b]: `${this.c}`};
->a : { c: number; b: number; }
->{ b: this.b, ...this.c, [this.b]: `${this.c}`} : { c: number; b: number; }
+>a : { [x: number]: string; c: number; b: number; }
+>{ b: this.b, ...this.c, [this.b]: `${this.c}`} : { [x: number]: string; c: number; b: number; }
 >b : number
 >this.b : number
 >this : this

--- a/tests/cases/compiler/spreadIndexSignature.ts
+++ b/tests/cases/compiler/spreadIndexSignature.ts
@@ -1,0 +1,8 @@
+// @target: esnext
+
+declare const strings: Record<string, string>;
+declare const symbols: Record<symbol, string>;
+
+const o1 = { a: 1, ...strings };
+const o2 = { [Symbol.iterator]: 1, ...strings };
+const o3 = { [Symbol.iterator]: 1, ...symbols };


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #56431
Related: https://github.com/microsoft/TypeScript/issues/27273 (does not change the behavior of dropping index signatures from the left side of a spread)

This would need a lot more test coverage if it proves viable but wanted to run the top repos first.
