### PR TITLE
Show implied options in --showConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "playwright": "^1.38.0",
                 "source-map-support": "^0.5.21",
                 "tslib": "^2.5.0",
-                "typescript": "^5.3.2",
+                "typescript": "^5.4.0-dev.20231206",
                 "which": "^2.0.2"
             },
             "engines": {
@@ -3786,9 +3786,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-            "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+            "version": "5.4.0-dev.20231207",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231207.tgz",
+            "integrity": "sha512-9OsUooJnRMwemgmnZVwLewnl3XzbEj61obef4BbooBr9w9L7i0ILMDYHAwQnYsxx/LLpw1+mvbDl30jO48mReA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -6584,9 +6584,9 @@
             }
         },
         "typescript": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-            "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+            "version": "5.4.0-dev.20231207",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231207.tgz",
+            "integrity": "sha512-9OsUooJnRMwemgmnZVwLewnl3XzbEj61obef4BbooBr9w9L7i0ILMDYHAwQnYsxx/LLpw1+mvbDl30jO48mReA==",
             "dev": true
         },
         "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "playwright": "^1.38.0",
                 "source-map-support": "^0.5.21",
                 "tslib": "^2.5.0",
-                "typescript": "^5.4.0-dev.20231206",
+                "typescript": "5.4.0-dev.20231206",
                 "which": "^2.0.2"
             },
             "engines": {
@@ -3786,9 +3786,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.0-dev.20231207",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231207.tgz",
-            "integrity": "sha512-9OsUooJnRMwemgmnZVwLewnl3XzbEj61obef4BbooBr9w9L7i0ILMDYHAwQnYsxx/LLpw1+mvbDl30jO48mReA==",
+            "version": "5.4.0-dev.20231206",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231206.tgz",
+            "integrity": "sha512-bKJ5+3jwj4qTzNg7C97rCVLgyyYuzjYh/Pf0zlpOyyq9vpI3TVLO09d1gQ8jS5M+BSLONojTijei0KHmFoBezw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -6584,9 +6584,9 @@
             }
         },
         "typescript": {
-            "version": "5.4.0-dev.20231207",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231207.tgz",
-            "integrity": "sha512-9OsUooJnRMwemgmnZVwLewnl3XzbEj61obef4BbooBr9w9L7i0ILMDYHAwQnYsxx/LLpw1+mvbDl30jO48mReA==",
+            "version": "5.4.0-dev.20231206",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231206.tgz",
+            "integrity": "sha512-bKJ5+3jwj4qTzNg7C97rCVLgyyYuzjYh/Pf0zlpOyyq9vpI3TVLO09d1gQ8jS5M+BSLONojTijei0KHmFoBezw==",
             "dev": true
         },
         "typical": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "playwright": "^1.38.0",
         "source-map-support": "^0.5.21",
         "tslib": "^2.5.0",
-        "typescript": "^5.3.2",
+        "typescript": "^5.4.0-dev.20231206",
         "which": "^2.0.2"
     },
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "playwright": "^1.38.0",
         "source-map-support": "^0.5.21",
         "tslib": "^2.5.0",
-        "typescript": "^5.4.0-dev.20231206",
+        "typescript": "5.4.0-dev.20231206",
         "which": "^2.0.2"
     },
     "overrides": {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8590,7 +8590,7 @@ export function getSetExternalModuleIndicator(options: CompilerOptions): (file: 
 type CompilerOptionKeys = keyof { [K in keyof CompilerOptions as string extends K ? never : K]: any; };
 function createComputedCompilerOptions<T extends Record<string, CompilerOptionKeys[]>>(
     options: {
-        [K in keyof T & CompilerOptionKeys]: {
+        [K in keyof T & CompilerOptionKeys | StrictOptionName]: {
             dependencies: T[K];
             computeValue: (compilerOptions: Pick<CompilerOptions, K | T[K][number]>) => Exclude<CompilerOptions[K], undefined>;
         };
@@ -8813,7 +8813,7 @@ export const computedOptions = createComputedCompilerOptions({
             return getStrictOptionValue(compilerOptions, "useUnknownInCatchVariables");
         },
     },
-}) satisfies Record<StrictOptionName, any>;
+});
 
 /** @internal */
 export const getEmitScriptTarget = computedOptions.target.computeValue;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8588,51 +8588,176 @@ export function getSetExternalModuleIndicator(options: CompilerOptions): (file: 
 }
 
 /** @internal */
-export function getEmitScriptTarget(compilerOptions: { module?: CompilerOptions["module"]; target?: CompilerOptions["target"]; }): ScriptTarget {
-    return compilerOptions.target ??
-        ((compilerOptions.module === ModuleKind.Node16 && ScriptTarget.ES2022) ||
-            (compilerOptions.module === ModuleKind.NodeNext && ScriptTarget.ESNext) ||
-            ScriptTarget.ES5);
+export interface ComputedCompilerOption<N extends keyof CompilerOptions, K extends keyof CompilerOptions, R extends CompilerOptions[N]> {
+    name: N;
+    dependencies: readonly K[];
+    computeValue: (compilerOptions: Pick<CompilerOptions, N | K>) => R;
 }
 
 /** @internal */
-export function getEmitModuleKind(compilerOptions: { module?: CompilerOptions["module"]; target?: CompilerOptions["target"]; }) {
-    return typeof compilerOptions.module === "number" ?
-        compilerOptions.module :
-        getEmitScriptTarget(compilerOptions) >= ScriptTarget.ES2015 ? ModuleKind.ES2015 : ModuleKind.CommonJS;
+function computedCompilerOption<N extends keyof CompilerOptions, K extends keyof CompilerOptions, R extends CompilerOptions[N]>(
+    name: N,
+    dependencies: readonly K[],
+    computeValue: (compilerOptions: Pick<CompilerOptions, N | K>) => R,
+): ComputedCompilerOption<N, K, R> {
+    return { name, dependencies, computeValue };
 }
+
+/** @internal */
+export const computedOptions = {
+    target: computedCompilerOption("target", ["module"], compilerOptions => {
+        return compilerOptions.target ??
+            ((compilerOptions.module === ModuleKind.Node16 && ScriptTarget.ES2022) ||
+                (compilerOptions.module === ModuleKind.NodeNext && ScriptTarget.ESNext) ||
+                ScriptTarget.ES5);
+    }),
+    module: computedCompilerOption("module", ["target"], (compilerOptions): ModuleKind => {
+        return typeof compilerOptions.module === "number" ?
+            compilerOptions.module :
+            computedOptions.target.computeValue(compilerOptions) >= ScriptTarget.ES2015 ? ModuleKind.ES2015 : ModuleKind.CommonJS;
+    }),
+    moduleResolution: computedCompilerOption("moduleResolution", ["module", "target"], (compilerOptions): ModuleResolutionKind => {
+        let moduleResolution = compilerOptions.moduleResolution;
+        if (moduleResolution === undefined) {
+            switch (computedOptions.module.computeValue(compilerOptions)) {
+                case ModuleKind.CommonJS:
+                    moduleResolution = ModuleResolutionKind.Node10;
+                    break;
+                case ModuleKind.Node16:
+                    moduleResolution = ModuleResolutionKind.Node16;
+                    break;
+                case ModuleKind.NodeNext:
+                    moduleResolution = ModuleResolutionKind.NodeNext;
+                    break;
+                default:
+                    moduleResolution = ModuleResolutionKind.Classic;
+                    break;
+            }
+        }
+        return moduleResolution;
+    }),
+    moduleDetection: computedCompilerOption("moduleDetection", ["module", "target"], (compilerOptions): ModuleDetectionKind => {
+        return compilerOptions.moduleDetection ||
+            (computedOptions.module.computeValue(compilerOptions) === ModuleKind.Node16 ||
+                    computedOptions.module.computeValue(compilerOptions) === ModuleKind.NodeNext ? ModuleDetectionKind.Force : ModuleDetectionKind.Auto);
+    }),
+    isolatedModules: computedCompilerOption("isolatedModules", ["verbatimModuleSyntax"], compilerOptions => {
+        return !!(compilerOptions.isolatedModules || compilerOptions.verbatimModuleSyntax);
+    }),
+    esModuleInterop: computedCompilerOption("esModuleInterop", ["module", "target"], (compilerOptions): boolean | undefined => {
+        if (compilerOptions.esModuleInterop !== undefined) {
+            return compilerOptions.esModuleInterop;
+        }
+        switch (computedOptions.module.computeValue(compilerOptions)) {
+            case ModuleKind.Node16:
+            case ModuleKind.NodeNext:
+                return true;
+        }
+    }),
+    allowSyntheticDefaultImports: computedCompilerOption("allowSyntheticDefaultImports", ["module", "target", "moduleResolution"], (compilerOptions): boolean => {
+        if (compilerOptions.allowSyntheticDefaultImports !== undefined) {
+            return compilerOptions.allowSyntheticDefaultImports;
+        }
+        return computedOptions.esModuleInterop.computeValue(compilerOptions)
+            || computedOptions.module.computeValue(compilerOptions) === ModuleKind.System
+            || computedOptions.moduleResolution.computeValue(compilerOptions) === ModuleResolutionKind.Bundler;
+    }),
+    resolvePackageJsonExports: computedCompilerOption("resolvePackageJsonExports", ["moduleResolution"], (compilerOptions): boolean => {
+        const moduleResolution = computedOptions.moduleResolution.computeValue(compilerOptions);
+        if (!moduleResolutionSupportsPackageJsonExportsAndImports(moduleResolution)) {
+            return false;
+        }
+        if (compilerOptions.resolvePackageJsonExports !== undefined) {
+            return compilerOptions.resolvePackageJsonExports;
+        }
+        switch (moduleResolution) {
+            case ModuleResolutionKind.Node16:
+            case ModuleResolutionKind.NodeNext:
+            case ModuleResolutionKind.Bundler:
+                return true;
+        }
+        return false;
+    }),
+    resolvePackageJsonImports: computedCompilerOption("resolvePackageJsonImports", ["moduleResolution", "resolvePackageJsonExports"], (compilerOptions): boolean => {
+        const moduleResolution = computedOptions.moduleResolution.computeValue(compilerOptions);
+        if (!moduleResolutionSupportsPackageJsonExportsAndImports(moduleResolution)) {
+            return false;
+        }
+        if (compilerOptions.resolvePackageJsonExports !== undefined) {
+            return compilerOptions.resolvePackageJsonExports;
+        }
+        switch (moduleResolution) {
+            case ModuleResolutionKind.Node16:
+            case ModuleResolutionKind.NodeNext:
+            case ModuleResolutionKind.Bundler:
+                return true;
+        }
+        return false;
+    }),
+    resolveJsonModule: computedCompilerOption("resolveJsonModule", ["moduleResolution", "module", "target"], (compilerOptions): boolean | undefined => {
+        if (compilerOptions.resolveJsonModule !== undefined) {
+            return compilerOptions.resolveJsonModule;
+        }
+        return computedOptions.moduleResolution.computeValue(compilerOptions) === ModuleResolutionKind.Bundler;
+    }),
+    declaration: computedCompilerOption("declaration", ["composite"], compilerOptions => {
+        return !!(compilerOptions.declaration || compilerOptions.composite);
+    }),
+    preserveConstEnums: computedCompilerOption("preserveConstEnums", ["isolatedModules", "verbatimModuleSyntax"], (compilerOptions): boolean => {
+        return !!(compilerOptions.preserveConstEnums || computedOptions.isolatedModules.computeValue(compilerOptions));
+    }),
+    incremental: computedCompilerOption("incremental", ["composite"], compilerOptions => {
+        return !!(compilerOptions.incremental || compilerOptions.composite);
+    }),
+    declarationMap: computedCompilerOption("declarationMap", ["declaration", "composite"], (compilerOptions): boolean => {
+        return !!(compilerOptions.declarationMap && computedOptions.declaration.computeValue(compilerOptions));
+    }),
+    allowJs: computedCompilerOption("allowJs", ["checkJs"], compilerOptions => {
+        return compilerOptions.allowJs === undefined ? !!compilerOptions.checkJs : compilerOptions.allowJs;
+    }),
+    useDefineForClassFields: computedCompilerOption("useDefineForClassFields", ["target", "module"], (compilerOptions): boolean => {
+        return compilerOptions.useDefineForClassFields === undefined
+            ? computedOptions.target.computeValue(compilerOptions) >= ScriptTarget.ES2022
+            : compilerOptions.useDefineForClassFields;
+    }),
+};
+
+/** @internal */
+export const getEmitScriptTarget = computedOptions.target.computeValue;
+/** @internal */
+export const getEmitModuleKind = computedOptions.module.computeValue;
+/** @internal */
+export const getEmitModuleResolutionKind = computedOptions.moduleResolution.computeValue;
+/** @internal */
+export const getEmitModuleDetectionKind = computedOptions.moduleDetection.computeValue;
+/** @internal */
+export const getIsolatedModules = computedOptions.isolatedModules.computeValue;
+/** @internal */
+export const getESModuleInterop = computedOptions.esModuleInterop.computeValue;
+/** @internal */
+export const getAllowSyntheticDefaultImports = computedOptions.allowSyntheticDefaultImports.computeValue;
+/** @internal */
+export const getResolvePackageJsonExports = computedOptions.resolvePackageJsonExports.computeValue;
+/** @internal */
+export const getResolvePackageJsonImports = computedOptions.resolvePackageJsonImports.computeValue;
+/** @internal */
+export const getResolveJsonModule = computedOptions.resolveJsonModule.computeValue;
+/** @internal */
+export const getEmitDeclarations = computedOptions.declaration.computeValue;
+/** @internal */
+export const shouldPreserveConstEnums = computedOptions.preserveConstEnums.computeValue;
+/** @internal */
+export const isIncrementalCompilation = computedOptions.incremental.computeValue;
+/** @internal */
+export const getAreDeclarationMapsEnabled = computedOptions.declarationMap.computeValue;
+/** @internal */
+export const getAllowJSCompilerOption = computedOptions.allowJs.computeValue;
+/** @internal */
+export const getUseDefineForClassFields = computedOptions.useDefineForClassFields.computeValue;
 
 /** @internal */
 export function emitModuleKindIsNonNodeESM(moduleKind: ModuleKind) {
     return moduleKind >= ModuleKind.ES2015 && moduleKind <= ModuleKind.ESNext;
-}
-
-/** @internal */
-export function getEmitModuleResolutionKind(compilerOptions: CompilerOptions) {
-    let moduleResolution = compilerOptions.moduleResolution;
-    if (moduleResolution === undefined) {
-        switch (getEmitModuleKind(compilerOptions)) {
-            case ModuleKind.CommonJS:
-                moduleResolution = ModuleResolutionKind.Node10;
-                break;
-            case ModuleKind.Node16:
-                moduleResolution = ModuleResolutionKind.Node16;
-                break;
-            case ModuleKind.NodeNext:
-                moduleResolution = ModuleResolutionKind.NodeNext;
-                break;
-            default:
-                moduleResolution = ModuleResolutionKind.Classic;
-                break;
-        }
-    }
-    return moduleResolution;
-}
-
-/** @internal */
-export function getEmitModuleDetectionKind(options: CompilerOptions) {
-    return options.moduleDetection ||
-        (getEmitModuleKind(options) === ModuleKind.Node16 || getEmitModuleKind(options) === ModuleKind.NodeNext ? ModuleDetectionKind.Force : ModuleDetectionKind.Auto);
 }
 
 /** @internal */
@@ -8653,11 +8778,6 @@ export function hasJsonModuleEmitEnabled(options: CompilerOptions) {
 }
 
 /** @internal */
-export function getIsolatedModules(options: CompilerOptions) {
-    return !!(options.isolatedModules || options.verbatimModuleSyntax);
-}
-
-/** @internal */
 export function importNameElisionDisabled(options: CompilerOptions) {
     return options.verbatimModuleSyntax || options.isolatedModules && options.preserveValueImports;
 }
@@ -8673,34 +8793,6 @@ export function unusedLabelIsError(options: CompilerOptions): boolean {
 }
 
 /** @internal */
-export function getAreDeclarationMapsEnabled(options: CompilerOptions) {
-    return !!(getEmitDeclarations(options) && options.declarationMap);
-}
-
-/** @internal */
-export function getESModuleInterop(compilerOptions: CompilerOptions) {
-    if (compilerOptions.esModuleInterop !== undefined) {
-        return compilerOptions.esModuleInterop;
-    }
-    switch (getEmitModuleKind(compilerOptions)) {
-        case ModuleKind.Node16:
-        case ModuleKind.NodeNext:
-            return true;
-    }
-    return undefined;
-}
-
-/** @internal */
-export function getAllowSyntheticDefaultImports(compilerOptions: CompilerOptions) {
-    if (compilerOptions.allowSyntheticDefaultImports !== undefined) {
-        return compilerOptions.allowSyntheticDefaultImports;
-    }
-    return getESModuleInterop(compilerOptions)
-        || getEmitModuleKind(compilerOptions) === ModuleKind.System
-        || getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Bundler;
-}
-
-/** @internal */
 export function moduleResolutionSupportsPackageJsonExportsAndImports(moduleResolution: ModuleResolutionKind): boolean {
     return moduleResolution >= ModuleResolutionKind.Node16 && moduleResolution <= ModuleResolutionKind.NodeNext
         || moduleResolution === ModuleResolutionKind.Bundler;
@@ -8710,65 +8802,6 @@ export function moduleResolutionSupportsPackageJsonExportsAndImports(moduleResol
 export function shouldResolveJsRequire(compilerOptions: CompilerOptions): boolean {
     // `bundler` doesn't support resolving `require`, but needs to in `noDtsResolution` to support Find Source Definition
     return !!compilerOptions.noDtsResolution || getEmitModuleResolutionKind(compilerOptions) !== ModuleResolutionKind.Bundler;
-}
-
-/** @internal */
-export function getResolvePackageJsonExports(compilerOptions: CompilerOptions) {
-    const moduleResolution = getEmitModuleResolutionKind(compilerOptions);
-    if (!moduleResolutionSupportsPackageJsonExportsAndImports(moduleResolution)) {
-        return false;
-    }
-    if (compilerOptions.resolvePackageJsonExports !== undefined) {
-        return compilerOptions.resolvePackageJsonExports;
-    }
-    switch (moduleResolution) {
-        case ModuleResolutionKind.Node16:
-        case ModuleResolutionKind.NodeNext:
-        case ModuleResolutionKind.Bundler:
-            return true;
-    }
-    return false;
-}
-
-/** @internal */
-export function getResolvePackageJsonImports(compilerOptions: CompilerOptions) {
-    const moduleResolution = getEmitModuleResolutionKind(compilerOptions);
-    if (!moduleResolutionSupportsPackageJsonExportsAndImports(moduleResolution)) {
-        return false;
-    }
-    if (compilerOptions.resolvePackageJsonExports !== undefined) {
-        return compilerOptions.resolvePackageJsonExports;
-    }
-    switch (moduleResolution) {
-        case ModuleResolutionKind.Node16:
-        case ModuleResolutionKind.NodeNext:
-        case ModuleResolutionKind.Bundler:
-            return true;
-    }
-    return false;
-}
-
-/** @internal */
-export function getResolveJsonModule(compilerOptions: CompilerOptions) {
-    if (compilerOptions.resolveJsonModule !== undefined) {
-        return compilerOptions.resolveJsonModule;
-    }
-    return getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Bundler;
-}
-
-/** @internal */
-export function getEmitDeclarations(compilerOptions: CompilerOptions): boolean {
-    return !!(compilerOptions.declaration || compilerOptions.composite);
-}
-
-/** @internal */
-export function shouldPreserveConstEnums(compilerOptions: CompilerOptions): boolean {
-    return !!(compilerOptions.preserveConstEnums || getIsolatedModules(compilerOptions));
-}
-
-/** @internal */
-export function isIncrementalCompilation(options: CompilerOptions) {
-    return !!(options.incremental || options.composite);
 }
 
 /** @internal */
@@ -8785,16 +8818,6 @@ export type StrictOptionName =
 /** @internal */
 export function getStrictOptionValue(compilerOptions: CompilerOptions, flag: StrictOptionName): boolean {
     return compilerOptions[flag] === undefined ? !!compilerOptions.strict : !!compilerOptions[flag];
-}
-
-/** @internal */
-export function getAllowJSCompilerOption(compilerOptions: CompilerOptions): boolean {
-    return compilerOptions.allowJs === undefined ? !!compilerOptions.checkJs : compilerOptions.allowJs;
-}
-
-/** @internal */
-export function getUseDefineForClassFields(compilerOptions: CompilerOptions): boolean {
-    return compilerOptions.useDefineForClassFields === undefined ? getEmitScriptTarget(compilerOptions) >= ScriptTarget.ES2022 : compilerOptions.useDefineForClassFields;
 }
 
 /** @internal */

--- a/tests/baselines/reference/config/showConfig/Show TSConfig with compileOnSave and more/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Show TSConfig with compileOnSave and more/tsconfig.json
@@ -4,7 +4,15 @@
         "target": "es5",
         "module": "commonjs",
         "strict": true,
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "strictBindCallApply": true,
+        "strictPropertyInitialization": true,
+        "alwaysStrict": true,
+        "useUnknownInCatchVariables": true
     },
     "references": [
         {

--- a/tests/baselines/reference/config/showConfig/Show TSConfig with compileOnSave and more/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Show TSConfig with compileOnSave and more/tsconfig.json
@@ -3,7 +3,8 @@
         "esModuleInterop": true,
         "target": "es5",
         "module": "commonjs",
-        "strict": true
+        "strict": true,
+        "allowSyntheticDefaultImports": true
     },
     "references": [
         {

--- a/tests/baselines/reference/config/showConfig/Show TSConfig with paths and more/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Show TSConfig with paths and more/tsconfig.json
@@ -25,7 +25,8 @@
         },
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "allowSyntheticDefaultImports": true
     },
     "include": [
         "./src/**/*"

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/checkJs/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/checkJs/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "checkJs": true
+        "checkJs": true,
+        "allowJs": true
     }
 }

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/composite/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/composite/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
-        "composite": true
+        "composite": true,
+        "declaration": true,
+        "incremental": true
     }
 }

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/isolatedModules/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/isolatedModules/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "isolatedModules": true
+        "isolatedModules": true,
+        "preserveConstEnums": true
     }
 }

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/module/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/module/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "module": "none"
+        "module": "none",
+        "moduleResolution": "classic"
     }
 }

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/strict/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/strict/tsconfig.json
@@ -1,5 +1,13 @@
 {
     "compilerOptions": {
-        "strict": true
+        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "strictBindCallApply": true,
+        "strictPropertyInitialization": true,
+        "alwaysStrict": true,
+        "useUnknownInCatchVariables": true
     }
 }

--- a/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/verbatimModuleSyntax/tsconfig.json
+++ b/tests/baselines/reference/config/showConfig/Shows tsconfig for single option/verbatimModuleSyntax/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
-        "verbatimModuleSyntax": true
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+        "preserveConstEnums": true
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes my minor annoyance from earlier today

`--showConfig` on this tsconfig:

```json
{
  "compilerOptions": {
    "module": "NodeNext"
  }
}
```

Before:

```json
{
    "compilerOptions": {
        "module": "nodenext"
    },
    "files": [
        "./main.ts",
    ]
}
```

After:

```json
{
    "compilerOptions": {
        "module": "nodenext",
        "target": "esnext",
        "moduleResolution": "nodenext",
        "moduleDetection": "force",
        "esModuleInterop": true,
        "allowSyntheticDefaultImports": true,
        "useDefineForClassFields": true
    },
    "files": [
        "./main.ts"
    ]
}
```