### PR TITLE
fix(42220): Missing 'used before declaration' for class expression used in own computed property name

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2831,7 +2831,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // still might be illegal if usage is in the initializer of the variable declaration (eg var a = a)
                 return !isImmediatelyUsedInInitializerOfBlockScopedVariable(declaration as VariableDeclaration, usage);
             }
-            else if (isClassDeclaration(declaration)) {
+            else if (isClassLike(declaration)) {
                 // still might be illegal if the usage is within a computed property name in the class (eg class A { static p = "a"; [A.p]() {} })
                 return !findAncestor(usage, n => isComputedPropertyName(n) && n.parent.parent === declaration);
             }

--- a/tests/baselines/reference/computedPropertyNamesWithStaticProperty.errors.txt
+++ b/tests/baselines/reference/computedPropertyNamesWithStaticProperty.errors.txt
@@ -1,25 +1,49 @@
-computedPropertyNamesWithStaticProperty.ts(3,10): error TS2449: Class 'C' used before its declaration.
-computedPropertyNamesWithStaticProperty.ts(6,10): error TS2449: Class 'C' used before its declaration.
-computedPropertyNamesWithStaticProperty.ts(9,6): error TS2449: Class 'C' used before its declaration.
+computedPropertyNamesWithStaticProperty.ts(3,10): error TS2449: Class 'C1' used before its declaration.
+computedPropertyNamesWithStaticProperty.ts(6,10): error TS2449: Class 'C1' used before its declaration.
+computedPropertyNamesWithStaticProperty.ts(9,6): error TS2449: Class 'C1' used before its declaration.
+computedPropertyNamesWithStaticProperty.ts(14,10): error TS2449: Class 'C2' used before its declaration.
+computedPropertyNamesWithStaticProperty.ts(17,10): error TS2449: Class 'C2' used before its declaration.
+computedPropertyNamesWithStaticProperty.ts(20,6): error TS2449: Class 'C2' used before its declaration.
 
 
-==== computedPropertyNamesWithStaticProperty.ts (3 errors) ====
-    class C {
+==== computedPropertyNamesWithStaticProperty.ts (6 errors) ====
+    class C1 {
         static staticProp = 10;
-        get [C.staticProp]() {
-             ~
-!!! error TS2449: Class 'C' used before its declaration.
-!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:1:7: 'C' is declared here.
+        get [C1.staticProp]() {
+             ~~
+!!! error TS2449: Class 'C1' used before its declaration.
+!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:1:7: 'C1' is declared here.
             return "hello";
         }
-        set [C.staticProp](x: string) {
-             ~
-!!! error TS2449: Class 'C' used before its declaration.
-!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:1:7: 'C' is declared here.
+        set [C1.staticProp](x: string) {
+             ~~
+!!! error TS2449: Class 'C1' used before its declaration.
+!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:1:7: 'C1' is declared here.
             var y = x;
         }
-        [C.staticProp]() { }
-         ~
-!!! error TS2449: Class 'C' used before its declaration.
-!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:1:7: 'C' is declared here.
+        [C1.staticProp]() { }
+         ~~
+!!! error TS2449: Class 'C1' used before its declaration.
+!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:1:7: 'C1' is declared here.
     }
+    
+    (class C2 {
+        static staticProp = 10;
+        get [C2.staticProp]() {
+             ~~
+!!! error TS2449: Class 'C2' used before its declaration.
+!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:12:8: 'C2' is declared here.
+            return "hello";
+        }
+        set [C2.staticProp](x: string) {
+             ~~
+!!! error TS2449: Class 'C2' used before its declaration.
+!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:12:8: 'C2' is declared here.
+            var y = x;
+        }
+        [C2.staticProp]() { }
+         ~~
+!!! error TS2449: Class 'C2' used before its declaration.
+!!! related TS2728 computedPropertyNamesWithStaticProperty.ts:12:8: 'C2' is declared here.
+    })
+    

--- a/tests/baselines/reference/computedPropertyNamesWithStaticProperty.js
+++ b/tests/baselines/reference/computedPropertyNamesWithStaticProperty.js
@@ -1,25 +1,49 @@
 //// [tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts] ////
 
 //// [computedPropertyNamesWithStaticProperty.ts]
-class C {
+class C1 {
     static staticProp = 10;
-    get [C.staticProp]() {
+    get [C1.staticProp]() {
         return "hello";
     }
-    set [C.staticProp](x: string) {
+    set [C1.staticProp](x: string) {
         var y = x;
     }
-    [C.staticProp]() { }
+    [C1.staticProp]() { }
 }
 
-//// [computedPropertyNamesWithStaticProperty.js]
-class C {
-    get [C.staticProp]() {
+(class C2 {
+    static staticProp = 10;
+    get [C2.staticProp]() {
         return "hello";
     }
-    set [C.staticProp](x) {
+    set [C2.staticProp](x: string) {
         var y = x;
     }
-    [C.staticProp]() { }
+    [C2.staticProp]() { }
+})
+
+
+//// [computedPropertyNamesWithStaticProperty.js]
+var _a;
+class C1 {
+    get [C1.staticProp]() {
+        return "hello";
+    }
+    set [C1.staticProp](x) {
+        var y = x;
+    }
+    [C1.staticProp]() { }
 }
-C.staticProp = 10;
+C1.staticProp = 10;
+(_a = class C2 {
+        get [C2.staticProp]() {
+            return "hello";
+        }
+        set [C2.staticProp](x) {
+            var y = x;
+        }
+        [C2.staticProp]() { }
+    },
+    _a.staticProp = 10,
+    _a);

--- a/tests/baselines/reference/computedPropertyNamesWithStaticProperty.symbols
+++ b/tests/baselines/reference/computedPropertyNamesWithStaticProperty.symbols
@@ -1,34 +1,68 @@
 //// [tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts] ////
 
 === computedPropertyNamesWithStaticProperty.ts ===
-class C {
->C : Symbol(C, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
+class C1 {
+>C1 : Symbol(C1, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
 
     static staticProp = 10;
->staticProp : Symbol(C.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 9))
+>staticProp : Symbol(C1.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 10))
 
-    get [C.staticProp]() {
->[C.staticProp] : Symbol(C[C.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 1, 27))
->C.staticProp : Symbol(C.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 9))
->C : Symbol(C, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
->staticProp : Symbol(C.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 9))
+    get [C1.staticProp]() {
+>[C1.staticProp] : Symbol(C1[C1.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 1, 27))
+>C1.staticProp : Symbol(C1.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 10))
+>C1 : Symbol(C1, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
+>staticProp : Symbol(C1.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 10))
 
         return "hello";
     }
-    set [C.staticProp](x: string) {
->[C.staticProp] : Symbol(C[C.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 4, 5))
->C.staticProp : Symbol(C.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 9))
->C : Symbol(C, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
->staticProp : Symbol(C.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 9))
->x : Symbol(x, Decl(computedPropertyNamesWithStaticProperty.ts, 5, 23))
+    set [C1.staticProp](x: string) {
+>[C1.staticProp] : Symbol(C1[C1.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 4, 5))
+>C1.staticProp : Symbol(C1.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 10))
+>C1 : Symbol(C1, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
+>staticProp : Symbol(C1.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 10))
+>x : Symbol(x, Decl(computedPropertyNamesWithStaticProperty.ts, 5, 24))
 
         var y = x;
 >y : Symbol(y, Decl(computedPropertyNamesWithStaticProperty.ts, 6, 11))
->x : Symbol(x, Decl(computedPropertyNamesWithStaticProperty.ts, 5, 23))
+>x : Symbol(x, Decl(computedPropertyNamesWithStaticProperty.ts, 5, 24))
     }
-    [C.staticProp]() { }
->[C.staticProp] : Symbol(C[C.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 7, 5))
->C.staticProp : Symbol(C.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 9))
->C : Symbol(C, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
->staticProp : Symbol(C.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 9))
+    [C1.staticProp]() { }
+>[C1.staticProp] : Symbol(C1[C1.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 7, 5))
+>C1.staticProp : Symbol(C1.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 10))
+>C1 : Symbol(C1, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 0))
+>staticProp : Symbol(C1.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 0, 10))
 }
+
+(class C2 {
+>C2 : Symbol(C2, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 1))
+
+    static staticProp = 10;
+>staticProp : Symbol(C2.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 11))
+
+    get [C2.staticProp]() {
+>[C2.staticProp] : Symbol(C2[C2.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 12, 27))
+>C2.staticProp : Symbol(C2.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 11))
+>C2 : Symbol(C2, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 1))
+>staticProp : Symbol(C2.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 11))
+
+        return "hello";
+    }
+    set [C2.staticProp](x: string) {
+>[C2.staticProp] : Symbol(C2[C2.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 15, 5))
+>C2.staticProp : Symbol(C2.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 11))
+>C2 : Symbol(C2, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 1))
+>staticProp : Symbol(C2.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 11))
+>x : Symbol(x, Decl(computedPropertyNamesWithStaticProperty.ts, 16, 24))
+
+        var y = x;
+>y : Symbol(y, Decl(computedPropertyNamesWithStaticProperty.ts, 17, 11))
+>x : Symbol(x, Decl(computedPropertyNamesWithStaticProperty.ts, 16, 24))
+    }
+    [C2.staticProp]() { }
+>[C2.staticProp] : Symbol(C2[C2.staticProp], Decl(computedPropertyNamesWithStaticProperty.ts, 18, 5))
+>C2.staticProp : Symbol(C2.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 11))
+>C2 : Symbol(C2, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 1))
+>staticProp : Symbol(C2.staticProp, Decl(computedPropertyNamesWithStaticProperty.ts, 11, 11))
+
+})
+

--- a/tests/baselines/reference/computedPropertyNamesWithStaticProperty.types
+++ b/tests/baselines/reference/computedPropertyNamesWithStaticProperty.types
@@ -1,26 +1,26 @@
 //// [tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts] ////
 
 === computedPropertyNamesWithStaticProperty.ts ===
-class C {
->C : C
+class C1 {
+>C1 : C1
 
     static staticProp = 10;
 >staticProp : number
 >10 : 10
 
-    get [C.staticProp]() {
->[C.staticProp] : string
->C.staticProp : number
->C : typeof C
+    get [C1.staticProp]() {
+>[C1.staticProp] : string
+>C1.staticProp : number
+>C1 : typeof C1
 >staticProp : number
 
         return "hello";
 >"hello" : "hello"
     }
-    set [C.staticProp](x: string) {
->[C.staticProp] : string
->C.staticProp : number
->C : typeof C
+    set [C1.staticProp](x: string) {
+>[C1.staticProp] : string
+>C1.staticProp : number
+>C1 : typeof C1
 >staticProp : number
 >x : string
 
@@ -28,9 +28,47 @@ class C {
 >y : string
 >x : string
     }
-    [C.staticProp]() { }
->[C.staticProp] : () => void
->C.staticProp : number
->C : typeof C
+    [C1.staticProp]() { }
+>[C1.staticProp] : () => void
+>C1.staticProp : number
+>C1 : typeof C1
 >staticProp : number
 }
+
+(class C2 {
+>(class C2 {    static staticProp = 10;    get [C2.staticProp]() {        return "hello";    }    set [C2.staticProp](x: string) {        var y = x;    }    [C2.staticProp]() { }}) : typeof C2
+>class C2 {    static staticProp = 10;    get [C2.staticProp]() {        return "hello";    }    set [C2.staticProp](x: string) {        var y = x;    }    [C2.staticProp]() { }} : typeof C2
+>C2 : typeof C2
+
+    static staticProp = 10;
+>staticProp : number
+>10 : 10
+
+    get [C2.staticProp]() {
+>[C2.staticProp] : string
+>C2.staticProp : number
+>C2 : typeof C2
+>staticProp : number
+
+        return "hello";
+>"hello" : "hello"
+    }
+    set [C2.staticProp](x: string) {
+>[C2.staticProp] : string
+>C2.staticProp : number
+>C2 : typeof C2
+>staticProp : number
+>x : string
+
+        var y = x;
+>y : string
+>x : string
+    }
+    [C2.staticProp]() { }
+>[C2.staticProp] : () => void
+>C2.staticProp : number
+>C2 : typeof C2
+>staticProp : number
+
+})
+

--- a/tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts
+++ b/tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts
@@ -1,11 +1,22 @@
 // @target: es6
-class C {
+class C1 {
     static staticProp = 10;
-    get [C.staticProp]() {
+    get [C1.staticProp]() {
         return "hello";
     }
-    set [C.staticProp](x: string) {
+    set [C1.staticProp](x: string) {
         var y = x;
     }
-    [C.staticProp]() { }
+    [C1.staticProp]() { }
 }
+
+(class C2 {
+    static staticProp = 10;
+    get [C2.staticProp]() {
+        return "hello";
+    }
+    set [C2.staticProp](x: string) {
+        var y = x;
+    }
+    [C2.staticProp]() { }
+})


### PR DESCRIPTION
Fixes #42220