### PR TITLE
Always emit `Object` type in decorator metadata for import type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -47787,28 +47787,35 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             isTypeOnly = !!rootValueSymbol?.declarations?.every(isTypeOnlyImportOrExportDeclaration);
         }
         const valueSymbol = resolveEntityName(typeName, SymbolFlags.Value, /*ignoreErrors*/ true, /*dontResolveAlias*/ true, location);
-        const resolvedSymbol = valueSymbol && valueSymbol.flags & SymbolFlags.Alias ? resolveAlias(valueSymbol) : valueSymbol;
+        const resolvedValueSymbol = valueSymbol && valueSymbol.flags & SymbolFlags.Alias ? resolveAlias(valueSymbol) : valueSymbol;
         isTypeOnly ||= !!(valueSymbol && getTypeOnlyAliasDeclaration(valueSymbol, SymbolFlags.Value));
 
         // Resolve the symbol as a type so that we can provide a more useful hint for the type serializer.
-        const typeSymbol = resolveEntityName(typeName, SymbolFlags.Type, /*ignoreErrors*/ true, /*dontResolveAlias*/ false, location);
-        if (resolvedSymbol && resolvedSymbol === typeSymbol) {
+        const typeSymbol = resolveEntityName(typeName, SymbolFlags.Type, /*ignoreErrors*/ true, /*dontResolveAlias*/ true, location);
+        const resolvedTypeSymbol = typeSymbol && typeSymbol.flags & SymbolFlags.Alias ? resolveAlias(typeSymbol) : typeSymbol;
+
+        // In case the value symbol can't be resolved (e.g. because of missing declarations), use type symbol for reachability check.
+        if (!valueSymbol) {
+            isTypeOnly ||= !!(typeSymbol && getTypeOnlyAliasDeclaration(typeSymbol, SymbolFlags.Type));
+        }
+
+        if (resolvedValueSymbol && resolvedValueSymbol === resolvedTypeSymbol) {
             const globalPromiseSymbol = getGlobalPromiseConstructorSymbol(/*reportErrors*/ false);
-            if (globalPromiseSymbol && resolvedSymbol === globalPromiseSymbol) {
+            if (globalPromiseSymbol && resolvedValueSymbol === globalPromiseSymbol) {
                 return TypeReferenceSerializationKind.Promise;
             }
 
-            const constructorType = getTypeOfSymbol(resolvedSymbol);
+            const constructorType = getTypeOfSymbol(resolvedValueSymbol);
             if (constructorType && isConstructorType(constructorType)) {
                 return isTypeOnly ? TypeReferenceSerializationKind.TypeWithCallSignature : TypeReferenceSerializationKind.TypeWithConstructSignatureAndValue;
             }
         }
 
         // We might not be able to resolve type symbol so use unknown type in that case (eg error case)
-        if (!typeSymbol) {
+        if (!resolvedTypeSymbol) {
             return isTypeOnly ? TypeReferenceSerializationKind.ObjectType : TypeReferenceSerializationKind.Unknown;
         }
-        const type = getDeclaredTypeOfSymbol(typeSymbol);
+        const type = getDeclaredTypeOfSymbol(resolvedTypeSymbol);
         if (isErrorType(type)) {
             return isTypeOnly ? TypeReferenceSerializationKind.ObjectType : TypeReferenceSerializationKind.Unknown;
         }

--- a/tests/baselines/reference/decoratorMetadataTypeOnlyImport.errors.txt
+++ b/tests/baselines/reference/decoratorMetadataTypeOnlyImport.errors.txt
@@ -1,0 +1,18 @@
+a.ts(1,22): error TS2307: Cannot find module 'unknown-module' or its corresponding type declarations.
+
+
+==== ./a.ts (1 errors) ====
+    import { List } from 'unknown-module';
+                         ~~~~~~~~~~~~~~~~
+!!! error TS2307: Cannot find module 'unknown-module' or its corresponding type declarations.
+    export type MyList = List<number>;
+    
+==== ./b.ts (0 errors) ====
+    import { type MyList } from './a';
+    
+    declare var Decorator: any;
+    
+    class Foo {
+      @Decorator myList?: MyList;
+    }
+    

--- a/tests/baselines/reference/decoratorMetadataTypeOnlyImport.js
+++ b/tests/baselines/reference/decoratorMetadataTypeOnlyImport.js
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts] ////
+
+//// [a.ts]
+import { List } from 'unknown-module';
+export type MyList = List<number>;
+
+//// [b.ts]
+import { type MyList } from './a';
+
+declare var Decorator: any;
+
+class Foo {
+  @Decorator myList?: MyList;
+}
+
+
+//// [a.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//// [b.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    __decorate([
+        Decorator,
+        __metadata("design:type", Object)
+    ], Foo.prototype, "myList", void 0);
+    return Foo;
+}());

--- a/tests/baselines/reference/decoratorMetadataTypeOnlyImport.symbols
+++ b/tests/baselines/reference/decoratorMetadataTypeOnlyImport.symbols
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts] ////
+
+=== ./a.ts ===
+import { List } from 'unknown-module';
+>List : Symbol(List, Decl(a.ts, 0, 8))
+
+export type MyList = List<number>;
+>MyList : Symbol(MyList, Decl(a.ts, 0, 38))
+>List : Symbol(List, Decl(a.ts, 0, 8))
+
+=== ./b.ts ===
+import { type MyList } from './a';
+>MyList : Symbol(MyList, Decl(b.ts, 0, 8))
+
+declare var Decorator: any;
+>Decorator : Symbol(Decorator, Decl(b.ts, 2, 11))
+
+class Foo {
+>Foo : Symbol(Foo, Decl(b.ts, 2, 27))
+
+  @Decorator myList?: MyList;
+>Decorator : Symbol(Decorator, Decl(b.ts, 2, 11))
+>myList : Symbol(Foo.myList, Decl(b.ts, 4, 11))
+>MyList : Symbol(MyList, Decl(b.ts, 0, 8))
+}
+

--- a/tests/baselines/reference/decoratorMetadataTypeOnlyImport.types
+++ b/tests/baselines/reference/decoratorMetadataTypeOnlyImport.types
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts] ////
+
+=== ./a.ts ===
+import { List } from 'unknown-module';
+>List : any
+
+export type MyList = List<number>;
+>MyList : List<number>
+
+=== ./b.ts ===
+import { type MyList } from './a';
+>MyList : any
+
+declare var Decorator: any;
+>Decorator : any
+
+class Foo {
+>Foo : Foo
+
+  @Decorator myList?: MyList;
+>Decorator : any
+>myList : List<number>
+}
+

--- a/tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts
+++ b/tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts
@@ -1,0 +1,15 @@
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+
+// @filename: ./a.ts
+import { List } from 'unknown-module';
+export type MyList = List<number>;
+
+// @filename: ./b.ts
+import { type MyList } from './a';
+
+declare var Decorator: any;
+
+class Foo {
+  @Decorator myList?: MyList;
+}


### PR DESCRIPTION
Always emit `Object` type in legacy decorator metadata for identifiers imported with `import type`, even if the type is only partially resolved.

<details>
<summary>
Without the fix, the added test case shows the following emit:
</summary>

```js
//// [tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts] ////

//// [a.ts]
import { List } from 'unknown-module';
export type MyList = List<number>;

//// [b.ts]
import { type MyList } from './a';

declare var Decorator: any;

class Foo {
  @Decorator myList?: MyList;
}


//// [a.js]
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
//// [b.js]
"use strict";
var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
    return c > 3 && r && Object.defineProperty(target, key, r), r;
};
var __metadata = (this && this.__metadata) || function (k, v) {
    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
};
Object.defineProperty(exports, "__esModule", { value: true });
var Foo = /** @class */ (function () {
    function Foo() {
    }
    var _a;
    __decorate([
        Decorator,
        __metadata("design:type", typeof (_a = typeof a_1.MyList !== "undefined" && a_1.MyList) === "function" ? _a : Object)
    ], Foo.prototype, "myList", void 0);
    return Foo;
}());
```

</details>

Fixes #56530