### PR TITLE
Fast path for unions of string literals only

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17047,6 +17047,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             }
         }
         const objectFlags = (includes & TypeFlags.NotPrimitiveUnion ? 0 : ObjectFlags.PrimitiveUnion) |
+            (includes & TypeFlags.NotStringLiteral ? 0 : ObjectFlags.StringLiteralUnion) |
             (includes & TypeFlags.Intersection ? ObjectFlags.ContainsIntersections : 0);
         return getUnionTypeFromSortedList(typeSet, objectFlags, aliasSymbol, aliasTypeArguments, origin);
     }
@@ -20747,7 +20748,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         if (t & TypeFlags.Any || s & TypeFlags.Never || source === wildcardType) return true;
         if (t & TypeFlags.Unknown && !(relation === strictSubtypeRelation && s & TypeFlags.Any)) return true;
         if (t & TypeFlags.Never) return false;
-        if (s & TypeFlags.StringLike && t & TypeFlags.String) return true;
+        if ((s & TypeFlags.StringLike || s & TypeFlags.Union && getObjectFlags(source) & ObjectFlags.StringLiteralUnion) && t & TypeFlags.String) return true;
         if (
             s & TypeFlags.StringLiteral && s & TypeFlags.EnumLiteral &&
             t & TypeFlags.StringLiteral && !(t & TypeFlags.EnumLiteral) &&

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -6154,6 +6154,8 @@ export const enum TypeFlags {
     IncludesInstantiable = Substitution,
     /** @internal */
     NotPrimitiveUnion = Any | Unknown | Void | Never | Object | Intersection | IncludesInstantiable,
+    /** @internal */
+    NotStringLiteral = ~(StringLiteral | EnumLiteral | TemplateLiteral | StringMapping)
 }
 
 export type DestructuringPattern = BindingPattern | ObjectLiteralExpression | ArrayLiteralExpression;
@@ -6307,6 +6309,7 @@ export const enum ObjectFlags {
     /** @internal */
     IsUnknownLikeUnion = 1 << 26, // Union of null, undefined, and empty object type
     /** @internal */
+    StringLiteralUnion = 1 << 27, // Union of only string and template literals
 
     // Flags that require TypeFlags.Intersection
     /** @internal */


### PR DESCRIPTION
This PR adds a fast path for relating unions of only string literal, template literal, or string mapping types to the `string` type. Should have a positive impact on performance, though not sure how much.