### PR TITLE
When relating a deferred index type over a mapped type on the source side ...

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22518,7 +22518,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 }
                 if (isDeferredMappedIndex) {
                     const mappedType = (source as IndexType).type as MappedType;
-                    const nameType = getNameTypeFromMappedType(mappedType)
+                    const nameType = getNameTypeFromMappedType(mappedType);
                     // Unlike on the target side, on the source side we do *not* include the generic part of the `nameType`, since that comes from a
                     // (potentially anonymous) mapped type local type parameter, so that'd never assign outside the mapped type body, but we still want to
                     // allow assignments of index types of identical (or similar enough) mapped types.

--- a/tests/baselines/reference/declarationEmitNestedAnonymousMappedType.js
+++ b/tests/baselines/reference/declarationEmitNestedAnonymousMappedType.js
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts] ////
+
+//// [declarationEmitNestedAnonymousMappedType.ts]
+export function enumFromStrings<const Members extends readonly string[]>() {
+    type Part1 = {
+        [key in keyof Members as Members[key] extends string
+        ? Members[key]
+        : never]: Members[key];
+    };
+    type Part2 = { [Property in keyof Part1]: Part1[Property] };
+    return Object.create(null) as Part2;
+}
+
+
+//// [declarationEmitNestedAnonymousMappedType.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.enumFromStrings = void 0;
+function enumFromStrings() {
+    return Object.create(null);
+}
+exports.enumFromStrings = enumFromStrings;
+
+
+//// [declarationEmitNestedAnonymousMappedType.d.ts]
+export declare function enumFromStrings<const Members extends readonly string[]>(): { [Property in keyof { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }]: { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }[Property]; };

--- a/tests/baselines/reference/declarationEmitNestedAnonymousMappedType.symbols
+++ b/tests/baselines/reference/declarationEmitNestedAnonymousMappedType.symbols
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts] ////
+
+=== declarationEmitNestedAnonymousMappedType.ts ===
+export function enumFromStrings<const Members extends readonly string[]>() {
+>enumFromStrings : Symbol(enumFromStrings, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 0))
+>Members : Symbol(Members, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 32))
+
+    type Part1 = {
+>Part1 : Symbol(Part1, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 76))
+
+        [key in keyof Members as Members[key] extends string
+>key : Symbol(key, Decl(declarationEmitNestedAnonymousMappedType.ts, 2, 9))
+>Members : Symbol(Members, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 32))
+>Members : Symbol(Members, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 32))
+>key : Symbol(key, Decl(declarationEmitNestedAnonymousMappedType.ts, 2, 9))
+
+        ? Members[key]
+>Members : Symbol(Members, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 32))
+>key : Symbol(key, Decl(declarationEmitNestedAnonymousMappedType.ts, 2, 9))
+
+        : never]: Members[key];
+>Members : Symbol(Members, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 32))
+>key : Symbol(key, Decl(declarationEmitNestedAnonymousMappedType.ts, 2, 9))
+
+    };
+    type Part2 = { [Property in keyof Part1]: Part1[Property] };
+>Part2 : Symbol(Part2, Decl(declarationEmitNestedAnonymousMappedType.ts, 5, 6))
+>Property : Symbol(Property, Decl(declarationEmitNestedAnonymousMappedType.ts, 6, 20))
+>Part1 : Symbol(Part1, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 76))
+>Part1 : Symbol(Part1, Decl(declarationEmitNestedAnonymousMappedType.ts, 0, 76))
+>Property : Symbol(Property, Decl(declarationEmitNestedAnonymousMappedType.ts, 6, 20))
+
+    return Object.create(null) as Part2;
+>Object.create : Symbol(ObjectConstructor.create, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>create : Symbol(ObjectConstructor.create, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>Part2 : Symbol(Part2, Decl(declarationEmitNestedAnonymousMappedType.ts, 5, 6))
+}
+

--- a/tests/baselines/reference/declarationEmitNestedAnonymousMappedType.types
+++ b/tests/baselines/reference/declarationEmitNestedAnonymousMappedType.types
@@ -1,0 +1,24 @@
+//// [tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts] ////
+
+=== declarationEmitNestedAnonymousMappedType.ts ===
+export function enumFromStrings<const Members extends readonly string[]>() {
+>enumFromStrings : <const Members extends readonly string[]>() => { [Property in keyof { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }]: { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }[Property]; }
+
+    type Part1 = {
+>Part1 : { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }
+
+        [key in keyof Members as Members[key] extends string
+        ? Members[key]
+        : never]: Members[key];
+    };
+    type Part2 = { [Property in keyof Part1]: Part1[Property] };
+>Part2 : { [Property in keyof { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }]: { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }[Property]; }
+
+    return Object.create(null) as Part2;
+>Object.create(null) as Part2 : { [Property in keyof { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }]: { [key in keyof Members as Members[key] extends string ? Members[key] : never]: Members[key]; }[Property]; }
+>Object.create(null) : any
+>Object.create : { (o: object): any; (o: object, properties: PropertyDescriptorMap & ThisType<any>): any; }
+>Object : ObjectConstructor
+>create : { (o: object): any; (o: object, properties: PropertyDescriptorMap & ThisType<any>): any; }
+}
+

--- a/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
+++ b/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
@@ -1,0 +1,10 @@
+// @declaration: true
+export function enumFromStrings<const Members extends readonly string[]>() {
+    type Part1 = {
+        [key in keyof Members as Members[key] extends string
+        ? Members[key]
+        : never]: Members[key];
+    };
+    type Part2 = { [Property in keyof Part1]: Part1[Property] };
+    return Object.create(null) as Part2;
+}


### PR DESCRIPTION
actually compare against the mapped type's apparent keys.

FIxes #56718 - the emit is fine (all the anonymous/local types are inlined and duplicated like you'd expect), our relationship logic was just too strict when relating deferred index types of mapped types, so in the emit, when the `keyof {big anonymous mapped type}` got duplicated into two places, we failed to recognize them as the same type.