### PR TITLE
Fix repository_dispatch syntax

### DIFF
--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -2,7 +2,7 @@ name: New Release Branch
 
 on:
   repository_dispatch:
-    types: new-release-branch
+    types: [new-release-branch]
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,7 +6,7 @@ on:
   # enable users to manually trigger with workflow_dispatch
   workflow_dispatch: {}
   repository_dispatch:
-    types: publish-nightly
+    types: [publish-nightly]
 
 permissions:
   contents: read

--- a/.github/workflows/set-version.yaml
+++ b/.github/workflows/set-version.yaml
@@ -2,7 +2,7 @@ name: Set branch version
 
 on:
   repository_dispatch:
-    types: set-version
+    types: [set-version]
 
 permissions:
   contents: read

--- a/.github/workflows/sync-branch.yaml
+++ b/.github/workflows/sync-branch.yaml
@@ -2,7 +2,7 @@ name: Sync branch with master
 
 on:
   repository_dispatch:
-    types: sync-branch
+    types: [sync-branch]
   workflow_dispatch:
     inputs:
       branch_name:

--- a/.github/workflows/twoslash-repros.yaml
+++ b/.github/workflows/twoslash-repros.yaml
@@ -7,7 +7,7 @@ on:
   schedule:
     - cron: '0 8 * * *'
   repository_dispatch:
-    types: run-twoslash-repros
+    types: [run-twoslash-repros]
   workflow_dispatch:
     inputs:
       issue:


### PR DESCRIPTION
At some point, this was a string, but it's been an array for a while and the GHA extension complains.