### PR TITLE
Strip tags in placeholders

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16925,10 +16925,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function removeStringLiteralsMatchedByTemplateLiterals(types: Type[]) {
-        const templates = filter(types, t =>
-            !!(t.flags & TypeFlags.TemplateLiteral) &&
-            isPatternLiteralType(t) &&
-            (t as TemplateLiteralType).types.every(t => !(t.flags & TypeFlags.Intersection) || !areIntersectedTypesAvoidingPrimitiveReduction((t as IntersectionType).types))) as TemplateLiteralType[];
+        const templates = filter(types, t => !!(t.flags & TypeFlags.TemplateLiteral) && isPatternLiteralType(t)) as TemplateLiteralType[];
         if (templates.length) {
             let i = types.length;
             while (i > 0) {
@@ -17439,20 +17436,17 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         return reduceLeft(types, (n, t) => n + getConstituentCount(t), 0);
     }
 
-    function areIntersectedTypesAvoidingPrimitiveReduction(types: Type[], primitiveFlags = TypeFlags.String | TypeFlags.Number | TypeFlags.BigInt): boolean {
-        if (types.length !== 2) {
-            return false;
-        }
-        const [t1, t2] = types;
-        return !!(t1.flags & primitiveFlags) && t2 === emptyTypeLiteralType || !!(t2.flags & primitiveFlags) && t1 === emptyTypeLiteralType;
-    }
-
     function getTypeFromIntersectionTypeNode(node: IntersectionTypeNode): Type {
         const links = getNodeLinks(node);
         if (!links.resolvedType) {
             const aliasSymbol = getAliasSymbolForTypeNode(node);
             const types = map(node.types, getTypeFromTypeNode);
-            const noSupertypeReduction = areIntersectedTypesAvoidingPrimitiveReduction(types);
+            // We perform no supertype reduction for X & {} or {} & X, where X is one of string, number, bigint,
+            // or a pattern literal template type. This enables union types like "a" | "b" | string & {} or
+            // "aa" | "ab" | `a${string}` which preserve the literal types for purposes of statement completion.
+            const emptyIndex = types.length === 2 ? types.indexOf(emptyTypeLiteralType) : -1;
+            const t = emptyIndex >= 0 ? types[1 - emptyIndex] : unknownType;
+            const noSupertypeReduction = !!(t.flags & (TypeFlags.String | TypeFlags.Number | TypeFlags.BigInt) || t.flags & TypeFlags.TemplateLiteral && isPatternLiteralType(t));
             links.resolvedType = getIntersectionType(types, aliasSymbol, getTypeArgumentsForAliasSymbol(aliasSymbol), noSupertypeReduction);
         }
         return links.resolvedType;
@@ -17735,7 +17729,6 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function createTemplateLiteralType(texts: readonly string[], types: readonly Type[]) {
         const type = createType(TypeFlags.TemplateLiteral) as TemplateLiteralType;
-        type.objectFlags = getPropagatingFlagsOfTypes(types, /*excludeKinds*/ TypeFlags.Nullable);
         type.texts = texts;
         type.types = types;
         return type;
@@ -18060,12 +18053,25 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function isPatternLiteralPlaceholderType(type: Type): boolean {
         if (type.flags & TypeFlags.Intersection) {
-            return !isGenericType(type) && some((type as IntersectionType).types, t => !!(t.flags & (TypeFlags.Literal | TypeFlags.Nullable)) || isPatternLiteralPlaceholderType(t));
+            // Return true if the intersection consists of one or more placeholders and zero or
+            // more object type tags.
+            let seenPlaceholder = false;
+            for (const t of (type as IntersectionType).types) {
+                if (t.flags & (TypeFlags.Literal | TypeFlags.Nullable) || isPatternLiteralPlaceholderType(t)) {
+                    seenPlaceholder = true;
+                }
+                else if (!(t.flags & TypeFlags.Object)) {
+                    return false;
+                }
+            }
+            return seenPlaceholder;
         }
         return !!(type.flags & (TypeFlags.Any | TypeFlags.String | TypeFlags.Number | TypeFlags.BigInt)) || isPatternLiteralType(type);
     }
 
     function isPatternLiteralType(type: Type) {
+        // A pattern literal type is a template literal or a string mapping type that contains only
+        // non-generic pattern literal placeholders.
         return !!(type.flags & TypeFlags.TemplateLiteral) && every((type as TemplateLiteralType).types, isPatternLiteralPlaceholderType) ||
             !!(type.flags & TypeFlags.StringMapping) && isPatternLiteralPlaceholderType((type as StringMappingType).type);
     }
@@ -18083,12 +18089,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getGenericObjectFlags(type: Type): ObjectFlags {
-        if (type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral)) {
-            if (!((type as UnionOrIntersectionType | TemplateLiteralType).objectFlags & ObjectFlags.IsGenericTypeComputed)) {
-                (type as UnionOrIntersectionType | TemplateLiteralType).objectFlags |= ObjectFlags.IsGenericTypeComputed |
-                    reduceLeft((type as UnionOrIntersectionType | TemplateLiteralType).types, (flags, t) => flags | getGenericObjectFlags(t), 0);
+        if (type.flags & (TypeFlags.UnionOrIntersection)) {
+            if (!((type as UnionOrIntersectionType).objectFlags & ObjectFlags.IsGenericTypeComputed)) {
+                (type as UnionOrIntersectionType).objectFlags |= ObjectFlags.IsGenericTypeComputed |
+                    reduceLeft((type as UnionOrIntersectionType).types, (flags, t) => flags | getGenericObjectFlags(t), 0);
             }
-            return (type as UnionOrIntersectionType | TemplateLiteralType).objectFlags & ObjectFlags.IsGenericType;
+            return (type as UnionOrIntersectionType).objectFlags & ObjectFlags.IsGenericType;
         }
         if (type.flags & TypeFlags.Substitution) {
             if (!((type as SubstitutionType).objectFlags & ObjectFlags.IsGenericTypeComputed)) {
@@ -18098,7 +18104,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return (type as SubstitutionType).objectFlags & ObjectFlags.IsGenericType;
         }
         return (type.flags & TypeFlags.InstantiableNonPrimitive || isGenericMappedType(type) || isGenericTupleType(type) ? ObjectFlags.IsGenericObjectType : 0) |
-            (type.flags & (TypeFlags.InstantiableNonPrimitive | TypeFlags.Index | TypeFlags.StringMapping) && !isPatternLiteralType(type) ? ObjectFlags.IsGenericIndexType : 0);
+            (type.flags & (TypeFlags.InstantiableNonPrimitive | TypeFlags.Index | TypeFlags.TemplateLiteral | TypeFlags.StringMapping) && !isPatternLiteralType(type) ? ObjectFlags.IsGenericIndexType : 0);
     }
 
     function getSimplifiedType(type: Type, writing: boolean): Type {
@@ -24768,7 +24774,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     objectFlags & ObjectFlags.Anonymous && type.symbol && type.symbol.flags & (SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.Class | SymbolFlags.TypeLiteral | SymbolFlags.ObjectLiteral) && type.symbol.declarations ||
                     objectFlags & (ObjectFlags.Mapped | ObjectFlags.ReverseMapped | ObjectFlags.ObjectRestType | ObjectFlags.InstantiationExpressionType)
                 ) ||
-            type.flags & (TypeFlags.UnionOrIntersection | TypeFlags.TemplateLiteral) && !(type.flags & TypeFlags.EnumLiteral) && !isNonGenericTopLevelType(type) && some((type as UnionOrIntersectionType | TemplateLiteralType).types, couldContainTypeVariables));
+            type.flags & TypeFlags.UnionOrIntersection && !(type.flags & TypeFlags.EnumLiteral) && !isNonGenericTopLevelType(type) && some((type as UnionOrIntersectionType).types, couldContainTypeVariables));
         if (type.flags & TypeFlags.ObjectFlagsType) {
             (type as ObjectFlagsType).objectFlags |= ObjectFlags.CouldContainTypeVariablesComputed | (result ? ObjectFlags.CouldContainTypeVariables : 0);
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6130,7 +6130,7 @@ export const enum TypeFlags {
     Instantiable = InstantiableNonPrimitive | InstantiablePrimitive,
     StructuredOrInstantiable = StructuredType | Instantiable,
     /** @internal */
-    ObjectFlagsType = Any | Nullable | Never | Object | Union | Intersection | TemplateLiteral,
+    ObjectFlagsType = Any | Nullable | Never | Object | Union | Intersection,
     /** @internal */
     Simplifiable = IndexedAccess | Conditional,
     /** @internal */
@@ -6289,7 +6289,7 @@ export const enum ObjectFlags {
     /** @internal */
     IdenticalBaseTypeExists = 1 << 26, // has a defined cachedEquivalentBaseType member
 
-    // Flags that require TypeFlags.UnionOrIntersection, TypeFlags.Substitution, or TypeFlags.TemplateLiteral
+    // Flags that require TypeFlags.UnionOrIntersection or TypeFlags.Substitution
     /** @internal */
     IsGenericTypeComputed = 1 << 21, // IsGenericObjectType flag has been computed
     /** @internal */
@@ -6316,7 +6316,7 @@ export const enum ObjectFlags {
 }
 
 /** @internal */
-export type ObjectFlagsType = NullableType | ObjectType | UnionType | IntersectionType | TemplateLiteralType;
+export type ObjectFlagsType = NullableType | ObjectType | UnionType | IntersectionType;
 
 // Object types (TypeFlags.ObjectType)
 // dprint-ignore
@@ -6675,8 +6675,6 @@ export interface ConditionalType extends InstantiableType {
 }
 
 export interface TemplateLiteralType extends InstantiableType {
-    /** @internal */
-    objectFlags: ObjectFlags;
     texts: readonly string[]; // Always one element longer than types
     types: readonly Type[]; // Always at least one element
 }

--- a/tests/baselines/reference/templateLiteralIntersection.types
+++ b/tests/baselines/reference/templateLiteralIntersection.types
@@ -18,7 +18,7 @@ type OriginA1 = `${A}`
 >OriginA1 : "a"
 
 type OriginA2 = `${MixA}`
->OriginA2 : `${MixA}`
+>OriginA2 : "a"
 
 type B = `${typeof a}`
 >B : "a"
@@ -32,23 +32,23 @@ type OriginB1 = `${B}`
 >OriginB1 : "a"
 
 type OriginB2 = `${MixB}`
->OriginB2 : `${MixB}`
+>OriginB2 : "a"
 
 type MixC = { foo: string } & A
 >MixC : { foo: string; } & "a"
 >foo : string
 
 type OriginC = `${MixC}`
->OriginC : `${MixC}`
+>OriginC : "a"
 
 type MixD<T extends string> =
->MixD : `${T & { foo: string; }}`
+>MixD : `${T}`
 
     `${T & { foo: string }}`
 >foo : string
 
 type OriginD = `${MixD<A & { foo: string }> & { foo: string }}`;
->OriginD : `${`${"a" & { foo: string; } & { foo: string; }}` & { foo: string; }}`
+>OriginD : "a"
 >foo : string
 >foo : string
 

--- a/tests/baselines/reference/templateLiteralIntersection2.errors.txt
+++ b/tests/baselines/reference/templateLiteralIntersection2.errors.txt
@@ -1,11 +1,10 @@
-templateLiteralIntersection2.ts(7,12): error TS2345: Argument of type '"foo/bar"' is not assignable to parameter of type '`${Path}/${Path}`'.
 templateLiteralIntersection2.ts(20,10): error TS2345: Argument of type '""' is not assignable to parameter of type '`a${string}` & `${string}a`'.
   Type '""' is not assignable to type '`a${string}`'.
 templateLiteralIntersection2.ts(22,10): error TS2345: Argument of type '"ab"' is not assignable to parameter of type '`a${string}` & `${string}a`'.
   Type '"ab"' is not assignable to type '`${string}a`'.
 
 
-==== templateLiteralIntersection2.ts (3 errors) ====
+==== templateLiteralIntersection2.ts (2 errors) ====
     type Path = string & { _pathBrand: any };
     
     type JoinedPath = `${Path}/${Path}`;
@@ -13,8 +12,6 @@ templateLiteralIntersection2.ts(22,10): error TS2345: Argument of type '"ab"' is
     declare function joinedPath(p: JoinedPath): void;
     
     joinedPath("foo/bar");
-               ~~~~~~~~~
-!!! error TS2345: Argument of type '"foo/bar"' is not assignable to parameter of type '`${Path}/${Path}`'.
     
     declare const somePath: Path;
     

--- a/tests/baselines/reference/templateLiteralIntersection2.types
+++ b/tests/baselines/reference/templateLiteralIntersection2.types
@@ -6,15 +6,15 @@ type Path = string & { _pathBrand: any };
 >_pathBrand : any
 
 type JoinedPath = `${Path}/${Path}`;
->JoinedPath : `${Path}/${Path}`
+>JoinedPath : `${string}/${string}`
 
 declare function joinedPath(p: JoinedPath): void;
 >joinedPath : (p: JoinedPath) => void
->p : `${Path}/${Path}`
+>p : `${string}/${string}`
 
 joinedPath("foo/bar");
 >joinedPath("foo/bar") : void
->joinedPath : (p: `${Path}/${Path}`) => void
+>joinedPath : (p: `${string}/${string}`) => void
 >"foo/bar" : "foo/bar"
 
 declare const somePath: Path;
@@ -22,8 +22,8 @@ declare const somePath: Path;
 
 joinedPath(`${somePath}/${somePath}`);
 >joinedPath(`${somePath}/${somePath}`) : void
->joinedPath : (p: `${Path}/${Path}`) => void
->`${somePath}/${somePath}` : `${Path}/${Path}`
+>joinedPath : (p: `${string}/${string}`) => void
+>`${somePath}/${somePath}` : `${string}/${string}`
 >somePath : Path
 >somePath : Path
 

--- a/tests/baselines/reference/templateLiteralIntersection3.types
+++ b/tests/baselines/reference/templateLiteralIntersection3.types
@@ -24,19 +24,19 @@ options1[`foo/${path}`] = false;
 >options1[`foo/${path}`] = false : false
 >options1[`foo/${path}`] : boolean
 >options1 : { prop: number; } & { [k: string]: boolean; }
->`foo/${path}` : `foo/${Path}`
+>`foo/${path}` : `foo/${string}`
 >path : Path
 >false : false
 
 
 // Lowercase<`foo/${Path}`> => `foo/${Lowercase<Path>}`
 declare const lowercasePath: Lowercase<`foo/${Path}`>;
->lowercasePath : `foo/${Lowercase<`${Path}`>}`
+>lowercasePath : `foo/${Lowercase<string>}`
 
 options1[lowercasePath] = false;
 >options1[lowercasePath] = false : false
 >options1[lowercasePath] : boolean
 >options1 : { prop: number; } & { [k: string]: boolean; }
->lowercasePath : `foo/${Lowercase<`${Path}`>}`
+>lowercasePath : `foo/${Lowercase<string>}`
 >false : false
 

--- a/tests/baselines/reference/templateLiteralTypesPatterns.errors.txt
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.errors.txt
@@ -376,9 +376,9 @@ templateLiteralTypesPatterns.ts(211,5): error TS2345: Argument of type '"abcTest
     }
     
     // repro from https://github.com/microsoft/TypeScript/issues/54177#issuecomment-1538436654
-    function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+    function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string}Downcast` & {}) {}
     conversionTest("testDowncast");
-    function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+    function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
     conversionTest2("testDowncast");
     
     function foo(str: `${`a${string}` & `${string}a`}Test`) {}

--- a/tests/baselines/reference/templateLiteralTypesPatterns.errors.txt
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.errors.txt
@@ -55,7 +55,7 @@ templateLiteralTypesPatterns.ts(129,9): error TS2345: Argument of type '"1.1e-10
 templateLiteralTypesPatterns.ts(140,1): error TS2322: Type '`a${string}`' is not assignable to type '`a${number}`'.
 templateLiteralTypesPatterns.ts(141,1): error TS2322: Type '"bno"' is not assignable to type '`a${any}`'.
 templateLiteralTypesPatterns.ts(160,7): error TS2322: Type '"anything"' is not assignable to type '`${number} ${number}`'.
-templateLiteralTypesPatterns.ts(211,5): error TS2345: Argument of type '"abcTest"' is not assignable to parameter of type '`${`a${string}` & `${string}a`}Test`'.
+templateLiteralTypesPatterns.ts(215,5): error TS2345: Argument of type '"abcTest"' is not assignable to parameter of type '`${`a${string}` & `${string}a`}Test`'.
 
 
 ==== templateLiteralTypesPatterns.ts (58 errors) ====
@@ -380,6 +380,10 @@ templateLiteralTypesPatterns.ts(211,5): error TS2345: Argument of type '"abcTest
     conversionTest("testDowncast");
     function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
     conversionTest2("testDowncast");
+    function conversionTest3(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+    conversionTest3("testDowncast");
+    function conversionTest4(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+    conversionTest4("testDowncast");
     
     function foo(str: `${`a${string}` & `${string}a`}Test`) {}
     foo("abaTest"); // ok

--- a/tests/baselines/reference/templateLiteralTypesPatterns.js
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.js
@@ -208,6 +208,10 @@ function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDownc
 conversionTest("testDowncast");
 function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
 conversionTest2("testDowncast");
+function conversionTest3(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+conversionTest3("testDowncast");
+function conversionTest4(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+conversionTest4("testDowncast");
 
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}
 foo("abaTest"); // ok
@@ -367,6 +371,10 @@ function conversionTest(groupName) { }
 conversionTest("testDowncast");
 function conversionTest2(groupName) { }
 conversionTest2("testDowncast");
+function conversionTest3(groupName) { }
+conversionTest3("testDowncast");
+function conversionTest4(groupName) { }
+conversionTest4("testDowncast");
 function foo(str) { }
 foo("abaTest"); // ok
 foo("abcTest"); // error

--- a/tests/baselines/reference/templateLiteralTypesPatterns.js
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.js
@@ -204,9 +204,9 @@ export abstract class BB {
 }
 
 // repro from https://github.com/microsoft/TypeScript/issues/54177#issuecomment-1538436654
-function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string}Downcast` & {}) {}
 conversionTest("testDowncast");
-function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
 conversionTest2("testDowncast");
 
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}

--- a/tests/baselines/reference/templateLiteralTypesPatterns.symbols
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.symbols
@@ -488,14 +488,14 @@ export abstract class BB {
 }
 
 // repro from https://github.com/microsoft/TypeScript/issues/54177#issuecomment-1538436654
-function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string}Downcast` & {}) {}
 >conversionTest : Symbol(conversionTest, Decl(templateLiteralTypesPatterns.ts, 200, 1))
 >groupName : Symbol(groupName, Decl(templateLiteralTypesPatterns.ts, 203, 24))
 
 conversionTest("testDowncast");
 >conversionTest : Symbol(conversionTest, Decl(templateLiteralTypesPatterns.ts, 200, 1))
 
-function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
 >conversionTest2 : Symbol(conversionTest2, Decl(templateLiteralTypesPatterns.ts, 204, 31))
 >groupName : Symbol(groupName, Decl(templateLiteralTypesPatterns.ts, 205, 25))
 

--- a/tests/baselines/reference/templateLiteralTypesPatterns.symbols
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.symbols
@@ -502,13 +502,27 @@ function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDown
 conversionTest2("testDowncast");
 >conversionTest2 : Symbol(conversionTest2, Decl(templateLiteralTypesPatterns.ts, 204, 31))
 
+function conversionTest3(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+>conversionTest3 : Symbol(conversionTest3, Decl(templateLiteralTypesPatterns.ts, 206, 32))
+>groupName : Symbol(groupName, Decl(templateLiteralTypesPatterns.ts, 207, 25))
+
+conversionTest3("testDowncast");
+>conversionTest3 : Symbol(conversionTest3, Decl(templateLiteralTypesPatterns.ts, 206, 32))
+
+function conversionTest4(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+>conversionTest4 : Symbol(conversionTest4, Decl(templateLiteralTypesPatterns.ts, 208, 32))
+>groupName : Symbol(groupName, Decl(templateLiteralTypesPatterns.ts, 209, 25))
+
+conversionTest4("testDowncast");
+>conversionTest4 : Symbol(conversionTest4, Decl(templateLiteralTypesPatterns.ts, 208, 32))
+
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}
->foo : Symbol(foo, Decl(templateLiteralTypesPatterns.ts, 206, 32))
->str : Symbol(str, Decl(templateLiteralTypesPatterns.ts, 208, 13))
+>foo : Symbol(foo, Decl(templateLiteralTypesPatterns.ts, 210, 32))
+>str : Symbol(str, Decl(templateLiteralTypesPatterns.ts, 212, 13))
 
 foo("abaTest"); // ok
->foo : Symbol(foo, Decl(templateLiteralTypesPatterns.ts, 206, 32))
+>foo : Symbol(foo, Decl(templateLiteralTypesPatterns.ts, 210, 32))
 
 foo("abcTest"); // error
->foo : Symbol(foo, Decl(templateLiteralTypesPatterns.ts, 206, 32))
+>foo : Symbol(foo, Decl(templateLiteralTypesPatterns.ts, 210, 32))
 

--- a/tests/baselines/reference/templateLiteralTypesPatterns.types
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.types
@@ -638,20 +638,20 @@ export abstract class BB {
 // repro from https://github.com/microsoft/TypeScript/issues/54177#issuecomment-1538436654
 function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
 >conversionTest : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) => void
->groupName : `${string & {}}Downcast` | "downcast" | "dataDowncast" | "editingDowncast"
+>groupName : `${string & {}}Downcast` | "downcast"
 
 conversionTest("testDowncast");
 >conversionTest("testDowncast") : void
->conversionTest : (groupName: `${string & {}}Downcast` | "downcast" | "dataDowncast" | "editingDowncast") => void
+>conversionTest : (groupName: `${string & {}}Downcast` | "downcast") => void
 >"testDowncast" : "testDowncast"
 
 function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
 >conversionTest2 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) => void
->groupName : "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`
+>groupName : "downcast" | `${{} & string}Downcast`
 
 conversionTest2("testDowncast");
 >conversionTest2("testDowncast") : void
->conversionTest2 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) => void
+>conversionTest2 : (groupName: "downcast" | `${{} & string}Downcast`) => void
 >"testDowncast" : "testDowncast"
 
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}

--- a/tests/baselines/reference/templateLiteralTypesPatterns.types
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.types
@@ -656,20 +656,20 @@ conversionTest2("testDowncast");
 
 function conversionTest3(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
 >conversionTest3 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) => void
->groupName : "downcast" | `${string & {}}Downcast`
+>groupName : `${string}Downcast` | "downcast"
 
 conversionTest3("testDowncast");
 >conversionTest3("testDowncast") : void
->conversionTest3 : (groupName: "downcast" | `${string & {}}Downcast`) => void
+>conversionTest3 : (groupName: `${string}Downcast` | "downcast") => void
 >"testDowncast" : "testDowncast"
 
 function conversionTest4(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
 >conversionTest4 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) => void
->groupName : "downcast" | `${{} & string}Downcast`
+>groupName : `${string}Downcast` | "downcast"
 
 conversionTest4("testDowncast");
 >conversionTest4("testDowncast") : void
->conversionTest4 : (groupName: "downcast" | `${{} & string}Downcast`) => void
+>conversionTest4 : (groupName: `${string}Downcast` | "downcast") => void
 >"testDowncast" : "testDowncast"
 
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}

--- a/tests/baselines/reference/templateLiteralTypesPatterns.types
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.types
@@ -636,22 +636,22 @@ export abstract class BB {
 }
 
 // repro from https://github.com/microsoft/TypeScript/issues/54177#issuecomment-1538436654
-function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
->conversionTest : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) => void
->groupName : `${string & {}}Downcast` | "downcast"
+function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string}Downcast` & {}) {}
+>conversionTest : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${string}Downcast` & {}) => void
+>groupName : (`${string}Downcast` & {}) | "downcast" | "dataDowncast" | "editingDowncast"
 
 conversionTest("testDowncast");
 >conversionTest("testDowncast") : void
->conversionTest : (groupName: `${string & {}}Downcast` | "downcast") => void
+>conversionTest : (groupName: (`${string}Downcast` & {}) | "downcast" | "dataDowncast" | "editingDowncast") => void
 >"testDowncast" : "testDowncast"
 
-function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
->conversionTest2 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) => void
->groupName : "downcast" | `${{} & string}Downcast`
+function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
+>conversionTest2 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) => void
+>groupName : "downcast" | "dataDowncast" | "editingDowncast" | ({} & `${string}Downcast`)
 
 conversionTest2("testDowncast");
 >conversionTest2("testDowncast") : void
->conversionTest2 : (groupName: "downcast" | `${{} & string}Downcast`) => void
+>conversionTest2 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | ({} & `${string}Downcast`)) => void
 >"testDowncast" : "testDowncast"
 
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}

--- a/tests/baselines/reference/templateLiteralTypesPatterns.types
+++ b/tests/baselines/reference/templateLiteralTypesPatterns.types
@@ -654,6 +654,24 @@ conversionTest2("testDowncast");
 >conversionTest2 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | ({} & `${string}Downcast`)) => void
 >"testDowncast" : "testDowncast"
 
+function conversionTest3(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+>conversionTest3 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) => void
+>groupName : "downcast" | `${string & {}}Downcast`
+
+conversionTest3("testDowncast");
+>conversionTest3("testDowncast") : void
+>conversionTest3 : (groupName: "downcast" | `${string & {}}Downcast`) => void
+>"testDowncast" : "testDowncast"
+
+function conversionTest4(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+>conversionTest4 : (groupName: "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) => void
+>groupName : "downcast" | `${{} & string}Downcast`
+
+conversionTest4("testDowncast");
+>conversionTest4("testDowncast") : void
+>conversionTest4 : (groupName: "downcast" | `${{} & string}Downcast`) => void
+>"testDowncast" : "testDowncast"
+
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}
 >foo : (str: `${`a${string}` & `${string}a`}Test`) => void
 >str : `${`a${string}` & `${string}a`}Test`

--- a/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
+++ b/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
@@ -202,9 +202,9 @@ export abstract class BB {
 }
 
 // repro from https://github.com/microsoft/TypeScript/issues/54177#issuecomment-1538436654
-function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string}Downcast` & {}) {}
 conversionTest("testDowncast");
-function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
 conversionTest2("testDowncast");
 
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}

--- a/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
+++ b/tests/cases/conformance/types/literal/templateLiteralTypesPatterns.ts
@@ -206,6 +206,10 @@ function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDownc
 conversionTest("testDowncast");
 function conversionTest2(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | {} & `${string}Downcast`) {}
 conversionTest2("testDowncast");
+function conversionTest3(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+conversionTest3("testDowncast");
+function conversionTest4(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${{} & string}Downcast`) {}
+conversionTest4("testDowncast");
 
 function foo(str: `${`a${string}` & `${string}a`}Test`) {}
 foo("abaTest"); // ok

--- a/tests/cases/fourslash/stringLiteralCompletionsForOpenEndedTemplateLiteralType.ts
+++ b/tests/cases/fourslash/stringLiteralCompletionsForOpenEndedTemplateLiteralType.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts" />
 
-//// function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string & {}}Downcast`) {}
+//// function conversionTest(groupName: | "downcast" | "dataDowncast" | "editingDowncast" | `${string}Downcast` & {}) {}
 //// conversionTest("/**/");
 
 verify.completions({ marker: "", exact: ["downcast", "dataDowncast", "editingDowncast"] });


### PR DESCRIPTION
This PR builds on #56434 to strip object type tags in template literal placeholders. We can merge this in case we decide to go that way.