### PR TITLE
Fix(15506) - Disallow non-any/number/string operands on comparisons

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -3122,7 +3122,7 @@ function getContextualType(previousToken: Node, position: number, sourceFile: So
         case SyntaxKind.OpenBraceToken:
             return isJsxExpression(parent) && !isJsxElement(parent.parent) && !isJsxFragment(parent.parent) ? checker.getContextualTypeForJsxAttribute(parent.parent) : undefined;
         default:
-            const argInfo = SignatureHelp.getArgumentInfoForCompletions(previousToken, position, sourceFile);
+            const argInfo = SignatureHelp.getArgumentInfoForCompletions(previousToken, position, sourceFile, checker);
             return argInfo ?
                 // At `,`, treat this as the next argument after the comma.
                 checker.getContextualTypeForArgumentAtIndex(argInfo.invocation, argInfo.argumentIndex + (previousToken.kind === SyntaxKind.CommaToken ? 1 : 0)) :

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -407,7 +407,7 @@ function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringL
         case SyntaxKind.NewExpression:
         case SyntaxKind.JsxAttribute:
             if (!isRequireCallArgument(node) && !isImportCall(parent)) {
-                const argumentInfo = SignatureHelp.getArgumentInfoForCompletions(parent.kind === SyntaxKind.JsxAttribute ? parent.parent : node, position, sourceFile);
+                const argumentInfo = SignatureHelp.getArgumentInfoForCompletions(parent.kind === SyntaxKind.JsxAttribute ? parent.parent : node, position, sourceFile, typeChecker);
                 // Get string literal completions from specialized signatures of the target
                 // i.e. declare function f(a: 'A');
                 // f("/*completion position*/")

--- a/tests/baselines/reference/ambiguousGenericAssertion1.errors.txt
+++ b/tests/baselines/reference/ambiguousGenericAssertion1.errors.txt
@@ -3,9 +3,10 @@ ambiguousGenericAssertion1.ts(4,15): error TS2304: Cannot find name 'x'.
 ambiguousGenericAssertion1.ts(4,16): error TS1005: ')' expected.
 ambiguousGenericAssertion1.ts(4,19): error TS1005: ',' expected.
 ambiguousGenericAssertion1.ts(4,21): error TS1005: ';' expected.
+ambiguousGenericAssertion1.ts(4,24): error TS2365: Operator '>' cannot be applied to types 'any' and '<T>(x: T) => T'.
 
 
-==== ambiguousGenericAssertion1.ts (5 errors) ====
+==== ambiguousGenericAssertion1.ts (6 errors) ====
     function f<T>(x: T): T { return null; }
     var r = <T>(x: T) => x;
     var r2 = < <T>(x: T) => T>f; // valid
@@ -20,4 +21,6 @@ ambiguousGenericAssertion1.ts(4,21): error TS1005: ';' expected.
 !!! error TS1005: ',' expected.
                         ~~
 !!! error TS1005: ';' expected.
+                           ~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and '<T>(x: T) => T'.
     

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalObjects.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalObjects.errors.txt
@@ -1,0 +1,365 @@
+comparisonOperatorWithIdenticalObjects.ts(61,12): error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithIdenticalObjects.ts(62,12): error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(63,12): error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithIdenticalObjects.ts(64,12): error TS2365: Operator '<' cannot be applied to types 'A3' and 'B3'.
+comparisonOperatorWithIdenticalObjects.ts(65,12): error TS2365: Operator '<' cannot be applied to types 'A4' and 'B4'.
+comparisonOperatorWithIdenticalObjects.ts(66,12): error TS2365: Operator '<' cannot be applied to types 'A5' and 'B5'.
+comparisonOperatorWithIdenticalObjects.ts(67,12): error TS2365: Operator '<' cannot be applied to types 'A6' and 'B6'.
+comparisonOperatorWithIdenticalObjects.ts(69,12): error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithIdenticalObjects.ts(70,12): error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(71,12): error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+comparisonOperatorWithIdenticalObjects.ts(72,12): error TS2365: Operator '<' cannot be applied to types 'B3' and 'A3'.
+comparisonOperatorWithIdenticalObjects.ts(73,12): error TS2365: Operator '<' cannot be applied to types 'B4' and 'A4'.
+comparisonOperatorWithIdenticalObjects.ts(74,12): error TS2365: Operator '<' cannot be applied to types 'B5' and 'A5'.
+comparisonOperatorWithIdenticalObjects.ts(75,12): error TS2365: Operator '<' cannot be applied to types 'B6' and 'A6'.
+comparisonOperatorWithIdenticalObjects.ts(78,12): error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithIdenticalObjects.ts(79,12): error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(80,12): error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithIdenticalObjects.ts(81,12): error TS2365: Operator '>' cannot be applied to types 'A3' and 'B3'.
+comparisonOperatorWithIdenticalObjects.ts(82,12): error TS2365: Operator '>' cannot be applied to types 'A4' and 'B4'.
+comparisonOperatorWithIdenticalObjects.ts(83,12): error TS2365: Operator '>' cannot be applied to types 'A5' and 'B5'.
+comparisonOperatorWithIdenticalObjects.ts(84,12): error TS2365: Operator '>' cannot be applied to types 'A6' and 'B6'.
+comparisonOperatorWithIdenticalObjects.ts(86,12): error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithIdenticalObjects.ts(87,12): error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(88,12): error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+comparisonOperatorWithIdenticalObjects.ts(89,12): error TS2365: Operator '>' cannot be applied to types 'B3' and 'A3'.
+comparisonOperatorWithIdenticalObjects.ts(90,12): error TS2365: Operator '>' cannot be applied to types 'B4' and 'A4'.
+comparisonOperatorWithIdenticalObjects.ts(91,12): error TS2365: Operator '>' cannot be applied to types 'B5' and 'A5'.
+comparisonOperatorWithIdenticalObjects.ts(92,12): error TS2365: Operator '>' cannot be applied to types 'B6' and 'A6'.
+comparisonOperatorWithIdenticalObjects.ts(95,12): error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithIdenticalObjects.ts(96,12): error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(97,12): error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithIdenticalObjects.ts(98,12): error TS2365: Operator '<=' cannot be applied to types 'A3' and 'B3'.
+comparisonOperatorWithIdenticalObjects.ts(99,12): error TS2365: Operator '<=' cannot be applied to types 'A4' and 'B4'.
+comparisonOperatorWithIdenticalObjects.ts(100,12): error TS2365: Operator '<=' cannot be applied to types 'A5' and 'B5'.
+comparisonOperatorWithIdenticalObjects.ts(101,12): error TS2365: Operator '<=' cannot be applied to types 'A6' and 'B6'.
+comparisonOperatorWithIdenticalObjects.ts(103,12): error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithIdenticalObjects.ts(104,12): error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(105,12): error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+comparisonOperatorWithIdenticalObjects.ts(106,12): error TS2365: Operator '<=' cannot be applied to types 'B3' and 'A3'.
+comparisonOperatorWithIdenticalObjects.ts(107,12): error TS2365: Operator '<=' cannot be applied to types 'B4' and 'A4'.
+comparisonOperatorWithIdenticalObjects.ts(108,12): error TS2365: Operator '<=' cannot be applied to types 'B5' and 'A5'.
+comparisonOperatorWithIdenticalObjects.ts(109,12): error TS2365: Operator '<=' cannot be applied to types 'B6' and 'A6'.
+comparisonOperatorWithIdenticalObjects.ts(112,12): error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithIdenticalObjects.ts(113,12): error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(114,12): error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithIdenticalObjects.ts(115,12): error TS2365: Operator '>=' cannot be applied to types 'A3' and 'B3'.
+comparisonOperatorWithIdenticalObjects.ts(116,12): error TS2365: Operator '>=' cannot be applied to types 'A4' and 'B4'.
+comparisonOperatorWithIdenticalObjects.ts(117,12): error TS2365: Operator '>=' cannot be applied to types 'A5' and 'B5'.
+comparisonOperatorWithIdenticalObjects.ts(118,12): error TS2365: Operator '>=' cannot be applied to types 'A6' and 'B6'.
+comparisonOperatorWithIdenticalObjects.ts(120,12): error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithIdenticalObjects.ts(121,12): error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+comparisonOperatorWithIdenticalObjects.ts(122,12): error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+comparisonOperatorWithIdenticalObjects.ts(123,12): error TS2365: Operator '>=' cannot be applied to types 'B3' and 'A3'.
+comparisonOperatorWithIdenticalObjects.ts(124,12): error TS2365: Operator '>=' cannot be applied to types 'B4' and 'A4'.
+comparisonOperatorWithIdenticalObjects.ts(125,12): error TS2365: Operator '>=' cannot be applied to types 'B5' and 'A5'.
+comparisonOperatorWithIdenticalObjects.ts(126,12): error TS2365: Operator '>=' cannot be applied to types 'B6' and 'A6'.
+
+
+==== comparisonOperatorWithIdenticalObjects.ts (56 errors) ====
+    class A1 {
+        public a: string;
+        public b: number;
+        public c: boolean;
+        public d: any;
+        public e: Object;
+        public fn(a: string): string {
+            return null;
+        }
+    }
+    class B1 {
+        public a: string;
+        public b: number;
+        public c: boolean;
+        public d: any;
+        public e: Object;
+        public fn(b: string): string {
+            return null;
+        }
+    }
+    
+    class Base {
+        private a: string;
+        private fn(b: string): string {
+            return null;
+        }
+    }
+    class A2 extends Base { }
+    class B2 extends Base { }
+    
+    interface A3 { f(a: number): string; }
+    interface B3 { f(a: number): string; }
+    
+    interface A4 { new (a: string): A1; }
+    interface B4 { new (a: string): B1; }
+    
+    interface A5 { [x: number]: number; }
+    interface B5 { [x: number]: number; }
+    
+    interface A6 { [x: string]: string; }
+    interface B6 { [x: string]: string; }
+    
+    var a1: A1;
+    var a2: A2;
+    var a3: A3;
+    var a4: A4;
+    var a5: A5;
+    var a6: A6;
+    
+    var b1: B1;
+    var b2: B2;
+    var b3: B3;
+    var b4: B4;
+    var b5: B5;
+    var b6: B6;
+    
+    var base1: Base;
+    var base2: Base;
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+    var r1a2 = base1 < base2;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+    var r1a3 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+    var r1a4 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A3' and 'B3'.
+    var r1a5 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A4' and 'B4'.
+    var r1a6 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A5' and 'B5'.
+    var r1a7 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A6' and 'B6'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+    var r1b2 = base2 < base1;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Base' and 'Base'.
+    var r1b3 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+    var r1b4 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B3' and 'A3'.
+    var r1b5 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B4' and 'A4'.
+    var r1b6 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B5' and 'A5'.
+    var r1b7 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+    var r2a2 = base1 > base2;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+    var r2a3 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+    var r2a4 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A3' and 'B3'.
+    var r2a5 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A4' and 'B4'.
+    var r2a6 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A5' and 'B5'.
+    var r2a7 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A6' and 'B6'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+    var r2b2 = base2 > base1;
+               ~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Base' and 'Base'.
+    var r2b3 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+    var r2b4 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B3' and 'A3'.
+    var r2b5 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B4' and 'A4'.
+    var r2b6 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B5' and 'A5'.
+    var r2b7 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+    var r3a2 = base1 <= base2;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+    var r3a3 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+    var r3a4 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A3' and 'B3'.
+    var r3a5 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A4' and 'B4'.
+    var r3a6 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A5' and 'B5'.
+    var r3a7 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A6' and 'B6'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+    var r3b2 = base2 <= base1;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Base' and 'Base'.
+    var r3b3 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+    var r3b4 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B3' and 'A3'.
+    var r3b5 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B4' and 'A4'.
+    var r3b6 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B5' and 'A5'.
+    var r3b7 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+    var r4a2 = base1 >= base2;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+    var r4a3 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+    var r4a4 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A3' and 'B3'.
+    var r4a5 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A4' and 'B4'.
+    var r4a6 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A5' and 'B5'.
+    var r4a7 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A6' and 'B6'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+    var r4b2 = base2 >= base1;
+               ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Base' and 'Base'.
+    var r4b3 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+    var r4b4 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B3' and 'A3'.
+    var r4b5 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B4' and 'A4'.
+    var r4b6 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B5' and 'A5'.
+    var r4b7 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B6' and 'A6'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = base1 == base2;
+    var r5a3 = a2 == b2;
+    var r5a4 = a3 == b3;
+    var r5a5 = a4 == b4;
+    var r5a6 = a5 == b5;
+    var r5a7 = a6 == b6;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = base2 == base1;
+    var r5b3 = b2 == a2;
+    var r5b4 = b3 == a3;
+    var r5b5 = b4 == a4;
+    var r5b6 = b5 == a5;
+    var r5b7 = b6 == a6;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = base1 != base2;
+    var r6a3 = a2 != b2;
+    var r6a4 = a3 != b3;
+    var r6a5 = a4 != b4;
+    var r6a6 = a5 != b5;
+    var r6a7 = a6 != b6;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = base2 != base1;
+    var r6b3 = b2 != a2;
+    var r6b4 = b3 != a3;
+    var r6b5 = b4 != a4;
+    var r6b6 = b5 != a5;
+    var r6b7 = b6 != a6;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = base1 === base2;
+    var r7a3 = a2 === b2;
+    var r7a4 = a3 === b3;
+    var r7a5 = a4 === b4;
+    var r7a6 = a5 === b5;
+    var r7a7 = a6 === b6;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = base2 === base1;
+    var r7b3 = b2 === a2;
+    var r7b4 = b3 === a3;
+    var r7b5 = b4 === a4;
+    var r7b6 = b5 === a5;
+    var r7b7 = b6 === a6;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = base1 !== base2;
+    var r8a3 = a2 !== b2;
+    var r8a4 = a3 !== b3;
+    var r8a5 = a4 !== b4;
+    var r8a6 = a5 !== b5;
+    var r8a7 = a6 !== b6;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = base2 !== base1;
+    var r8b3 = b2 !== a2;
+    var r8b4 = b3 !== a3;
+    var r8b5 = b4 !== a4;
+    var r8b6 = b5 !== a5;
+    var r8b7 = b6 !== a6;

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
@@ -1,22 +1,30 @@
+comparisonOperatorWithIdenticalPrimitiveType.ts(11,11): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(13,11): error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
 comparisonOperatorWithIdenticalPrimitiveType.ts(15,11): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(15,18): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(16,11): error TS18050: The value 'undefined' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(16,23): error TS18050: The value 'undefined' cannot be used here.
+comparisonOperatorWithIdenticalPrimitiveType.ts(20,11): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(22,11): error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
 comparisonOperatorWithIdenticalPrimitiveType.ts(24,11): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(24,18): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(25,11): error TS18050: The value 'undefined' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(25,23): error TS18050: The value 'undefined' cannot be used here.
+comparisonOperatorWithIdenticalPrimitiveType.ts(29,11): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(31,11): error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
 comparisonOperatorWithIdenticalPrimitiveType.ts(33,11): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(33,19): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(34,11): error TS18050: The value 'undefined' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(34,24): error TS18050: The value 'undefined' cannot be used here.
+comparisonOperatorWithIdenticalPrimitiveType.ts(38,11): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithIdenticalPrimitiveType.ts(40,11): error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
 comparisonOperatorWithIdenticalPrimitiveType.ts(42,11): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(42,19): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(43,11): error TS18050: The value 'undefined' cannot be used here.
 comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value 'undefined' cannot be used here.
 
 
-==== comparisonOperatorWithIdenticalPrimitiveType.ts (16 errors) ====
+==== comparisonOperatorWithIdenticalPrimitiveType.ts (24 errors) ====
     enum E { a, b, c }
     
     var a: number;
@@ -28,8 +36,12 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     // operator <
     var ra1 = a < a;
     var ra2 = b < b;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
     var ra3 = c < c;
     var ra4 = d < d;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
     var ra5 = e < e;
     var ra6 = null < null;
               ~~~~
@@ -45,8 +57,12 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     // operator >
     var rb1 = a > a;
     var rb2 = b > b;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
     var rb3 = c > c;
     var rb4 = d > d;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
     var rb5 = e > e;
     var rb6 = null > null;
               ~~~~
@@ -62,8 +78,12 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     // operator <=
     var rc1 = a <= a;
     var rc2 = b <= b;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
     var rc3 = c <= c;
     var rc4 = d <= d;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
     var rc5 = e <= e;
     var rc6 = null <= null;
               ~~~~
@@ -79,8 +99,12 @@ comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS18050: The value
     // operator >=
     var rd1 = a >= a;
     var rd2 = b >= b;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
     var rd3 = c >= c;
     var rd4 = d >= d;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
     var rd5 = e >= e;
     var rd6 = null >= null;
               ~~~~

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalTypeParameter.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalTypeParameter.errors.txt
@@ -1,0 +1,25 @@
+comparisonOperatorWithIdenticalTypeParameter.ts(2,14): error TS2365: Operator '<' cannot be applied to types 'T' and 'T'.
+comparisonOperatorWithIdenticalTypeParameter.ts(3,14): error TS2365: Operator '>' cannot be applied to types 'T' and 'T'.
+comparisonOperatorWithIdenticalTypeParameter.ts(4,14): error TS2365: Operator '<=' cannot be applied to types 'T' and 'T'.
+comparisonOperatorWithIdenticalTypeParameter.ts(5,14): error TS2365: Operator '>=' cannot be applied to types 'T' and 'T'.
+
+
+==== comparisonOperatorWithIdenticalTypeParameter.ts (4 errors) ====
+    function foo<T>(t: T) {
+        var r1 = t < t;
+                 ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'T'.
+        var r2 = t > t;
+                 ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and 'T'.
+        var r3 = t <= t;
+                 ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and 'T'.
+        var r4 = t >= t;
+                 ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and 'T'.
+        var r5 = t == t;
+        var r6 = t != t;
+        var r7 = t === t;
+        var r8 = t !== t;
+    }

--- a/tests/baselines/reference/comparisonOperatorWithInvalidOperand.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithInvalidOperand.errors.txt
@@ -1,0 +1,393 @@
+comparisonOperatorWithInvalidOperand.ts(10,17): error TS2737: BigInt literals are not available when targeting lower than ES2020.
+comparisonOperatorWithInvalidOperand.ts(15,11): error TS2737: BigInt literals are not available when targeting lower than ES2020.
+comparisonOperatorWithInvalidOperand.ts(19,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithInvalidOperand.ts(20,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(21,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(22,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(23,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(24,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(25,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(26,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(27,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(28,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithInvalidOperand.ts(29,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(30,1): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(33,1): error TS2365: Operator '<' cannot be applied to types 'number' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(34,1): error TS2365: Operator '<' cannot be applied to types 'number' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(35,1): error TS2365: Operator '<' cannot be applied to types 'number' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(36,1): error TS2365: Operator '<' cannot be applied to types 'number' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(37,1): error TS2365: Operator '<' cannot be applied to types 'number' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(39,1): error TS2365: Operator '<' cannot be applied to types 'number' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(46,1): error TS2365: Operator '<' cannot be applied to types 'Date' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(47,1): error TS2365: Operator '<' cannot be applied to types 'Date' and 'boolean'.
+comparisonOperatorWithInvalidOperand.ts(51,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithInvalidOperand.ts(52,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(53,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(54,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(55,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(56,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(57,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(58,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(59,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(60,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithInvalidOperand.ts(61,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(62,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(65,1): error TS2365: Operator '>' cannot be applied to types 'number' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(66,1): error TS2365: Operator '>' cannot be applied to types 'number' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(67,1): error TS2365: Operator '>' cannot be applied to types 'number' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(68,1): error TS2365: Operator '>' cannot be applied to types 'number' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(69,1): error TS2365: Operator '>' cannot be applied to types 'number' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(71,1): error TS2365: Operator '>' cannot be applied to types 'number' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(78,1): error TS2365: Operator '>' cannot be applied to types 'Date' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(79,1): error TS2365: Operator '>' cannot be applied to types 'Date' and 'boolean'.
+comparisonOperatorWithInvalidOperand.ts(83,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithInvalidOperand.ts(84,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(85,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(86,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(87,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(88,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(89,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(90,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(91,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(92,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithInvalidOperand.ts(93,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(94,1): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(97,1): error TS2365: Operator '<=' cannot be applied to types 'number' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(98,1): error TS2365: Operator '<=' cannot be applied to types 'number' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(99,1): error TS2365: Operator '<=' cannot be applied to types 'number' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(100,1): error TS2365: Operator '<=' cannot be applied to types 'number' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(101,1): error TS2365: Operator '<=' cannot be applied to types 'number' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(103,1): error TS2365: Operator '<=' cannot be applied to types 'number' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(110,1): error TS2365: Operator '<=' cannot be applied to types 'Date' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(111,1): error TS2365: Operator '<=' cannot be applied to types 'Date' and 'boolean'.
+comparisonOperatorWithInvalidOperand.ts(115,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
+comparisonOperatorWithInvalidOperand.ts(116,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(117,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(118,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(119,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(120,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(121,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(122,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(123,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(124,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithInvalidOperand.ts(125,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'number'.
+comparisonOperatorWithInvalidOperand.ts(126,1): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'bigint'.
+comparisonOperatorWithInvalidOperand.ts(129,1): error TS2365: Operator '>=' cannot be applied to types 'number' and 'string'.
+comparisonOperatorWithInvalidOperand.ts(130,1): error TS2365: Operator '>=' cannot be applied to types 'number' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(131,1): error TS2365: Operator '>=' cannot be applied to types 'number' and 'number[]'.
+comparisonOperatorWithInvalidOperand.ts(132,1): error TS2365: Operator '>=' cannot be applied to types 'number' and '{}'.
+comparisonOperatorWithInvalidOperand.ts(133,1): error TS2365: Operator '>=' cannot be applied to types 'number' and 'string[]'.
+comparisonOperatorWithInvalidOperand.ts(135,1): error TS2365: Operator '>=' cannot be applied to types 'number' and 'Number'.
+comparisonOperatorWithInvalidOperand.ts(142,1): error TS2365: Operator '>=' cannot be applied to types 'Date' and 'Date'.
+comparisonOperatorWithInvalidOperand.ts(143,1): error TS2365: Operator '>=' cannot be applied to types 'Date' and 'boolean'.
+
+
+==== comparisonOperatorWithInvalidOperand.ts (82 errors) ====
+    // repro #15506
+    // assumes that only valid comparisons are between anys, numbers and strings
+    var a: boolean = false;
+    var b: number = 0;
+    var c: string = "";
+    var d: Date = new Date();
+    var e: number[] = [];
+    var f: {} = {};
+    var g: string[] = [];
+    var h: bigint = 9007199254740991n;
+                    ~~~~~~~~~~~~~~~~~
+!!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
+    var i: Number = 0;
+    var j: any;
+    // Literal
+    const k = 0;
+    const l = 9007199254740991n;
+              ~~~~~~~~~~~~~~~~~
+!!! error TS2737: BigInt literals are not available when targeting lower than ES2020.
+    
+    // operator <
+    // boolean
+    a < a;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
+    a < b;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'number'.
+    a < c;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'string'.
+    a < d;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'Date'.
+    a < e;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'number[]'.
+    a < f;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and '{}'.
+    a < g;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'string[]'.
+    a < h;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'bigint'.
+    a < i;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'Number'.
+    a < j;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+    a < k;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'number'.
+    a < l;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'bigint'.
+    
+    // number
+    b < c;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'number' and 'string'.
+    b < d;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'number' and 'Date'.
+    b < e;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'number' and 'number[]'.
+    b < f;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'number' and '{}'.
+    b < g;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'number' and 'string[]'.
+    b < h;
+    b < i;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'number' and 'Number'.
+    b < j;
+    b < k;
+    b < l;
+    k < l;
+    
+    // Date
+    d < d;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Date' and 'Date'.
+    d < a;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Date' and 'boolean'.
+    
+    // operator >
+    // boolean
+    a > a;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
+    a > b;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
+    a > c;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'string'.
+    a > d;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'Date'.
+    a > e;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number[]'.
+    a > f;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and '{}'.
+    a > g;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'string[]'.
+    a > h;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'bigint'.
+    a > i;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'Number'.
+    a > j;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+    a > k;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
+    a > l;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'bigint'.
+    
+    // number
+    b > c;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'number' and 'string'.
+    b > d;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'number' and 'Date'.
+    b > e;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'number' and 'number[]'.
+    b > f;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'number' and '{}'.
+    b > g;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'number' and 'string[]'.
+    b > h;
+    b > i;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'number' and 'Number'.
+    b > j;
+    b > k;
+    b > l;
+    k > l;
+    
+    // Date
+    d > d;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Date' and 'Date'.
+    d > a;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Date' and 'boolean'.
+    
+    // operator <=
+    // boolean
+    a <= a;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
+    a <= b;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'number'.
+    a <= c;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'string'.
+    a <= d;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'Date'.
+    a <= e;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'number[]'.
+    a <= f;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and '{}'.
+    a <= g;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'string[]'.
+    a <= h;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'bigint'.
+    a <= i;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'Number'.
+    a <= j;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+    a <= k;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'number'.
+    a <= l;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'bigint'.
+    
+    // number
+    b <= c;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'number' and 'string'.
+    b <= d;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'number' and 'Date'.
+    b <= e;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'number' and 'number[]'.
+    b <= f;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'number' and '{}'.
+    b <= g;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'number' and 'string[]'.
+    b <= h;
+    b <= i;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'number' and 'Number'.
+    b <= j;
+    b <= k;
+    b <= l;
+    k <= l;
+    
+    // Date
+    d <= d;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Date' and 'Date'.
+    d <= a;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Date' and 'boolean'.
+    
+    // operator >=
+    // boolean
+    a >= a;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
+    a >= b;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'number'.
+    a >= c;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'string'.
+    a >= d;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'Date'.
+    a >= e;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'number[]'.
+    a >= f;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and '{}'.
+    a >= g;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'string[]'.
+    a >= h;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'bigint'.
+    a >= i;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'Number'.
+    a >= j;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+    a >= k;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'number'.
+    a >= l;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'bigint'.
+    
+    // number
+    b >= c;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'number' and 'string'.
+    b >= d;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'number' and 'Date'.
+    b >= e;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'number' and 'number[]'.
+    b >= f;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'number' and '{}'.
+    b >= g;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'number' and 'string[]'.
+    b >= h;
+    b >= i;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'number' and 'Number'.
+    b >= j;
+    b >= k;
+    b >= l;
+    k >= l;
+    
+    // Date
+    d >= d;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Date' and 'Date'.
+    d >= a;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Date' and 'boolean'.
+    

--- a/tests/baselines/reference/comparisonOperatorWithInvalidOperand.js
+++ b/tests/baselines/reference/comparisonOperatorWithInvalidOperand.js
@@ -1,0 +1,280 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithInvalidOperand.ts] ////
+
+//// [comparisonOperatorWithInvalidOperand.ts]
+// repro #15506
+// assumes that only valid comparisons are between anys, numbers and strings
+var a: boolean = false;
+var b: number = 0;
+var c: string = "";
+var d: Date = new Date();
+var e: number[] = [];
+var f: {} = {};
+var g: string[] = [];
+var h: bigint = 9007199254740991n;
+var i: Number = 0;
+var j: any;
+// Literal
+const k = 0;
+const l = 9007199254740991n;
+
+// operator <
+// boolean
+a < a;
+a < b;
+a < c;
+a < d;
+a < e;
+a < f;
+a < g;
+a < h;
+a < i;
+a < j;
+a < k;
+a < l;
+
+// number
+b < c;
+b < d;
+b < e;
+b < f;
+b < g;
+b < h;
+b < i;
+b < j;
+b < k;
+b < l;
+k < l;
+
+// Date
+d < d;
+d < a;
+
+// operator >
+// boolean
+a > a;
+a > b;
+a > c;
+a > d;
+a > e;
+a > f;
+a > g;
+a > h;
+a > i;
+a > j;
+a > k;
+a > l;
+
+// number
+b > c;
+b > d;
+b > e;
+b > f;
+b > g;
+b > h;
+b > i;
+b > j;
+b > k;
+b > l;
+k > l;
+
+// Date
+d > d;
+d > a;
+
+// operator <=
+// boolean
+a <= a;
+a <= b;
+a <= c;
+a <= d;
+a <= e;
+a <= f;
+a <= g;
+a <= h;
+a <= i;
+a <= j;
+a <= k;
+a <= l;
+
+// number
+b <= c;
+b <= d;
+b <= e;
+b <= f;
+b <= g;
+b <= h;
+b <= i;
+b <= j;
+b <= k;
+b <= l;
+k <= l;
+
+// Date
+d <= d;
+d <= a;
+
+// operator >=
+// boolean
+a >= a;
+a >= b;
+a >= c;
+a >= d;
+a >= e;
+a >= f;
+a >= g;
+a >= h;
+a >= i;
+a >= j;
+a >= k;
+a >= l;
+
+// number
+b >= c;
+b >= d;
+b >= e;
+b >= f;
+b >= g;
+b >= h;
+b >= i;
+b >= j;
+b >= k;
+b >= l;
+k >= l;
+
+// Date
+d >= d;
+d >= a;
+
+
+//// [comparisonOperatorWithInvalidOperand.js]
+// repro #15506
+// assumes that only valid comparisons are between anys, numbers and strings
+var a = false;
+var b = 0;
+var c = "";
+var d = new Date();
+var e = [];
+var f = {};
+var g = [];
+var h = 9007199254740991n;
+var i = 0;
+var j;
+// Literal
+var k = 0;
+var l = 9007199254740991n;
+// operator <
+// boolean
+a < a;
+a < b;
+a < c;
+a < d;
+a < e;
+a < f;
+a < g;
+a < h;
+a < i;
+a < j;
+a < k;
+a < l;
+// number
+b < c;
+b < d;
+b < e;
+b < f;
+b < g;
+b < h;
+b < i;
+b < j;
+b < k;
+b < l;
+k < l;
+// Date
+d < d;
+d < a;
+// operator >
+// boolean
+a > a;
+a > b;
+a > c;
+a > d;
+a > e;
+a > f;
+a > g;
+a > h;
+a > i;
+a > j;
+a > k;
+a > l;
+// number
+b > c;
+b > d;
+b > e;
+b > f;
+b > g;
+b > h;
+b > i;
+b > j;
+b > k;
+b > l;
+k > l;
+// Date
+d > d;
+d > a;
+// operator <=
+// boolean
+a <= a;
+a <= b;
+a <= c;
+a <= d;
+a <= e;
+a <= f;
+a <= g;
+a <= h;
+a <= i;
+a <= j;
+a <= k;
+a <= l;
+// number
+b <= c;
+b <= d;
+b <= e;
+b <= f;
+b <= g;
+b <= h;
+b <= i;
+b <= j;
+b <= k;
+b <= l;
+k <= l;
+// Date
+d <= d;
+d <= a;
+// operator >=
+// boolean
+a >= a;
+a >= b;
+a >= c;
+a >= d;
+a >= e;
+a >= f;
+a >= g;
+a >= h;
+a >= i;
+a >= j;
+a >= k;
+a >= l;
+// number
+b >= c;
+b >= d;
+b >= e;
+b >= f;
+b >= g;
+b >= h;
+b >= i;
+b >= j;
+b >= k;
+b >= l;
+k >= l;
+// Date
+d >= d;
+d >= a;

--- a/tests/baselines/reference/comparisonOperatorWithInvalidOperand.symbols
+++ b/tests/baselines/reference/comparisonOperatorWithInvalidOperand.symbols
@@ -1,0 +1,461 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithInvalidOperand.ts] ////
+
+=== comparisonOperatorWithInvalidOperand.ts ===
+// repro #15506
+// assumes that only valid comparisons are between anys, numbers and strings
+var a: boolean = false;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+var b: number = 0;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+
+var c: string = "";
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+var d: Date = new Date();
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+
+var e: number[] = [];
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+var f: {} = {};
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+var g: string[] = [];
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+var h: bigint = 9007199254740991n;
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+var i: Number = 0;
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+>Number : Symbol(Number, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+var j: any;
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+// Literal
+const k = 0;
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+const l = 9007199254740991n;
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// operator <
+// boolean
+a < a;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+a < b;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+
+a < c;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+a < d;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+a < e;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+a < f;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+a < g;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+a < h;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+a < i;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+a < j;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+a < k;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+a < l;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// number
+b < c;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+b < d;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+b < e;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+b < f;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+b < g;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+b < h;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+b < i;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+b < j;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+b < k;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+b < l;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+k < l;
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// Date
+d < d;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+d < a;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+// operator >
+// boolean
+a > a;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+a > b;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+
+a > c;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+a > d;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+a > e;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+a > f;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+a > g;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+a > h;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+a > i;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+a > j;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+a > k;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+a > l;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// number
+b > c;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+b > d;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+b > e;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+b > f;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+b > g;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+b > h;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+b > i;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+b > j;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+b > k;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+b > l;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+k > l;
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// Date
+d > d;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+d > a;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+// operator <=
+// boolean
+a <= a;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+a <= b;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+
+a <= c;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+a <= d;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+a <= e;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+a <= f;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+a <= g;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+a <= h;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+a <= i;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+a <= j;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+a <= k;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+a <= l;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// number
+b <= c;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+b <= d;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+b <= e;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+b <= f;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+b <= g;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+b <= h;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+b <= i;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+b <= j;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+b <= k;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+b <= l;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+k <= l;
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// Date
+d <= d;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+d <= a;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+// operator >=
+// boolean
+a >= a;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+
+a >= b;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+
+a >= c;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+a >= d;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+a >= e;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+a >= f;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+a >= g;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+a >= h;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+a >= i;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+a >= j;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+a >= k;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+a >= l;
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// number
+b >= c;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>c : Symbol(c, Decl(comparisonOperatorWithInvalidOperand.ts, 4, 3))
+
+b >= d;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+b >= e;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>e : Symbol(e, Decl(comparisonOperatorWithInvalidOperand.ts, 6, 3))
+
+b >= f;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>f : Symbol(f, Decl(comparisonOperatorWithInvalidOperand.ts, 7, 3))
+
+b >= g;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>g : Symbol(g, Decl(comparisonOperatorWithInvalidOperand.ts, 8, 3))
+
+b >= h;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>h : Symbol(h, Decl(comparisonOperatorWithInvalidOperand.ts, 9, 3))
+
+b >= i;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>i : Symbol(i, Decl(comparisonOperatorWithInvalidOperand.ts, 10, 3))
+
+b >= j;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>j : Symbol(j, Decl(comparisonOperatorWithInvalidOperand.ts, 11, 3))
+
+b >= k;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+
+b >= l;
+>b : Symbol(b, Decl(comparisonOperatorWithInvalidOperand.ts, 3, 3))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+k >= l;
+>k : Symbol(k, Decl(comparisonOperatorWithInvalidOperand.ts, 13, 5))
+>l : Symbol(l, Decl(comparisonOperatorWithInvalidOperand.ts, 14, 5))
+
+// Date
+d >= d;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+
+d >= a;
+>d : Symbol(d, Decl(comparisonOperatorWithInvalidOperand.ts, 5, 3))
+>a : Symbol(a, Decl(comparisonOperatorWithInvalidOperand.ts, 2, 3))
+

--- a/tests/baselines/reference/comparisonOperatorWithInvalidOperand.types
+++ b/tests/baselines/reference/comparisonOperatorWithInvalidOperand.types
@@ -1,0 +1,570 @@
+//// [tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithInvalidOperand.ts] ////
+
+=== comparisonOperatorWithInvalidOperand.ts ===
+// repro #15506
+// assumes that only valid comparisons are between anys, numbers and strings
+var a: boolean = false;
+>a : boolean
+>false : false
+
+var b: number = 0;
+>b : number
+>0 : 0
+
+var c: string = "";
+>c : string
+>"" : ""
+
+var d: Date = new Date();
+>d : Date
+>new Date() : Date
+>Date : DateConstructor
+
+var e: number[] = [];
+>e : number[]
+>[] : undefined[]
+
+var f: {} = {};
+>f : {}
+>{} : {}
+
+var g: string[] = [];
+>g : string[]
+>[] : undefined[]
+
+var h: bigint = 9007199254740991n;
+>h : bigint
+>9007199254740991n : 9007199254740991n
+
+var i: Number = 0;
+>i : Number
+>0 : 0
+
+var j: any;
+>j : any
+
+// Literal
+const k = 0;
+>k : 0
+>0 : 0
+
+const l = 9007199254740991n;
+>l : 9007199254740991n
+>9007199254740991n : 9007199254740991n
+
+// operator <
+// boolean
+a < a;
+>a < a : boolean
+>a : false
+>a : false
+
+a < b;
+>a < b : boolean
+>a : false
+>b : number
+
+a < c;
+>a < c : boolean
+>a : false
+>c : string
+
+a < d;
+>a < d : boolean
+>a : false
+>d : Date
+
+a < e;
+>a < e : boolean
+>a : false
+>e : number[]
+
+a < f;
+>a < f : boolean
+>a : false
+>f : {}
+
+a < g;
+>a < g : boolean
+>a : false
+>g : string[]
+
+a < h;
+>a < h : boolean
+>a : false
+>h : bigint
+
+a < i;
+>a < i : boolean
+>a : false
+>i : Number
+
+a < j;
+>a < j : boolean
+>a : false
+>j : any
+
+a < k;
+>a < k : boolean
+>a : false
+>k : 0
+
+a < l;
+>a < l : boolean
+>a : false
+>l : 9007199254740991n
+
+// number
+b < c;
+>b < c : boolean
+>b : number
+>c : string
+
+b < d;
+>b < d : boolean
+>b : number
+>d : Date
+
+b < e;
+>b < e : boolean
+>b : number
+>e : number[]
+
+b < f;
+>b < f : boolean
+>b : number
+>f : {}
+
+b < g;
+>b < g : boolean
+>b : number
+>g : string[]
+
+b < h;
+>b < h : boolean
+>b : number
+>h : bigint
+
+b < i;
+>b < i : boolean
+>b : number
+>i : Number
+
+b < j;
+>b < j : boolean
+>b : number
+>j : any
+
+b < k;
+>b < k : boolean
+>b : number
+>k : 0
+
+b < l;
+>b < l : boolean
+>b : number
+>l : 9007199254740991n
+
+k < l;
+>k < l : boolean
+>k : 0
+>l : 9007199254740991n
+
+// Date
+d < d;
+>d < d : boolean
+>d : Date
+>d : Date
+
+d < a;
+>d < a : boolean
+>d : Date
+>a : false
+
+// operator >
+// boolean
+a > a;
+>a > a : boolean
+>a : false
+>a : false
+
+a > b;
+>a > b : boolean
+>a : false
+>b : number
+
+a > c;
+>a > c : boolean
+>a : false
+>c : string
+
+a > d;
+>a > d : boolean
+>a : false
+>d : Date
+
+a > e;
+>a > e : boolean
+>a : false
+>e : number[]
+
+a > f;
+>a > f : boolean
+>a : false
+>f : {}
+
+a > g;
+>a > g : boolean
+>a : false
+>g : string[]
+
+a > h;
+>a > h : boolean
+>a : false
+>h : bigint
+
+a > i;
+>a > i : boolean
+>a : false
+>i : Number
+
+a > j;
+>a > j : boolean
+>a : false
+>j : any
+
+a > k;
+>a > k : boolean
+>a : false
+>k : 0
+
+a > l;
+>a > l : boolean
+>a : false
+>l : 9007199254740991n
+
+// number
+b > c;
+>b > c : boolean
+>b : number
+>c : string
+
+b > d;
+>b > d : boolean
+>b : number
+>d : Date
+
+b > e;
+>b > e : boolean
+>b : number
+>e : number[]
+
+b > f;
+>b > f : boolean
+>b : number
+>f : {}
+
+b > g;
+>b > g : boolean
+>b : number
+>g : string[]
+
+b > h;
+>b > h : boolean
+>b : number
+>h : bigint
+
+b > i;
+>b > i : boolean
+>b : number
+>i : Number
+
+b > j;
+>b > j : boolean
+>b : number
+>j : any
+
+b > k;
+>b > k : boolean
+>b : number
+>k : 0
+
+b > l;
+>b > l : boolean
+>b : number
+>l : 9007199254740991n
+
+k > l;
+>k > l : boolean
+>k : 0
+>l : 9007199254740991n
+
+// Date
+d > d;
+>d > d : boolean
+>d : Date
+>d : Date
+
+d > a;
+>d > a : boolean
+>d : Date
+>a : false
+
+// operator <=
+// boolean
+a <= a;
+>a <= a : boolean
+>a : false
+>a : false
+
+a <= b;
+>a <= b : boolean
+>a : false
+>b : number
+
+a <= c;
+>a <= c : boolean
+>a : false
+>c : string
+
+a <= d;
+>a <= d : boolean
+>a : false
+>d : Date
+
+a <= e;
+>a <= e : boolean
+>a : false
+>e : number[]
+
+a <= f;
+>a <= f : boolean
+>a : false
+>f : {}
+
+a <= g;
+>a <= g : boolean
+>a : false
+>g : string[]
+
+a <= h;
+>a <= h : boolean
+>a : false
+>h : bigint
+
+a <= i;
+>a <= i : boolean
+>a : false
+>i : Number
+
+a <= j;
+>a <= j : boolean
+>a : false
+>j : any
+
+a <= k;
+>a <= k : boolean
+>a : false
+>k : 0
+
+a <= l;
+>a <= l : boolean
+>a : false
+>l : 9007199254740991n
+
+// number
+b <= c;
+>b <= c : boolean
+>b : number
+>c : string
+
+b <= d;
+>b <= d : boolean
+>b : number
+>d : Date
+
+b <= e;
+>b <= e : boolean
+>b : number
+>e : number[]
+
+b <= f;
+>b <= f : boolean
+>b : number
+>f : {}
+
+b <= g;
+>b <= g : boolean
+>b : number
+>g : string[]
+
+b <= h;
+>b <= h : boolean
+>b : number
+>h : bigint
+
+b <= i;
+>b <= i : boolean
+>b : number
+>i : Number
+
+b <= j;
+>b <= j : boolean
+>b : number
+>j : any
+
+b <= k;
+>b <= k : boolean
+>b : number
+>k : 0
+
+b <= l;
+>b <= l : boolean
+>b : number
+>l : 9007199254740991n
+
+k <= l;
+>k <= l : boolean
+>k : 0
+>l : 9007199254740991n
+
+// Date
+d <= d;
+>d <= d : boolean
+>d : Date
+>d : Date
+
+d <= a;
+>d <= a : boolean
+>d : Date
+>a : false
+
+// operator >=
+// boolean
+a >= a;
+>a >= a : boolean
+>a : false
+>a : false
+
+a >= b;
+>a >= b : boolean
+>a : false
+>b : number
+
+a >= c;
+>a >= c : boolean
+>a : false
+>c : string
+
+a >= d;
+>a >= d : boolean
+>a : false
+>d : Date
+
+a >= e;
+>a >= e : boolean
+>a : false
+>e : number[]
+
+a >= f;
+>a >= f : boolean
+>a : false
+>f : {}
+
+a >= g;
+>a >= g : boolean
+>a : false
+>g : string[]
+
+a >= h;
+>a >= h : boolean
+>a : false
+>h : bigint
+
+a >= i;
+>a >= i : boolean
+>a : false
+>i : Number
+
+a >= j;
+>a >= j : boolean
+>a : false
+>j : any
+
+a >= k;
+>a >= k : boolean
+>a : false
+>k : 0
+
+a >= l;
+>a >= l : boolean
+>a : false
+>l : 9007199254740991n
+
+// number
+b >= c;
+>b >= c : boolean
+>b : number
+>c : string
+
+b >= d;
+>b >= d : boolean
+>b : number
+>d : Date
+
+b >= e;
+>b >= e : boolean
+>b : number
+>e : number[]
+
+b >= f;
+>b >= f : boolean
+>b : number
+>f : {}
+
+b >= g;
+>b >= g : boolean
+>b : number
+>g : string[]
+
+b >= h;
+>b >= h : boolean
+>b : number
+>h : bigint
+
+b >= i;
+>b >= i : boolean
+>b : number
+>i : Number
+
+b >= j;
+>b >= j : boolean
+>b : number
+>j : any
+
+b >= k;
+>b >= k : boolean
+>b : number
+>k : 0
+
+b >= l;
+>b >= l : boolean
+>b : number
+>l : 9007199254740991n
+
+k >= l;
+>k >= l : boolean
+>k : 0
+>l : 9007199254740991n
+
+// Date
+d >= d;
+>d >= d : boolean
+>d : Date
+>d : Date
+
+d >= a;
+>d >= a : boolean
+>d : Date
+>a : false
+

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.errors.txt
@@ -4,48 +4,56 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(37,12): error TS23
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(38,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(45,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(49,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(62,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(63,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(64,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(65,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(66,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(79,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(80,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(81,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(82,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(83,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: C): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: string): void; }' and '{ fn(a: number, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(96,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: string): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(97,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): C; }' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(98,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: C): void; }' and '{ fn(a?: Base): void; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(99,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
+comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(100,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(103,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(): Base; }' and 'new () => Base' have no overlap.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(104,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(a: number, b: string): void; }' and '{ fn(a: string): void; }' have no overlap.
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(105,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(a: Base, b: string): void; }' and '{ fn(a: Derived, b: Base): void; }' have no overlap.
@@ -96,7 +104,7 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(166,12): error TS2
 comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }' have no overlap.
 
 
-==== comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts (96 errors) ====
+==== comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts (104 errors) ====
     class Base {
         public a: string;
     }
@@ -150,6 +158,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r1b1 = b1 < a1;
                ~~~~~~~
@@ -170,6 +180,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator >
     var r2a1 = a1 > b1;
@@ -191,6 +203,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r2b1 = b1 > a1;
                ~~~~~~~
@@ -211,6 +225,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator <=
     var r3a1 = a1 <= b1;
@@ -232,6 +248,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r3b1 = b1 <= a1;
                ~~~~~~~~
@@ -252,6 +270,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator >=
     var r4a1 = a1 >= b1;
@@ -273,6 +293,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: C[]): void; }'.
     var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T): T; }' and '{ fn<T>(t: T[]): T; }'.
     
     var r4b1 = b1 >= a1;
                ~~~~~~~~
@@ -293,6 +315,8 @@ comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts(167,12): error TS2
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: C[]): void; }' and '{ fn(...a: Base[]): void; }'.
     var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(t: T[]): T; }' and '{ fn<T>(t: T): T; }'.
     
     // operator ==
     var r5a1 = a1 == b1;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.errors.txt
@@ -4,48 +4,56 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(37,12): err
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(38,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => C'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(45,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types 'new () => C' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(49,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => C'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(62,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(63,12): error TS2365: Operator '>' cannot be applied to types 'new () => C' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(64,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(65,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(66,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => C'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(79,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(80,12): error TS2365: Operator '<=' cannot be applied to types 'new () => C' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(81,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(82,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(83,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => C'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: C) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and '{ fn(): Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: string) => Base' and 'new (a: number, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(96,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: string) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(97,12): error TS2365: Operator '>=' cannot be applied to types 'new () => C' and 'new () => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(98,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: C) => Base' and 'new (a?: Base) => Base'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(99,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(100,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(103,12): error TS2367: This comparison appears to be unintentional because the types '{ fn(): Base; }' and 'new () => Base' have no overlap.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(104,12): error TS2367: This comparison appears to be unintentional because the types 'new (a: number, b: string) => Base' and 'new (a: string) => Base' have no overlap.
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(105,12): error TS2367: This comparison appears to be unintentional because the types 'new (a: Base, b: string) => Base' and 'new (a: Derived, b: Base) => Base' have no overlap.
@@ -96,7 +104,7 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(166,12): er
 comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): error TS2367: This comparison appears to be unintentional because the types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base' have no overlap.
 
 
-==== comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts (96 errors) ====
+==== comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts (104 errors) ====
     class Base {
         public a: string;
     }
@@ -150,6 +158,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r1b1 = b1 < a1;
                ~~~~~~~
@@ -170,6 +180,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator >
     var r2a1 = a1 > b1;
@@ -191,6 +203,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r2b1 = b1 > a1;
                ~~~~~~~
@@ -211,6 +225,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator <=
     var r3a1 = a1 <= b1;
@@ -232,6 +248,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r3b1 = b1 <= a1;
                ~~~~~~~~
@@ -252,6 +270,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator >=
     var r4a1 = a1 >= b1;
@@ -273,6 +293,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: C[]) => Base'.
     var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T) => T' and 'new <T>(t: T[]) => T'.
     
     var r4b1 = b1 >= a1;
                ~~~~~~~~
@@ -293,6 +315,8 @@ comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts(167,12): er
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: C[]) => Base' and 'new (...a: Base[]) => Base'.
     var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(t: T[]) => T' and 'new <T>(t: T) => T'.
     
     // operator ==
     var r5a1 = a1 == b1;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.errors.txt
@@ -1,27 +1,35 @@
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(26,12): error TS2365: Operator '<' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(27,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(28,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(29,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(31,12): error TS2365: Operator '<' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(37,12): error TS2365: Operator '>' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(38,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(39,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(40,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(42,12): error TS2365: Operator '>' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(43,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(44,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(45,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(48,12): error TS2365: Operator '<=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(49,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(50,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(51,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(53,12): error TS2365: Operator '<=' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(54,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(55,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(56,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(59,12): error TS2365: Operator '>=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: number; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(60,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: C; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(61,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(62,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(64,12): error TS2365: Operator '>=' cannot be applied to types '{ [b: string]: number; }' and '{ [a: string]: string; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(65,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: C; }' and '{ [index: string]: Base; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(66,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(67,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(70,12): error TS2367: This comparison appears to be unintentional because the types '{ [a: string]: string; }' and '{ [b: string]: number; }' have no overlap.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(71,12): error TS2367: This comparison appears to be unintentional because the types '{ [index: string]: Base; }' and '{ [index: string]: C; }' have no overlap.
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(72,12): error TS2367: This comparison appears to be unintentional because the types '{ [index: number]: Base; }' and '{ [index: number]: C; }' have no overlap.
@@ -48,7 +56,7 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(109,12): error TS
 comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS2367: This comparison appears to be unintentional because the types '{ [index: number]: C; }' and '{ [index: number]: Base; }' have no overlap.
 
 
-==== comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts (48 errors) ====
+==== comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts (56 errors) ====
     class Base {
         public a: string;
     }
@@ -84,6 +92,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r1b1 = b1 < a1;
                ~~~~~~~
@@ -95,6 +105,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator >
     var r2a1 = a1 > b1;
@@ -107,6 +119,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r2b1 = b1 > a1;
                ~~~~~~~
@@ -118,6 +132,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator <=
     var r3a1 = a1 <= b1;
@@ -130,6 +146,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r3b1 = b1 <= a1;
                ~~~~~~~~
@@ -141,6 +159,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~~
 !!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator >=
     var r4a1 = a1 >= b1;
@@ -153,6 +173,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: number]: C; }'.
     var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Derived; }' and '{ [index: string]: Base; }'.
     
     var r4b1 = b1 >= a1;
                ~~~~~~~~
@@ -164,6 +186,8 @@ comparisonOperatorWithNoRelationshipObjectsOnIndexSignature.ts(110,12): error TS
                ~~~~~~~~
 !!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: C; }' and '{ [index: number]: Base; }'.
     var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: number]: Derived; }'.
     
     // operator ==
     var r5a1 = a1 == b1;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.errors.txt
@@ -1,0 +1,296 @@
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(37,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(47,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(62,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(63,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(64,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(77,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(78,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(79,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(80,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(81,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+
+
+==== comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    class C {
+        public c: string;
+    }
+    
+    var a1: { fn<T>(x: T): T };
+    var b1: { fn(): string };
+    
+    var a2: { fn<T>(x: T): T };
+    var b2: { fn(x: string): number };
+    
+    var a3: { fn<T>(x?: T): T };
+    var b3: { fn(x?: string): number };
+    
+    var a4: { fn<T>(...x: T[]): T };
+    var b4: { fn(...x: string[]): number };
+    
+    var a5: { fn<T>(x: T, y: T): T };
+    var b5: { fn(x: string, y: number): string };
+    
+    var a6: { fn<T, U extends T>(x: T, y: U): T };
+    var b6: { fn(x: Base, y: C): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(): string; }'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): number; }'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): number; }'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): number; }'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U extends T>(x: T, y: U): T; }' and '{ fn(x: Base, y: C): Base; }'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): string; }' and '{ fn<T>(x: T): T; }'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): number; }' and '{ fn<T>(x: T): T; }'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): number; }' and '{ fn<T>(x?: T): T; }'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): number; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T, y: T): T; }'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: Base, y: C): Base; }' and '{ fn<T, U extends T>(x: T, y: U): T; }'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.errors.txt
@@ -1,0 +1,296 @@
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(37,12): error TS2365: Operator '<' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(47,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(55,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(62,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(63,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(64,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(72,12): error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(77,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(78,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(79,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(80,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(81,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(88,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts(89,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+
+
+==== comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    class C {
+        public c: string;
+    }
+    
+    var a1: { new <T>(x: T): T };
+    var b1: { new (): string };
+    
+    var a2: { new <T>(x: T): T };
+    var b2: { new (x: string): number };
+    
+    var a3: { new <T>(x?: T): T };
+    var b3: { new (x?: string): number };
+    
+    var a4: { new <T>(...x: T[]): T };
+    var b4: { new (...x: string[]): number };
+    
+    var a5: { new <T>(x: T, y: T): T };
+    var b5: { new (x: string, y: number): string };
+    
+    var a6: { new <T, U extends T>(x: T, y: U): T };
+    var b6: { new (x: Base, y: C): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new () => string'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => number'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => number'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => number'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => string'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T, U extends T>(x: T, y: U) => T' and 'new (x: Base, y: C) => Base'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => string' and 'new <T>(x: T) => T'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => number' and 'new <T>(x: T) => T'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => number' and 'new <T>(x?: T) => T'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => number' and 'new <T>(...x: T[]) => T'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T, y: T) => T'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: Base, y: C) => Base' and 'new <T, U extends T>(x: T, y: U) => T'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipTypeParameter.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipTypeParameter.errors.txt
@@ -6,41 +6,121 @@ comparisonOperatorWithNoRelationshipTypeParameter.ts(16,14): error TS2367: This 
 comparisonOperatorWithNoRelationshipTypeParameter.ts(17,14): error TS2367: This comparison appears to be unintentional because the types 'T' and 'U' have no overlap.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(18,14): error TS2367: This comparison appears to be unintentional because the types 'T' and 'U' have no overlap.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(19,14): error TS2367: This comparison appears to be unintentional because the types 'T' and 'U' have no overlap.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(22,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(23,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(24,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(25,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(26,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(27,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(28,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(30,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(31,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(32,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(33,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(34,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(35,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(36,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(39,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(40,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(41,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(42,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(43,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(44,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(45,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(47,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(48,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(49,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(50,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(51,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(52,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(53,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(56,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(57,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(58,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(59,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(60,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(61,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(62,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(64,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(65,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(66,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(67,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(68,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(69,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(70,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(73,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(74,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(75,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(76,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(77,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(78,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(79,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(81,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(82,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(83,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(84,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(85,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(86,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(87,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(90,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(91,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(92,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(93,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(94,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(95,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(96,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(98,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(99,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(100,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(101,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(102,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(103,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(104,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(107,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(108,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(109,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(110,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(111,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(112,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(113,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(115,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(116,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(117,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(118,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(119,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(120,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(121,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(124,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(125,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(126,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(127,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(128,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(129,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(130,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(132,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(133,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(134,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(135,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(136,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(137,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(138,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(141,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(142,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(143,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(144,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(145,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(146,16): error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(147,16): error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(149,16): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(150,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(151,16): error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(152,16): error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
 comparisonOperatorWithNoRelationshipTypeParameter.ts(153,16): error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(154,16): error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+comparisonOperatorWithNoRelationshipTypeParameter.ts(155,16): error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
 
 
-==== comparisonOperatorWithNoRelationshipTypeParameter.ts (40 errors) ====
+==== comparisonOperatorWithNoRelationshipTypeParameter.ts (120 errors) ====
     enum E { a, b, c }
     
     var a: boolean;
@@ -79,201 +159,361 @@ comparisonOperatorWithNoRelationshipTypeParameter.ts(153,16): error TS2365: Oper
     
         // operator <
         var r1a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r1a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r1a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r1a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r1a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r1a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r1a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r1b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r1b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r1b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r1b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r1b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r1b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r1b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator >
         var r2a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r2a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r2a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r2a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r2a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r2a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r2a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r2b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r2b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r2b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r2b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r2b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r2b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r2b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator <=
         var r3a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r3a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r3a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r3a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r3a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r3a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r3a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r3b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r3b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r3b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r3b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r3b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r3b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r3b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator >=
         var r4a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r4a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r4a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r4a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r4a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r4a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r4a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r4b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r4b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r4b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r4b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r4b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r4b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r4b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator ==
         var r5a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r5a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r5a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r5a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r5a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r5a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r5a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r5b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r5b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r5b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r5b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r5b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r5b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r5b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator !=
         var r6a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r6a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r6a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r6a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r6a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r6a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r6a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r6b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r6b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r6b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r6b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r6b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r6b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r6b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator ===
         var r7a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r7a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r7a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r7a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r7a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r7a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r7a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r7b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r7b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r7b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r7b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r7b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r7b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r7b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     
         // operator !==
         var r8a1 = t < a;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
         var r8a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r8a3 = t < c;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
         var r8a4 = t < d;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
         var r8a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
         var r8a6 = t < f;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
         var r8a7 = t < g;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
     
         var r8b1 = a < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
         var r8b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r8b3 = c < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
         var r8b4 = d < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
         var r8b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
         var r8b6 = f < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
         var r8b7 = g < t;
+                   ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
     }

--- a/tests/baselines/reference/comparisonOperatorWithNumericLiteral.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNumericLiteral.errors.txt
@@ -1,0 +1,82 @@
+comparisonOperatorWithNumericLiteral.ts(5,1): error TS2365: Operator '>' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(6,1): error TS2365: Operator '>' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(7,1): error TS2365: Operator '>' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+comparisonOperatorWithNumericLiteral.ts(10,1): error TS2365: Operator '<' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(11,1): error TS2365: Operator '<' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(12,1): error TS2365: Operator '<' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+comparisonOperatorWithNumericLiteral.ts(15,1): error TS2365: Operator '>=' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(16,1): error TS2365: Operator '>=' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(17,1): error TS2365: Operator '>=' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+comparisonOperatorWithNumericLiteral.ts(20,1): error TS2365: Operator '<=' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(21,1): error TS2365: Operator '<=' cannot be applied to types 'BrandedNum' and 'number'.
+comparisonOperatorWithNumericLiteral.ts(22,1): error TS2365: Operator '<=' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+
+
+==== comparisonOperatorWithNumericLiteral.ts (12 errors) ====
+    type BrandedNum = number & { __numberBrand: any };
+    var x : BrandedNum;
+    
+    // operator >
+    x > 0;
+    ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'BrandedNum' and 'number'.
+    x > <number>0;
+    ~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'BrandedNum' and 'number'.
+    x > <BrandedNum>0;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+    
+    // operator <
+    x < 0;
+    ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'BrandedNum' and 'number'.
+    x < <number>0;
+    ~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'BrandedNum' and 'number'.
+    x < <BrandedNum>0;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+    
+    // operator >=
+    x >= 0;
+    ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'BrandedNum' and 'number'.
+    x >= <number>0;
+    ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'BrandedNum' and 'number'.
+    x >= <BrandedNum>0;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+    
+    // operator <=
+    x <= 0;
+    ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'BrandedNum' and 'number'.
+    x <= <number>0;
+    ~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'BrandedNum' and 'number'.
+    x <= <BrandedNum>0;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'BrandedNum' and 'BrandedNum'.
+    
+    // operator ==
+    x == 0;
+    x == <number>0;
+    x == <BrandedNum>0;
+    
+    // operator !=
+    x != 0;
+    x != <number>0;
+    x != <BrandedNum>0;
+    
+    // operator ===
+    x === 0;
+    x === <number>0;
+    x === <BrandedNum>0;
+    
+    // operator !==
+    x !== 0;
+    x !== <number>0;
+    x !== <BrandedNum>0;
+    

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsAny.errors.txt
@@ -1,0 +1,290 @@
+comparisonOperatorWithOneOperandIsAny.ts(6,18): error TS2365: Operator '<' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(7,18): error TS2365: Operator '>' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(8,18): error TS2365: Operator '<=' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(9,18): error TS2365: Operator '>=' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(15,18): error TS2365: Operator '<' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsAny.ts(16,18): error TS2365: Operator '>' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsAny.ts(17,18): error TS2365: Operator '<=' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsAny.ts(18,18): error TS2365: Operator '>=' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsAny.ts(34,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsAny.ts(37,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsAny.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsAny.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsAny.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(45,12): error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(47,12): error TS2365: Operator '<' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(48,12): error TS2365: Operator '<' cannot be applied to types 'string[]' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(51,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsAny.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsAny.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsAny.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsAny.ts(59,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(62,12): error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(64,12): error TS2365: Operator '>' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(65,12): error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(68,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsAny.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsAny.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsAny.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsAny.ts(76,12): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(79,12): error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(81,12): error TS2365: Operator '<=' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(82,12): error TS2365: Operator '<=' cannot be applied to types 'string[]' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(85,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsAny.ts(88,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsAny.ts(90,12): error TS2365: Operator '>=' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsAny.ts(91,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsAny.ts(93,12): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(96,12): error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(98,12): error TS2365: Operator '>=' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsAny.ts(99,12): error TS2365: Operator '>=' cannot be applied to types 'string[]' and 'any'.
+
+
+==== comparisonOperatorWithOneOperandIsAny.ts (40 errors) ====
+    var x: any;
+    
+    enum E { a, b, c }
+    
+    function foo<T>(t: T) {
+        var foo_r1 = t < x;
+                     ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any'.
+        var foo_r2 = t > x;
+                     ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and 'any'.
+        var foo_r3 = t <= x;
+                     ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and 'any'.
+        var foo_r4 = t >= x;
+                     ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and 'any'.
+        var foo_r5 = t == x;
+        var foo_r6 = t != x;
+        var foo_r7 = t === x;
+        var foo_r8 = t !== x;
+    
+        var foo_r1 = x < t;
+                     ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'T'.
+        var foo_r2 = x > t;
+                     ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'T'.
+        var foo_r3 = x <= t;
+                     ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'T'.
+        var foo_r4 = x >= t;
+                     ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'T'.
+        var foo_r5 = x == t;
+        var foo_r6 = x != t;
+        var foo_r7 = x === t;
+        var foo_r8 = x !== t;
+    }
+    
+    var a: boolean;
+    var b: number;
+    var c: string;
+    var d: void;
+    var e: E;
+    var f: {};
+    var g: string[];
+    
+    // operator <
+    var r1a1 = x < a;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+    var r1a2 = x < b;
+    var r1a3 = x < c;
+    var r1a4 = x < d;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+    var r1a5 = x < e;
+    var r1a6 = x < f;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and '{}'.
+    var r1a7 = x < g;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'string[]'.
+    
+    var r1b1 = a < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+    var r1b2 = b < x;
+    var r1b3 = c < x;
+    var r1b4 = d < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+    var r1b5 = e < x;
+    var r1b6 = f < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{}' and 'any'.
+    var r1b7 = g < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator >
+    var r2a1 = x > a;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+    var r2a2 = x > b;
+    var r2a3 = x > c;
+    var r2a4 = x > d;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+    var r2a5 = x > e;
+    var r2a6 = x > f;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and '{}'.
+    var r2a7 = x > g;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'string[]'.
+    
+    var r2b1 = a > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+    var r2b2 = b > x;
+    var r2b3 = c > x;
+    var r2b4 = d > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+    var r2b5 = e > x;
+    var r2b6 = f > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{}' and 'any'.
+    var r2b7 = g > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator <=
+    var r3a1 = x <= a;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+    var r3a2 = x <= b;
+    var r3a3 = x <= c;
+    var r3a4 = x <= d;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+    var r3a5 = x <= e;
+    var r3a6 = x <= f;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and '{}'.
+    var r3a7 = x <= g;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'string[]'.
+    
+    var r3b1 = a <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+    var r3b2 = b <= x;
+    var r3b3 = c <= x;
+    var r3b4 = d <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+    var r3b5 = e <= x;
+    var r3b6 = f <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{}' and 'any'.
+    var r3b7 = g <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator >=
+    var r4a1 = x >= a;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+    var r4a2 = x >= b;
+    var r4a3 = x >= c;
+    var r4a4 = x >= d;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+    var r4a5 = x >= e;
+    var r4a6 = x >= f;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and '{}'.
+    var r4a7 = x >= g;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'string[]'.
+    
+    var r4b1 = a >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+    var r4b2 = b >= x;
+    var r4b3 = c >= x;
+    var r4b4 = d >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+    var r4b5 = e >= x;
+    var r4b6 = f >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{}' and 'any'.
+    var r4b7 = g >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator ==
+    var r5a1 = x == a;
+    var r5a2 = x == b;
+    var r5a3 = x == c;
+    var r5a4 = x == d;
+    var r5a5 = x == e;
+    var r5a6 = x == f;
+    var r5a7 = x == g;
+    
+    var r5b1 = a == x;
+    var r5b2 = b == x;
+    var r5b3 = c == x;
+    var r5b4 = d == x;
+    var r5b5 = e == x;
+    var r5b6 = f == x;
+    var r5b7 = g == x;
+    
+    // operator !=
+    var r6a1 = x != a;
+    var r6a2 = x != b;
+    var r6a3 = x != c;
+    var r6a4 = x != d;
+    var r6a5 = x != e;
+    var r6a6 = x != f;
+    var r6a7 = x != g;
+    
+    var r6b1 = a != x;
+    var r6b2 = b != x;
+    var r6b3 = c != x;
+    var r6b4 = d != x;
+    var r6b5 = e != x;
+    var r6b6 = f != x;
+    var r6b7 = g != x;
+    
+    // operator ===
+    var r7a1 = x === a;
+    var r7a2 = x === b;
+    var r7a3 = x === c;
+    var r7a4 = x === d;
+    var r7a5 = x === e;
+    var r7a6 = x === f;
+    var r7a7 = x === g;
+    
+    var r7b1 = a === x;
+    var r7b2 = b === x;
+    var r7b3 = c === x;
+    var r7b4 = d === x;
+    var r7b5 = e === x;
+    var r7b6 = f === x;
+    var r7b7 = g === x;
+    
+    // operator !==
+    var r8a1 = x !== a;
+    var r8a2 = x !== b;
+    var r8a3 = x !== c;
+    var r8a4 = x !== d;
+    var r8a5 = x !== e;
+    var r8a6 = x !== f;
+    var r8a7 = x !== g;
+    
+    var r8b1 = a !== x;
+    var r8b2 = b !== x;
+    var r8b3 = c !== x;
+    var r8b4 = d !== x;
+    var r8b5 = e !== x;
+    var r8b6 = f !== x;
+    var r8b7 = g !== x;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
@@ -1,83 +1,131 @@
+comparisonOperatorWithOneOperandIsNull.ts(4,18): error TS2365: Operator '<' cannot be applied to types 'T' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(4,22): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(5,18): error TS2365: Operator '>' cannot be applied to types 'T' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(5,22): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(6,18): error TS2365: Operator '<=' cannot be applied to types 'T' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(6,23): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(7,18): error TS2365: Operator '>=' cannot be applied to types 'T' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(7,23): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(13,18): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(13,18): error TS2365: Operator '<' cannot be applied to types 'any' and 'T'.
 comparisonOperatorWithOneOperandIsNull.ts(14,18): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(14,18): error TS2365: Operator '>' cannot be applied to types 'any' and 'T'.
 comparisonOperatorWithOneOperandIsNull.ts(15,18): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(15,18): error TS2365: Operator '<=' cannot be applied to types 'any' and 'T'.
 comparisonOperatorWithOneOperandIsNull.ts(16,18): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(16,18): error TS2365: Operator '>=' cannot be applied to types 'any' and 'T'.
 comparisonOperatorWithOneOperandIsNull.ts(32,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(32,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
 comparisonOperatorWithOneOperandIsNull.ts(33,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(34,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(35,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(35,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
 comparisonOperatorWithOneOperandIsNull.ts(36,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(37,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(37,12): error TS2365: Operator '<' cannot be applied to types 'any' and '{}'.
 comparisonOperatorWithOneOperandIsNull.ts(38,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(38,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsNull.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(40,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(41,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(42,16): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(43,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(44,16): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(45,12): error TS2365: Operator '<' cannot be applied to types '{}' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(45,16): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(46,12): error TS2365: Operator '<' cannot be applied to types 'string[]' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(46,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(49,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(49,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
 comparisonOperatorWithOneOperandIsNull.ts(50,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(51,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(52,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(52,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
 comparisonOperatorWithOneOperandIsNull.ts(53,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(54,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'any' and '{}'.
 comparisonOperatorWithOneOperandIsNull.ts(55,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(55,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsNull.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(57,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(58,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(59,16): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(60,12): error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(60,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(61,16): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(62,12): error TS2365: Operator '>' cannot be applied to types '{}' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(62,16): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(63,12): error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(63,16): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(66,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(66,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
 comparisonOperatorWithOneOperandIsNull.ts(67,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(68,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(69,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(69,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
 comparisonOperatorWithOneOperandIsNull.ts(70,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(71,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'any' and '{}'.
 comparisonOperatorWithOneOperandIsNull.ts(72,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(72,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsNull.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(74,17): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(75,17): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(76,17): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(77,12): error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(77,17): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(78,17): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(79,12): error TS2365: Operator '<=' cannot be applied to types '{}' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(79,17): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(80,12): error TS2365: Operator '<=' cannot be applied to types 'string[]' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(80,17): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(83,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(83,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
 comparisonOperatorWithOneOperandIsNull.ts(84,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(85,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(86,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(86,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
 comparisonOperatorWithOneOperandIsNull.ts(87,12): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(88,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(88,12): error TS2365: Operator '>=' cannot be applied to types 'any' and '{}'.
 comparisonOperatorWithOneOperandIsNull.ts(89,12): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(89,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsNull.ts(91,12): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(91,17): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(92,17): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(93,17): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(94,12): error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(94,17): error TS18050: The value 'null' cannot be used here.
 comparisonOperatorWithOneOperandIsNull.ts(95,17): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(96,12): error TS2365: Operator '>=' cannot be applied to types '{}' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(96,17): error TS18050: The value 'null' cannot be used here.
+comparisonOperatorWithOneOperandIsNull.ts(97,12): error TS2365: Operator '>=' cannot be applied to types 'string[]' and 'any'.
 comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null' cannot be used here.
 
 
-==== comparisonOperatorWithOneOperandIsNull.ts (64 errors) ====
+==== comparisonOperatorWithOneOperandIsNull.ts (104 errors) ====
     enum E { a, b, c }
     
     function foo<T>(t: T) {
         var foo_r1 = t < null;
+                     ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any'.
                          ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
         var foo_r2 = t > null;
+                     ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and 'any'.
                          ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
         var foo_r3 = t <= null;
+                     ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and 'any'.
                           ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
         var foo_r4 = t >= null;
+                     ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and 'any'.
                           ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
         var foo_r5 = t == null;
@@ -88,15 +136,23 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
         var foo_r1 = null < t;
                      ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+                     ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'T'.
         var foo_r2 = null > t;
                      ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+                     ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'T'.
         var foo_r3 = null <= t;
                      ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+                     ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'T'.
         var foo_r4 = null >= t;
                      ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+                     ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'T'.
         var foo_r5 = null == t;
         var foo_r6 = null != t;
         var foo_r7 = null === t;
@@ -115,6 +171,8 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r1a1 = null < a;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
     var r1a2 = null < b;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
@@ -124,17 +182,25 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r1a4 = null < d;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
     var r1a5 = null < e;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r1a6 = null < f;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and '{}'.
     var r1a7 = null < g;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'string[]'.
     
     var r1b1 = a < null;
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r1b2 = b < null;
@@ -144,15 +210,21 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r1b4 = d < null;
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r1b5 = e < null;
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r1b6 = f < null;
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{}' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r1b7 = g < null;
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string[]' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     
@@ -160,6 +232,8 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r2a1 = null > a;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
     var r2a2 = null > b;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
@@ -169,17 +243,25 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r2a4 = null > d;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
     var r2a5 = null > e;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r2a6 = null > f;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and '{}'.
     var r2a7 = null > g;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'string[]'.
     
     var r2b1 = a > null;
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r2b2 = b > null;
@@ -189,15 +271,21 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r2b4 = d > null;
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r2b5 = e > null;
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r2b6 = f > null;
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{}' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r2b7 = g > null;
+               ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
                    ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     
@@ -205,6 +293,8 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r3a1 = null <= a;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
     var r3a2 = null <= b;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
@@ -214,17 +304,25 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r3a4 = null <= d;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
     var r3a5 = null <= e;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r3a6 = null <= f;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and '{}'.
     var r3a7 = null <= g;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'string[]'.
     
     var r3b1 = a <= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r3b2 = b <= null;
@@ -234,15 +332,21 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r3b4 = d <= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r3b5 = e <= null;
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r3b6 = f <= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{}' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r3b7 = g <= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'string[]' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     
@@ -250,6 +354,8 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r4a1 = null >= a;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
     var r4a2 = null >= b;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
@@ -259,17 +365,25 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
     var r4a4 = null >= d;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
     var r4a5 = null >= e;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r4a6 = null >= f;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and '{}'.
     var r4a7 = null >= g;
                ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'string[]'.
     
     var r4b1 = a >= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r4b2 = b >= null;
@@ -279,15 +393,21 @@ comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS18050: The value 'null
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r4b4 = d >= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r4b5 = e >= null;
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r4b6 = f >= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{}' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     var r4b7 = g >= null;
+               ~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'string[]' and 'any'.
                     ~~~~
 !!! error TS18050: The value 'null' cannot be used here.
     

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsUndefined.errors.txt
@@ -1,0 +1,290 @@
+comparisonOperatorWithOneOperandIsUndefined.ts(6,18): error TS2365: Operator '<' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(7,18): error TS2365: Operator '>' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(8,18): error TS2365: Operator '<=' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(9,18): error TS2365: Operator '>=' cannot be applied to types 'T' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(15,18): error TS2365: Operator '<' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsUndefined.ts(16,18): error TS2365: Operator '>' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsUndefined.ts(17,18): error TS2365: Operator '<=' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsUndefined.ts(18,18): error TS2365: Operator '>=' cannot be applied to types 'any' and 'T'.
+comparisonOperatorWithOneOperandIsUndefined.ts(34,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsUndefined.ts(37,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsUndefined.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsUndefined.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsUndefined.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(45,12): error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(47,12): error TS2365: Operator '<' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(48,12): error TS2365: Operator '<' cannot be applied to types 'string[]' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(51,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsUndefined.ts(54,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsUndefined.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsUndefined.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsUndefined.ts(59,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(62,12): error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(64,12): error TS2365: Operator '>' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(65,12): error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(68,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsUndefined.ts(71,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsUndefined.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsUndefined.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsUndefined.ts(76,12): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(79,12): error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(81,12): error TS2365: Operator '<=' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(82,12): error TS2365: Operator '<=' cannot be applied to types 'string[]' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(85,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+comparisonOperatorWithOneOperandIsUndefined.ts(88,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+comparisonOperatorWithOneOperandIsUndefined.ts(90,12): error TS2365: Operator '>=' cannot be applied to types 'any' and '{}'.
+comparisonOperatorWithOneOperandIsUndefined.ts(91,12): error TS2365: Operator '>=' cannot be applied to types 'any' and 'string[]'.
+comparisonOperatorWithOneOperandIsUndefined.ts(93,12): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(96,12): error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(98,12): error TS2365: Operator '>=' cannot be applied to types '{}' and 'any'.
+comparisonOperatorWithOneOperandIsUndefined.ts(99,12): error TS2365: Operator '>=' cannot be applied to types 'string[]' and 'any'.
+
+
+==== comparisonOperatorWithOneOperandIsUndefined.ts (40 errors) ====
+    var x: typeof undefined;
+    
+    enum E { a, b, c }
+    
+    function foo<T>(t: T) {
+        var foo_r1 = t < x;
+                     ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any'.
+        var foo_r2 = t > x;
+                     ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and 'any'.
+        var foo_r3 = t <= x;
+                     ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and 'any'.
+        var foo_r4 = t >= x;
+                     ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and 'any'.
+        var foo_r5 = t == x;
+        var foo_r6 = t != x;
+        var foo_r7 = t === x;
+        var foo_r8 = t !== x;
+    
+        var foo_r1 = x < t;
+                     ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'T'.
+        var foo_r2 = x > t;
+                     ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'T'.
+        var foo_r3 = x <= t;
+                     ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'T'.
+        var foo_r4 = x >= t;
+                     ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'T'.
+        var foo_r5 = x == t;
+        var foo_r6 = x != t;
+        var foo_r7 = x === t;
+        var foo_r8 = x !== t;
+    }
+    
+    var a: boolean;
+    var b: number;
+    var c: string;
+    var d: void;
+    var e: E;
+    var f: {};
+    var g: string[];
+    
+    // operator <
+    var r1a1 = x < a;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'boolean'.
+    var r1a2 = x < b;
+    var r1a3 = x < c;
+    var r1a4 = x < d;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'void'.
+    var r1a5 = x < e;
+    var r1a6 = x < f;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and '{}'.
+    var r1a7 = x < g;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'any' and 'string[]'.
+    
+    var r1b1 = a < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'any'.
+    var r1b2 = b < x;
+    var r1b3 = c < x;
+    var r1b4 = d < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'any'.
+    var r1b5 = e < x;
+    var r1b6 = f < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{}' and 'any'.
+    var r1b7 = g < x;
+               ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator >
+    var r2a1 = x > a;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
+    var r2a2 = x > b;
+    var r2a3 = x > c;
+    var r2a4 = x > d;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'void'.
+    var r2a5 = x > e;
+    var r2a6 = x > f;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and '{}'.
+    var r2a7 = x > g;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'string[]'.
+    
+    var r2b1 = a > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
+    var r2b2 = b > x;
+    var r2b3 = c > x;
+    var r2b4 = d > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'any'.
+    var r2b5 = e > x;
+    var r2b6 = f > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{}' and 'any'.
+    var r2b7 = g > x;
+               ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator <=
+    var r3a1 = x <= a;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'boolean'.
+    var r3a2 = x <= b;
+    var r3a3 = x <= c;
+    var r3a4 = x <= d;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'void'.
+    var r3a5 = x <= e;
+    var r3a6 = x <= f;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and '{}'.
+    var r3a7 = x <= g;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'any' and 'string[]'.
+    
+    var r3b1 = a <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'any'.
+    var r3b2 = b <= x;
+    var r3b3 = c <= x;
+    var r3b4 = d <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'any'.
+    var r3b5 = e <= x;
+    var r3b6 = f <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{}' and 'any'.
+    var r3b7 = g <= x;
+               ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator >=
+    var r4a1 = x >= a;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'boolean'.
+    var r4a2 = x >= b;
+    var r4a3 = x >= c;
+    var r4a4 = x >= d;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'void'.
+    var r4a5 = x >= e;
+    var r4a6 = x >= f;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and '{}'.
+    var r4a7 = x >= g;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'any' and 'string[]'.
+    
+    var r4b1 = a >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'any'.
+    var r4b2 = b >= x;
+    var r4b3 = c >= x;
+    var r4b4 = d >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'any'.
+    var r4b5 = e >= x;
+    var r4b6 = f >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{}' and 'any'.
+    var r4b7 = g >= x;
+               ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'string[]' and 'any'.
+    
+    // operator ==
+    var r5a1 = x == a;
+    var r5a2 = x == b;
+    var r5a3 = x == c;
+    var r5a4 = x == d;
+    var r5a5 = x == e;
+    var r5a6 = x == f;
+    var r5a7 = x == g;
+    
+    var r5b1 = a == x;
+    var r5b2 = b == x;
+    var r5b3 = c == x;
+    var r5b4 = d == x;
+    var r5b5 = e == x;
+    var r5b6 = f == x;
+    var r5b7 = g == x;
+    
+    // operator !=
+    var r6a1 = x != a;
+    var r6a2 = x != b;
+    var r6a3 = x != c;
+    var r6a4 = x != d;
+    var r6a5 = x != e;
+    var r6a6 = x != f;
+    var r6a7 = x != g;
+    
+    var r6b1 = a != x;
+    var r6b2 = b != x;
+    var r6b3 = c != x;
+    var r6b4 = d != x;
+    var r6b5 = e != x;
+    var r6b6 = f != x;
+    var r6b7 = g != x;
+    
+    // operator ===
+    var r7a1 = x === a;
+    var r7a2 = x === b;
+    var r7a3 = x === c;
+    var r7a4 = x === d;
+    var r7a5 = x === e;
+    var r7a6 = x === f;
+    var r7a7 = x === g;
+    
+    var r7b1 = a === x;
+    var r7b2 = b === x;
+    var r7b3 = c === x;
+    var r7b4 = d === x;
+    var r7b5 = e === x;
+    var r7b6 = f === x;
+    var r7b7 = g === x;
+    
+    // operator !==
+    var r8a1 = x !== a;
+    var r8a2 = x !== b;
+    var r8a3 = x !== c;
+    var r8a4 = x !== d;
+    var r8a5 = x !== e;
+    var r8a6 = x !== f;
+    var r8a7 = x !== g;
+    
+    var r8b1 = a !== x;
+    var r8b2 = b !== x;
+    var r8b3 = c !== x;
+    var r8b4 = d !== x;
+    var r8b5 = e !== x;
+    var r8b6 = f !== x;
+    var r8b7 = g !== x;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnCallSignature.errors.txt
@@ -1,0 +1,526 @@
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(49,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(50,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(51,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(52,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(53,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(54,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(55,13): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(56,13): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(59,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(60,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(61,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(62,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(63,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(64,12): error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(65,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(66,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(67,12): error TS2365: Operator '<' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(68,13): error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(69,13): error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(73,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(74,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(75,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(76,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(77,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(78,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(79,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(80,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(81,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(82,13): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(83,13): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(86,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(87,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(88,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(89,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(90,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(91,12): error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(92,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(93,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(94,12): error TS2365: Operator '>' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(95,13): error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(96,13): error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(100,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(101,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(102,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(103,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(104,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(105,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(106,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(107,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(108,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(109,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(110,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(113,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(114,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(115,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(116,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(117,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(118,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(119,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(120,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(121,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(122,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(123,13): error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(127,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(128,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(129,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(130,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(131,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(132,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(133,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(134,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(135,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(136,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(137,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(140,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(141,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(142,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(143,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(144,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(145,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(146,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(147,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(148,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(149,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+comparisonOperatorWithSubtypeObjectOnCallSignature.ts(150,13): error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+
+
+==== comparisonOperatorWithSubtypeObjectOnCallSignature.ts (88 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { fn(): void };
+    var b1: { fn(): void };
+    
+    var a2: { fn(a: number, b: string): void };
+    var b2: { fn(a: number, b: string): void };
+    
+    var a3: { fn(a: number, b: string): void };
+    var b3: { fn(a: number): void };
+    
+    var a4: { fn(a: number, b: string): void };
+    var b4: { fn(): void };
+    
+    var a5: { fn(a: Base): void };
+    var b5: { fn(a: Derived): void };
+    
+    var a6: { fn(a: Derived, b: Base): void };
+    var b6: { fn(a: Base, b: Derived): void };
+    
+    var a7: { fn(): void };
+    var b7: { fn(): Base };
+    
+    var a8: { fn(): Base };
+    var b8: { fn(): Base };
+    
+    var a9: { fn(): Base };
+    var b9: { fn(): Derived };
+    
+    var a10: { fn(a?: Base): void };
+    var b10: { fn(a?: Derived): void };
+    
+    var a11: { fn(...a: Base[]): void };
+    var b11: { fn(...a: Derived[]): void };
+    
+    //var a12: { fn<T, U extends T>(t: T, u: U): T[] };
+    //var b12: { fn<A, B extends A>(a: A, b: B): A[] };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r1a8 = a8 < b8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r1a9 = a9 < b9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r1a10 = a10 < b10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r1a11 = a11 < b11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r1a12 = a12 < b12;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r1b8 = b8 < a8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r1b9 = b9 < a9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r1b10 = b10 < a10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r1b11 = b11 < a11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r1b12 = b12 < a12;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r2a8 = a8 > b8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r2a9 = a9 > b9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r2a10 = a10 > b10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r2a11 = a11 > b11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r2a12 = a12 > b12;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r2b8 = b8 > a8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r2b9 = b9 > a9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r2b10 = b10 > a10;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r2b11 = b11 > a11;
+                ~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r2b12 = b12 > a12;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r3a8 = a8 <= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r3a9 = a9 <= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r3a10 = a10 <= b10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r3a11 = a11 <= b11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r3a12 = a12 <= b12;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r3b8 = b8 <= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r3b9 = b9 <= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r3b10 = b10 <= a10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r3b11 = b11 <= a11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r3b12 = b12 <= a12;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number): void; }'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(): void; }'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base): void; }' and '{ fn(a: Derived): void; }'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived, b: Base): void; }' and '{ fn(a: Base, b: Derived): void; }'.
+    var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): Base; }'.
+    var r4a8 = a8 >= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r4a9 = a9 >= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Derived; }'.
+    var r4a10 = a10 >= b10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Base): void; }' and '{ fn(a?: Derived): void; }'.
+    var r4a11 = a11 >= b11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Base[]): void; }' and '{ fn(...a: Derived[]): void; }'.
+    //var r4a12 = a12 >= b12;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(): void; }'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number, b: string): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: number): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): void; }' and '{ fn(a: number, b: string): void; }'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Derived): void; }' and '{ fn(a: Base): void; }'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a: Base, b: Derived): void; }' and '{ fn(a: Derived, b: Base): void; }'.
+    var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): void; }'.
+    var r4b8 = b8 >= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Base; }' and '{ fn(): Base; }'.
+    var r4b9 = b9 >= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(): Derived; }' and '{ fn(): Base; }'.
+    var r4b10 = b10 >= a10;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(a?: Derived): void; }' and '{ fn(a?: Base): void; }'.
+    var r4b11 = b11 >= a11;
+                ~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...a: Derived[]): void; }' and '{ fn(...a: Base[]): void; }'.
+    //var r4b12 = b12 >= a12;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    var r5a7 = a7 == b7;
+    var r5a8 = a8 == b8;
+    var r5a9 = a9 == b9;
+    var r5a10 = a10 == b10;
+    var r5a11 = a11 == b11;
+    //var r5a12 = a12 == b12;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    var r5b7 = b7 == a7;
+    var r5b8 = b8 == a8;
+    var r5b9 = b9 == a9;
+    var r5b10 = b10 == a10;
+    var r5b11 = b11 == a11;
+    //var r5b12 = b12 == a12;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    var r6a7 = a7 != b7;
+    var r6a8 = a8 != b8;
+    var r6a9 = a9 != b9;
+    var r6a10 = a10 != b10;
+    var r6a11 = a11 != b11;
+    //var r6a12 = a12 != b12;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    var r6b7 = b7 != a7;
+    var r6b8 = b8 != a8;
+    var r6b9 = b9 != a9;
+    var r6b10 = b10 != a10;
+    var r6b11 = b11 != a11;
+    //var r6b12 = b12 != a12;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    var r7a7 = a7 === b7;
+    var r7a8 = a8 === b8;
+    var r7a9 = a9 === b9;
+    var r7a10 = a10 === b10;
+    var r7a11 = a11 === b11;
+    //var r7a12 = a12 === b12;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    var r7b7 = b7 === a7;
+    var r7b8 = b8 === a8;
+    var r7b9 = b9 === a9;
+    var r7b10 = b10 === a10;
+    var r7b11 = b11 === a11;
+    //var r7b12 = b12 === a12;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    var r8a7 = a7 !== b7;
+    var r8a8 = a8 !== b8;
+    var r8a9 = a9 !== b9;
+    var r8a10 = a10 !== b10;
+    var r8a11 = a11 !== b11;
+    //var r8a12 = a12 !== b12;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    var r8b7 = b7 !== a7;
+    var r8b8 = b8 !== a8;
+    var r8b9 = b9 !== a9;
+    var r8b10 = b10 !== a10;
+    var r8b11 = b11 !== a11;
+    //var r8b12 = b12 !== a12;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnConstructorSignature.errors.txt
@@ -1,0 +1,440 @@
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(45,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(46,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(47,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(48,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(51,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(52,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(53,12): error TS2365: Operator '<' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(54,12): error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(55,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(56,12): error TS2365: Operator '<' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(57,12): error TS2365: Operator '<' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(58,12): error TS2365: Operator '<' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(59,12): error TS2365: Operator '<' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(63,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(64,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(65,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(66,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(67,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(68,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(69,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(70,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(71,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(74,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(75,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(76,12): error TS2365: Operator '>' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(77,12): error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(78,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(79,12): error TS2365: Operator '>' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(80,12): error TS2365: Operator '>' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(81,12): error TS2365: Operator '>' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(82,12): error TS2365: Operator '>' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(86,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(87,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(88,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(89,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(90,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(91,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(92,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(93,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(94,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(97,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(98,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(99,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(100,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(101,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(102,12): error TS2365: Operator '<=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(103,12): error TS2365: Operator '<=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(104,12): error TS2365: Operator '<=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(105,12): error TS2365: Operator '<=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(109,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(110,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(111,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(112,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(113,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(114,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(115,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(116,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(117,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(120,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(121,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(122,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(123,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(124,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(125,12): error TS2365: Operator '>=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(126,12): error TS2365: Operator '>=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(127,12): error TS2365: Operator '>=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts(128,12): error TS2365: Operator '>=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+
+
+==== comparisonOperatorWithSubtypeObjectOnConstructorSignature.ts (72 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { new (): Base };
+    var b1: { new (): Base };
+    
+    var a2: { new (a: number, b: string): Base };
+    var b2: { new (a: number, b: string): Base };
+    
+    var a3: { new (a: number, b: string): Base };
+    var b3: { new (a: number): Base };
+    
+    var a4: { new (a: number, b: string): Base };
+    var b4: { new (): Base };
+    
+    var a5: { new (a: Base): Base };
+    var b5: { new (a: Derived): Base };
+    
+    var a6: { new (a: Derived, b: Base): Base };
+    var b6: { new (a: Base, b: Derived): Base };
+    
+    var a7: { new (): Base };
+    var b7: { new (): Derived };
+    
+    var a8: { new (a?: Base): Base };
+    var b8: { new (a?: Derived): Base };
+    
+    var a9: { new (...a: Base[]): Base };
+    var b9: { new (...a: Derived[]): Base };
+    
+    //var a10: { <T, U extends T>(t: T, u: U): T[] };
+    //var b10: { <A, B extends A>(a: A, b: B): A[] };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r1a7 = a7 < b7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r1a8 = a8 < b8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r1a9 = a9 < b9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r1a10 = a10 < b10;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r1b7 = b7 < a7;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r1b8 = b8 < a8;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r1b9 = b9 < a9;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r1b10 = b10 < a10;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r2a7 = a7 > b7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r2a8 = a8 > b8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r2a9 = a9 > b9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r2a10 = a10 > b10;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r2b7 = b7 > a7;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r2b8 = b8 > a8;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r2b9 = b9 > a9;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r2b10 = b10 > a10;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r3a7 = a7 <= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r3a8 = a8 <= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r3a9 = a9 <= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r3a10 = a10 <= b10;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r3b7 = b7 <= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r3b8 = b8 <= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r3b9 = b9 <= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r3b10 = b10 <= a10;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number) => Base'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new () => Base'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Base) => Base' and 'new (a: Derived) => Base'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived, b: Base) => Base' and 'new (a: Base, b: Derived) => Base'.
+    var r4a7 = a7 >= b7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Derived'.
+    var r4a8 = a8 >= b8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a?: Base) => Base' and 'new (a?: Derived) => Base'.
+    var r4a9 = a9 >= b9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: Base[]) => Base' and 'new (...a: Derived[]) => Base'.
+    //var r4a10 = a10 >= b10;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new () => Base'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number, b: string) => Base' and 'new (a: number, b: string) => Base'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: number) => Base' and 'new (a: number, b: string) => Base'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Base' and 'new (a: number, b: string) => Base'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Derived) => Base' and 'new (a: Base) => Base'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a: Base, b: Derived) => Base' and 'new (a: Derived, b: Base) => Base'.
+    var r4b7 = b7 >= a7;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new () => Derived' and 'new () => Base'.
+    var r4b8 = b8 >= a8;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (a?: Derived) => Base' and 'new (a?: Base) => Base'.
+    var r4b9 = b9 >= a9;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...a: Derived[]) => Base' and 'new (...a: Base[]) => Base'.
+    //var r4b10 = b10 >= a10;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    var r5a7 = a7 == b7;
+    var r5a8 = a8 == b8;
+    var r5a9 = a9 == b9;
+    //var r5a10 = a10 == b10;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    var r5b7 = b7 == a7;
+    var r5b8 = b8 == a8;
+    var r5b9 = b9 == a9;
+    //var r5b10 = b10 == a10;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    var r6a7 = a7 != b7;
+    var r6a8 = a8 != b8;
+    var r6a9 = a9 != b9;
+    //var r6a10 = a10 != b10;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    var r6b7 = b7 != a7;
+    var r6b8 = b8 != a8;
+    var r6b9 = b9 != a9;
+    //var r6b10 = b10 != a10;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    var r7a7 = a7 === b7;
+    var r7a8 = a8 === b8;
+    var r7a9 = a9 === b9;
+    //var r7a10 = a10 === b10;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    var r7b7 = b7 === a7;
+    var r7b8 = b8 === a8;
+    var r7b9 = b9 === a9;
+    //var r7b10 = b10 === a10;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    var r8a7 = a7 !== b7;
+    var r8a8 = a8 !== b8;
+    var r8a9 = a9 !== b9;
+    //var r8a10 = a10 !== b10;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    var r8b7 = b7 !== a7;
+    var r8b8 = b8 !== a8;
+    var r8b9 = b9 !== a9;
+    //var r8b10 = b10 !== a10;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnIndexSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnIndexSignature.errors.txt
@@ -1,0 +1,206 @@
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(22,12): error TS2365: Operator '<' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(23,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(24,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(25,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(27,12): error TS2365: Operator '<' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(28,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(29,12): error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(30,12): error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(33,12): error TS2365: Operator '>' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(34,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(35,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(36,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(38,12): error TS2365: Operator '>' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(39,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(40,12): error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(41,12): error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(44,12): error TS2365: Operator '<=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(45,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(46,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(47,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(49,12): error TS2365: Operator '<=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(50,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(51,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(52,12): error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(55,12): error TS2365: Operator '>=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(56,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(57,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(58,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(60,12): error TS2365: Operator '>=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(61,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(62,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+comparisonOperatorWithSubtypeObjectOnIndexSignature.ts(63,12): error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+
+
+==== comparisonOperatorWithSubtypeObjectOnIndexSignature.ts (32 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { [a: string]: string };
+    var b1: { [b: string]: string };
+    
+    var a2: { [index: string]: Base };
+    var b2: { [index: string]: Derived };
+    
+    var a3: { [index: number]: string };
+    var b3: { [index: number]: string };
+    
+    var a4: { [index: number]: Base };
+    var b4: { [index: string]: Derived };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r1a1 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r1a1 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r1a1 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r1b1 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r1b1 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r1b1 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r2a1 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r2a1 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r2a1 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r2b1 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r2b1 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r2b1 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r3a1 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r3a1 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r3a1 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r3b1 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r3b1 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r3b1 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [a: string]: string; }' and '{ [b: string]: string; }'.
+    var r4a1 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Base; }' and '{ [index: string]: Derived; }'.
+    var r4a1 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r4a1 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: Base; }' and '{ [index: string]: Derived; }'.
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [b: string]: string; }' and '{ [a: string]: string; }'.
+    var r4b1 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: string]: Base; }'.
+    var r4b1 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: number]: string; }' and '{ [index: number]: string; }'.
+    var r4b1 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ [index: string]: Derived; }' and '{ [index: number]: Base; }'.
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a1 = a2 == b2;
+    var r5a1 = a3 == b3;
+    var r5a1 = a4 == b4;
+    
+    var r5b1 = b1 == a1;
+    var r5b1 = b2 == a2;
+    var r5b1 = b3 == a3;
+    var r5b1 = b4 == a4;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a1 = a2 != b2;
+    var r6a1 = a3 != b3;
+    var r6a1 = a4 != b4;
+    
+    var r6b1 = b1 != a1;
+    var r6b1 = b2 != a2;
+    var r6b1 = b3 != a3;
+    var r6b1 = b4 != a4;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a1 = a2 === b2;
+    var r7a1 = a3 === b3;
+    var r7a1 = a4 === b4;
+    
+    var r7b1 = b1 === a1;
+    var r7b1 = b2 === a2;
+    var r7b1 = b3 === a3;
+    var r7b1 = b4 === a4;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a1 = a2 !== b2;
+    var r8a1 = a3 !== b3;
+    var r8a1 = a4 !== b4;
+    
+    var r8b1 = b1 !== a1;
+    var r8b1 = b2 !== a2;
+    var r8b1 = b3 !== a3;
+    var r8b1 = b4 !== a4;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.errors.txt
@@ -1,0 +1,311 @@
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(31,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(68,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(76,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(83,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(93,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+
+
+==== comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { fn<T>(x: T): T };
+    var b1: { fn(x: string): string };
+    
+    var a2: { fn<T>(x: T): T };
+    var b2: { fn(x: string, y: number): string };
+    
+    var a3: { fn<T, U>(x: T, y: U): T };
+    var b3: { fn(x: string, y: number): string };
+    
+    var a4: { fn<T>(x?: T): T };
+    var b4: { fn(x?: string): string };
+    
+    var a5: { fn<T>(...x: T[]): T };
+    var b5: { fn(...x: string[]): string };
+    
+    var a6: { fn<T>(x: T, y: T): T };
+    var b6: { fn(x: string, y: number): {} };
+    
+    //var a7: { fn<T, U extends T>(x: T, y: U): T };
+    var b7: { fn(x: Base, y: Derived): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r1a7 = a7 < b7;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r1b7 = b7 < a7;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r2a7 = a7 > b7;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r2b7 = b7 > a7;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r3a7 = a7 <= b7;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r3b7 = b7 <= a7;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string): string; }'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T, U>(x: T, y: U): T; }' and '{ fn(x: string, y: number): string; }'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x?: T): T; }' and '{ fn(x?: string): string; }'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(...x: T[]): T; }' and '{ fn(...x: string[]): string; }'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn<T>(x: T, y: T): T; }' and '{ fn(x: string, y: number): {}; }'.
+    //var r4a7 = a7 >= b7;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string): string; }' and '{ fn<T>(x: T): T; }'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T>(x: T): T; }'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): string; }' and '{ fn<T, U>(x: T, y: U): T; }'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x?: string): string; }' and '{ fn<T>(x?: T): T; }'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(...x: string[]): string; }' and '{ fn<T>(...x: T[]): T; }'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{ fn(x: string, y: number): {}; }' and '{ fn<T>(x: T, y: T): T; }'.
+    //var r4b7 = b7 >= a7;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    //var r5a7 = a7 == b7;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    //var r5b7 = b7 == a7;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    //var r6a7 = a7 != b7;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    //var r6b7 = b7 != a7;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    //var r7a7 = a7 === b7;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    //var r7b7 = b7 === a7;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    //var r8a7 = a7 !== b7;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    //var r8b7 = b7 !== a7;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.errors.txt
@@ -1,0 +1,311 @@
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(31,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(32,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(33,12): error TS2365: Operator '<' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(34,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(35,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(36,12): error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(39,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(40,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(41,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(42,12): error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(43,12): error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(44,12): error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(48,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(49,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(50,12): error TS2365: Operator '>' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(51,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(52,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(53,12): error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(56,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(57,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(58,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(59,12): error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(60,12): error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(61,12): error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(65,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(66,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(67,12): error TS2365: Operator '<=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(68,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(69,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(70,12): error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(73,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(74,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(75,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(76,12): error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(77,12): error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(78,12): error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(82,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(83,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(84,12): error TS2365: Operator '>=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(85,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(86,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(87,12): error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(90,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(91,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(92,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(93,12): error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(94,12): error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts(95,12): error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+
+
+==== comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts (48 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    var a1: { new <T>(x: T): T };
+    var b1: { new (x: string): string };
+    
+    var a2: { new <T>(x: T): T };
+    var b2: { new (x: string, y: number): string };
+    
+    var a3: { new <T, U>(x: T, y: U): T };
+    var b3: { new (x: string, y: number): string };
+    
+    var a4: { new <T>(x?: T): T };
+    var b4: { new (x?: string): string };
+    
+    var a5: { new <T>(...x: T[]): T };
+    var b5: { new (...x: string[]): string };
+    
+    var a6: { new <T>(x: T, y: T): T };
+    var b6: { new (x: string, y: number): {} };
+    
+    //var a7: { new <T, U extends T>(x: T, y: U): T };
+    var b7: { new (x: Base, y: Derived): Base };
+    
+    // operator <
+    var r1a1 = a1 < b1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r1a2 = a2 < b2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r1a3 = a3 < b3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r1a4 = a4 < b4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r1a5 = a5 < b5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r1a6 = a6 < b6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r1a7 = a7 < b7;
+    
+    var r1b1 = b1 < a1;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r1b2 = b2 < a2;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r1b3 = b3 < a3;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r1b4 = b4 < a4;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r1b5 = b5 < a5;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r1b6 = b6 < a6;
+               ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r1b7 = b7 < a7;
+    
+    // operator >
+    var r2a1 = a1 > b1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r2a2 = a2 > b2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r2a3 = a3 > b3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r2a4 = a4 > b4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r2a5 = a5 > b5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r2a6 = a6 > b6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r2a7 = a7 > b7;
+    
+    var r2b1 = b1 > a1;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r2b2 = b2 > a2;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r2b3 = b3 > a3;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r2b4 = b4 > a4;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r2b5 = b5 > a5;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r2b6 = b6 > a6;
+               ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r2b7 = b7 > a7;
+    
+    // operator <=
+    var r3a1 = a1 <= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r3a2 = a2 <= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r3a3 = a3 <= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r3a4 = a4 <= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r3a5 = a5 <= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r3a6 = a6 <= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r3a7 = a7 <= b7;
+    
+    var r3b1 = b1 <= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r3b2 = b2 <= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r3b3 = b3 <= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r3b4 = b4 <= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r3b5 = b5 <= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r3b6 = b6 <= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r3b7 = b7 <= a7;
+    
+    // operator >=
+    var r4a1 = a1 >= b1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string) => string'.
+    var r4a2 = a2 >= b2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T) => T' and 'new (x: string, y: number) => string'.
+    var r4a3 = a3 >= b3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T, U>(x: T, y: U) => T' and 'new (x: string, y: number) => string'.
+    var r4a4 = a4 >= b4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x?: T) => T' and 'new (x?: string) => string'.
+    var r4a5 = a5 >= b5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(...x: T[]) => T' and 'new (...x: string[]) => string'.
+    var r4a6 = a6 >= b6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new <T>(x: T, y: T) => T' and 'new (x: string, y: number) => {}'.
+    //var r4a7 = a7 >= b7;
+    
+    var r4b1 = b1 >= a1;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string) => string' and 'new <T>(x: T) => T'.
+    var r4b2 = b2 >= a2;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T>(x: T) => T'.
+    var r4b3 = b3 >= a3;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => string' and 'new <T, U>(x: T, y: U) => T'.
+    var r4b4 = b4 >= a4;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x?: string) => string' and 'new <T>(x?: T) => T'.
+    var r4b5 = b5 >= a5;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (...x: string[]) => string' and 'new <T>(...x: T[]) => T'.
+    var r4b6 = b6 >= a6;
+               ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'new (x: string, y: number) => {}' and 'new <T>(x: T, y: T) => T'.
+    //var r4b7 = b7 >= a7;
+    
+    // operator ==
+    var r5a1 = a1 == b1;
+    var r5a2 = a2 == b2;
+    var r5a3 = a3 == b3;
+    var r5a4 = a4 == b4;
+    var r5a5 = a5 == b5;
+    var r5a6 = a6 == b6;
+    //var r5a7 = a7 == b7;
+    
+    var r5b1 = b1 == a1;
+    var r5b2 = b2 == a2;
+    var r5b3 = b3 == a3;
+    var r5b4 = b4 == a4;
+    var r5b5 = b5 == a5;
+    var r5b6 = b6 == a6;
+    //var r5b7 = b7 == a7;
+    
+    // operator !=
+    var r6a1 = a1 != b1;
+    var r6a2 = a2 != b2;
+    var r6a3 = a3 != b3;
+    var r6a4 = a4 != b4;
+    var r6a5 = a5 != b5;
+    var r6a6 = a6 != b6;
+    //var r6a7 = a7 != b7;
+    
+    var r6b1 = b1 != a1;
+    var r6b2 = b2 != a2;
+    var r6b3 = b3 != a3;
+    var r6b4 = b4 != a4;
+    var r6b5 = b5 != a5;
+    var r6b6 = b6 != a6;
+    //var r6b7 = b7 != a7;
+    
+    // operator ===
+    var r7a1 = a1 === b1;
+    var r7a2 = a2 === b2;
+    var r7a3 = a3 === b3;
+    var r7a4 = a4 === b4;
+    var r7a5 = a5 === b5;
+    var r7a6 = a6 === b6;
+    //var r7a7 = a7 === b7;
+    
+    var r7b1 = b1 === a1;
+    var r7b2 = b2 === a2;
+    var r7b3 = b3 === a3;
+    var r7b4 = b4 === a4;
+    var r7b5 = b5 === a5;
+    var r7b6 = b6 === a6;
+    //var r7b7 = b7 === a7;
+    
+    // operator !==
+    var r8a1 = a1 !== b1;
+    var r8a2 = a2 !== b2;
+    var r8a3 = a3 !== b3;
+    var r8a4 = a4 !== b4;
+    var r8a5 = a5 !== b5;
+    var r8a6 = a6 !== b6;
+    //var r8a7 = a7 !== b7;
+    
+    var r8b1 = b1 !== a1;
+    var r8b2 = b2 !== a2;
+    var r8b3 = b3 !== a3;
+    var r8b4 = b4 !== a4;
+    var r8b5 = b5 !== a5;
+    var r8b6 = b6 !== a6;
+    //var r8b7 = b7 !== a7;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnOptionalProperty.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnOptionalProperty.errors.txt
@@ -1,0 +1,70 @@
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(14,11): error TS2365: Operator '<' cannot be applied to types 'I' and 'J'.
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(15,11): error TS2365: Operator '<' cannot be applied to types 'J' and 'I'.
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(18,11): error TS2365: Operator '>' cannot be applied to types 'I' and 'J'.
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(19,11): error TS2365: Operator '>' cannot be applied to types 'J' and 'I'.
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(22,11): error TS2365: Operator '<=' cannot be applied to types 'I' and 'J'.
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(23,11): error TS2365: Operator '<=' cannot be applied to types 'J' and 'I'.
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(26,11): error TS2365: Operator '>=' cannot be applied to types 'I' and 'J'.
+comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts(27,11): error TS2365: Operator '>=' cannot be applied to types 'J' and 'I'.
+
+
+==== comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts (8 errors) ====
+    interface I {
+        a: string;
+        b?: number;
+    }
+    
+    interface J {
+        a: string;
+    }
+    
+    var a: I;
+    var b: J;
+    
+    // operator <
+    var ra1 = a < b;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'I' and 'J'.
+    var ra2 = b < a;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'J' and 'I'.
+    
+    // operator >
+    var rb1 = a > b;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'I' and 'J'.
+    var rb2 = b > a;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'J' and 'I'.
+    
+    // operator <=
+    var rc1 = a <= b;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'I' and 'J'.
+    var rc2 = b <= a;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'J' and 'I'.
+    
+    // operator >=
+    var rd1 = a >= b;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'I' and 'J'.
+    var rd2 = b >= a;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'J' and 'I'.
+    
+    // operator ==
+    var re1 = a == b;
+    var re2 = b == a;
+    
+    // operator !=
+    var rf1 = a != b;
+    var rf2 = b != a;
+    
+    // operator ===
+    var rg1 = a === b;
+    var rg2 = b === a;
+    
+    // operator !==
+    var rh1 = a !== b;
+    var rh2 = b !== a;

--- a/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnProperty.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithSubtypeObjectOnProperty.errors.txt
@@ -1,0 +1,129 @@
+comparisonOperatorWithSubtypeObjectOnProperty.ts(33,11): error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(34,11): error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(35,11): error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(36,11): error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(39,11): error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(40,11): error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(41,11): error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(42,11): error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(45,11): error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(46,11): error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(47,11): error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(48,11): error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(51,11): error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(52,11): error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(53,11): error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+comparisonOperatorWithSubtypeObjectOnProperty.ts(54,11): error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+
+
+==== comparisonOperatorWithSubtypeObjectOnProperty.ts (16 errors) ====
+    class Base {
+        public a: string;
+    }
+    
+    class Derived extends Base {
+        public b: string;
+    }
+    
+    class A1 {
+        public a: Base;
+        public b: Base;
+    }
+    
+    class B1 {
+        public a: Base;
+        public b: Derived;
+    }
+    
+    class A2 {
+        private a;
+    }
+    
+    class B2 extends A2 {
+        private b;
+    }
+    
+    var a1: A1;
+    var a2: A2;
+    var b1: B1;
+    var b2: B2;
+    
+    // operator <
+    var ra1 = a1 < b1;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A1' and 'B1'.
+    var ra2 = a2 < b2;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'A2' and 'B2'.
+    var ra3 = b1 < a1;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B1' and 'A1'.
+    var ra4 = b2 < a2;
+              ~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator >
+    var rb1 = a1 > b1;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A1' and 'B1'.
+    var rb2 = a2 > b2;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'A2' and 'B2'.
+    var rb3 = b1 > a1;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B1' and 'A1'.
+    var rb4 = b2 > a2;
+              ~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator <=
+    var rc1 = a1 <= b1;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A1' and 'B1'.
+    var rc2 = a2 <= b2;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'A2' and 'B2'.
+    var rc3 = b1 <= a1;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B1' and 'A1'.
+    var rc4 = b2 <= a2;
+              ~~~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator >=
+    var rd1 = a1 >= b1;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A1' and 'B1'.
+    var rd2 = a2 >= b2;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'A2' and 'B2'.
+    var rd3 = b1 >= a1;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B1' and 'A1'.
+    var rd4 = b2 >= a2;
+              ~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'B2' and 'A2'.
+    
+    // operator ==
+    var re1 = a1 == b1;
+    var re2 = a2 == b2;
+    var re3 = b1 == a1;
+    var re4 = b2 == a2;
+    
+    // operator !=
+    var rf1 = a1 != b1;
+    var rf2 = a2 != b2;
+    var rf3 = b1 != a1;
+    var rf4 = b2 != a2;
+    
+    // operator ===
+    var rg1 = a1 === b1;
+    var rg2 = a2 === b2;
+    var rg3 = b1 === a1;
+    var rg4 = b2 === a2;
+    
+    // operator !==
+    var rh1 = a1 !== b1;
+    var rh2 = a2 !== b2;
+    var rh3 = b1 !== a1;
+    var rh4 = b2 !== a2;

--- a/tests/baselines/reference/comparisonOperatorWithTypeParameter.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithTypeParameter.errors.txt
@@ -30,9 +30,25 @@ comparisonOperatorWithTypeParameter.ts(37,15): error TS2367: This comparison app
 comparisonOperatorWithTypeParameter.ts(38,15): error TS2367: This comparison appears to be unintentional because the types 'V' and 'T' have no overlap.
 comparisonOperatorWithTypeParameter.ts(39,15): error TS2367: This comparison appears to be unintentional because the types 'V' and 'T' have no overlap.
 comparisonOperatorWithTypeParameter.ts(40,15): error TS2367: This comparison appears to be unintentional because the types 'V' and 'T' have no overlap.
+comparisonOperatorWithTypeParameter.ts(43,15): error TS2365: Operator '<' cannot be applied to types 'T' and '{}'.
+comparisonOperatorWithTypeParameter.ts(44,15): error TS2365: Operator '>' cannot be applied to types 'T' and '{}'.
+comparisonOperatorWithTypeParameter.ts(45,15): error TS2365: Operator '<=' cannot be applied to types 'T' and '{}'.
+comparisonOperatorWithTypeParameter.ts(46,15): error TS2365: Operator '>=' cannot be applied to types 'T' and '{}'.
+comparisonOperatorWithTypeParameter.ts(52,15): error TS2365: Operator '<' cannot be applied to types '{}' and 'T'.
+comparisonOperatorWithTypeParameter.ts(53,15): error TS2365: Operator '>' cannot be applied to types '{}' and 'T'.
+comparisonOperatorWithTypeParameter.ts(54,15): error TS2365: Operator '<=' cannot be applied to types '{}' and 'T'.
+comparisonOperatorWithTypeParameter.ts(55,15): error TS2365: Operator '>=' cannot be applied to types '{}' and 'T'.
+comparisonOperatorWithTypeParameter.ts(61,15): error TS2365: Operator '<' cannot be applied to types 'T' and 'Object'.
+comparisonOperatorWithTypeParameter.ts(62,15): error TS2365: Operator '>' cannot be applied to types 'T' and 'Object'.
+comparisonOperatorWithTypeParameter.ts(63,15): error TS2365: Operator '<=' cannot be applied to types 'T' and 'Object'.
+comparisonOperatorWithTypeParameter.ts(64,15): error TS2365: Operator '>=' cannot be applied to types 'T' and 'Object'.
+comparisonOperatorWithTypeParameter.ts(70,15): error TS2365: Operator '<' cannot be applied to types 'Object' and 'T'.
+comparisonOperatorWithTypeParameter.ts(71,15): error TS2365: Operator '>' cannot be applied to types 'Object' and 'T'.
+comparisonOperatorWithTypeParameter.ts(72,15): error TS2365: Operator '<=' cannot be applied to types 'Object' and 'T'.
+comparisonOperatorWithTypeParameter.ts(73,15): error TS2365: Operator '>=' cannot be applied to types 'Object' and 'T'.
 
 
-==== comparisonOperatorWithTypeParameter.ts (32 errors) ====
+==== comparisonOperatorWithTypeParameter.ts (48 errors) ====
     var a: {};
     var b: Object;
     
@@ -140,36 +156,68 @@ comparisonOperatorWithTypeParameter.ts(40,15): error TS2367: This comparison app
     
         // ok
         var re1 = t < a;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and '{}'.
         var re2 = t > a;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and '{}'.
         var re3 = t <= a;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and '{}'.
         var re4 = t >= a;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and '{}'.
         var re5 = t == a;
         var re6 = t != a;
         var re7 = t === a;
         var re8 = t !== a;
     
         var rf1 = a < t;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{}' and 'T'.
         var rf2 = a > t;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types '{}' and 'T'.
         var rf3 = a <= t;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types '{}' and 'T'.
         var rf4 = a >= t;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types '{}' and 'T'.
         var rf5 = a == t;
         var rf6 = a != t;
         var rf7 = a === t;
         var rf8 = a !== t;
     
         var rg1 = t < b;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'T' and 'Object'.
         var rg2 = t > b;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'T' and 'Object'.
         var rg3 = t <= b;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'T' and 'Object'.
         var rg4 = t >= b;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'T' and 'Object'.
         var rg5 = t == b;
         var rg6 = t != b;
         var rg7 = t === b;
         var rg8 = t !== b;
     
         var rh1 = b < t;
+                  ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Object' and 'T'.
         var rh2 = b > t;
+                  ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'Object' and 'T'.
         var rh3 = b <= t;
+                  ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'Object' and 'T'.
         var rh4 = b >= t;
+                  ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'Object' and 'T'.
         var rh5 = b == t;
         var rh6 = b != t;
         var rh7 = b === t;

--- a/tests/baselines/reference/contextuallyTypedIife.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedIife.errors.txt
@@ -1,10 +1,7 @@
-contextuallyTypedIifeStrict.ts(14,10): error TS18048: 'j' is possibly 'undefined'.
-contextuallyTypedIifeStrict.ts(15,10): error TS18048: 'k' is possibly 'undefined'.
-contextuallyTypedIifeStrict.ts(16,17): error TS18048: 'o' is possibly 'undefined'.
-contextuallyTypedIifeStrict.ts(20,40): error TS2365: Operator '>' cannot be applied to types 'never' and 'number'.
+contextuallyTypedIife.ts(20,40): error TS2365: Operator '>' cannot be applied to types 'never' and 'number'.
 
 
-==== contextuallyTypedIifeStrict.ts (4 errors) ====
+==== contextuallyTypedIife.ts (1 errors) ====
     // arrow
     (jake => { })("build");
     // function expression
@@ -19,14 +16,8 @@ contextuallyTypedIifeStrict.ts(20,40): error TS2365: Operator '>' cannot be appl
     ((n = 10) => n + 1)();
     // optional parameters
     ((j?) => j + 1)(12);
-             ~
-!!! error TS18048: 'j' is possibly 'undefined'.
     ((k?) => k + 1)();
-             ~
-!!! error TS18048: 'k' is possibly 'undefined'.
-    ((l, o?) => l + o)(12);
-                    ~
-!!! error TS18048: 'o' is possibly 'undefined'.
+    ((l, o?) => l + o)(12); // o should be any
     // rest parameters
     ((...numbers) => numbers.every(n => n > 0))(5,6,7);
     ((...mixed) => mixed.every(n => !!n))(5,'oops','oh no');

--- a/tests/baselines/reference/grammarAmbiguities.errors.txt
+++ b/tests/baselines/reference/grammarAmbiguities.errors.txt
@@ -1,8 +1,10 @@
+grammarAmbiguities.ts(8,3): error TS2365: Operator '<' cannot be applied to types '<A, B>(x: any) => any' and 'any'.
 grammarAmbiguities.ts(8,10): error TS2554: Expected 1 arguments, but got 2.
+grammarAmbiguities.ts(9,3): error TS2365: Operator '<' cannot be applied to types '<A, B>(x: any) => any' and 'any'.
 grammarAmbiguities.ts(9,10): error TS2554: Expected 1 arguments, but got 2.
 
 
-==== grammarAmbiguities.ts (2 errors) ====
+==== grammarAmbiguities.ts (4 errors) ====
     function f(n: any) { return null; }
     function g<A, B>(x: any) { return null; }
     interface A { }
@@ -11,9 +13,13 @@ grammarAmbiguities.ts(9,10): error TS2554: Expected 1 arguments, but got 2.
     
     f(g<A, B>(7));
     f(g < A, B > 7); // Should error
+      ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '<A, B>(x: any) => any' and 'any'.
              ~~~~~
 !!! error TS2554: Expected 1 arguments, but got 2.
     f(g < A, B > +(7)); // Should error
+      ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '<A, B>(x: any) => any' and 'any'.
              ~~~~~~~~
 !!! error TS2554: Expected 1 arguments, but got 2.
     

--- a/tests/baselines/reference/instantiationExpressionErrors.errors.txt
+++ b/tests/baselines/reference/instantiationExpressionErrors.errors.txt
@@ -1,7 +1,9 @@
 instantiationExpressionErrors.ts(7,13): error TS1477: An instantiation expression cannot be followed by a property access.
 instantiationExpressionErrors.ts(8,13): error TS1477: An instantiation expression cannot be followed by a property access.
+instantiationExpressionErrors.ts(13,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'any'.
 instantiationExpressionErrors.ts(13,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'string[]'.
 instantiationExpressionErrors.ts(13,14): error TS2693: 'number' only refers to a type, but is being used as a value here.
+instantiationExpressionErrors.ts(18,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'any'.
 instantiationExpressionErrors.ts(18,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
 instantiationExpressionErrors.ts(18,14): error TS2693: 'number' only refers to a type, but is being used as a value here.
 instantiationExpressionErrors.ts(18,29): error TS1109: Expression expected.
@@ -10,13 +12,14 @@ instantiationExpressionErrors.ts(23,23): error TS1005: '(' expected.
 instantiationExpressionErrors.ts(26,24): error TS2558: Expected 0 type arguments, but got 1.
 instantiationExpressionErrors.ts(39,2): error TS2554: Expected 0 arguments, but got 1.
 instantiationExpressionErrors.ts(43,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+instantiationExpressionErrors.ts(43,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
 instantiationExpressionErrors.ts(44,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
 instantiationExpressionErrors.ts(44,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
 instantiationExpressionErrors.ts(45,12): error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
 instantiationExpressionErrors.ts(45,12): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
 
 
-==== instantiationExpressionErrors.ts (16 errors) ====
+==== instantiationExpressionErrors.ts (19 errors) ====
     declare let f: { <T>(): T, g<U>(): U };
     
     // Type arguments in member expressions
@@ -34,6 +37,8 @@ instantiationExpressionErrors.ts(45,12): error TS2365: Operator '>' cannot be ap
     // `[` is an expression starter and cannot immediately follow a type argument list
     
     const a6 = f<number>['g'];  // Error
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'any'.
                ~~~~~~~~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'string[]'.
                  ~~~~~~
@@ -43,6 +48,8 @@ instantiationExpressionErrors.ts(45,12): error TS2365: Operator '>' cannot be ap
     // An `<` cannot immediately follow a type argument list
     
     const a8 = f<number><number>;  // Relational operator error
+               ~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'any'.
                ~~~~~~~~~~~~~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'number'.
                  ~~~~~~
@@ -84,6 +91,8 @@ instantiationExpressionErrors.ts(45,12): error TS2365: Operator '>' cannot be ap
     const r1 = f < true > true;
                ~~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.
+               ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
     const r2 = f < true > +1;
                ~~~~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ <T>(): T; g<U>(): U; }' and 'boolean'.

--- a/tests/baselines/reference/intTypeCheck.errors.txt
+++ b/tests/baselines/reference/intTypeCheck.errors.txt
@@ -8,6 +8,7 @@ intTypeCheck.ts(100,20): error TS2351: This expression is not constructable.
 intTypeCheck.ts(101,5): error TS2739: Type 'Base' is missing the following properties from type 'i1': p, p3, p6
 intTypeCheck.ts(103,5): error TS2322: Type '() => void' is not assignable to type 'i1'.
 intTypeCheck.ts(106,5): error TS2322: Type 'boolean' is not assignable to type 'i1'.
+intTypeCheck.ts(106,16): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(106,20): error TS1109: Expression expected.
 intTypeCheck.ts(106,21): error TS2693: 'i1' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(107,21): error TS2351: This expression is not constructable.
@@ -21,6 +22,7 @@ intTypeCheck.ts(114,17): error TS2350: Only a void function can be called with t
 intTypeCheck.ts(115,5): error TS2322: Type 'Base' is not assignable to type 'i2'.
   Type 'Base' provides no match for the signature '(): any'.
 intTypeCheck.ts(120,5): error TS2322: Type 'boolean' is not assignable to type 'i2'.
+intTypeCheck.ts(120,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(120,21): error TS1109: Expression expected.
 intTypeCheck.ts(120,22): error TS2693: 'i2' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(121,21): error TS2351: This expression is not constructable.
@@ -35,6 +37,7 @@ intTypeCheck.ts(129,5): error TS2322: Type 'Base' is not assignable to type 'i3'
 intTypeCheck.ts(131,5): error TS2322: Type '() => void' is not assignable to type 'i3'.
   Type '() => void' provides no match for the signature 'new (): any'.
 intTypeCheck.ts(134,5): error TS2322: Type 'boolean' is not assignable to type 'i3'.
+intTypeCheck.ts(134,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(134,21): error TS1109: Expression expected.
 intTypeCheck.ts(134,22): error TS2693: 'i3' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(135,21): error TS2351: This expression is not constructable.
@@ -42,6 +45,7 @@ intTypeCheck.ts(135,21): error TS2351: This expression is not constructable.
 intTypeCheck.ts(142,21): error TS2351: This expression is not constructable.
   Type 'i4' has no construct signatures.
 intTypeCheck.ts(148,5): error TS2322: Type 'boolean' is not assignable to type 'i4'.
+intTypeCheck.ts(148,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(148,21): error TS1109: Expression expected.
 intTypeCheck.ts(148,22): error TS2693: 'i4' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(149,21): error TS2351: This expression is not constructable.
@@ -54,6 +58,7 @@ intTypeCheck.ts(156,21): error TS2351: This expression is not constructable.
 intTypeCheck.ts(157,5): error TS2739: Type 'Base' is missing the following properties from type 'i5': p, p3, p6
 intTypeCheck.ts(159,5): error TS2322: Type '() => void' is not assignable to type 'i5'.
 intTypeCheck.ts(162,5): error TS2322: Type 'boolean' is not assignable to type 'i5'.
+intTypeCheck.ts(162,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(162,21): error TS1109: Expression expected.
 intTypeCheck.ts(162,22): error TS2693: 'i5' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(163,21): error TS2351: This expression is not constructable.
@@ -69,6 +74,7 @@ intTypeCheck.ts(171,5): error TS2322: Type 'Base' is not assignable to type 'i6'
 intTypeCheck.ts(173,5): error TS2322: Type '() => void' is not assignable to type 'i6'.
   Type 'void' is not assignable to type 'number'.
 intTypeCheck.ts(176,5): error TS2322: Type 'boolean' is not assignable to type 'i6'.
+intTypeCheck.ts(176,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(176,21): error TS1109: Expression expected.
 intTypeCheck.ts(176,22): error TS2693: 'i6' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(177,21): error TS2351: This expression is not constructable.
@@ -83,6 +89,7 @@ intTypeCheck.ts(185,17): error TS2352: Conversion of type 'Base' to type 'i7' ma
 intTypeCheck.ts(187,5): error TS2322: Type '() => void' is not assignable to type 'i7'.
   Type '() => void' provides no match for the signature 'new (): any'.
 intTypeCheck.ts(190,5): error TS2322: Type 'boolean' is not assignable to type 'i7'.
+intTypeCheck.ts(190,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(190,21): error TS1109: Expression expected.
 intTypeCheck.ts(190,22): error TS2693: 'i7' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(191,21): error TS2351: This expression is not constructable.
@@ -90,13 +97,14 @@ intTypeCheck.ts(191,21): error TS2351: This expression is not constructable.
 intTypeCheck.ts(198,21): error TS2351: This expression is not constructable.
   Type 'i8' has no construct signatures.
 intTypeCheck.ts(204,5): error TS2322: Type 'boolean' is not assignable to type 'i8'.
+intTypeCheck.ts(204,17): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 intTypeCheck.ts(204,21): error TS1109: Expression expected.
 intTypeCheck.ts(204,22): error TS2693: 'i8' only refers to a type, but is being used as a value here.
 intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
   Type '{}' has no construct signatures.
 
 
-==== intTypeCheck.ts (63 errors) ====
+==== intTypeCheck.ts (71 errors) ====
     interface i1 {
         //Property Signatures
         p;
@@ -221,6 +229,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj9: i1 = new <i1> anyVar;
         ~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i1'.
+                   ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                        ~
 !!! error TS1109: Expression expected.
                         ~~
@@ -256,6 +266,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj20: i2 = new <i2> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i2'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -292,6 +304,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj31: i3 = new <i3> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i3'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -318,6 +332,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj42: i4 = new <i4> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i4'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -353,6 +369,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj53: i5 = new <i5> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i5'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -391,6 +409,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj64: i6 = new <i6> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i6'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -427,6 +447,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj75: i7 = new <i7> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i7'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~
@@ -453,6 +475,8 @@ intTypeCheck.ts(205,21): error TS2351: This expression is not constructable.
     var obj86: i8 = new <i8> anyVar;
         ~~~~~
 !!! error TS2322: Type 'boolean' is not assignable to type 'i8'.
+                    ~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
                         ~
 !!! error TS1109: Expression expected.
                          ~~

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -10,6 +10,7 @@
 11.tsx(1,2): error TS2304: Cannot find name 'a'.
 11.tsx(1,10): error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
 12.tsx(1,1): error TS1109: Expression expected.
+12.tsx(1,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 12.tsx(1,2): error TS1109: Expression expected.
 12.tsx(1,5): error TS1109: Expression expected.
 12.tsx(1,7): error TS1128: Declaration or statement expected.
@@ -20,12 +21,14 @@
 13.tsx(1,7): error TS2304: Cannot find name 'a'.
 13.tsx(1,9): error TS1003: Identifier expected.
 14.tsx(1,3): error TS1003: Identifier expected.
+14.tsx(1,3): error TS2365: Operator '>' cannot be applied to types 'any[]' and 'any'.
 14.tsx(1,4): error TS2304: Cannot find name 'foo'.
 14.tsx(1,9): error TS1109: Expression expected.
 14.tsx(1,11): error TS2304: Cannot find name 'a'.
 14.tsx(1,13): error TS2304: Cannot find name 'foo'.
 14.tsx(1,18): error TS1109: Expression expected.
 15.tsx(1,3): error TS1003: Identifier expected.
+15.tsx(1,3): error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
 15.tsx(1,11): error TS1109: Expression expected.
 15.tsx(1,13): error TS2304: Cannot find name 'a'.
 15.tsx(1,22): error TS1109: Expression expected.
@@ -158,10 +161,12 @@
 !!! error TS2304: Cannot find name 'a'.
              ~
 !!! error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
-==== 12.tsx (6 errors) ====
+==== 12.tsx (7 errors) ====
     <.a></.a>;
     ~
 !!! error TS1109: Expression expected.
+    ~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
      ~
 !!! error TS1109: Expression expected.
         ~~
@@ -182,10 +187,12 @@
 !!! error TS2304: Cannot find name 'a'.
             ~
 !!! error TS1003: Identifier expected.
-==== 14.tsx (6 errors) ====
+==== 14.tsx (7 errors) ====
     <a[foo]></a[foo]>;
       ~
 !!! error TS1003: Identifier expected.
+      ~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any[]' and 'any'.
        ~~~
 !!! error TS2304: Cannot find name 'foo'.
             ~~
@@ -196,10 +203,12 @@
 !!! error TS2304: Cannot find name 'foo'.
                      ~
 !!! error TS1109: Expression expected.
-==== 15.tsx (4 errors) ====
+==== 15.tsx (5 errors) ====
     <a['foo']></a['foo']>;
       ~
 !!! error TS1003: Identifier expected.
+      ~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'string[]' and 'any'.
               ~~
 !!! error TS1109: Expression expected.
                 ~

--- a/tests/baselines/reference/parserConstructorAmbiguity1.errors.txt
+++ b/tests/baselines/reference/parserConstructorAmbiguity1.errors.txt
@@ -1,7 +1,10 @@
+parserConstructorAmbiguity1.ts(1,1): error TS2365: Operator '<' cannot be applied to types 'Date' and 'any'.
 parserConstructorAmbiguity1.ts(1,10): error TS2304: Cannot find name 'A'.
 
 
-==== parserConstructorAmbiguity1.ts (1 errors) ====
+==== parserConstructorAmbiguity1.ts (2 errors) ====
     new Date<A;
+    ~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Date' and 'any'.
              ~
 !!! error TS2304: Cannot find name 'A'.

--- a/tests/baselines/reference/parserConstructorAmbiguity2.errors.txt
+++ b/tests/baselines/reference/parserConstructorAmbiguity2.errors.txt
@@ -1,7 +1,10 @@
+parserConstructorAmbiguity2.ts(1,1): error TS2365: Operator '<' cannot be applied to types 'Date' and 'any'.
 parserConstructorAmbiguity2.ts(1,10): error TS2304: Cannot find name 'A'.
 
 
-==== parserConstructorAmbiguity2.ts (1 errors) ====
+==== parserConstructorAmbiguity2.ts (2 errors) ====
     new Date<A
+    ~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Date' and 'any'.
              ~
 !!! error TS2304: Cannot find name 'A'.

--- a/tests/baselines/reference/parserConstructorAmbiguity4.errors.txt
+++ b/tests/baselines/reference/parserConstructorAmbiguity4.errors.txt
@@ -1,10 +1,13 @@
+parserConstructorAmbiguity4.ts(1,1): error TS2365: Operator '<' cannot be applied to types 'Date' and 'any'.
 parserConstructorAmbiguity4.ts(1,10): error TS2304: Cannot find name 'A'.
 parserConstructorAmbiguity4.ts(1,14): error TS2304: Cannot find name 'B'.
 parserConstructorAmbiguity4.ts(1,18): error TS2304: Cannot find name 'C'.
 
 
-==== parserConstructorAmbiguity4.ts (3 errors) ====
+==== parserConstructorAmbiguity4.ts (4 errors) ====
     new Date<A ? B : C
+    ~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'Date' and 'any'.
              ~
 !!! error TS2304: Cannot find name 'A'.
                  ~

--- a/tests/baselines/reference/parserTypeAssertionInObjectCreationExpression1.errors.txt
+++ b/tests/baselines/reference/parserTypeAssertionInObjectCreationExpression1.errors.txt
@@ -1,10 +1,13 @@
+parserTypeAssertionInObjectCreationExpression1.ts(1,1): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
 parserTypeAssertionInObjectCreationExpression1.ts(1,5): error TS1109: Expression expected.
 parserTypeAssertionInObjectCreationExpression1.ts(1,6): error TS2304: Cannot find name 'T'.
 parserTypeAssertionInObjectCreationExpression1.ts(1,8): error TS2304: Cannot find name 'Foo'.
 
 
-==== parserTypeAssertionInObjectCreationExpression1.ts (3 errors) ====
+==== parserTypeAssertionInObjectCreationExpression1.ts (4 errors) ====
     new <T>Foo()
+    ~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'any'.
         ~
 !!! error TS1109: Expression expected.
          ~

--- a/tests/baselines/reference/signatureHelpRestArgs.baseline
+++ b/tests/baselines/reference/signatureHelpRestArgs.baseline
@@ -1,0 +1,709 @@
+// === SignatureHelp ===
+=== /tests/cases/fourslash/signatureHelpRestArgs.ts ===
+// function fn(a: number, b: number, c: number) {}
+// const a = [1, 2] as const;
+// const b = [1] as const;
+// 
+// fn(...a, );
+//          ^
+// | ----------------------------------------------------------------------
+// | fn(a: number, b: number, **c: number**): void
+// | ----------------------------------------------------------------------
+// fn(, ...a);
+//    ^
+// | ----------------------------------------------------------------------
+// | fn(**a: number**, b: number, c: number): void
+// | ----------------------------------------------------------------------
+// 
+// fn(...b, );
+//          ^
+// | ----------------------------------------------------------------------
+// | fn(a: number, **b: number**, c: number): void
+// | ----------------------------------------------------------------------
+// fn(, ...b, );
+//    ^
+// | ----------------------------------------------------------------------
+// | fn(**a: number**, b: number, c: number): void
+// | ----------------------------------------------------------------------
+//            ^
+// | ----------------------------------------------------------------------
+// | fn(a: number, b: number, **c: number**): void
+// | ----------------------------------------------------------------------
+
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpRestArgs.ts",
+      "position": 109,
+      "name": "1"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "fn",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "a",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "a",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "b",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "b",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "c",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "c",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 103,
+        "length": 6
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 4
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpRestArgs.ts",
+      "position": 115,
+      "name": "2"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "fn",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "a",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "a",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "b",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "b",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "c",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "c",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 115,
+        "length": 6
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpRestArgs.ts",
+      "position": 134,
+      "name": "3"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "fn",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "a",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "a",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "b",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "b",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "c",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "c",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 128,
+        "length": 6
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 1,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpRestArgs.ts",
+      "position": 140,
+      "name": "4"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "fn",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "a",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "a",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "b",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "b",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "c",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "c",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 140,
+        "length": 8
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 0,
+      "argumentCount": 3
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/signatureHelpRestArgs.ts",
+      "position": 148,
+      "name": "5"
+    },
+    "item": {
+      "items": [
+        {
+          "isVariadic": false,
+          "prefixDisplayParts": [
+            {
+              "text": "fn",
+              "kind": "functionName"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            }
+          ],
+          "suffixDisplayParts": [
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ":",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "separatorDisplayParts": [
+            {
+              "text": ",",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "space"
+            }
+          ],
+          "parameters": [
+            {
+              "name": "a",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "a",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "b",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "b",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            },
+            {
+              "name": "c",
+              "documentation": [],
+              "displayParts": [
+                {
+                  "text": "c",
+                  "kind": "parameterName"
+                },
+                {
+                  "text": ":",
+                  "kind": "punctuation"
+                },
+                {
+                  "text": " ",
+                  "kind": "space"
+                },
+                {
+                  "text": "number",
+                  "kind": "keyword"
+                }
+              ],
+              "isOptional": false,
+              "isRest": false
+            }
+          ],
+          "documentation": [],
+          "tags": []
+        }
+      ],
+      "applicableSpan": {
+        "start": 140,
+        "length": 8
+      },
+      "selectedItemIndex": 0,
+      "argumentIndex": 2,
+      "argumentCount": 3
+    }
+  }
+]

--- a/tests/baselines/reference/stringLiteralTypesWithVariousOperators01.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesWithVariousOperators01.errors.txt
@@ -1,0 +1,36 @@
+stringLiteralTypesWithVariousOperators01.ts(24,9): error TS2365: Operator '<' cannot be applied to types 'string | number' and 'string | number'.
+stringLiteralTypesWithVariousOperators01.ts(25,9): error TS2365: Operator '>=' cannot be applied to types 'string | number' and 'string'.
+
+
+==== stringLiteralTypesWithVariousOperators01.ts (2 errors) ====
+    let abc: "ABC" = "ABC";
+    let xyz: "XYZ" = "XYZ";
+    let abcOrXyz: "ABC" | "XYZ" = abc || xyz;
+    let abcOrXyzOrNumber: "ABC" | "XYZ" | number = abcOrXyz || 100;
+    
+    let a = "" + abc;
+    let b = abc + "";
+    let c = 10 + abc;
+    let d = abc + 10;
+    let e = xyz + abc;
+    let f = abc + xyz;
+    let g = true + abc;
+    let h = abc + true;
+    let i = abc + abcOrXyz + xyz;
+    let j = abcOrXyz + abcOrXyz;
+    let k = +abcOrXyz;
+    let l = -abcOrXyz;
+    let m = abcOrXyzOrNumber + "";
+    let n = "" + abcOrXyzOrNumber;
+    let o = abcOrXyzOrNumber + abcOrXyz;
+    let p = abcOrXyz + abcOrXyzOrNumber;
+    let q = !abcOrXyzOrNumber;
+    let r = ~abcOrXyzOrNumber;
+    let s = abcOrXyzOrNumber < abcOrXyzOrNumber;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string | number' and 'string | number'.
+    let t = abcOrXyzOrNumber >= abcOrXyz;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'string | number' and 'string'.
+    let u = abc === abcOrXyz;
+    let v = abcOrXyz === abcOrXyzOrNumber;

--- a/tests/baselines/reference/tsxFragmentErrors.errors.txt
+++ b/tests/baselines/reference/tsxFragmentErrors.errors.txt
@@ -1,10 +1,11 @@
 file.tsx(9,7): error TS2304: Cannot find name 'div'.
 file.tsx(9,7): error TS17015: Expected corresponding closing tag for JSX fragment.
+file.tsx(9,7): error TS2365: Operator '>' cannot be applied to types 'any' and 'Element'.
 file.tsx(9,11): error TS17014: JSX fragment has no corresponding closing tag.
 file.tsx(11,17): error TS1005: '</' expected.
 
 
-==== file.tsx (4 errors) ====
+==== file.tsx (5 errors) ====
     declare module JSX {
     	interface Element { }
     	interface IntrinsicElements {
@@ -18,10 +19,14 @@ file.tsx(11,17): error TS1005: '</' expected.
 !!! error TS2304: Cannot find name 'div'.
           ~~~
 !!! error TS17015: Expected corresponding closing tag for JSX fragment.
+          ~~~~~~~~~~~~~
               ~~~~~~~~~
     
     
+    
     <>eof   // Error
+    ~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'Element'.
     ~~
 !!! error TS17014: JSX fragment has no corresponding closing tag.
                     

--- a/tests/baselines/reference/typeAssertions.errors.txt
+++ b/tests/baselines/reference/typeAssertions.errors.txt
@@ -12,6 +12,7 @@ typeAssertions.ts(44,14): error TS1005: '>' expected.
 typeAssertions.ts(44,14): error TS2304: Cannot find name 'is'.
 typeAssertions.ts(44,17): error TS1005: ')' expected.
 typeAssertions.ts(44,17): error TS2693: 'string' only refers to a type, but is being used as a value here.
+typeAssertions.ts(44,17): error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
 typeAssertions.ts(44,48): error TS1005: ';' expected.
 typeAssertions.ts(45,2): error TS2322: Type 'string | number' is not assignable to type 'string'.
   Type 'number' is not assignable to type 'string'.
@@ -23,7 +24,7 @@ typeAssertions.ts(48,44): error TS2693: 'string' only refers to a type, but is b
 typeAssertions.ts(48,50): error TS1128: Declaration or statement expected.
 
 
-==== typeAssertions.ts (18 errors) ====
+==== typeAssertions.ts (19 errors) ====
     // Function call whose argument is a 1 arg generic function call with explicit type arguments
     function fn1<T>(t: T) { }
     function fn2(t: any) { }
@@ -96,6 +97,8 @@ typeAssertions.ts(48,50): error TS1128: Declaration or statement expected.
 !!! related TS1007 typeAssertions.ts:44:3: The parser expected to find a ')' to match the '(' token here.
                     ~~~~~~
 !!! error TS2693: 'string' only refers to a type, but is being used as a value here.
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'any' and 'boolean'.
                                                    ~
 !!! error TS1005: ';' expected.
     	str = numOrStr; // Error, no narrowing occurred

--- a/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithInvalidOperand.ts
+++ b/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithInvalidOperand.ts
@@ -1,0 +1,142 @@
+// repro #15506
+// assumes that only valid comparisons are between anys, numbers and strings
+var a: boolean = false;
+var b: number = 0;
+var c: string = "";
+var d: Date = new Date();
+var e: number[] = [];
+var f: {} = {};
+var g: string[] = [];
+var h: bigint = 9007199254740991n;
+var i: Number = 0;
+var j: any;
+const k = 0;
+const l = 9007199254740991n;
+
+// operator <
+// boolean
+a < a;
+a < b;
+a < c;
+a < d;
+a < e;
+a < f;
+a < g;
+a < h;
+a < i;
+a < j;
+a < k;
+a < l;
+
+// number
+b < c;
+b < d;
+b < e;
+b < f;
+b < g;
+b < h;
+b < i;
+b < j;
+b < k;
+b < l;
+k < l;
+
+// Date
+d < d;
+d < a;
+
+// operator >
+// boolean
+a > a;
+a > b;
+a > c;
+a > d;
+a > e;
+a > f;
+a > g;
+a > h;
+a > i;
+a > j;
+a > k;
+a > l;
+
+// number
+b > c;
+b > d;
+b > e;
+b > f;
+b > g;
+b > h;
+b > i;
+b > j;
+b > k;
+b > l;
+k > l;
+
+// Date
+d > d;
+d > a;
+
+// operator <=
+// boolean
+a <= a;
+a <= b;
+a <= c;
+a <= d;
+a <= e;
+a <= f;
+a <= g;
+a <= h;
+a <= i;
+a <= j;
+a <= k;
+a <= l;
+
+// number
+b <= c;
+b <= d;
+b <= e;
+b <= f;
+b <= g;
+b <= h;
+b <= i;
+b <= j;
+b <= k;
+b <= l;
+k <= l;
+
+// Date
+d <= d;
+d <= a;
+
+// operator >=
+// boolean
+a >= a;
+a >= b;
+a >= c;
+a >= d;
+a >= e;
+a >= f;
+a >= g;
+a >= h;
+a >= i;
+a >= j;
+a >= k;
+a >= l;
+
+// number
+b >= c;
+b >= d;
+b >= e;
+b >= f;
+b >= g;
+b >= h;
+b >= i;
+b >= j;
+b >= k;
+b >= l;
+k >= l;
+
+// Date
+d >= d;
+d >= a;

--- a/tests/cases/fourslash/signatureHelpRestArgs.ts
+++ b/tests/cases/fourslash/signatureHelpRestArgs.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts" />
+
+////function fn(a: number, b: number, c: number) {}
+////const a = [1, 2] as const;
+////const b = [1] as const;
+////
+////fn(...a, /*1*/);
+////fn(/*2*/, ...a);
+////
+////fn(...b, /*3*/);
+////fn(/*4*/, ...b, /*5*/);
+
+verify.baselineSignatureHelp();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `main` branch
* [X] You've successfully run `hereby runtests` locally
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #
