### PR TITLE
fix(56567): import type from = require('foo') fails to parse

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7498,8 +7498,9 @@ namespace Parser {
         return nextToken() === SyntaxKind.StringLiteral;
     }
 
-    function nextTokenIsFromKeyword() {
-        return nextToken() === SyntaxKind.FromKeyword;
+    function nextTokenIsFromKeywordOrEqualsToken() {
+        nextToken();
+        return token() === SyntaxKind.FromKeyword || token() == SyntaxKind.EqualsToken;
     }
 
     function nextTokenIsIdentifierOrStringLiteralOnSameLine() {
@@ -8335,7 +8336,7 @@ namespace Parser {
         let isTypeOnly = false;
         if (
             identifier?.escapedText === "type" &&
-            (token() !== SyntaxKind.FromKeyword || isIdentifier() && lookAhead(nextTokenIsFromKeyword)) &&
+            (token() !== SyntaxKind.FromKeyword || isIdentifier() && lookAhead(nextTokenIsFromKeywordOrEqualsToken)) &&
             (isIdentifier() || tokenAfterImportDefinitelyProducesImportDeclaration())
         ) {
             isTypeOnly = true;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7500,7 +7500,7 @@ namespace Parser {
 
     function nextTokenIsFromKeywordOrEqualsToken() {
         nextToken();
-        return token() === SyntaxKind.FromKeyword || token() == SyntaxKind.EqualsToken;
+        return token() === SyntaxKind.FromKeyword || token() === SyntaxKind.EqualsToken;
     }
 
     function nextTokenIsIdentifierOrStringLiteralOnSameLine() {

--- a/tests/baselines/reference/importDefaultNamedType3.js
+++ b/tests/baselines/reference/importDefaultNamedType3.js
@@ -1,0 +1,22 @@
+//// [tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts] ////
+
+//// [a.ts]
+export class A {}
+
+//// [b.ts]
+import type from = require('./a');
+
+
+//// [a.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.A = void 0;
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+exports.A = A;
+//// [b.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/importDefaultNamedType3.symbols
+++ b/tests/baselines/reference/importDefaultNamedType3.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts] ////
+
+=== /b.ts ===
+import type from = require('./a');
+>from : Symbol(from, Decl(b.ts, 0, 0))
+
+=== /a.ts ===
+export class A {}
+>A : Symbol(A, Decl(a.ts, 0, 0))
+

--- a/tests/baselines/reference/importDefaultNamedType3.types
+++ b/tests/baselines/reference/importDefaultNamedType3.types
@@ -1,0 +1,10 @@
+//// [tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts] ////
+
+=== /b.ts ===
+import type from = require('./a');
+>from : typeof from
+
+=== /a.ts ===
+export class A {}
+>A : A
+

--- a/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts
@@ -1,0 +1,5 @@
+// @Filename: /a.ts
+export class A {}
+
+// @Filename: /b.ts
+import type from = require('./a');


### PR DESCRIPTION
Fixes #56567