### PR TITLE
Fix "Extract to type alias" not available at end of span

### DIFF
--- a/tests/cases/fourslash/refactorExtractType89.ts
+++ b/tests/cases/fourslash/refactorExtractType89.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+//// interface Yadda<T> { x: T }
+//// 
+//// export let blah: Yadda/*a*/<string>/*b*/;
+
+goTo.marker("a");
+verify.refactorAvailableForTriggerReason("invoked", "Extract type", "Extract to type alias")
+
+goTo.marker("b");
+edit.applyRefactor({
+    triggerReason: "invoked",
+    refactorName: "Extract type",
+    actionName: "Extract to type alias",
+    actionDescription: "Extract to type alias",
+    newContent: `interface Yadda<T> { x: T }
+
+type /*RENAME*/NewType = Yadda<string>;
+
+export let blah: NewType;`,
+});

--- a/tests/cases/fourslash/refactorExtractType89.ts
+++ b/tests/cases/fourslash/refactorExtractType89.ts
@@ -1,8 +1,10 @@
 /// <reference path='fourslash.ts' />
 
 //// interface Yadda<T> { x: T }
-//// 
+////
 //// export let blah: Yadda/*a*/<string>/*b*/;
+////
+//// interface YaddaWithDefault<T = boolean/*c*/> { x: T/*d*/ }
 
 goTo.marker("a");
 verify.refactorAvailableForTriggerReason("invoked", "Extract type", "Extract to type alias")
@@ -17,5 +19,43 @@ edit.applyRefactor({
 
 type /*RENAME*/NewType = Yadda<string>;
 
-export let blah: NewType;`,
+export let blah: NewType;
+
+interface YaddaWithDefault<T = boolean> { x: T }`,
+});
+
+goTo.marker("c");
+edit.applyRefactor({
+    triggerReason: "invoked",
+    refactorName: "Extract type",
+    actionName: "Extract to type alias",
+    actionDescription: "Extract to type alias",
+    newContent: `interface Yadda<T> { x: T }
+
+type NewType = Yadda<string>;
+
+export let blah: NewType;
+
+type /*RENAME*/NewType_1 = boolean;
+
+interface YaddaWithDefault<T = NewType_1> { x: T }`
+});
+
+goTo.marker("d");
+edit.applyRefactor({
+    triggerReason: "invoked",
+    refactorName: "Extract type",
+    actionName: "Extract to type alias",
+    actionDescription: "Extract to type alias",
+    newContent: `interface Yadda<T> { x: T }
+
+type NewType = Yadda<string>;
+
+export let blah: NewType;
+
+type NewType_1 = boolean;
+
+type /*RENAME*/NewType_2<T> = T;
+
+interface YaddaWithDefault<T = NewType_1> { x: NewType_2<T> }`
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #56401 

This PR somewhat refactors the way we find `firstType` token when looking for the closest type node. To fix the original issue, we had to also consider the previous token. Now, to keep the exisiting behavior as much as possible, this is done as a second fallback.  