### PR TITLE
fix(56706): "Show call hierarchy" does not work with arrow methods in a class

### DIFF
--- a/tests/baselines/reference/callHierarchyClassPropertyArrowFunction.callHierarchy.txt
+++ b/tests/baselines/reference/callHierarchyClassPropertyArrowFunction.callHierarchy.txt
@@ -1,0 +1,44 @@
+// === Call Hierarchy ===
+╭ name: callee
+├ kind: function
+├ containerName: C
+├ file: /tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts
+├ span:
+│ ╭ /tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts:6:14-7:6
+│ │ 6:     callee = () => {
+│ │                 ^^^^^^^
+│ │ 7:     }
+│ │    ^^^^^
+│ ╰
+├ selectionSpan:
+│ ╭ /tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts:6:5-6:11
+│ │ 6:     callee = () => {
+│ │        ^^^^^^
+│ ╰
+├ incoming:
+│ ╭ from:
+│ │ ╭ name: caller
+│ │ ├ kind: function
+│ │ ├ containerName: C
+│ │ ├ file: /tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts
+│ │ ├ span:
+│ │ │ ╭ /tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts:2:14-4:6
+│ │ │ │ 2:     caller = () => {
+│ │ │ │                 ^^^^^^^
+│ │ │ │ 3:         this.callee();
+│ │ │ │    ^^^^^^^^^^^^^^^^^^^^^^
+│ │ │ │ 4:     }
+│ │ │ │    ^^^^^
+│ │ │ ╰
+│ │ ├ selectionSpan:
+│ │ │ ╭ /tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts:2:5-2:11
+│ │ │ │ 2:     caller = () => {
+│ │ │ │        ^^^^^^
+│ │ │ ╰
+│ │ ╰ incoming: none
+│ ├ fromSpans:
+│ │ ╭ /tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts:3:14-3:20
+│ │ │ 3:         this.callee();
+│ │ │                 ^^^^^^
+│ ╰ ╰
+╰ outgoing: none

--- a/tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts
+++ b/tests/cases/fourslash/callHierarchyClassPropertyArrowFunction.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts" />
+
+////class C {
+////    caller = () => {
+////        this.callee();
+////    }
+////
+////    /**/callee = () => {
+////    }
+////}
+
+goTo.marker();
+verify.baselineCallHierarchy();


### PR DESCRIPTION
Fixes #56706