### PR TITLE
Fix branch name in new cherry pick workflow

### DIFF
--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -62,7 +62,7 @@ jobs:
 
             const title = `🤖 Pick PR #${PR} (${pr.data.title.substring(0, 35)}${pr.data.title.length > 35 ? "..." : ""}) into ${TARGET_BRANCH}`;
 
-            await exec.exec("git", ["switch", "--detach", TARGET_BRANCH]);
+            await exec.exec("git", ["switch", "--detach", `origin/${TARGET_BRANCH}`]);
             await exec.exec("git", ["switch", "-c", pickBranch]);
             await exec.exec("git", ["cherry-pick", pr.data.merge_commit_sha]);
             await exec.exec("git", ["push", "--force", "--set-upstream", "origin", pickBranch]);


### PR DESCRIPTION
#56493 and my test on https://github.com/microsoft/TypeScript/actions/runs/6950676150/job/18911263971 didn't work because I forgot that `git switch` doesn't do the same thing as `git checkout` and create local branches for remote refs on switch. I actually don't want that behavior anyhow, but should have specified `origin/${TARGET_BRANCH}`.