### PR TITLE
fix(56733): Auto fix "add missing properties" of enums does not correct namespace of enum

### DIFF
--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -674,7 +674,7 @@ function tryGetValueFromType(context: CodeFixContextBase, checker: TypeChecker, 
     }
     if (type.flags & TypeFlags.EnumLike) {
         const enumMember = type.symbol.exports ? firstOrUndefinedIterator(type.symbol.exports.values()) : type.symbol;
-        const name = checker.symbolToExpression(type.symbol.parent ? type.symbol.parent : type.symbol, SymbolFlags.Value, /*enclosingDeclaration*/ undefined, /*flags*/ undefined);
+        const name = checker.symbolToExpression(type.symbol.parent ? type.symbol.parent : type.symbol, SymbolFlags.Value, /*enclosingDeclaration*/ undefined, /*flags*/ NodeBuilderFlags.UseFullyQualifiedType);
         return enumMember === undefined || name === undefined ? factory.createNumericLiteral(0) : factory.createPropertyAccessExpression(name, checker.symbolToString(enumMember));
     }
     if (type.flags & TypeFlags.NumberLiteral) {

--- a/tests/cases/fourslash/codeFixAddMissingProperties29.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties29.ts
@@ -1,0 +1,27 @@
+/// <reference path="fourslash.ts" />
+
+////namespace Foo.Bar {
+////    export enum E {
+////        E1 = 0,
+////        E2 = 1,
+////    }
+////    export interface Baz {
+////        prop1: string;
+////        prop2: number;
+////        prop3: E.E1;
+////        prop4: Foo.Bar.E.E1;
+////    }
+////}
+////[|const foo: Foo.Bar.Baz = {}|]
+
+verify.codeFix({
+    index: 0,
+    description: ts.Diagnostics.Add_missing_properties.message,
+    newRangeContent:
+`const foo: Foo.Bar.Baz = {
+    prop1: "",
+    prop2: 0,
+    prop3: Foo.Bar.E.E1,
+    prop4: Foo.Bar.E.E1
+}`,
+});


### PR DESCRIPTION
Fixes #56733

