### PR TITLE
Don’t emit file references that are already referenced via imports

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -617,6 +617,11 @@ export function transformDeclarations(context: TransformationContext) {
 
         function mapReferencesIntoArray(references: FileReference[], outputFilePath: string): (file: SourceFile) => void {
             return file => {
+                if (exportedModulesFromDeclarationEmit?.includes(file.symbol)) {
+                    // Already have an import declaration resolving to this file
+                    return;
+                }
+
                 let declFileName: string;
                 if (file.isDeclarationFile) { // Neither decl files or js should have their refs changed
                     declFileName = file.fileName;

--- a/tests/baselines/reference/declFileForExportedImport.js
+++ b/tests/baselines/reference/declFileForExportedImport.js
@@ -29,6 +29,5 @@ var z = exports.b.x;
 //// [declFileForExportedImport_0.d.ts]
 export declare var x: number;
 //// [declFileForExportedImport_1.d.ts]
-/// <reference path="declFileForExportedImport_0.d.ts" />
 export import a = require('./declFileForExportedImport_0');
 export import b = a;

--- a/tests/baselines/reference/declarationEmitRedundantTripleSlashModuleAugmentation.js
+++ b/tests/baselines/reference/declarationEmitRedundantTripleSlashModuleAugmentation.js
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/declarationEmitRedundantTripleSlashModuleAugmentation.ts] ////
+
+//// [index.d.ts]
+declare module "foo" {
+    export interface Original {}
+}
+
+//// [augmentation.ts]
+export interface FooOptions {}
+declare module "foo" {
+    export interface Augmentation {}
+}
+
+//// [index.ts]
+import { Original, Augmentation } from "foo";
+import type { FooOptions } from "./augmentation";
+export interface _ {
+    original: Original;
+    augmentation: Augmentation;
+    options: FooOptions;
+}
+
+
+
+
+//// [augmentation.d.ts]
+export interface FooOptions {
+}
+declare module "foo" {
+    interface Augmentation {
+    }
+}
+//// [index.d.ts]
+import { Original, Augmentation } from "foo";
+import type { FooOptions } from "./augmentation";
+export interface _ {
+    original: Original;
+    augmentation: Augmentation;
+    options: FooOptions;
+}

--- a/tests/baselines/reference/importDecl.js
+++ b/tests/baselines/reference/importDecl.js
@@ -210,9 +210,6 @@ export declare function foo(): d;
 import m4 = require("./importDecl_require");
 export declare function foo2(): m4.d;
 //// [importDecl_1.d.ts]
-/// <reference path="importDecl_require.d.ts" />
-/// <reference path="importDecl_require1.d.ts" />
-/// <reference path="importDecl_require2.d.ts" />
 /// <reference path="importDecl_require3.d.ts" />
 /// <reference path="importDecl_require4.d.ts" />
 import m4 = require("./importDecl_require");

--- a/tests/baselines/reference/importDeclarationUsedAsTypeQuery.js
+++ b/tests/baselines/reference/importDeclarationUsedAsTypeQuery.js
@@ -32,6 +32,5 @@ export declare class B {
     id: number;
 }
 //// [importDeclarationUsedAsTypeQuery_1.d.ts]
-/// <reference path="importDeclarationUsedAsTypeQuery_require.d.ts" />
 import a = require('./importDeclarationUsedAsTypeQuery_require');
 export declare var x: typeof a;

--- a/tests/cases/compiler/declarationEmitRedundantTripleSlashModuleAugmentation.ts
+++ b/tests/cases/compiler/declarationEmitRedundantTripleSlashModuleAugmentation.ts
@@ -1,0 +1,24 @@
+// @declaration: true
+// @emitDeclarationOnly: true
+// @noTypesAndSymbols: true
+// @module: nodenext
+
+// @Filename: /node_modules/foo/index.d.ts
+declare module "foo" {
+    export interface Original {}
+}
+
+// @Filename: /augmentation.ts
+export interface FooOptions {}
+declare module "foo" {
+    export interface Augmentation {}
+}
+
+// @Filename: /index.ts
+import { Original, Augmentation } from "foo";
+import type { FooOptions } from "./augmentation";
+export interface _ {
+    original: Original;
+    augmentation: Augmentation;
+    options: FooOptions;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes:

> Just an extra note that TS is adding:
> 
> ```ts
> /// <reference path="../../module/module.d.ts" />
> ```
> 
> even though there also exists a related type import, importing from the same file:
> 
> ```ts
> import type { ModuleOptions } from '../../module/module';
> ```
> 
> So in that case at least the reference looks redundant.

from https://github.com/microsoft/TypeScript/issues/56571#issuecomment-1830869896
