### PR TITLE
Directly copy only the index signature in addition to declared properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13062,7 +13062,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 // copy index signature symbol as well (for quickinfo)
                 const sourceIndex = getIndexSymbol(source.symbol);
                 if (sourceIndex) {
-                   symbolTable.set(InternalSymbolName.Index, sourceIndex);
+                    symbolTable.set(InternalSymbolName.Index, sourceIndex);
                 }
                 members = symbolTable;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13058,12 +13058,11 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         const baseTypes = getBaseTypes(source);
         if (baseTypes.length) {
             if (source.symbol && members === getMembersOfSymbol(source.symbol)) {
-                const symbolTable = createSymbolTable();
-                // copy all symbols (except type parameters), including the ones with internal names like `InternalSymbolName.Index`
-                for (const symbol of members.values()) {
-                    if (!(symbol.flags & SymbolFlags.TypeParameter)) {
-                        symbolTable.set(symbol.escapedName, symbol);
-                    }
+                const symbolTable = createSymbolTable(source.declaredProperties);
+                // copy index signature symbol as well (for quickinfo)
+                const sourceIndex = getIndexSymbol(source.symbol);
+                if (sourceIndex) {
+                   symbolTable.set(InternalSymbolName.Index, sourceIndex);
                 }
                 members = symbolTable;
             }

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.errors.txt
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.errors.txt
@@ -1,0 +1,23 @@
+conflictingTypeParameterSymbolTransfer.ts(14,16): error TS2304: Cannot find name 'U'.
+
+
+==== conflictingTypeParameterSymbolTransfer.ts (1 errors) ====
+    // @strict
+    
+    // Via #56620
+    
+    class Base<U> { }
+    export class C2<T> extends Base<unknown> {
+        T: number;
+        constructor(T: number) {
+            super();
+            // Should not error
+            this.T = T;
+    
+            // Should error
+            let a: U = null;
+                   ~
+!!! error TS2304: Cannot find name 'U'.
+        }
+    }
+    

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.errors.txt
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.errors.txt
@@ -1,11 +1,10 @@
-conflictingTypeParameterSymbolTransfer.ts(14,16): error TS2304: Cannot find name 'U'.
+conflictingTypeParameterSymbolTransfer.ts(13,16): error TS2304: Cannot find name 'U'.
 
 
 ==== conflictingTypeParameterSymbolTransfer.ts (1 errors) ====
     // @strict
     
     // Via #56620
-    
     class Base<U> { }
     export class C2<T> extends Base<unknown> {
         T: number;
@@ -21,3 +20,21 @@ conflictingTypeParameterSymbolTransfer.ts(14,16): error TS2304: Cannot find name
         }
     }
     
+    // via #56689
+    class Leg { }
+    class Foo<t> extends Leg {
+        t = {} as t
+    
+        // should allow this access since t was declared as a property on Foo
+        foo = this.t
+    }
+    
+    // via #56661
+    class BaseClass { }
+    class Item<data> extends BaseClass {
+        data: data;
+        getData() {
+            // should OK
+            return this.data;
+        }
+    }

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.js
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.js
@@ -1,0 +1,60 @@
+//// [tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts] ////
+
+//// [conflictingTypeParameterSymbolTransfer.ts]
+// @strict
+
+// Via #56620
+
+class Base<U> { }
+export class C2<T> extends Base<unknown> {
+    T: number;
+    constructor(T: number) {
+        super();
+        // Should not error
+        this.T = T;
+
+        // Should error
+        let a: U = null;
+    }
+}
+
+
+//// [conflictingTypeParameterSymbolTransfer.js]
+"use strict";
+// @strict
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.C2 = void 0;
+// Via #56620
+var Base = /** @class */ (function () {
+    function Base() {
+    }
+    return Base;
+}());
+var C2 = /** @class */ (function (_super) {
+    __extends(C2, _super);
+    function C2(T) {
+        var _this = _super.call(this) || this;
+        // Should not error
+        _this.T = T;
+        // Should error
+        var a = null;
+        return _this;
+    }
+    return C2;
+}(Base));
+exports.C2 = C2;

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.js
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.js
@@ -4,7 +4,6 @@
 // @strict
 
 // Via #56620
-
 class Base<U> { }
 export class C2<T> extends Base<unknown> {
     T: number;
@@ -18,6 +17,24 @@ export class C2<T> extends Base<unknown> {
     }
 }
 
+// via #56689
+class Leg { }
+class Foo<t> extends Leg {
+    t = {} as t
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t
+}
+
+// via #56661
+class BaseClass { }
+class Item<data> extends BaseClass {
+    data: data;
+    getData() {
+        // should OK
+        return this.data;
+    }
+}
 
 //// [conflictingTypeParameterSymbolTransfer.js]
 "use strict";
@@ -58,3 +75,37 @@ var C2 = /** @class */ (function (_super) {
     return C2;
 }(Base));
 exports.C2 = C2;
+// via #56689
+var Leg = /** @class */ (function () {
+    function Leg() {
+    }
+    return Leg;
+}());
+var Foo = /** @class */ (function (_super) {
+    __extends(Foo, _super);
+    function Foo() {
+        var _this = _super !== null && _super.apply(this, arguments) || this;
+        _this.t = {};
+        // should allow this access since t was declared as a property on Foo
+        _this.foo = _this.t;
+        return _this;
+    }
+    return Foo;
+}(Leg));
+// via #56661
+var BaseClass = /** @class */ (function () {
+    function BaseClass() {
+    }
+    return BaseClass;
+}());
+var Item = /** @class */ (function (_super) {
+    __extends(Item, _super);
+    function Item() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Item.prototype.getData = function () {
+        // should OK
+        return this.data;
+    };
+    return Item;
+}(BaseClass));

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.symbols
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts] ////
+
+=== conflictingTypeParameterSymbolTransfer.ts ===
+// @strict
+
+// Via #56620
+
+class Base<U> { }
+>Base : Symbol(Base, Decl(conflictingTypeParameterSymbolTransfer.ts, 0, 0))
+>U : Symbol(U, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 11))
+
+export class C2<T> extends Base<unknown> {
+>C2 : Symbol(C2, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 17))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
+>Base : Symbol(Base, Decl(conflictingTypeParameterSymbolTransfer.ts, 0, 0))
+
+    T: number;
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
+
+    constructor(T: number) {
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 7, 16))
+
+        super();
+>super : Symbol(Base, Decl(conflictingTypeParameterSymbolTransfer.ts, 0, 0))
+
+        // Should not error
+        this.T = T;
+>this.T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
+>this : Symbol(C2, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 17))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 7, 16))
+
+        // Should error
+        let a: U = null;
+>a : Symbol(a, Decl(conflictingTypeParameterSymbolTransfer.ts, 13, 11))
+>U : Symbol(U)
+    }
+}
+

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.symbols
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.symbols
@@ -4,36 +4,79 @@
 // @strict
 
 // Via #56620
-
 class Base<U> { }
 >Base : Symbol(Base, Decl(conflictingTypeParameterSymbolTransfer.ts, 0, 0))
->U : Symbol(U, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 11))
+>U : Symbol(U, Decl(conflictingTypeParameterSymbolTransfer.ts, 3, 11))
 
 export class C2<T> extends Base<unknown> {
->C2 : Symbol(C2, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 17))
->T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
+>C2 : Symbol(C2, Decl(conflictingTypeParameterSymbolTransfer.ts, 3, 17))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 42))
 >Base : Symbol(Base, Decl(conflictingTypeParameterSymbolTransfer.ts, 0, 0))
 
     T: number;
->T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 42))
 
     constructor(T: number) {
->T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 7, 16))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 6, 16))
 
         super();
 >super : Symbol(Base, Decl(conflictingTypeParameterSymbolTransfer.ts, 0, 0))
 
         // Should not error
         this.T = T;
->this.T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
->this : Symbol(C2, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 17))
->T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 5, 42))
->T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 7, 16))
+>this.T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 42))
+>this : Symbol(C2, Decl(conflictingTypeParameterSymbolTransfer.ts, 3, 17))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 16), Decl(conflictingTypeParameterSymbolTransfer.ts, 4, 42))
+>T : Symbol(T, Decl(conflictingTypeParameterSymbolTransfer.ts, 6, 16))
 
         // Should error
         let a: U = null;
->a : Symbol(a, Decl(conflictingTypeParameterSymbolTransfer.ts, 13, 11))
+>a : Symbol(a, Decl(conflictingTypeParameterSymbolTransfer.ts, 12, 11))
 >U : Symbol(U)
     }
 }
 
+// via #56689
+class Leg { }
+>Leg : Symbol(Leg, Decl(conflictingTypeParameterSymbolTransfer.ts, 14, 1))
+
+class Foo<t> extends Leg {
+>Foo : Symbol(Foo, Decl(conflictingTypeParameterSymbolTransfer.ts, 17, 13))
+>t : Symbol(t, Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 10), Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 26))
+>Leg : Symbol(Leg, Decl(conflictingTypeParameterSymbolTransfer.ts, 14, 1))
+
+    t = {} as t
+>t : Symbol(t, Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 10), Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 26))
+>t : Symbol(t, Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 10), Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 26))
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t
+>foo : Symbol(Foo.foo, Decl(conflictingTypeParameterSymbolTransfer.ts, 19, 15))
+>this.t : Symbol(t, Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 10), Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 26))
+>this : Symbol(Foo, Decl(conflictingTypeParameterSymbolTransfer.ts, 17, 13))
+>t : Symbol(t, Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 10), Decl(conflictingTypeParameterSymbolTransfer.ts, 18, 26))
+}
+
+// via #56661
+class BaseClass { }
+>BaseClass : Symbol(BaseClass, Decl(conflictingTypeParameterSymbolTransfer.ts, 23, 1))
+
+class Item<data> extends BaseClass {
+>Item : Symbol(Item, Decl(conflictingTypeParameterSymbolTransfer.ts, 26, 19))
+>data : Symbol(data, Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 11), Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 36))
+>BaseClass : Symbol(BaseClass, Decl(conflictingTypeParameterSymbolTransfer.ts, 23, 1))
+
+    data: data;
+>data : Symbol(data, Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 11), Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 36))
+>data : Symbol(data, Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 11), Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 36))
+
+    getData() {
+>getData : Symbol(Item.getData, Decl(conflictingTypeParameterSymbolTransfer.ts, 28, 15))
+
+        // should OK
+        return this.data;
+>this.data : Symbol(data, Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 11), Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 36))
+>this : Symbol(Item, Decl(conflictingTypeParameterSymbolTransfer.ts, 26, 19))
+>data : Symbol(data, Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 11), Decl(conflictingTypeParameterSymbolTransfer.ts, 27, 36))
+    }
+}

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.types
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.types
@@ -1,0 +1,38 @@
+//// [tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts] ////
+
+=== conflictingTypeParameterSymbolTransfer.ts ===
+// @strict
+
+// Via #56620
+
+class Base<U> { }
+>Base : Base<U>
+
+export class C2<T> extends Base<unknown> {
+>C2 : C2<T>
+>Base : Base<unknown>
+
+    T: number;
+>T : number
+
+    constructor(T: number) {
+>T : number
+
+        super();
+>super() : void
+>super : typeof Base
+
+        // Should not error
+        this.T = T;
+>this.T = T : number
+>this.T : number
+>this : this
+>T : number
+>T : number
+
+        // Should error
+        let a: U = null;
+>a : U
+    }
+}
+

--- a/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.types
+++ b/tests/baselines/reference/conflictingTypeParameterSymbolTransfer.types
@@ -4,7 +4,6 @@
 // @strict
 
 // Via #56620
-
 class Base<U> { }
 >Base : Base<U>
 
@@ -36,3 +35,45 @@ export class C2<T> extends Base<unknown> {
     }
 }
 
+// via #56689
+class Leg { }
+>Leg : Leg
+
+class Foo<t> extends Leg {
+>Foo : Foo<t>
+>Leg : Leg
+
+    t = {} as t
+>t : t
+>{} as t : t
+>{} : {}
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t
+>foo : t
+>this.t : t
+>this : this
+>t : t
+}
+
+// via #56661
+class BaseClass { }
+>BaseClass : BaseClass
+
+class Item<data> extends BaseClass {
+>Item : Item<data>
+>BaseClass : BaseClass
+
+    data: data;
+>data : data
+
+    getData() {
+>getData : () => data
+
+        // should OK
+        return this.data;
+>this.data : data
+>this : this
+>data : data
+    }
+}

--- a/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
+++ b/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
@@ -1,0 +1,16 @@
+// @strict
+
+// Via #56620
+
+class Base<U> { }
+export class C2<T> extends Base<unknown> {
+    T: number;
+    constructor(T: number) {
+        super();
+        // Should not error
+        this.T = T;
+
+        // Should error
+        let a: U = null;
+    }
+}

--- a/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
+++ b/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
@@ -1,7 +1,6 @@
 // @strict
 
 // Via #56620
-
 class Base<U> { }
 export class C2<T> extends Base<unknown> {
     T: number;
@@ -12,5 +11,24 @@ export class C2<T> extends Base<unknown> {
 
         // Should error
         let a: U = null;
+    }
+}
+
+// via #56689
+class Leg { }
+class Foo<t> extends Leg {
+    t = {} as t
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t
+}
+
+// via #56661
+class BaseClass { }
+class Item<data> extends BaseClass {
+    data: data;
+    getData() {
+        // should OK
+        return this.data;
     }
 }


### PR DESCRIPTION
Fixes #56620

Partial revert of #55252