### PR TITLE
fix(56513): Allow Intl locales to be readonly arrays

### DIFF
--- a/src/lib/es2016.intl.d.ts
+++ b/src/lib/es2016.intl.d.ts
@@ -9,5 +9,5 @@ declare namespace Intl {
      * @param locale A list of String values for which to get the canonical locale names
      * @returns An array containing the canonical and validated locale names.
      */
-    function getCanonicalLocales(locale?: string | string[]): string[];
+    function getCanonicalLocales(locale?: string | string[] | Readonly<string[]>): string[];
 }

--- a/src/lib/es2016.intl.d.ts
+++ b/src/lib/es2016.intl.d.ts
@@ -9,5 +9,5 @@ declare namespace Intl {
      * @param locale A list of String values for which to get the canonical locale names
      * @returns An array containing the canonical and validated locale names.
      */
-    function getCanonicalLocales(locale?: string | string[] | Readonly<string[]>): string[];
+    function getCanonicalLocales(locale?: string | readonly string[]): string[];
 }

--- a/src/lib/es2018.intl.d.ts
+++ b/src/lib/es2018.intl.d.ts
@@ -30,9 +30,9 @@ declare namespace Intl {
     }
 
     interface PluralRulesConstructor {
-        new (locales?: string | string[], options?: PluralRulesOptions): PluralRules;
-        (locales?: string | string[], options?: PluralRulesOptions): PluralRules;
-        supportedLocalesOf(locales: string | string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
+        new (locales?: string | string[] | Readonly<string[]>, options?: PluralRulesOptions): PluralRules;
+        (locales?: string | string[] | Readonly<string[]>, options?: PluralRulesOptions): PluralRules;
+        supportedLocalesOf(locales: string | string[] | Readonly<string[]>, options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
     }
 
     const PluralRules: PluralRulesConstructor;

--- a/src/lib/es2018.intl.d.ts
+++ b/src/lib/es2018.intl.d.ts
@@ -30,9 +30,9 @@ declare namespace Intl {
     }
 
     interface PluralRulesConstructor {
-        new (locales?: string | string[] | Readonly<string[]>, options?: PluralRulesOptions): PluralRules;
-        (locales?: string | string[] | Readonly<string[]>, options?: PluralRulesOptions): PluralRules;
-        supportedLocalesOf(locales: string | string[] | Readonly<string[]>, options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
+        new (locales?: string | readonly string[], options?: PluralRulesOptions): PluralRules;
+        (locales?: string | readonly string[], options?: PluralRulesOptions): PluralRules;
+        supportedLocalesOf(locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[];
     }
 
     const PluralRules: PluralRulesConstructor;

--- a/tests/baselines/reference/es2016IntlAPIs.types
+++ b/tests/baselines/reference/es2016IntlAPIs.types
@@ -9,9 +9,9 @@ console.log(Intl.getCanonicalLocales('EN-US'));
 >console : Console
 >log : (...data: any[]) => void
 >Intl.getCanonicalLocales('EN-US') : string[]
->Intl.getCanonicalLocales : (locale?: string | string[]) => string[]
+>Intl.getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
 >Intl : typeof Intl
->getCanonicalLocales : (locale?: string | string[]) => string[]
+>getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
 >'EN-US' : "EN-US"
 
 // Expected output: Array ["en-US"]
@@ -22,9 +22,9 @@ console.log(Intl.getCanonicalLocales(['EN-US', 'Fr']));
 >console : Console
 >log : (...data: any[]) => void
 >Intl.getCanonicalLocales(['EN-US', 'Fr']) : string[]
->Intl.getCanonicalLocales : (locale?: string | string[]) => string[]
+>Intl.getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
 >Intl : typeof Intl
->getCanonicalLocales : (locale?: string | string[]) => string[]
+>getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
 >['EN-US', 'Fr'] : string[]
 >'EN-US' : "EN-US"
 >'Fr' : "Fr"
@@ -34,9 +34,9 @@ console.log(Intl.getCanonicalLocales(['EN-US', 'Fr']));
 try {
   Intl.getCanonicalLocales('EN_US');
 >Intl.getCanonicalLocales('EN_US') : string[]
->Intl.getCanonicalLocales : (locale?: string | string[]) => string[]
+>Intl.getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
 >Intl : typeof Intl
->getCanonicalLocales : (locale?: string | string[]) => string[]
+>getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
 >'EN_US' : "EN_US"
 
 } catch (err) {

--- a/tests/baselines/reference/es2016IntlAPIs.types
+++ b/tests/baselines/reference/es2016IntlAPIs.types
@@ -9,9 +9,9 @@ console.log(Intl.getCanonicalLocales('EN-US'));
 >console : Console
 >log : (...data: any[]) => void
 >Intl.getCanonicalLocales('EN-US') : string[]
->Intl.getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
+>Intl.getCanonicalLocales : (locale?: string | readonly string[]) => string[]
 >Intl : typeof Intl
->getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
+>getCanonicalLocales : (locale?: string | readonly string[]) => string[]
 >'EN-US' : "EN-US"
 
 // Expected output: Array ["en-US"]
@@ -22,9 +22,9 @@ console.log(Intl.getCanonicalLocales(['EN-US', 'Fr']));
 >console : Console
 >log : (...data: any[]) => void
 >Intl.getCanonicalLocales(['EN-US', 'Fr']) : string[]
->Intl.getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
+>Intl.getCanonicalLocales : (locale?: string | readonly string[]) => string[]
 >Intl : typeof Intl
->getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
+>getCanonicalLocales : (locale?: string | readonly string[]) => string[]
 >['EN-US', 'Fr'] : string[]
 >'EN-US' : "EN-US"
 >'Fr' : "Fr"
@@ -34,9 +34,9 @@ console.log(Intl.getCanonicalLocales(['EN-US', 'Fr']));
 try {
   Intl.getCanonicalLocales('EN_US');
 >Intl.getCanonicalLocales('EN_US') : string[]
->Intl.getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
+>Intl.getCanonicalLocales : (locale?: string | readonly string[]) => string[]
 >Intl : typeof Intl
->getCanonicalLocales : (locale?: string | string[] | readonly string[]) => string[]
+>getCanonicalLocales : (locale?: string | readonly string[]) => string[]
 >'EN_US' : "EN_US"
 
 } catch (err) {

--- a/tests/baselines/reference/es2018IntlAPIs.types
+++ b/tests/baselines/reference/es2018IntlAPIs.types
@@ -25,11 +25,11 @@ console.log(Intl.PluralRules.supportedLocalesOf(locales, options).join(', '));
 >Intl.PluralRules.supportedLocalesOf(locales, options).join(', ') : string
 >Intl.PluralRules.supportedLocalesOf(locales, options).join : (separator?: string) => string
 >Intl.PluralRules.supportedLocalesOf(locales, options) : string[]
->Intl.PluralRules.supportedLocalesOf : (locales: string | string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
+>Intl.PluralRules.supportedLocalesOf : (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
 >Intl.PluralRules : Intl.PluralRulesConstructor
 >Intl : typeof Intl
 >PluralRules : Intl.PluralRulesConstructor
->supportedLocalesOf : (locales: string | string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
+>supportedLocalesOf : (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
 >locales : string[]
 >options : { readonly localeMatcher: "lookup"; }
 >join : (separator?: string) => string

--- a/tests/baselines/reference/es2018IntlAPIs.types
+++ b/tests/baselines/reference/es2018IntlAPIs.types
@@ -25,11 +25,11 @@ console.log(Intl.PluralRules.supportedLocalesOf(locales, options).join(', '));
 >Intl.PluralRules.supportedLocalesOf(locales, options).join(', ') : string
 >Intl.PluralRules.supportedLocalesOf(locales, options).join : (separator?: string) => string
 >Intl.PluralRules.supportedLocalesOf(locales, options) : string[]
->Intl.PluralRules.supportedLocalesOf : (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
+>Intl.PluralRules.supportedLocalesOf : (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
 >Intl.PluralRules : Intl.PluralRulesConstructor
 >Intl : typeof Intl
 >PluralRules : Intl.PluralRulesConstructor
->supportedLocalesOf : (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
+>supportedLocalesOf : (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }) => string[]
 >locales : string[]
 >options : { readonly localeMatcher: "lookup"; }
 >join : (separator?: string) => string

--- a/tests/baselines/reference/localesObjectArgument.js
+++ b/tests/baselines/reference/localesObjectArgument.js
@@ -10,6 +10,8 @@ const num = 1000;
 const bigint = 123456789123456789n;
 const str = "";
 
+const readonlyLocales: Readonly<string[]> = ['de-DE', 'ja-JP'];
+
 now.toLocaleString(enUS);
 now.toLocaleDateString(enUS);
 now.toLocaleTimeString(enUS);
@@ -32,28 +34,36 @@ str.localeCompare(str, [deDE, jaJP]);
 
 new Intl.PluralRules(enUS);
 new Intl.PluralRules([deDE, jaJP]);
+new Intl.PluralRules(readonlyLocales);
 Intl.PluralRules.supportedLocalesOf(enUS);
 Intl.PluralRules.supportedLocalesOf([deDE, jaJP]);
+Intl.PluralRules.supportedLocalesOf(readonlyLocales);
 
 new Intl.RelativeTimeFormat(enUS);
 new Intl.RelativeTimeFormat([deDE, jaJP]);
+new Intl.RelativeTimeFormat(readonlyLocales);
 Intl.RelativeTimeFormat.supportedLocalesOf(enUS);
 Intl.RelativeTimeFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.RelativeTimeFormat.supportedLocalesOf(readonlyLocales);
 
 new Intl.Collator(enUS);
 new Intl.Collator([deDE, jaJP]);
+new Intl.Collator(readonlyLocales);
 Intl.Collator.supportedLocalesOf(enUS);
 Intl.Collator.supportedLocalesOf([deDE, jaJP]);
 
 new Intl.DateTimeFormat(enUS);
 new Intl.DateTimeFormat([deDE, jaJP]);
+new Intl.DateTimeFormat(readonlyLocales);
 Intl.DateTimeFormat.supportedLocalesOf(enUS);
 Intl.DateTimeFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.DateTimeFormat.supportedLocalesOf(readonlyLocales);
 
 new Intl.NumberFormat(enUS);
 new Intl.NumberFormat([deDE, jaJP]);
+new Intl.NumberFormat(readonlyLocales);
 Intl.NumberFormat.supportedLocalesOf(enUS);
-Intl.NumberFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.NumberFormat.supportedLocalesOf(readonlyLocales);
 
 
 //// [localesObjectArgument.js]
@@ -64,6 +74,7 @@ const now = new Date();
 const num = 1000;
 const bigint = 123456789123456789n;
 const str = "";
+const readonlyLocales = ['de-DE', 'ja-JP'];
 now.toLocaleString(enUS);
 now.toLocaleDateString(enUS);
 now.toLocaleTimeString(enUS);
@@ -82,21 +93,29 @@ str.localeCompare(str, enUS);
 str.localeCompare(str, [deDE, jaJP]);
 new Intl.PluralRules(enUS);
 new Intl.PluralRules([deDE, jaJP]);
+new Intl.PluralRules(readonlyLocales);
 Intl.PluralRules.supportedLocalesOf(enUS);
 Intl.PluralRules.supportedLocalesOf([deDE, jaJP]);
+Intl.PluralRules.supportedLocalesOf(readonlyLocales);
 new Intl.RelativeTimeFormat(enUS);
 new Intl.RelativeTimeFormat([deDE, jaJP]);
+new Intl.RelativeTimeFormat(readonlyLocales);
 Intl.RelativeTimeFormat.supportedLocalesOf(enUS);
 Intl.RelativeTimeFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.RelativeTimeFormat.supportedLocalesOf(readonlyLocales);
 new Intl.Collator(enUS);
 new Intl.Collator([deDE, jaJP]);
+new Intl.Collator(readonlyLocales);
 Intl.Collator.supportedLocalesOf(enUS);
 Intl.Collator.supportedLocalesOf([deDE, jaJP]);
 new Intl.DateTimeFormat(enUS);
 new Intl.DateTimeFormat([deDE, jaJP]);
+new Intl.DateTimeFormat(readonlyLocales);
 Intl.DateTimeFormat.supportedLocalesOf(enUS);
 Intl.DateTimeFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.DateTimeFormat.supportedLocalesOf(readonlyLocales);
 new Intl.NumberFormat(enUS);
 new Intl.NumberFormat([deDE, jaJP]);
+new Intl.NumberFormat(readonlyLocales);
 Intl.NumberFormat.supportedLocalesOf(enUS);
-Intl.NumberFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.NumberFormat.supportedLocalesOf(readonlyLocales);

--- a/tests/baselines/reference/localesObjectArgument.symbols
+++ b/tests/baselines/reference/localesObjectArgument.symbols
@@ -32,6 +32,10 @@ const bigint = 123456789123456789n;
 const str = "";
 >str : Symbol(str, Decl(localesObjectArgument.ts, 7, 5))
 
+const readonlyLocales: Readonly<string[]> = ['de-DE', 'ja-JP'];
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
+>Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
+
 now.toLocaleString(enUS);
 >now.toLocaleString : Symbol(Date.toLocaleString, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.date.d.ts, --, --))
 >now : Symbol(now, Decl(localesObjectArgument.ts, 4, 5))
@@ -151,6 +155,12 @@ new Intl.PluralRules([deDE, jaJP]);
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
 
+new Intl.PluralRules(readonlyLocales);
+>Intl.PluralRules : Symbol(Intl.PluralRules, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>PluralRules : Symbol(Intl.PluralRules, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
+
 Intl.PluralRules.supportedLocalesOf(enUS);
 >Intl.PluralRules.supportedLocalesOf : Symbol(Intl.PluralRulesConstructor.supportedLocalesOf, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Intl.PluralRules : Symbol(Intl.PluralRules, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --))
@@ -168,6 +178,14 @@ Intl.PluralRules.supportedLocalesOf([deDE, jaJP]);
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
 
+Intl.PluralRules.supportedLocalesOf(readonlyLocales);
+>Intl.PluralRules.supportedLocalesOf : Symbol(Intl.PluralRulesConstructor.supportedLocalesOf, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.PluralRules : Symbol(Intl.PluralRules, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>PluralRules : Symbol(Intl.PluralRules, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --))
+>supportedLocalesOf : Symbol(Intl.PluralRulesConstructor.supportedLocalesOf, Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
+
 new Intl.RelativeTimeFormat(enUS);
 >Intl.RelativeTimeFormat : Symbol(Intl.RelativeTimeFormat, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
@@ -180,6 +198,12 @@ new Intl.RelativeTimeFormat([deDE, jaJP]);
 >RelativeTimeFormat : Symbol(Intl.RelativeTimeFormat, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
+
+new Intl.RelativeTimeFormat(readonlyLocales);
+>Intl.RelativeTimeFormat : Symbol(Intl.RelativeTimeFormat, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>RelativeTimeFormat : Symbol(Intl.RelativeTimeFormat, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
 
 Intl.RelativeTimeFormat.supportedLocalesOf(enUS);
 >Intl.RelativeTimeFormat.supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
@@ -198,6 +222,14 @@ Intl.RelativeTimeFormat.supportedLocalesOf([deDE, jaJP]);
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
 
+Intl.RelativeTimeFormat.supportedLocalesOf(readonlyLocales);
+>Intl.RelativeTimeFormat.supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.RelativeTimeFormat : Symbol(Intl.RelativeTimeFormat, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>RelativeTimeFormat : Symbol(Intl.RelativeTimeFormat, Decl(lib.es2020.intl.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>supportedLocalesOf : Symbol(supportedLocalesOf, Decl(lib.es2020.intl.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
+
 new Intl.Collator(enUS);
 >Intl.Collator : Symbol(Intl.Collator, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
@@ -210,6 +242,12 @@ new Intl.Collator([deDE, jaJP]);
 >Collator : Symbol(Intl.Collator, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
+
+new Intl.Collator(readonlyLocales);
+>Intl.Collator : Symbol(Intl.Collator, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>Collator : Symbol(Intl.Collator, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
 
 Intl.Collator.supportedLocalesOf(enUS);
 >Intl.Collator.supportedLocalesOf : Symbol(Intl.CollatorConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
@@ -241,6 +279,12 @@ new Intl.DateTimeFormat([deDE, jaJP]);
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
 
+new Intl.DateTimeFormat(readonlyLocales);
+>Intl.DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
+
 Intl.DateTimeFormat.supportedLocalesOf(enUS);
 >Intl.DateTimeFormat.supportedLocalesOf : Symbol(Intl.DateTimeFormatConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Intl.DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --))
@@ -258,6 +302,14 @@ Intl.DateTimeFormat.supportedLocalesOf([deDE, jaJP]);
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
 
+Intl.DateTimeFormat.supportedLocalesOf(readonlyLocales);
+>Intl.DateTimeFormat.supportedLocalesOf : Symbol(Intl.DateTimeFormatConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>Intl.DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>DateTimeFormat : Symbol(Intl.DateTimeFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --))
+>supportedLocalesOf : Symbol(Intl.DateTimeFormatConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
+
 new Intl.NumberFormat(enUS);
 >Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
@@ -271,6 +323,12 @@ new Intl.NumberFormat([deDE, jaJP]);
 >deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
 >jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
 
+new Intl.NumberFormat(readonlyLocales);
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
+
 Intl.NumberFormat.supportedLocalesOf(enUS);
 >Intl.NumberFormat.supportedLocalesOf : Symbol(Intl.NumberFormatConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
@@ -279,12 +337,11 @@ Intl.NumberFormat.supportedLocalesOf(enUS);
 >supportedLocalesOf : Symbol(Intl.NumberFormatConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >enUS : Symbol(enUS, Decl(localesObjectArgument.ts, 0, 5))
 
-Intl.NumberFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.NumberFormat.supportedLocalesOf(readonlyLocales);
 >Intl.NumberFormat.supportedLocalesOf : Symbol(Intl.NumberFormatConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
 >Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 >Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 2 more)
 >NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 >supportedLocalesOf : Symbol(Intl.NumberFormatConstructor.supportedLocalesOf, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.intl.d.ts, --, --))
->deDE : Symbol(deDE, Decl(localesObjectArgument.ts, 1, 5))
->jaJP : Symbol(jaJP, Decl(localesObjectArgument.ts, 2, 5))
+>readonlyLocales : Symbol(readonlyLocales, Decl(localesObjectArgument.ts, 9, 5))
 

--- a/tests/baselines/reference/localesObjectArgument.types
+++ b/tests/baselines/reference/localesObjectArgument.types
@@ -42,6 +42,12 @@ const str = "";
 >str : ""
 >"" : ""
 
+const readonlyLocales: Readonly<string[]> = ['de-DE', 'ja-JP'];
+>readonlyLocales : readonly string[]
+>['de-DE', 'ja-JP'] : string[]
+>'de-DE' : "de-DE"
+>'ja-JP' : "ja-JP"
+
 now.toLocaleString(enUS);
 >now.toLocaleString(enUS) : string
 >now.toLocaleString : { (): string; (locales?: string | string[], options?: Intl.DateTimeFormatOptions): string; (locales?: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string; }
@@ -188,25 +194,41 @@ new Intl.PluralRules([deDE, jaJP]);
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
 
-Intl.PluralRules.supportedLocalesOf(enUS);
->Intl.PluralRules.supportedLocalesOf(enUS) : string[]
->Intl.PluralRules.supportedLocalesOf : { (locales: string | string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+new Intl.PluralRules(readonlyLocales);
+>new Intl.PluralRules(readonlyLocales) : Intl.PluralRules
 >Intl.PluralRules : Intl.PluralRulesConstructor
 >Intl : typeof Intl
 >PluralRules : Intl.PluralRulesConstructor
->supportedLocalesOf : { (locales: string | string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>readonlyLocales : readonly string[]
+
+Intl.PluralRules.supportedLocalesOf(enUS);
+>Intl.PluralRules.supportedLocalesOf(enUS) : string[]
+>Intl.PluralRules.supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>Intl.PluralRules : Intl.PluralRulesConstructor
+>Intl : typeof Intl
+>PluralRules : Intl.PluralRulesConstructor
+>supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >enUS : Intl.Locale
 
 Intl.PluralRules.supportedLocalesOf([deDE, jaJP]);
 >Intl.PluralRules.supportedLocalesOf([deDE, jaJP]) : string[]
->Intl.PluralRules.supportedLocalesOf : { (locales: string | string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>Intl.PluralRules.supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >Intl.PluralRules : Intl.PluralRulesConstructor
 >Intl : typeof Intl
 >PluralRules : Intl.PluralRulesConstructor
->supportedLocalesOf : { (locales: string | string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >[deDE, jaJP] : Intl.Locale[]
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
+
+Intl.PluralRules.supportedLocalesOf(readonlyLocales);
+>Intl.PluralRules.supportedLocalesOf(readonlyLocales) : string[]
+>Intl.PluralRules.supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>Intl.PluralRules : Intl.PluralRulesConstructor
+>Intl : typeof Intl
+>PluralRules : Intl.PluralRulesConstructor
+>supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>readonlyLocales : readonly string[]
 
 new Intl.RelativeTimeFormat(enUS);
 >new Intl.RelativeTimeFormat(enUS) : Intl.RelativeTimeFormat
@@ -223,6 +245,13 @@ new Intl.RelativeTimeFormat([deDE, jaJP]);
 >[deDE, jaJP] : Intl.Locale[]
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
+
+new Intl.RelativeTimeFormat(readonlyLocales);
+>new Intl.RelativeTimeFormat(readonlyLocales) : Intl.RelativeTimeFormat
+>Intl.RelativeTimeFormat : { new (locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): Intl.RelativeTimeFormat; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): string[]; }
+>Intl : typeof Intl
+>RelativeTimeFormat : { new (locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): Intl.RelativeTimeFormat; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): string[]; }
+>readonlyLocales : readonly string[]
 
 Intl.RelativeTimeFormat.supportedLocalesOf(enUS);
 >Intl.RelativeTimeFormat.supportedLocalesOf(enUS) : string[]
@@ -244,6 +273,15 @@ Intl.RelativeTimeFormat.supportedLocalesOf([deDE, jaJP]);
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
 
+Intl.RelativeTimeFormat.supportedLocalesOf(readonlyLocales);
+>Intl.RelativeTimeFormat.supportedLocalesOf(readonlyLocales) : string[]
+>Intl.RelativeTimeFormat.supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions) => string[]
+>Intl.RelativeTimeFormat : { new (locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): Intl.RelativeTimeFormat; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): string[]; }
+>Intl : typeof Intl
+>RelativeTimeFormat : { new (locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): Intl.RelativeTimeFormat; supportedLocalesOf(locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions): string[]; }
+>supportedLocalesOf : (locales?: Intl.LocalesArgument, options?: Intl.RelativeTimeFormatOptions) => string[]
+>readonlyLocales : readonly string[]
+
 new Intl.Collator(enUS);
 >new Intl.Collator(enUS) : Intl.Collator
 >Intl.Collator : Intl.CollatorConstructor
@@ -259,6 +297,13 @@ new Intl.Collator([deDE, jaJP]);
 >[deDE, jaJP] : Intl.Locale[]
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
+
+new Intl.Collator(readonlyLocales);
+>new Intl.Collator(readonlyLocales) : Intl.Collator
+>Intl.Collator : Intl.CollatorConstructor
+>Intl : typeof Intl
+>Collator : Intl.CollatorConstructor
+>readonlyLocales : readonly string[]
 
 Intl.Collator.supportedLocalesOf(enUS);
 >Intl.Collator.supportedLocalesOf(enUS) : string[]
@@ -296,6 +341,13 @@ new Intl.DateTimeFormat([deDE, jaJP]);
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
 
+new Intl.DateTimeFormat(readonlyLocales);
+>new Intl.DateTimeFormat(readonlyLocales) : Intl.DateTimeFormat
+>Intl.DateTimeFormat : Intl.DateTimeFormatConstructor
+>Intl : typeof Intl
+>DateTimeFormat : Intl.DateTimeFormatConstructor
+>readonlyLocales : readonly string[]
+
 Intl.DateTimeFormat.supportedLocalesOf(enUS);
 >Intl.DateTimeFormat.supportedLocalesOf(enUS) : string[]
 >Intl.DateTimeFormat.supportedLocalesOf : { (locales: string | string[], options?: Intl.DateTimeFormatOptions): string[]; (locales: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string[]; }
@@ -316,6 +368,15 @@ Intl.DateTimeFormat.supportedLocalesOf([deDE, jaJP]);
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
 
+Intl.DateTimeFormat.supportedLocalesOf(readonlyLocales);
+>Intl.DateTimeFormat.supportedLocalesOf(readonlyLocales) : string[]
+>Intl.DateTimeFormat.supportedLocalesOf : { (locales: string | string[], options?: Intl.DateTimeFormatOptions): string[]; (locales: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string[]; }
+>Intl.DateTimeFormat : Intl.DateTimeFormatConstructor
+>Intl : typeof Intl
+>DateTimeFormat : Intl.DateTimeFormatConstructor
+>supportedLocalesOf : { (locales: string | string[], options?: Intl.DateTimeFormatOptions): string[]; (locales: Intl.LocalesArgument, options?: Intl.DateTimeFormatOptions): string[]; }
+>readonlyLocales : readonly string[]
+
 new Intl.NumberFormat(enUS);
 >new Intl.NumberFormat(enUS) : Intl.NumberFormat
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -332,6 +393,13 @@ new Intl.NumberFormat([deDE, jaJP]);
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
 
+new Intl.NumberFormat(readonlyLocales);
+>new Intl.NumberFormat(readonlyLocales) : Intl.NumberFormat
+>Intl.NumberFormat : Intl.NumberFormatConstructor
+>Intl : typeof Intl
+>NumberFormat : Intl.NumberFormatConstructor
+>readonlyLocales : readonly string[]
+
 Intl.NumberFormat.supportedLocalesOf(enUS);
 >Intl.NumberFormat.supportedLocalesOf(enUS) : string[]
 >Intl.NumberFormat.supportedLocalesOf : { (locales: string | string[], options?: Intl.NumberFormatOptions): string[]; (locales: Intl.LocalesArgument, options?: Intl.NumberFormatOptions): string[]; }
@@ -341,14 +409,12 @@ Intl.NumberFormat.supportedLocalesOf(enUS);
 >supportedLocalesOf : { (locales: string | string[], options?: Intl.NumberFormatOptions): string[]; (locales: Intl.LocalesArgument, options?: Intl.NumberFormatOptions): string[]; }
 >enUS : Intl.Locale
 
-Intl.NumberFormat.supportedLocalesOf([deDE, jaJP]);
->Intl.NumberFormat.supportedLocalesOf([deDE, jaJP]) : string[]
+Intl.NumberFormat.supportedLocalesOf(readonlyLocales);
+>Intl.NumberFormat.supportedLocalesOf(readonlyLocales) : string[]
 >Intl.NumberFormat.supportedLocalesOf : { (locales: string | string[], options?: Intl.NumberFormatOptions): string[]; (locales: Intl.LocalesArgument, options?: Intl.NumberFormatOptions): string[]; }
 >Intl.NumberFormat : Intl.NumberFormatConstructor
 >Intl : typeof Intl
 >NumberFormat : Intl.NumberFormatConstructor
 >supportedLocalesOf : { (locales: string | string[], options?: Intl.NumberFormatOptions): string[]; (locales: Intl.LocalesArgument, options?: Intl.NumberFormatOptions): string[]; }
->[deDE, jaJP] : Intl.Locale[]
->deDE : Intl.Locale
->jaJP : Intl.Locale
+>readonlyLocales : readonly string[]
 

--- a/tests/baselines/reference/localesObjectArgument.types
+++ b/tests/baselines/reference/localesObjectArgument.types
@@ -203,31 +203,31 @@ new Intl.PluralRules(readonlyLocales);
 
 Intl.PluralRules.supportedLocalesOf(enUS);
 >Intl.PluralRules.supportedLocalesOf(enUS) : string[]
->Intl.PluralRules.supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>Intl.PluralRules.supportedLocalesOf : { (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >Intl.PluralRules : Intl.PluralRulesConstructor
 >Intl : typeof Intl
 >PluralRules : Intl.PluralRulesConstructor
->supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>supportedLocalesOf : { (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >enUS : Intl.Locale
 
 Intl.PluralRules.supportedLocalesOf([deDE, jaJP]);
 >Intl.PluralRules.supportedLocalesOf([deDE, jaJP]) : string[]
->Intl.PluralRules.supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>Intl.PluralRules.supportedLocalesOf : { (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >Intl.PluralRules : Intl.PluralRulesConstructor
 >Intl : typeof Intl
 >PluralRules : Intl.PluralRulesConstructor
->supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>supportedLocalesOf : { (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >[deDE, jaJP] : Intl.Locale[]
 >deDE : Intl.Locale
 >jaJP : Intl.Locale
 
 Intl.PluralRules.supportedLocalesOf(readonlyLocales);
 >Intl.PluralRules.supportedLocalesOf(readonlyLocales) : string[]
->Intl.PluralRules.supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>Intl.PluralRules.supportedLocalesOf : { (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >Intl.PluralRules : Intl.PluralRulesConstructor
 >Intl : typeof Intl
 >PluralRules : Intl.PluralRulesConstructor
->supportedLocalesOf : { (locales: string | string[] | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
+>supportedLocalesOf : { (locales: string | readonly string[], options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; (locales: Intl.LocalesArgument, options?: { localeMatcher?: "lookup" | "best fit"; }): string[]; }
 >readonlyLocales : readonly string[]
 
 new Intl.RelativeTimeFormat(enUS);

--- a/tests/cases/conformance/es2016/es2016IntlAPIs.ts
+++ b/tests/cases/conformance/es2016/es2016IntlAPIs.ts
@@ -8,6 +8,10 @@ console.log(Intl.getCanonicalLocales('EN-US'));
 console.log(Intl.getCanonicalLocales(['EN-US', 'Fr']));
 // Expected output: Array ["en-US", "fr"]
 
+const readonlyLocales: Readonly<string[]> = ['EN-US', 'Fr'];
+console.log(Intl.getCanonicalLocales(readonlyLocales));
+// Expected output: Array ["en-US", "fr"]
+
 try {
   Intl.getCanonicalLocales('EN_US');
 } catch (err) {

--- a/tests/cases/conformance/es2016/es2016IntlAPIs.ts
+++ b/tests/cases/conformance/es2016/es2016IntlAPIs.ts
@@ -8,10 +8,6 @@ console.log(Intl.getCanonicalLocales('EN-US'));
 console.log(Intl.getCanonicalLocales(['EN-US', 'Fr']));
 // Expected output: Array ["en-US", "fr"]
 
-const readonlyLocales: Readonly<string[]> = ['EN-US', 'Fr'];
-console.log(Intl.getCanonicalLocales(readonlyLocales));
-// Expected output: Array ["en-US", "fr"]
-
 try {
   Intl.getCanonicalLocales('EN_US');
 } catch (err) {

--- a/tests/cases/conformance/es2020/localesObjectArgument.ts
+++ b/tests/cases/conformance/es2020/localesObjectArgument.ts
@@ -9,6 +9,8 @@ const num = 1000;
 const bigint = 123456789123456789n;
 const str = "";
 
+const readonlyLocales: Readonly<string[]> = ['de-DE', 'ja-JP'];
+
 now.toLocaleString(enUS);
 now.toLocaleDateString(enUS);
 now.toLocaleTimeString(enUS);
@@ -31,25 +33,33 @@ str.localeCompare(str, [deDE, jaJP]);
 
 new Intl.PluralRules(enUS);
 new Intl.PluralRules([deDE, jaJP]);
+new Intl.PluralRules(readonlyLocales);
 Intl.PluralRules.supportedLocalesOf(enUS);
 Intl.PluralRules.supportedLocalesOf([deDE, jaJP]);
+Intl.PluralRules.supportedLocalesOf(readonlyLocales);
 
 new Intl.RelativeTimeFormat(enUS);
 new Intl.RelativeTimeFormat([deDE, jaJP]);
+new Intl.RelativeTimeFormat(readonlyLocales);
 Intl.RelativeTimeFormat.supportedLocalesOf(enUS);
 Intl.RelativeTimeFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.RelativeTimeFormat.supportedLocalesOf(readonlyLocales);
 
 new Intl.Collator(enUS);
 new Intl.Collator([deDE, jaJP]);
+new Intl.Collator(readonlyLocales);
 Intl.Collator.supportedLocalesOf(enUS);
 Intl.Collator.supportedLocalesOf([deDE, jaJP]);
 
 new Intl.DateTimeFormat(enUS);
 new Intl.DateTimeFormat([deDE, jaJP]);
+new Intl.DateTimeFormat(readonlyLocales);
 Intl.DateTimeFormat.supportedLocalesOf(enUS);
 Intl.DateTimeFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.DateTimeFormat.supportedLocalesOf(readonlyLocales);
 
 new Intl.NumberFormat(enUS);
 new Intl.NumberFormat([deDE, jaJP]);
+new Intl.NumberFormat(readonlyLocales);
 Intl.NumberFormat.supportedLocalesOf(enUS);
-Intl.NumberFormat.supportedLocalesOf([deDE, jaJP]);
+Intl.NumberFormat.supportedLocalesOf(readonlyLocales);


### PR DESCRIPTION
Fixes #56513:

Updates the definitions for `Intl.getCanonicalLocales()` and `Intl.PluralRules` constructors/methods to accept readonly arrays. Several of the locations mentioned in the issue seem to be correctly defined now (essentially >= es2020) since they build off `LocalesArgument`.

