### PR TITLE
Try and deal with CodeQL reports on replace("*", ...)

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -89,6 +89,7 @@ import {
     removeExtension,
     removeFileExtension,
     removePrefix,
+    replaceFirstStar,
     ResolutionMode,
     ResolvedModuleWithFailedLookupLocations,
     ResolvedProjectReference,
@@ -2286,8 +2287,8 @@ function loadEntrypointsFromExportMap(
                     /*excludes*/ undefined,
                     [
                         isDeclarationFileName(target)
-                            ? target.replace("*", "**/*")
-                            : changeAnyExtension(target.replace("*", "**/*"), getDeclarationEmitExtensionForPath(target)),
+                            ? replaceFirstStar(target, "**/*")
+                            : changeAnyExtension(replaceFirstStar(target, "**/*"), getDeclarationEmitExtensionForPath(target)),
                     ],
                 ).forEach(entry => {
                     entrypoints = appendIfUnique(entrypoints, {
@@ -3096,7 +3097,7 @@ function tryLoadModuleUsingPaths(extensions: Extensions, moduleName: string, bas
             trace(state.host, Diagnostics.Module_name_0_matched_pattern_1, moduleName, matchedPatternText);
         }
         const resolved = forEach(paths[matchedPatternText], subst => {
-            const path = matchedStar ? subst.replace("*", matchedStar) : subst;
+            const path = matchedStar ? replaceFirstStar(subst, matchedStar) : subst;
             // When baseUrl is not specified, the command line parser resolves relative paths to the config file location.
             const candidate = normalizePath(combinePaths(baseDirectory, path));
             if (state.traceEnabled) {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -89,6 +89,7 @@ import {
     removeExtension,
     removeFileExtension,
     removePrefix,
+    replaceFirstStar,
     ResolutionMode,
     ResolvedModuleWithFailedLookupLocations,
     ResolvedProjectReference,
@@ -2286,8 +2287,8 @@ function loadEntrypointsFromExportMap(
                     /*excludes*/ undefined,
                     [
                         isDeclarationFileName(target)
-                            ? target.replace("*", () => "**/*")
-                            : changeAnyExtension(target.replace("*", () => "**/*"), getDeclarationEmitExtensionForPath(target)),
+                            ? replaceFirstStar(target, "**/*")
+                            : changeAnyExtension(replaceFirstStar(target, "**/*"), getDeclarationEmitExtensionForPath(target)),
                     ],
                 ).forEach(entry => {
                     entrypoints = appendIfUnique(entrypoints, {
@@ -3096,7 +3097,7 @@ function tryLoadModuleUsingPaths(extensions: Extensions, moduleName: string, bas
             trace(state.host, Diagnostics.Module_name_0_matched_pattern_1, moduleName, matchedPatternText);
         }
         const resolved = forEach(paths[matchedPatternText], subst => {
-            const path = matchedStar ? subst.replace("*", () => matchedStar) : subst;
+            const path = matchedStar ? replaceFirstStar(subst, matchedStar) : subst;
             // When baseUrl is not specified, the command line parser resolves relative paths to the config file location.
             const candidate = normalizePath(combinePaths(baseDirectory, path));
             if (state.traceEnabled) {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -89,7 +89,6 @@ import {
     removeExtension,
     removeFileExtension,
     removePrefix,
-    replaceFirstStar,
     ResolutionMode,
     ResolvedModuleWithFailedLookupLocations,
     ResolvedProjectReference,
@@ -2287,8 +2286,8 @@ function loadEntrypointsFromExportMap(
                     /*excludes*/ undefined,
                     [
                         isDeclarationFileName(target)
-                            ? replaceFirstStar(target, "**/*")
-                            : changeAnyExtension(replaceFirstStar(target, "**/*"), getDeclarationEmitExtensionForPath(target)),
+                            ? target.replace("*", () => "**/*")
+                            : changeAnyExtension(target.replace("*", () => "**/*"), getDeclarationEmitExtensionForPath(target)),
                     ],
                 ).forEach(entry => {
                     entrypoints = appendIfUnique(entrypoints, {
@@ -3097,7 +3096,7 @@ function tryLoadModuleUsingPaths(extensions: Extensions, moduleName: string, bas
             trace(state.host, Diagnostics.Module_name_0_matched_pattern_1, moduleName, matchedPatternText);
         }
         const resolved = forEach(paths[matchedPatternText], subst => {
-            const path = matchedStar ? replaceFirstStar(subst, matchedStar) : subst;
+            const path = matchedStar ? subst.replace("*", () => matchedStar) : subst;
             // When baseUrl is not specified, the command line parser resolves relative paths to the config file location.
             const candidate = normalizePath(combinePaths(baseDirectory, path));
             if (state.traceEnabled) {

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -93,6 +93,7 @@ import {
     removeFileExtension,
     removeSuffix,
     removeTrailingDirectorySeparator,
+    replaceFirstStar,
     ResolutionMode,
     resolvePath,
     ScriptKind,
@@ -810,7 +811,7 @@ function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<rea
                     ) {
                         const matchedStar = value.substring(prefix.length, value.length - suffix.length);
                         if (!pathIsRelative(matchedStar)) {
-                            return key.replace("*", matchedStar);
+                            return replaceFirstStar(key, matchedStar);
                         }
                     }
                 }
@@ -864,11 +865,11 @@ function tryGetModuleNameFromExports(options: CompilerOptions, targetFilePath: s
                 const trailingSlice = pathOrPattern.slice(starPos + 1);
                 if (startsWith(targetFilePath, leadingSlice) && endsWith(targetFilePath, trailingSlice)) {
                     const starReplacement = targetFilePath.slice(leadingSlice.length, targetFilePath.length - trailingSlice.length);
-                    return { moduleFileToTry: packageName.replace("*", starReplacement) };
+                    return { moduleFileToTry: replaceFirstStar(packageName, starReplacement) };
                 }
                 if (extensionSwappedTarget && startsWith(extensionSwappedTarget, leadingSlice) && endsWith(extensionSwappedTarget, trailingSlice)) {
                     const starReplacement = extensionSwappedTarget.slice(leadingSlice.length, extensionSwappedTarget.length - trailingSlice.length);
-                    return { moduleFileToTry: packageName.replace("*", starReplacement) };
+                    return { moduleFileToTry: replaceFirstStar(packageName, starReplacement) };
                 }
                 break;
         }

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -93,7 +93,6 @@ import {
     removeFileExtension,
     removeSuffix,
     removeTrailingDirectorySeparator,
-    replaceFirstStar,
     ResolutionMode,
     resolvePath,
     ScriptKind,
@@ -811,7 +810,7 @@ function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<rea
                     ) {
                         const matchedStar = value.substring(prefix.length, value.length - suffix.length);
                         if (!pathIsRelative(matchedStar)) {
-                            return replaceFirstStar(key, matchedStar);
+                            return key.replace("*", () => matchedStar);
                         }
                     }
                 }
@@ -865,11 +864,11 @@ function tryGetModuleNameFromExports(options: CompilerOptions, targetFilePath: s
                 const trailingSlice = pathOrPattern.slice(starPos + 1);
                 if (startsWith(targetFilePath, leadingSlice) && endsWith(targetFilePath, trailingSlice)) {
                     const starReplacement = targetFilePath.slice(leadingSlice.length, targetFilePath.length - trailingSlice.length);
-                    return { moduleFileToTry: replaceFirstStar(packageName, starReplacement) };
+                    return { moduleFileToTry: packageName.replace("*", () => starReplacement) };
                 }
                 if (extensionSwappedTarget && startsWith(extensionSwappedTarget, leadingSlice) && endsWith(extensionSwappedTarget, trailingSlice)) {
                     const starReplacement = extensionSwappedTarget.slice(leadingSlice.length, extensionSwappedTarget.length - trailingSlice.length);
-                    return { moduleFileToTry: replaceFirstStar(packageName, starReplacement) };
+                    return { moduleFileToTry: packageName.replace("*", () => starReplacement) };
                 }
                 break;
         }

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -93,6 +93,7 @@ import {
     removeFileExtension,
     removeSuffix,
     removeTrailingDirectorySeparator,
+    replaceFirstStar,
     ResolutionMode,
     resolvePath,
     ScriptKind,
@@ -810,7 +811,7 @@ function tryGetModuleNameFromPaths(relativeToBaseUrl: string, paths: MapLike<rea
                     ) {
                         const matchedStar = value.substring(prefix.length, value.length - suffix.length);
                         if (!pathIsRelative(matchedStar)) {
-                            return key.replace("*", () => matchedStar);
+                            return replaceFirstStar(key, matchedStar);
                         }
                     }
                 }
@@ -864,11 +865,11 @@ function tryGetModuleNameFromExports(options: CompilerOptions, targetFilePath: s
                 const trailingSlice = pathOrPattern.slice(starPos + 1);
                 if (startsWith(targetFilePath, leadingSlice) && endsWith(targetFilePath, trailingSlice)) {
                     const starReplacement = targetFilePath.slice(leadingSlice.length, targetFilePath.length - trailingSlice.length);
-                    return { moduleFileToTry: packageName.replace("*", () => starReplacement) };
+                    return { moduleFileToTry: replaceFirstStar(packageName, starReplacement) };
                 }
                 if (extensionSwappedTarget && startsWith(extensionSwappedTarget, leadingSlice) && endsWith(extensionSwappedTarget, trailingSlice)) {
                     const starReplacement = extensionSwappedTarget.slice(leadingSlice.length, extensionSwappedTarget.length - trailingSlice.length);
-                    return { moduleFileToTry: packageName.replace("*", () => starReplacement) };
+                    return { moduleFileToTry: replaceFirstStar(packageName, starReplacement) };
                 }
                 break;
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -10505,3 +10505,14 @@ export function hasResolutionModeOverride(node: ImportTypeNode | ImportDeclarati
     }
     return !!getResolutionModeOverride(node.attributes);
 }
+
+const stringReplace = String.prototype.replace;
+
+/** @internal */
+export function replaceFirstStar(s: string, replacement: string): string {
+    // `s.replace("*", replacement)` triggers CodeQL as they think it's a potentially incorrect string escaping.
+    // See: https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization/
+    // But, we really do want to replace only the first star.
+    // Attempt to defeat this analysis by indirectly calling the method.
+    return stringReplace.call(s, "*", replacement);
+}

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -10506,12 +10506,13 @@ export function hasResolutionModeOverride(node: ImportTypeNode | ImportDeclarati
     return !!getResolutionModeOverride(node.attributes);
 }
 
+const stringReplace = String.prototype.replace;
+
 /** @internal */
 export function replaceFirstStar(s: string, replacement: string): string {
-    // This code triggers CodeQL as they think it's a potentially incorrect string escaping.
+    // `s.replace("*", replacement)` triggers CodeQL as they think it's a potentially incorrect string escaping.
     // See: https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization/
     // But, we really do want to replace only the first star.
-
-    // TODO(jakebailey): Leaving this here to verify that CodeQL complains.
-    return s.replace("*", replacement);
+    // Attempt to defeat this analysis by indirectly calling the method.
+    return stringReplace.call(s, "*", replacement);
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -10505,3 +10505,13 @@ export function hasResolutionModeOverride(node: ImportTypeNode | ImportDeclarati
     }
     return !!getResolutionModeOverride(node.attributes);
 }
+
+/** @internal */
+export function replaceFirstStar(s: string, replacement: string): string {
+    // This code triggers CodeQL as they think it's a potentially incorrect string escaping.
+    // See: https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization/
+    // But, we really do want to replace only the first star.
+    
+    // TODO(jakebailey): Leaving this here to verify that CodeQL complains.
+    return s.replace("*", replacement);
+}

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -10511,7 +10511,7 @@ export function replaceFirstStar(s: string, replacement: string): string {
     // This code triggers CodeQL as they think it's a potentially incorrect string escaping.
     // See: https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization/
     // But, we really do want to replace only the first star.
-    
+
     // TODO(jakebailey): Leaving this here to verify that CodeQL complains.
     return s.replace("*", replacement);
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -10505,14 +10505,3 @@ export function hasResolutionModeOverride(node: ImportTypeNode | ImportDeclarati
     }
     return !!getResolutionModeOverride(node.attributes);
 }
-
-const stringReplace = String.prototype.replace;
-
-/** @internal */
-export function replaceFirstStar(s: string, replacement: string): string {
-    // `s.replace("*", replacement)` triggers CodeQL as they think it's a potentially incorrect string escaping.
-    // See: https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization/
-    // But, we really do want to replace only the first star.
-    // Attempt to defeat this analysis by indirectly calling the method.
-    return stringReplace.call(s, "*", replacement);
-}

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -3393,7 +3393,7 @@ export function quote(sourceFile: SourceFile, preferences: UserPreferences, text
     // Editors can pass in undefined or empty string - we want to infer the preference in those cases.
     const quotePreference = getQuotePreference(sourceFile, preferences);
     const quoted = JSON.stringify(text);
-    return quotePreference === QuotePreference.Single ? `'${stripQuotes(quoted).replace(/'/g, "\\'").replace(/\\"/g, '"')}'` : quoted;
+    return quotePreference === QuotePreference.Single ? `'${stripQuotes(quoted).replace(/'/g, () => "\\'").replace(/\\"/g, '"')}'` : quoted;
 }
 
 /** @internal */


### PR DESCRIPTION
We constantly have to dismiss this warning: https://github.com/microsoft/TypeScript/security/code-scanning/206

But, downstream users are now seeing this if they happen to vendor our code. There must be something we can do to make the code scanner not complain anymore.

~For now, I'm moving this out to a helper to make sure CodeQL is still mad, then will experiment later.~

~Using the replace method directly has tricked CodeQL. Maybe that is enough.~

We already bypassed this elsewhere using an arrow function, so I've done that instead.