### PR TITLE
fix a bug preventing a subclass property sharing a name with a type parameter from being accessed

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13062,7 +13062,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 const symbolTable = createSymbolTable();
                 // copy all symbols (except type parameters), including the ones with internal names like `InternalSymbolName.Index`
                 for (const symbol of members.values()) {
-                    if (!(symbol.flags & SymbolFlags.TypeParameter)) {
+                    // include declared properties that share a name with a type parameter by checking for multiple declarations
+                    if (!(symbol.flags & SymbolFlags.TypeParameter) || symbol.declarations?.some(declaration => declaration.kind !== SyntaxKind.TypeParameter)) {
                         symbolTable.set(symbol.escapedName, symbol);
                     }
                 }

--- a/tests/baselines/reference/classPropertySharingNameWithTypeParameter.js
+++ b/tests/baselines/reference/classPropertySharingNameWithTypeParameter.js
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/classPropertySharingNameWithTypeParameter.ts] ////
+
+//// [classPropertySharingNameWithTypeParameter.ts]
+class Leg {}
+
+class Foo<t> extends Leg {
+    t = {} as t
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t 
+}
+
+//// [classPropertySharingNameWithTypeParameter.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Leg = /** @class */ (function () {
+    function Leg() {
+    }
+    return Leg;
+}());
+var Foo = /** @class */ (function (_super) {
+    __extends(Foo, _super);
+    function Foo() {
+        var _this = _super !== null && _super.apply(this, arguments) || this;
+        _this.t = {};
+        // should allow this access since t was declared as a property on Foo
+        _this.foo = _this.t;
+        return _this;
+    }
+    return Foo;
+}(Leg));

--- a/tests/baselines/reference/classPropertySharingNameWithTypeParameter.symbols
+++ b/tests/baselines/reference/classPropertySharingNameWithTypeParameter.symbols
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/classPropertySharingNameWithTypeParameter.ts] ////
+
+=== classPropertySharingNameWithTypeParameter.ts ===
+class Leg {}
+>Leg : Symbol(Leg, Decl(classPropertySharingNameWithTypeParameter.ts, 0, 0))
+
+class Foo<t> extends Leg {
+>Foo : Symbol(Foo, Decl(classPropertySharingNameWithTypeParameter.ts, 0, 12))
+>t : Symbol(t, Decl(classPropertySharingNameWithTypeParameter.ts, 2, 10), Decl(classPropertySharingNameWithTypeParameter.ts, 2, 26))
+>Leg : Symbol(Leg, Decl(classPropertySharingNameWithTypeParameter.ts, 0, 0))
+
+    t = {} as t
+>t : Symbol(t, Decl(classPropertySharingNameWithTypeParameter.ts, 2, 10), Decl(classPropertySharingNameWithTypeParameter.ts, 2, 26))
+>t : Symbol(t, Decl(classPropertySharingNameWithTypeParameter.ts, 2, 10), Decl(classPropertySharingNameWithTypeParameter.ts, 2, 26))
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t 
+>foo : Symbol(Foo.foo, Decl(classPropertySharingNameWithTypeParameter.ts, 3, 15))
+>this.t : Symbol(t, Decl(classPropertySharingNameWithTypeParameter.ts, 2, 10), Decl(classPropertySharingNameWithTypeParameter.ts, 2, 26))
+>this : Symbol(Foo, Decl(classPropertySharingNameWithTypeParameter.ts, 0, 12))
+>t : Symbol(t, Decl(classPropertySharingNameWithTypeParameter.ts, 2, 10), Decl(classPropertySharingNameWithTypeParameter.ts, 2, 26))
+}

--- a/tests/baselines/reference/classPropertySharingNameWithTypeParameter.types
+++ b/tests/baselines/reference/classPropertySharingNameWithTypeParameter.types
@@ -1,0 +1,22 @@
+//// [tests/cases/compiler/classPropertySharingNameWithTypeParameter.ts] ////
+
+=== classPropertySharingNameWithTypeParameter.ts ===
+class Leg {}
+>Leg : Leg
+
+class Foo<t> extends Leg {
+>Foo : Foo<t>
+>Leg : Leg
+
+    t = {} as t
+>t : t
+>{} as t : t
+>{} : {}
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t 
+>foo : t
+>this.t : t
+>this : this
+>t : t
+}

--- a/tests/cases/compiler/classPropertySharingNameWithTypeParameter.ts
+++ b/tests/cases/compiler/classPropertySharingNameWithTypeParameter.ts
@@ -1,0 +1,8 @@
+class Leg {}
+
+class Foo<t> extends Leg {
+    t = {} as t
+
+    // should allow this access since t was declared as a property on Foo
+    foo = this.t 
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #56689

I have very little context here so happy to adjust if there is a better way to resolve this. It just looked like it would be straightforward to resolve when I encountered so decided to give it a shot 🙏 
