### PR TITLE
Handle package json watch life time

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -812,13 +812,13 @@ interface NodeModulesWatcher extends FileWatcher {
 }
 
 /** @internal */
-export interface PackageJsonWacher extends FileWatcher {
+export interface PackageJsonWatcher extends FileWatcher {
     projects: Set<Project | WildcardWatcher>;
 }
 
 /** @internal */
 export interface WildcardWatcher extends FileWatcher {
-    packageJsonWatches: Set<PackageJsonWacher> | undefined;
+    packageJsonWatches: Set<PackageJsonWatcher> | undefined;
 }
 
 function getDetailWatchInfo(watchType: WatchType, project: Project | NormalizedPath | undefined) {
@@ -1128,7 +1128,7 @@ export class ProjectService {
     /** @internal */
     readonly packageJsonCache: PackageJsonCache;
     /** @internal */
-    private packageJsonFilesMap: Map<Path, PackageJsonWacher> | undefined;
+    private packageJsonFilesMap: Map<Path, PackageJsonWatcher> | undefined;
     /** @internal */
     private incompleteCompletionsCache: IncompleteCompletionsCache | undefined;
     /** @internal */
@@ -4679,7 +4679,7 @@ export class ProjectService {
     /** @internal */
     private watchPackageJsonFile(file: string, path: Path, project: Project | WildcardWatcher) {
         Debug.assert(project !== undefined);
-        let result: PackageJsonWacher = (this.packageJsonFilesMap ??= new Map()).get(path);
+        let result = (this.packageJsonFilesMap ??= new Map()).get(path);
         if (!result) {
             // this.invalidateProjectPackageJson(path);
             let watcher: FileWatcher | undefined = this.watchFactory.watchFile(
@@ -4720,7 +4720,7 @@ export class ProjectService {
     }
 
     /** @internal */
-    private onPackageJsonChange(result: PackageJsonWacher) {
+    private onPackageJsonChange(result: PackageJsonWatcher) {
         result.projects.forEach(project => (project as Project).onPackageJsonChange?.());
     }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -808,7 +808,17 @@ interface NodeModulesWatcher extends FileWatcher {
     /** How many watchers of this directory were for closed ScriptInfo */
     refreshScriptInfoRefCount: number;
     /** List of project names whose module specifier cache should be cleared when package.jsons change */
-    affectedModuleSpecifierCacheProjects?: Set<string>;
+    affectedModuleSpecifierCacheProjects?: Set<Project>;
+}
+
+/** @internal */
+export interface PackageJsonWacher extends FileWatcher {
+    projects: Set<Project | WildcardWatcher>;
+}
+
+/** @internal */
+export interface WildcardWatcher extends FileWatcher {
+    packageJsonWatches: Set<PackageJsonWacher> | undefined;
 }
 
 function getDetailWatchInfo(watchType: WatchType, project: Project | NormalizedPath | undefined) {
@@ -1000,7 +1010,7 @@ export class ProjectService {
      * @internal
      */
     readonly filenameToScriptInfo = new Map<string, ScriptInfo>();
-    private readonly nodeModulesWatchers = new Map<string, NodeModulesWatcher>();
+    private readonly nodeModulesWatchers = new Map<Path, NodeModulesWatcher>();
     /**
      * Contains all the deleted script info's version information so that
      * it does not reset when creating script info again
@@ -1118,7 +1128,7 @@ export class ProjectService {
     /** @internal */
     readonly packageJsonCache: PackageJsonCache;
     /** @internal */
-    private packageJsonFilesMap: Map<Path, FileWatcher> | undefined;
+    private packageJsonFilesMap: Map<Path, PackageJsonWacher> | undefined;
     /** @internal */
     private incompleteCompletionsCache: IncompleteCompletionsCache | undefined;
     /** @internal */
@@ -1641,7 +1651,7 @@ export class ProjectService {
      * @internal
      */
     private watchWildcardDirectory(directory: Path, flags: WatchDirectoryFlags, configFileName: NormalizedPath, config: ParsedConfig) {
-        return this.watchFactory.watchDirectory(
+        let watcher: FileWatcher | undefined = this.watchFactory.watchDirectory(
             directory,
             fileOrDirectory => {
                 const fileOrDirectoryPath = this.toPath(fileOrDirectory);
@@ -1650,8 +1660,10 @@ export class ProjectService {
                     getBaseFileName(fileOrDirectoryPath) === "package.json" && !isInsideNodeModules(fileOrDirectoryPath) &&
                     (fsResult && fsResult.fileExists || !fsResult && this.host.fileExists(fileOrDirectoryPath))
                 ) {
-                    this.logger.info(`Config: ${configFileName} Detected new package.json: ${fileOrDirectory}`);
-                    this.onAddPackageJson(fileOrDirectoryPath);
+                    const file = this.getNormalizedAbsolutePath(fileOrDirectory);
+                    this.logger.info(`Config: ${configFileName} Detected new package.json: ${file}`);
+                    this.packageJsonCache.addOrUpdate(file, fileOrDirectoryPath);
+                    this.watchPackageJsonFile(file, fileOrDirectoryPath, result);
                 }
 
                 const configuredProjectForConfig = this.findConfiguredProjectByProjectName(configFileName);
@@ -1707,6 +1719,22 @@ export class ProjectService {
             WatchType.WildcardDirectory,
             configFileName,
         );
+
+        const result: WildcardWatcher = {
+            packageJsonWatches: undefined,
+            close() {
+                if (watcher) {
+                    watcher.close();
+                    watcher = undefined;
+                    result.packageJsonWatches?.forEach(watcher => {
+                        watcher.projects.delete(result);
+                        watcher.close();
+                    });
+                    result.packageJsonWatches = undefined;
+                }
+            },
+        };
+        return result;
     }
 
     /** @internal */
@@ -3012,7 +3040,7 @@ export class ProjectService {
             (!this.globalCacheLocationDirectoryPath ||
                 !startsWith(info.path, this.globalCacheLocationDirectoryPath))
         ) {
-            const indexOfNodeModules = info.path.indexOf("/node_modules/");
+            const indexOfNodeModules = info.fileName.indexOf("/node_modules/");
             if (!this.host.getModifiedTime || indexOfNodeModules === -1) {
                 info.fileWatcher = this.watchFactory.watchFile(
                     info.fileName,
@@ -3024,13 +3052,13 @@ export class ProjectService {
             }
             else {
                 info.mTime = this.getModifiedTime(info);
-                info.fileWatcher = this.watchClosedScriptInfoInNodeModules(info.path.substr(0, indexOfNodeModules) as Path);
+                info.fileWatcher = this.watchClosedScriptInfoInNodeModules(info.fileName.substring(0, indexOfNodeModules));
             }
         }
     }
 
-    private createNodeModulesWatcher(dir: Path) {
-        const watcher = this.watchFactory.watchDirectory(
+    private createNodeModulesWatcher(dir: string, dirPath: Path) {
+        let watcher: FileWatcher | undefined = this.watchFactory.watchDirectory(
             dir,
             fileOrDirectory => {
                 const fileOrDirectoryPath = removeIgnoredPath(this.toPath(fileOrDirectory));
@@ -3044,15 +3072,15 @@ export class ProjectService {
                         basename === "package.json" || basename === "node_modules"
                     )
                 ) {
-                    result.affectedModuleSpecifierCacheProjects.forEach(projectName => {
-                        this.findProject(projectName)?.getModuleSpecifierCache()?.clear();
+                    result.affectedModuleSpecifierCacheProjects.forEach(project => {
+                        project.getModuleSpecifierCache()?.clear();
                     });
                 }
 
                 // Refresh closed script info after an npm install
                 if (result.refreshScriptInfoRefCount) {
-                    if (dir === fileOrDirectoryPath) {
-                        this.refreshScriptInfosInDirectory(dir);
+                    if (dirPath === fileOrDirectoryPath) {
+                        this.refreshScriptInfosInDirectory(dirPath);
                     }
                     else {
                         const info = this.getScriptInfoForPath(fileOrDirectoryPath);
@@ -3076,32 +3104,36 @@ export class ProjectService {
             refreshScriptInfoRefCount: 0,
             affectedModuleSpecifierCacheProjects: undefined,
             close: () => {
-                if (!result.refreshScriptInfoRefCount && !result.affectedModuleSpecifierCacheProjects?.size) {
+                if (watcher && !result.refreshScriptInfoRefCount && !result.affectedModuleSpecifierCacheProjects?.size) {
                     watcher.close();
-                    this.nodeModulesWatchers.delete(dir);
+                    watcher = undefined;
+                    this.nodeModulesWatchers.delete(dirPath);
                 }
             },
         };
-        this.nodeModulesWatchers.set(dir, result);
+        this.nodeModulesWatchers.set(dirPath, result);
         return result;
     }
 
     /** @internal */
-    watchPackageJsonsInNodeModules(dir: Path, project: Project): FileWatcher {
-        const watcher = this.nodeModulesWatchers.get(dir) || this.createNodeModulesWatcher(dir);
-        (watcher.affectedModuleSpecifierCacheProjects ||= new Set()).add(project.getProjectName());
+    watchPackageJsonsInNodeModules(dir: string, project: Project): FileWatcher {
+        const dirPath = this.toPath(dir);
+        const watcher = this.nodeModulesWatchers.get(dirPath) || this.createNodeModulesWatcher(dir, dirPath);
+        Debug.assert(!watcher.affectedModuleSpecifierCacheProjects?.has(project));
+        (watcher.affectedModuleSpecifierCacheProjects ||= new Set()).add(project);
 
         return {
             close: () => {
-                watcher.affectedModuleSpecifierCacheProjects?.delete(project.getProjectName());
+                watcher.affectedModuleSpecifierCacheProjects?.delete(project);
                 watcher.close();
             },
         };
     }
 
-    private watchClosedScriptInfoInNodeModules(dir: Path): FileWatcher {
-        const watchDir = dir + "/node_modules" as Path;
-        const watcher = this.nodeModulesWatchers.get(watchDir) || this.createNodeModulesWatcher(watchDir);
+    private watchClosedScriptInfoInNodeModules(dir: string): FileWatcher {
+        const watchDir = dir + "/node_modules";
+        const watchDirPath = this.toPath(watchDir);
+        const watcher = this.nodeModulesWatchers.get(watchDirPath) || this.createNodeModulesWatcher(watchDir, watchDirPath);
         watcher.refreshScriptInfoRefCount++;
 
         return {
@@ -3406,7 +3438,9 @@ export class ProjectService {
                     });
                 }
                 if (includePackageJsonAutoImports !== args.preferences.includePackageJsonAutoImports) {
-                    this.invalidateProjectPackageJson(/*packageJsonPath*/ undefined);
+                    this.forEachProject(project => {
+                        project.onAutoImportProviderSettingsChanged();
+                    });
                 }
             }
             if (args.extraFileExtensions) {
@@ -4600,12 +4634,11 @@ export class ProjectService {
     }
 
     /** @internal */
-    getPackageJsonsVisibleToFile(fileName: string, rootDir?: string): readonly ProjectPackageJsonInfo[] {
+    getPackageJsonsVisibleToFile(fileName: string, project: Project, rootDir?: string): readonly ProjectPackageJsonInfo[] {
         const packageJsonCache = this.packageJsonCache;
         const rootPath = rootDir && this.toPath(rootDir);
-        const filePath = this.toPath(fileName);
         const result: ProjectPackageJsonInfo[] = [];
-        const processDirectory = (directory: Path): boolean | undefined => {
+        const processDirectory = (directory: string): boolean | undefined => {
             switch (packageJsonCache.directoryHasPackageJson(directory)) {
                 // Sync and check same directory again
                 case Ternary.Maybe:
@@ -4614,7 +4647,7 @@ export class ProjectService {
                 // Check package.json
                 case Ternary.True:
                     const packageJsonFileName = combinePaths(directory, "package.json");
-                    this.watchPackageJsonFile(packageJsonFileName as Path);
+                    this.watchPackageJsonFile(packageJsonFileName, this.toPath(packageJsonFileName), project);
                     const info = packageJsonCache.getInDirectory(directory);
                     if (info) result.push(info);
             }
@@ -4623,14 +4656,14 @@ export class ProjectService {
             }
         };
 
-        forEachAncestorDirectory(getDirectoryPath(filePath), processDirectory);
+        forEachAncestorDirectory(getDirectoryPath(fileName), processDirectory);
         return result;
     }
 
     /** @internal */
     getNearestAncestorDirectoryWithPackageJson(fileName: string): string | undefined {
         return forEachAncestorDirectory(fileName, directory => {
-            switch (this.packageJsonCache.directoryHasPackageJson(this.toPath(directory))) {
+            switch (this.packageJsonCache.directoryHasPackageJson(directory)) {
                 case Ternary.True:
                     return directory;
                 case Ternary.False:
@@ -4644,42 +4677,51 @@ export class ProjectService {
     }
 
     /** @internal */
-    private watchPackageJsonFile(path: Path) {
-        const watchers = this.packageJsonFilesMap || (this.packageJsonFilesMap = new Map());
-        if (!watchers.has(path)) {
-            this.invalidateProjectPackageJson(path);
-            watchers.set(
-                path,
-                this.watchFactory.watchFile(
-                    path,
-                    (fileName, eventKind) => {
-                        const path = this.toPath(fileName);
-                        switch (eventKind) {
-                            case FileWatcherEventKind.Created:
-                                return Debug.fail();
-                            case FileWatcherEventKind.Changed:
-                                this.packageJsonCache.addOrUpdate(path);
-                                this.invalidateProjectPackageJson(path);
-                                break;
-                            case FileWatcherEventKind.Deleted:
-                                this.packageJsonCache.delete(path);
-                                this.invalidateProjectPackageJson(path);
-                                watchers.get(path)!.close();
-                                watchers.delete(path);
-                        }
-                    },
-                    PollingInterval.Low,
-                    this.hostConfiguration.watchOptions,
-                    WatchType.PackageJson,
-                ),
+    private watchPackageJsonFile(file: string, path: Path, project: Project | WildcardWatcher) {
+        Debug.assert(project !== undefined);
+        let result: PackageJsonWacher = (this.packageJsonFilesMap ??= new Map()).get(path);
+        if (!result) {
+            // this.invalidateProjectPackageJson(path);
+            let watcher: FileWatcher | undefined = this.watchFactory.watchFile(
+                file,
+                (fileName, eventKind) => {
+                    switch (eventKind) {
+                        case FileWatcherEventKind.Created:
+                            return Debug.fail();
+                        case FileWatcherEventKind.Changed:
+                            this.packageJsonCache.addOrUpdate(fileName, path);
+                            this.onPackageJsonChange(result);
+                            break;
+                        case FileWatcherEventKind.Deleted:
+                            this.packageJsonCache.delete(path);
+                            this.onPackageJsonChange(result);
+                            result.projects.clear();
+                            result.close();
+                    }
+                },
+                PollingInterval.Low,
+                this.hostConfiguration.watchOptions,
+                WatchType.PackageJson,
             );
+            result = {
+                projects: new Set(),
+                close: () => {
+                    if (result.projects.size || !watcher) return;
+                    watcher.close();
+                    watcher = undefined;
+                    this.packageJsonFilesMap?.delete(path);
+                    this.packageJsonCache.invalidate(path);
+                },
+            };
+            this.packageJsonFilesMap.set(path, result);
         }
+        result.projects.add(project);
+        (project.packageJsonWatches ??= new Set()).add(result);
     }
 
     /** @internal */
-    private onAddPackageJson(path: Path) {
-        this.packageJsonCache.addOrUpdate(path);
-        this.watchPackageJsonFile(path);
+    private onPackageJsonChange(result: PackageJsonWacher) {
+        result.projects.forEach(project => (project as Project).onPackageJsonChange?.());
     }
 
     /** @internal */
@@ -4691,21 +4733,6 @@ export class ProjectService {
                 return PackageJsonAutoImportPreference.Off;
             default:
                 return PackageJsonAutoImportPreference.Auto;
-        }
-    }
-
-    /** @internal */
-    private invalidateProjectPackageJson(packageJsonPath: Path | undefined) {
-        this.configuredProjects.forEach(invalidate);
-        this.inferredProjects.forEach(invalidate);
-        this.externalProjects.forEach(invalidate);
-        function invalidate(project: Project) {
-            if (packageJsonPath) {
-                project.onPackageJsonChange(packageJsonPath);
-            }
-            else {
-                project.onAutoImportProviderSettingsChanged();
-            }
         }
     }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -144,6 +144,7 @@ import {
     ModuleImportResult,
     Msg,
     NormalizedPath,
+    PackageJsonWacher,
     projectContainsInfoDirectly,
     ProjectOptions,
     ProjectReferenceProjectLoadKind,
@@ -398,7 +399,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     originalConfiguredProjects: Set<NormalizedPath> | undefined;
 
     /** @internal */
-    private packageJsonsForAutoImport: Set<string> | undefined;
+    packageJsonWatches: Set<PackageJsonWacher> | undefined;
 
     /** @internal */
     noDtsResolutionProject?: AuxiliaryProject | undefined;
@@ -1080,6 +1081,12 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
         this.resolutionCache.clear();
         this.resolutionCache = undefined!;
         this.cachedUnresolvedImportsPerFile = undefined!;
+        this.packageJsonWatches?.forEach(watcher => {
+            watcher.projects.delete(this);
+            watcher.close();
+        });
+        this.packageJsonWatches = undefined;
+        this.moduleSpecifierCache.clear();
         this.moduleSpecifierCache = undefined!;
         this.directoryStructureHost = undefined!;
         this.exportMapCache = undefined;
@@ -1308,12 +1315,10 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     }
 
     /** @internal */
-    onPackageJsonChange(packageJsonPath: Path) {
-        if (this.packageJsonsForAutoImport?.has(packageJsonPath)) {
-            this.moduleSpecifierCache.clear();
-            if (this.autoImportProviderHost) {
-                this.autoImportProviderHost.markAsDirty();
-            }
+    onPackageJsonChange() {
+        this.moduleSpecifierCache.clear();
+        if (this.autoImportProviderHost) {
+            this.autoImportProviderHost.markAsDirty();
         }
     }
 
@@ -2078,7 +2083,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     /** @internal */
     getPackageJsonsVisibleToFile(fileName: string, rootDir?: string): readonly ProjectPackageJsonInfo[] {
         if (this.projectService.serverMode !== LanguageServiceMode.Semantic) return emptyArray;
-        return this.projectService.getPackageJsonsVisibleToFile(fileName, rootDir);
+        return this.projectService.getPackageJsonsVisibleToFile(fileName, this, rootDir);
     }
 
     /** @internal */
@@ -2088,9 +2093,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
 
     /** @internal */
     getPackageJsonsForAutoImport(rootDir?: string): readonly ProjectPackageJsonInfo[] {
-        const packageJsons = this.getPackageJsonsVisibleToFile(combinePaths(this.currentDirectory, inferredTypesContainingFile), rootDir);
-        this.packageJsonsForAutoImport = new Set(packageJsons.map(p => p.fileName));
-        return packageJsons;
+        return this.getPackageJsonsVisibleToFile(combinePaths(this.currentDirectory, inferredTypesContainingFile), rootDir);
     }
 
     /** @internal */
@@ -2188,7 +2191,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
 
     /** @internal */
     watchNodeModulesForPackageJsonChanges(directoryPath: string) {
-        return this.projectService.watchPackageJsonsInNodeModules(this.toPath(directoryPath), this);
+        return this.projectService.watchPackageJsonsInNodeModules(directoryPath, this);
     }
 
     /** @internal */

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -144,7 +144,7 @@ import {
     ModuleImportResult,
     Msg,
     NormalizedPath,
-    PackageJsonWacher,
+    PackageJsonWatcher,
     projectContainsInfoDirectly,
     ProjectOptions,
     ProjectReferenceProjectLoadKind,
@@ -399,7 +399,7 @@ export abstract class Project implements LanguageServiceHost, ModuleResolutionHo
     originalConfiguredProjects: Set<NormalizedPath> | undefined;
 
     /** @internal */
-    packageJsonWatches: Set<PackageJsonWacher> | undefined;
+    packageJsonWatches: Set<PackageJsonWatcher> | undefined;
 
     /** @internal */
     noDtsResolutionProject?: AuxiliaryProject | undefined;

--- a/src/testRunner/unittests/tsserver/packageJsonInfo.ts
+++ b/src/testRunner/unittests/tsserver/packageJsonInfo.ts
@@ -133,5 +133,13 @@ function setup(files: readonly File[] = [tsConfig, packageJson]) {
     const host = createServerHost(files);
     const session = new TestSession(host);
     openFilesForSession([files[0]], session);
-    return { host, session, projectService: session.getProjectService() };
+    const projectService = session.getProjectService();
+    const getPackageJsonsVisibleToFile = projectService.getPackageJsonsVisibleToFile;
+    projectService.getPackageJsonsVisibleToFile = (fileName, rootDir) => {
+        session.host.baselineHost(`getPackageJsonsVisibleToFile:: ${fileName} ${rootDir}`);
+        const result = getPackageJsonsVisibleToFile.call(projectService, fileName, rootDir);
+        session.host.baselineHost(`getPackageJsonsVisibleToFile:: ${fileName} ${rootDir}:: Result:: ${jsonToReadableText(result)}`);
+        return result;
+    };
+    return { host, session, projectService };
 }

--- a/src/testRunner/unittests/tsserver/packageJsonInfo.ts
+++ b/src/testRunner/unittests/tsserver/packageJsonInfo.ts
@@ -1,4 +1,3 @@
-import * as ts from "../../_namespaces/ts";
 import {
     jsonToReadableText,
 } from "../helpers";
@@ -39,12 +38,12 @@ describe("unittests:: tsserver:: packageJsonInfo::", () => {
     it("detects new package.json files that are added, caches them, and watches them", () => {
         // Initialize project without package.json
         const { session, projectService, host } = setup([tsConfig]);
-        assert.isUndefined(projectService.packageJsonCache.getInDirectory("/" as ts.Path));
+        assert.isUndefined(projectService.packageJsonCache.getInDirectory("/"));
 
         // Add package.json
         host.writeFile(packageJson.path, packageJson.content);
         session.host.baselineHost("Add package.json");
-        let packageJsonInfo = projectService.packageJsonCache.getInDirectory("/" as ts.Path)!;
+        let packageJsonInfo = projectService.packageJsonCache.getInDirectory("/")!;
         assert.ok(packageJsonInfo);
         assert.ok(packageJsonInfo.dependencies);
         assert.ok(packageJsonInfo.devDependencies);
@@ -60,7 +59,7 @@ describe("unittests:: tsserver:: packageJsonInfo::", () => {
             }),
         );
         session.host.baselineHost("Edit package.json");
-        packageJsonInfo = projectService.packageJsonCache.getInDirectory("/" as ts.Path)!;
+        packageJsonInfo = projectService.packageJsonCache.getInDirectory("/")!;
         assert.isUndefined(packageJsonInfo.dependencies);
 
         baselineTsserverLogs("packageJsonInfo", "detects new package.json files that are added, caches them, and watches them", session);
@@ -68,39 +67,39 @@ describe("unittests:: tsserver:: packageJsonInfo::", () => {
 
     it("finds package.json on demand, watches for deletion, and removes them from cache", () => {
         // Initialize project with package.json
-        const { session, projectService, host } = setup();
-        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts" as ts.Path);
-        assert.ok(projectService.packageJsonCache.getInDirectory("/" as ts.Path));
+        const { session, projectService, host, project } = setup();
+        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts", project);
+        assert.ok(projectService.packageJsonCache.getInDirectory("/"));
 
         // Delete package.json
         host.deleteFile(packageJson.path);
         session.host.baselineHost("delete packageJson");
-        assert.isUndefined(projectService.packageJsonCache.getInDirectory("/" as ts.Path));
+        assert.isUndefined(projectService.packageJsonCache.getInDirectory("/"));
         baselineTsserverLogs("packageJsonInfo", "finds package.json on demand, watches for deletion, and removes them from cache", session);
     });
 
     it("finds multiple package.json files when present", () => {
         // Initialize project with package.json at root
-        const { session, projectService, host } = setup();
+        const { session, projectService, host, project } = setup();
         // Add package.json in /src
         host.writeFile("/src/package.json", packageJson.content);
         session.host.baselineHost("packageJson");
-        assert.lengthOf(projectService.getPackageJsonsVisibleToFile("/a.ts" as ts.Path), 1);
-        assert.lengthOf(projectService.getPackageJsonsVisibleToFile("/src/b.ts" as ts.Path), 2);
+        assert.lengthOf(projectService.getPackageJsonsVisibleToFile("/a.ts", project), 1);
+        assert.lengthOf(projectService.getPackageJsonsVisibleToFile("/src/b.ts", project), 2);
         baselineTsserverLogs("packageJsonInfo", "finds multiple package.json files when present", session);
     });
 
     it("handles errors in json parsing of package.json", () => {
         const packageJsonContent = `{ "mod" }`;
-        const { session, projectService, host } = setup([tsConfig, { path: packageJson.path, content: packageJsonContent }]);
-        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts" as ts.Path);
-        const packageJsonInfo = projectService.packageJsonCache.getInDirectory("/" as ts.Path)!;
+        const { session, projectService, host, project } = setup([tsConfig, { path: packageJson.path, content: packageJsonContent }]);
+        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts", project);
+        const packageJsonInfo = projectService.packageJsonCache.getInDirectory("/")!;
         assert.isFalse(packageJsonInfo.parseable);
 
         host.writeFile(packageJson.path, packageJson.content);
         session.host.baselineHost("packageJson");
-        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts" as ts.Path);
-        const packageJsonInfo2 = projectService.packageJsonCache.getInDirectory("/" as ts.Path)!;
+        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts", project);
+        const packageJsonInfo2 = projectService.packageJsonCache.getInDirectory("/")!;
         assert.ok(packageJsonInfo2);
         assert.ok(packageJsonInfo2.dependencies);
         assert.ok(packageJsonInfo2.devDependencies);
@@ -111,15 +110,15 @@ describe("unittests:: tsserver:: packageJsonInfo::", () => {
 
     it("handles empty package.json", () => {
         const packageJsonContent = "";
-        const { session, projectService, host } = setup([tsConfig, { path: packageJson.path, content: packageJsonContent }]);
-        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts" as ts.Path);
-        const packageJsonInfo = projectService.packageJsonCache.getInDirectory("/" as ts.Path)!;
+        const { session, projectService, host, project } = setup([tsConfig, { path: packageJson.path, content: packageJsonContent }]);
+        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts", project);
+        const packageJsonInfo = projectService.packageJsonCache.getInDirectory("/")!;
         assert.isFalse(packageJsonInfo.parseable);
 
         host.writeFile(packageJson.path, packageJson.content);
         session.host.baselineHost("PackageJson");
-        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts" as ts.Path);
-        const packageJsonInfo2 = projectService.packageJsonCache.getInDirectory("/" as ts.Path)!;
+        projectService.getPackageJsonsVisibleToFile("/src/whatever/blah.ts", project);
+        const packageJsonInfo2 = projectService.packageJsonCache.getInDirectory("/")!;
         assert.ok(packageJsonInfo2);
         assert.ok(packageJsonInfo2.dependencies);
         assert.ok(packageJsonInfo2.devDependencies);
@@ -135,11 +134,11 @@ function setup(files: readonly File[] = [tsConfig, packageJson]) {
     openFilesForSession([files[0]], session);
     const projectService = session.getProjectService();
     const getPackageJsonsVisibleToFile = projectService.getPackageJsonsVisibleToFile;
-    projectService.getPackageJsonsVisibleToFile = (fileName, rootDir) => {
+    projectService.getPackageJsonsVisibleToFile = (fileName, project, rootDir) => {
         session.host.baselineHost(`getPackageJsonsVisibleToFile:: ${fileName} ${rootDir}`);
-        const result = getPackageJsonsVisibleToFile.call(projectService, fileName, rootDir);
+        const result = getPackageJsonsVisibleToFile.call(projectService, fileName, project, rootDir);
         session.host.baselineHost(`getPackageJsonsVisibleToFile:: ${fileName} ${rootDir}:: Result:: ${jsonToReadableText(result)}`);
         return result;
     };
-    return { host, session, projectService };
+    return { host, session, projectService, project: projectService.inferredProjects[0] };
 }

--- a/tests/baselines/reference/tsserver/autoImportProvider/Closes-AutoImportProviderProject-when-host-project-closes.js
+++ b/tests/baselines/reference/tsserver/autoImportProvider/Closes-AutoImportProviderProject-when-host-project-closes.js
@@ -223,4 +223,5 @@ FsWatchesRecursive::
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /tsconfig.json 2000 undefined Project: /tsconfig.json WatchType: Config file
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /tsconfig.json WatchType: Missing file

--- a/tests/baselines/reference/tsserver/autoImportProvider/Does-not-schedule-ensureProjectForOpenFiles-on-AutoImportProviderProject-creation.js
+++ b/tests/baselines/reference/tsserver/autoImportProvider/Does-not-schedule-ensureProjectForOpenFiles-on-AutoImportProviderProject-creation.js
@@ -234,7 +234,7 @@ Info seq  [hh:mm:ss:mss] event:
 After running Timeout callback:: count: 0
 
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/autoImportProvider/Responds-to-manual-changes-in-node_modules.js
+++ b/tests/baselines/reference/tsserver/autoImportProvider/Responds-to-manual-changes-in-node_modules.js
@@ -291,7 +291,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider_globalTypingsCache.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportProvider_globalTypingsCache.js
@@ -328,8 +328,8 @@ Info seq  [hh:mm:ss:mss] getCompletionData: Get previous token: *
 Info seq  [hh:mm:ss:mss] getExportInfoMap: cache miss or empty; calculating new results
 Info seq  [hh:mm:ss:mss] forEachExternalModuleToImportFrom autoImportProvider: *
 Info seq  [hh:mm:ss:mss] getExportInfoMap: done in * ms
-Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /library/caches/typescript/node_modules 1 undefined WatchType: node_modules for closed script infos and package.jsons affecting module specifier cache
-Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /library/caches/typescript/node_modules 1 undefined WatchType: node_modules for closed script infos and package.jsons affecting module specifier cache
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /Library/Caches/typescript/node_modules 1 undefined WatchType: node_modules for closed script infos and package.jsons affecting module specifier cache
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /Library/Caches/typescript/node_modules 1 undefined WatchType: node_modules for closed script infos and package.jsons affecting module specifier cache
 Info seq  [hh:mm:ss:mss] collectAutoImports: resolved 1 module specifiers, plus 0 ambient and 0 from cache
 Info seq  [hh:mm:ss:mss] collectAutoImports: response is complete
 Info seq  [hh:mm:ss:mss] collectAutoImports: *
@@ -935,6 +935,7 @@ watchedFiles::
 watchedDirectoriesRecursive::
 /Library/Caches/typescript/node_modules:
   {}
+  {} *new*
 /Library/Caches/typescript/node_modules/@types:
   {}
 /Library/Caches/typescript/node_modules/@types/node_modules/@types:
@@ -944,8 +945,6 @@ watchedDirectoriesRecursive::
 /Library/Caches/typescript/node_modules/@types/react-router-dom/node_modules/@types:
   {}
 /Library/Caches/typescript/node_modules/node_modules/@types:
-  {}
-/library/caches/typescript/node_modules: *new*
   {}
 /project:
   {}

--- a/tests/baselines/reference/tsserver/packageJsonInfo/detects-new-package.json-files-that-are-added,-caches-them,-and-watches-them.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/detects-new-package.json-files-that-are-added,-caches-them,-and-watches-them.js
@@ -150,7 +150,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
@@ -323,7 +323,7 @@ FsWatchesRecursive::
   {}
 
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/packageJsonInfo/finds-multiple-package.json-files-when-present.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/finds-multiple-package.json-files-when-present.js
@@ -166,7 +166,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
@@ -360,7 +360,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with src :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with src/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: src/package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /src/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /src/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: src/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with src/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/packageJsonInfo/finds-multiple-package.json-files-when-present.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/finds-multiple-package.json-files-when-present.js
@@ -409,3 +409,37 @@ Timeout callback:: count: 2
 8: *ensureProjectForOpenFiles* *deleted*
 9: /tsconfig.json *new*
 10: *ensureProjectForOpenFiles* *new*
+
+getPackageJsonsVisibleToFile:: /a.ts undefined
+
+getPackageJsonsVisibleToFile:: /a.ts undefined:: Result:: [
+  {
+    "dependencies": {},
+    "devDependencies": {},
+    "optionalDependencies": {},
+    "peerDependencies": {},
+    "parseable": true,
+    "fileName": "/package.json"
+  }
+]
+
+getPackageJsonsVisibleToFile:: /src/b.ts undefined
+
+getPackageJsonsVisibleToFile:: /src/b.ts undefined:: Result:: [
+  {
+    "dependencies": {},
+    "devDependencies": {},
+    "optionalDependencies": {},
+    "peerDependencies": {},
+    "parseable": true,
+    "fileName": "/src/package.json"
+  },
+  {
+    "dependencies": {},
+    "devDependencies": {},
+    "optionalDependencies": {},
+    "peerDependencies": {},
+    "parseable": true,
+    "fileName": "/package.json"
+  }
+]

--- a/tests/baselines/reference/tsserver/packageJsonInfo/finds-package.json-on-demand,-watches-for-deletion,-and-removes-them-from-cache.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/finds-package.json-on-demand,-watches-for-deletion,-and-removes-them-from-cache.js
@@ -355,6 +355,19 @@ FsWatchesRecursive::
 /:
   {}
 
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined
+
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined:: Result:: [
+  {
+    "dependencies": {},
+    "devDependencies": {},
+    "optionalDependencies": {},
+    "peerDependencies": {},
+    "parseable": true,
+    "fileName": "/package.json"
+  }
+]
+
 Info seq  [hh:mm:ss:mss] FileWatcher:: Triggered with /package.json 2:: WatchInfo: /package.json 2000 undefined Project: /dev/null/inferredProject1* WatchType: File location for typing installer
 TI:: [hh:mm:ss:mss] Got install request
     {

--- a/tests/baselines/reference/tsserver/packageJsonInfo/finds-package.json-on-demand,-watches-for-deletion,-and-removes-them-from-cache.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/finds-package.json-on-demand,-watches-for-deletion,-and-removes-them-from-cache.js
@@ -166,7 +166,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/packageJsonInfo/handles-empty-package.json.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/handles-empty-package.json.js
@@ -153,7 +153,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/packageJsonInfo/handles-empty-package.json.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/handles-empty-package.json.js
@@ -332,6 +332,15 @@ FsWatchesRecursive::
 /:
   {}
 
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined
+
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined:: Result:: [
+  {
+    "parseable": false,
+    "fileName": "/package.json"
+  }
+]
+
 Info seq  [hh:mm:ss:mss] FileWatcher:: Triggered with /package.json 1:: WatchInfo: /package.json 2000 undefined Project: /dev/null/inferredProject1* WatchType: File location for typing installer
 TI:: [hh:mm:ss:mss] Got install request
     {
@@ -447,3 +456,16 @@ PackageJson
   }
 }
 
+
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined
+
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined:: Result:: [
+  {
+    "dependencies": {},
+    "devDependencies": {},
+    "optionalDependencies": {},
+    "peerDependencies": {},
+    "parseable": true,
+    "fileName": "/package.json"
+  }
+]

--- a/tests/baselines/reference/tsserver/packageJsonInfo/handles-errors-in-json-parsing-of-package.json.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/handles-errors-in-json-parsing-of-package.json.js
@@ -153,7 +153,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /tsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /tsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /tsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /tsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/packageJsonInfo/handles-errors-in-json-parsing-of-package.json.js
+++ b/tests/baselines/reference/tsserver/packageJsonInfo/handles-errors-in-json-parsing-of-package.json.js
@@ -332,6 +332,15 @@ FsWatchesRecursive::
 /:
   {}
 
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined
+
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined:: Result:: [
+  {
+    "parseable": false,
+    "fileName": "/package.json"
+  }
+]
+
 Info seq  [hh:mm:ss:mss] FileWatcher:: Triggered with /package.json 1:: WatchInfo: /package.json 2000 undefined Project: /dev/null/inferredProject1* WatchType: File location for typing installer
 TI:: [hh:mm:ss:mss] Got install request
     {
@@ -447,3 +456,16 @@ packageJson
   }
 }
 
+
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined
+
+getPackageJsonsVisibleToFile:: /src/whatever/blah.ts undefined:: Result:: [
+  {
+    "dependencies": {},
+    "devDependencies": {},
+    "optionalDependencies": {},
+    "peerDependencies": {},
+    "parseable": true,
+    "fileName": "/package.json"
+  }
+]

--- a/tests/baselines/reference/tsserver/projects/loading-files-with-correct-priority.js
+++ b/tests/baselines/reference/tsserver/projects/loading-files-with-correct-priority.js
@@ -728,6 +728,7 @@ Info seq  [hh:mm:ss:mss] 	Files (1)
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /a 1 undefined Config: /a/tsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /a 1 undefined Config: /a/tsconfig.json WatchType: Wild card directory
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/tsconfig.json 2000 undefined Project: /a/tsconfig.json WatchType: Config file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /a/lib/lib.d.ts 500 undefined Project: /a/tsconfig.json WatchType: Missing file
 Info seq  [hh:mm:ss:mss] `remove Project::
@@ -782,11 +783,9 @@ PolledWatches *deleted*::
 /a/node_modules:
   {"pollingInterval":500}
 
-FsWatches::
+FsWatches *deleted*::
 /a/data/package.json:
   {}
-
-FsWatches *deleted*::
 /a/main.js:
   {}
 /a/main.ts:

--- a/tests/baselines/reference/tsserver/telemetry/even-for-project-with-ts-check-in-config.js
+++ b/tests/baselines/reference/tsserver/telemetry/even-for-project-with-ts-check-in-config.js
@@ -92,7 +92,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/telemetry/sends-telemetry-for-file-sizes.js
+++ b/tests/baselines/reference/tsserver/telemetry/sends-telemetry-for-file-sizes.js
@@ -105,7 +105,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/telemetry/sends-telemetry-for-typeAcquisition-settings.js
+++ b/tests/baselines/reference/tsserver/telemetry/sends-telemetry-for-typeAcquisition-settings.js
@@ -97,7 +97,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*, Cancelled earlier one
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: a/data/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /a/data/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /a/data/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: a/data/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with a/data/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/typingsInstaller/configured-projects-discover-from-bower_components.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/configured-projects-discover-from-bower_components.js
@@ -91,7 +91,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: tmp/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /tmp/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tmp/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: tmp/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/typingsInstaller/discover-from-bower.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/discover-from-bower.js
@@ -90,7 +90,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: tmp/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /tmp/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tmp/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: tmp/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-empty-types-has-import.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-empty-types-has-import.js
@@ -123,7 +123,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: tmp/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /tmp/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tmp/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: tmp/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-empty-types.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-empty-types.js
@@ -116,7 +116,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: tmp/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /tmp/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tmp/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: tmp/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-explicit-types.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules-explicit-types.js
@@ -120,7 +120,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: tmp/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /tmp/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tmp/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: tmp/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/discover-from-node_modules.js
@@ -111,7 +111,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: tmp/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /tmp/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tmp/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: tmp/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory

--- a/tests/baselines/reference/tsserver/typingsInstaller/multiple-projects.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/multiple-projects.js
@@ -860,6 +860,7 @@ Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/pr
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/project/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Close:: WatchInfo: /user/username/projects/node_modules/@types 1 undefined Project: /user/username/projects/project/tsconfig.json WatchType: Type roots
+Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/projects/project/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] FileWatcher:: Close:: WatchInfo: /user/username/projects/project/app.js 500 undefined WatchType: Closed Script info
 Info seq  [hh:mm:ss:mss] Project '/user/username/projects/project2/tsconfig.json' (Configured)
 Info seq  [hh:mm:ss:mss] 	Files (2)
@@ -895,8 +896,6 @@ PolledWatches *deleted*::
 FsWatches::
 /a/lib/lib.d.ts:
   {}
-/user/username/projects/project/package.json:
-  {}
 /user/username/projects/project2/package.json: *new*
   {}
 /user/username/projects/project2/tsconfig.json: *new*
@@ -904,6 +903,8 @@ FsWatches::
 
 FsWatches *deleted*::
 /user/username/projects/project/app.js:
+  {}
+/user/username/projects/project/package.json:
   {}
 /user/username/projects/project/tsconfig.json:
   {}

--- a/tests/baselines/reference/tsserver/typingsInstaller/scoped-name-discovery.js
+++ b/tests/baselines/reference/tsserver/typingsInstaller/scoped-name-discovery.js
@@ -106,7 +106,7 @@ Info seq  [hh:mm:ss:mss] Scheduled: /jsconfig.json
 Info seq  [hh:mm:ss:mss] Scheduled: *ensureProjectForOpenFiles*
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
 Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory
-Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: tmp/package.json
+Info seq  [hh:mm:ss:mss] Config: /jsconfig.json Detected new package.json: /tmp/package.json
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /tmp/package.json 250 undefined WatchType: package.json file
 Info seq  [hh:mm:ss:mss] Project: /jsconfig.json Detected file add/remove of non supported extension: tmp/package.json
 Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Triggered with tmp/package.json :: WatchInfo:  1 undefined Config: /jsconfig.json WatchType: Wild card directory


### PR DESCRIPTION
While working on TI closing watches, found out that the package.json watches added stay forever. So this PR handles the lifetime of that cache as well as closing the watchers

Fixes #54026