### PR TITLE
Fix cherry-pick job for unmerged PRs

### DIFF
--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -66,7 +66,7 @@ jobs:
             await exec.exec("git", ["config", "user.name", "TypeScript Bot"]);
             await exec.exec("git", ["switch", "--detach", `origin/${TARGET_BRANCH}`]);
             await exec.exec("git", ["switch", "-c", pickBranch]);
-            await exec.exec("git", ["cherry-pick", pr.data.merge_commit_sha]);
+            await exec.exec("git", ["cherry-pick", "-m", "-1", pr.data.merge_commit_sha]);
             await exec.exec("git", ["push", "--force", "--set-upstream", "origin", pickBranch]);
 
             const existingPulls = await github.rest.pulls.list({


### PR DESCRIPTION
When running this task on an unmerged PR, it will be using the merge commit that GitHub generates for every PR. You can't cherry-pick a merge commit without telling it which side of the merge is the intended base. So, the job fails with:

```
/usr/bin/git config user.email typescriptbot@microsoft.com
/usr/bin/git config user.name TypeScript Bot
/usr/bin/git switch --detach origin/release-5.3
HEAD is now at b4fe221e65 Cherry-pick #56489 into release-5.3 (#56490)
/usr/bin/git switch -c cherry-pick/56504/release-5.3
Switched to a new branch 'cherry-pick/56504/release-5.3'
/usr/bin/git cherry-pick dbd9bbb928adbe9e21cbbd8947729e206e463bcc
error: commit dbd9bbb928adbe9e21cbbd8947729e206e463bcc is a merge but no -m option was given.
fatal: cherry-pick failed
Error: The process '/usr/bin/git' failed with exit code 128
```

By specifying `-m 1`, we can tell git that `HEAD^1` is the merge base (i.e. main), and the cherry-pick will work.