### PR TITLE
fix(49419): Referencing this through a variable causes "Rename Symbol" to misbehave in Javascript

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -46727,9 +46727,13 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             case AssignmentDeclarationKind.ExportsProperty:
             case AssignmentDeclarationKind.PrototypeProperty:
                 return getSymbolOfNode(entityName.parent);
+            case AssignmentDeclarationKind.Property:
+                if (isPropertyAccessExpression(entityName.parent) && getLeftmostAccessExpression(entityName.parent) === entityName) {
+                    return undefined;
+                }
+                // falls through
             case AssignmentDeclarationKind.ThisProperty:
             case AssignmentDeclarationKind.ModuleExports:
-            case AssignmentDeclarationKind.Property:
                 return getSymbolOfDeclaration(entityName.parent.parent as BinaryExpression);
         }
     }

--- a/tests/baselines/reference/inferringClassMembersFromAssignments6.symbols
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments6.symbols
@@ -10,12 +10,12 @@ function Foonly() {
 
     self.x = 1
 >self.x : Symbol(Foonly.x, Decl(inferringClassMembersFromAssignments6.js, 1, 19))
->self : Symbol(Foonly.x, Decl(inferringClassMembersFromAssignments6.js, 1, 19))
+>self : Symbol(self, Decl(inferringClassMembersFromAssignments6.js, 1, 7))
 >x : Symbol(Foonly.x, Decl(inferringClassMembersFromAssignments6.js, 1, 19))
 
     self.m = function() {
 >self.m : Symbol(Foonly.m, Decl(inferringClassMembersFromAssignments6.js, 2, 14))
->self : Symbol(Foonly.m, Decl(inferringClassMembersFromAssignments6.js, 2, 14))
+>self : Symbol(self, Decl(inferringClassMembersFromAssignments6.js, 1, 7))
 >m : Symbol(Foonly.m, Decl(inferringClassMembersFromAssignments6.js, 2, 14))
 
         console.log(self.x)
@@ -39,7 +39,7 @@ Foonly.prototype.mreal = function() {
 
     self.y = 2
 >self.y : Symbol(Foonly.y, Decl(inferringClassMembersFromAssignments6.js, 8, 19))
->self : Symbol(Foonly.y, Decl(inferringClassMembersFromAssignments6.js, 8, 19))
+>self : Symbol(self, Decl(inferringClassMembersFromAssignments6.js, 8, 7))
 >y : Symbol(Foonly.y, Decl(inferringClassMembersFromAssignments6.js, 8, 19))
 }
 const foo = new Foonly()

--- a/tests/baselines/reference/inferringClassMembersFromAssignments7.symbols
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments7.symbols
@@ -11,12 +11,12 @@ class C {
 
         self.x = 1
 >self.x : Symbol(C.x, Decl(inferringClassMembersFromAssignments7.js, 2, 23))
->self : Symbol(C.x, Decl(inferringClassMembersFromAssignments7.js, 2, 23))
+>self : Symbol(self, Decl(inferringClassMembersFromAssignments7.js, 2, 11))
 >x : Symbol(C.x, Decl(inferringClassMembersFromAssignments7.js, 2, 23))
 
         self.m = function() {
 >self.m : Symbol(C.m, Decl(inferringClassMembersFromAssignments7.js, 3, 18))
->self : Symbol(C.m, Decl(inferringClassMembersFromAssignments7.js, 3, 18))
+>self : Symbol(self, Decl(inferringClassMembersFromAssignments7.js, 2, 11))
 >m : Symbol(C.m, Decl(inferringClassMembersFromAssignments7.js, 3, 18))
 
             console.log(self.x)
@@ -37,7 +37,7 @@ class C {
 
         self.y = 2
 >self.y : Symbol(C.y, Decl(inferringClassMembersFromAssignments7.js, 9, 23))
->self : Symbol(C.y, Decl(inferringClassMembersFromAssignments7.js, 9, 23))
+>self : Symbol(self, Decl(inferringClassMembersFromAssignments7.js, 9, 11))
 >y : Symbol(C.y, Decl(inferringClassMembersFromAssignments7.js, 9, 23))
     }
 }

--- a/tests/baselines/reference/renameJsPropertyAssignment4.baseline.jsonc
+++ b/tests/baselines/reference/renameJsPropertyAssignment4.baseline.jsonc
@@ -1,0 +1,15 @@
+// === findRenameLocations ===
+// === /a.js ===
+// function f() {
+//    <|var /*RENAME*/[|fooRENAME|] = this;|>
+//    <|[|fooRENAME|].x = 1;|>
+// }
+
+
+
+// === findRenameLocations ===
+// === /a.js ===
+// function f() {
+//    <|var [|fooRENAME|] = this;|>
+//    /*RENAME*/<|[|fooRENAME|].x = 1;|>
+// }

--- a/tests/baselines/reference/typeFromPropertyAssignment10.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment10.symbols
@@ -93,7 +93,7 @@ Outer.app.Application = (function () {
 
         me.view = new Outer.app.SomeView();
 >me.view : Symbol(Application.view, Decl(application.js, 7, 22))
->me : Symbol(Application.view, Decl(application.js, 7, 22))
+>me : Symbol(me, Decl(application.js, 7, 11))
 >view : Symbol(Application.view, Decl(application.js, 7, 22))
 >Outer.app.SomeView : Symbol(Outer.app.SomeView, Decl(someview.js, 0, 0))
 >Outer.app : Symbol(Outer.app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(someview.js, 6, 6), Decl(someview.js, 15, 6), Decl(application.js, 0, 6))

--- a/tests/baselines/reference/typeFromPropertyAssignment10_1.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment10_1.symbols
@@ -93,7 +93,7 @@ Outer.app.Application = (function () {
 
         me.view = new Outer.app.SomeView();
 >me.view : Symbol(Application.view, Decl(application.js, 7, 22))
->me : Symbol(Application.view, Decl(application.js, 7, 22))
+>me : Symbol(me, Decl(application.js, 7, 11))
 >view : Symbol(Application.view, Decl(application.js, 7, 22))
 >Outer.app.SomeView : Symbol(Outer.app.SomeView, Decl(someview.js, 0, 0))
 >Outer.app : Symbol(Outer.app, Decl(module.js, 0, 24), Decl(someview.js, 0, 6), Decl(someview.js, 6, 6), Decl(someview.js, 15, 6), Decl(application.js, 0, 6))

--- a/tests/baselines/reference/typeFromPropertyAssignment40.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment40.symbols
@@ -10,7 +10,7 @@ function Outer() {
 
     self.y = 2
 >self.y : Symbol(Outer.y, Decl(typeFromPropertyAssignment40.js, 1, 19))
->self : Symbol(Outer.y, Decl(typeFromPropertyAssignment40.js, 1, 19))
+>self : Symbol(self, Decl(typeFromPropertyAssignment40.js, 1, 7))
 >y : Symbol(Outer.y, Decl(typeFromPropertyAssignment40.js, 1, 19))
 }
 /** @type {Outer} */

--- a/tests/baselines/reference/typeFromPropertyAssignment9.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment9.symbols
@@ -46,7 +46,7 @@ my.predicate.query = function () {
 
     me.property = false;
 >me.property : Symbol(query.property, Decl(a.js, 9, 18))
->me : Symbol(query.property, Decl(a.js, 9, 18))
+>me : Symbol(me, Decl(a.js, 9, 7))
 >property : Symbol(query.property, Decl(a.js, 9, 18))
 
 };

--- a/tests/baselines/reference/typeFromPropertyAssignment9_1.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment9_1.symbols
@@ -46,7 +46,7 @@ my.predicate.query = function () {
 
     me.property = false;
 >me.property : Symbol(query.property, Decl(a.js, 9, 18))
->me : Symbol(query.property, Decl(a.js, 9, 18))
+>me : Symbol(me, Decl(a.js, 9, 7))
 >property : Symbol(query.property, Decl(a.js, 9, 18))
 
 };

--- a/tests/cases/fourslash/renameJsPropertyAssignment4.ts
+++ b/tests/cases/fourslash/renameJsPropertyAssignment4.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @Filename: /a.js
+////function f() {
+////   var /*1*/foo = this;
+////   /*2*/foo.x = 1;
+////}
+
+goTo.file("/a.js")
+verify.baselineRename(["1", "2"]);


### PR DESCRIPTION
Fixes #49419