### PR TITLE
Remove hereby gulp shim warning

### DIFF
--- a/.gulp.js
+++ b/.gulp.js
@@ -1,13 +1,7 @@
 const cp = require("child_process");
 const path = require("path");
-const chalk = require("chalk");
 
 const argv = process.argv.slice(2);
-
-// --tasks-simple is used by VS Code to infer a task list; try and keep that working.
-if (!argv.includes("--tasks-simple")) {
-    console.error(chalk.yellowBright("Warning: using gulp shim; please consider running hereby directly."));
-}
 
 const args = [
     ...process.execArgv,


### PR DESCRIPTION
It's been a year since we switched from gulp to hereby. I think this message has served its purpose and the repo never mentions gulp anywhere else anymore, so those who need to know already know and have chosen which CLI they want to use. I don't see us getting rid of the shim in short order anyhow; it's free to keep.

I'd like to bump chalk in #56561 and this is our only CJS use of the library.