### PR TITLE
fix(56699): [Formatting] Missing space after implements / extends generic

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -88,7 +88,7 @@ export function getAllRules(): RuleSpec[] {
     const functionOpenBraceLeftTokenRange = anyTokenIncludingMultilineComments;
 
     // Place a space before open brace in a TypeScript declaration that has braces as children (class, module, enum, etc)
-    const typeScriptOpenBraceLeftTokenRange = tokenRangeFrom([SyntaxKind.Identifier, SyntaxKind.MultiLineCommentTrivia, SyntaxKind.ClassKeyword, SyntaxKind.ExportKeyword, SyntaxKind.ImportKeyword]);
+    const typeScriptOpenBraceLeftTokenRange = tokenRangeFrom([SyntaxKind.Identifier, SyntaxKind.GreaterThanToken, SyntaxKind.MultiLineCommentTrivia, SyntaxKind.ClassKeyword, SyntaxKind.ExportKeyword, SyntaxKind.ImportKeyword]);
 
     // Place a space before open brace in a control flow construct
     const controlOpenBraceLeftTokenRange = tokenRangeFrom([SyntaxKind.CloseParenToken, SyntaxKind.MultiLineCommentTrivia, SyntaxKind.DoKeyword, SyntaxKind.TryKeyword, SyntaxKind.FinallyKeyword, SyntaxKind.ElseKeyword, SyntaxKind.CatchKeyword]);

--- a/tests/cases/fourslash/formatSpaceAfterImplementsExtends.ts
+++ b/tests/cases/fourslash/formatSpaceAfterImplementsExtends.ts
@@ -1,0 +1,27 @@
+///<reference path="fourslash.ts"/>
+
+////class C1 implements Array<string>{
+////}
+////
+////class C2 implements Number{
+////}
+////
+////class C3 extends Array<string>{
+////}
+////
+////class C4 extends Number{
+////}
+
+format.document();
+verify.currentFileContentIs(
+`class C1 implements Array<string> {
+}
+
+class C2 implements Number {
+}
+
+class C3 extends Array<string> {
+}
+
+class C4 extends Number {
+}`);

--- a/tests/cases/fourslash/genericsFormatting.ts
+++ b/tests/cases/fourslash/genericsFormatting.ts
@@ -26,7 +26,7 @@
 format.document();
 
 goTo.marker("inClassDeclaration");
-verify.currentLineContentIs("class Foo<T1, T2>  {");
+verify.currentLineContentIs("class Foo<T1, T2> {");
 
 goTo.marker("inMethodDeclaration");
 verify.currentLineContentIs("    public method<T3, T4>(a: T1, b: Array<T4>): Map<T1, T2, Array<T3>> {");


### PR DESCRIPTION
Fixes #56699

