### PR TITLE
Reduce file system calls during test setup.

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1445,6 +1445,7 @@ export interface System {
     realpath?(path: string): string;
     /** @internal */ getEnvironmentVariable(name: string): string;
     /** @internal */ tryEnableSourceMapsForHost?(): void;
+    /** @internal */ getAccessibleFileSystemEntries?(path: string): FileSystemEntries;
     /** @internal */ debugMode?: boolean;
     setTimeout?(callback: (...args: any[]) => void, ms: number, ...args: any[]): any;
     clearTimeout?(timeoutId: any): void;
@@ -1553,6 +1554,7 @@ export let sys: System = (() => {
             resolvePath: path => _path.resolve(path),
             fileExists,
             directoryExists,
+            getAccessibleFileSystemEntries,
             createDirectory(directoryName: string) {
                 if (!nodeSystem.directoryExists(directoryName)) {
                     // Wrapped in a try-catch to prevent crashing if we are in a race

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -25,7 +25,7 @@ export interface IO {
     fileExists(fileName: string): boolean;
     directoryExists(path: string): boolean;
     deleteFile(fileName: string): void;
-    enumerateTestFiles(runner: RunnerBase): (string | FileBasedTest)[];
+    enumerateTestFiles(runner: RunnerBase): string[];
     listFiles(path: string, filter?: RegExp, options?: { recursive?: boolean; }): string[];
     log(text: string): void;
     args(): string[];

--- a/src/harness/harnessIO.ts
+++ b/src/harness/harnessIO.ts
@@ -87,8 +87,7 @@ function createNodeIO(): IO {
     function listFiles(path: string, spec: RegExp, options: { recursive?: boolean; } = {}) {
         function filesInFolder(folder: string): string[] {
             let paths: string[] = [];
-            const dir = fs.opendirSync(folder);
-            for (let entry = dir.readSync(); entry; entry = dir.readSync()) {
+            for (const entry of fs.readdirSync(folder, { withFileTypes: true })) {
                 const pathToFile = pathModule.join(folder, entry.name);
 
                 if (entry.isSymbolicLink() && !fs.existsSync(pathToFile)) continue; // ignore invalid symlinks
@@ -100,7 +99,6 @@ function createNodeIO(): IO {
                     paths.push(pathToFile);
                 }
             }
-            dir.closeSync();
             return paths;
         }
 

--- a/src/harness/runnerbase.ts
+++ b/src/harness/runnerbase.ts
@@ -1,5 +1,4 @@
 import {
-    FileBasedTest,
     IO,
     userSpecifiedRoot,
 } from "./_namespaces/Harness";
@@ -22,7 +21,7 @@ export function setShardId(id: number) {
 
 export abstract class RunnerBase {
     // contains the tests to run
-    public tests: (string | FileBasedTest)[] = [];
+    public tests: string[] = [];
 
     /** Add a source file to the runner's list of tests that need to be initialized with initializeTests */
     public addTest(fileName: string) {
@@ -35,7 +34,7 @@ export abstract class RunnerBase {
 
     abstract kind(): TestRunnerKind;
 
-    abstract enumerateTestFiles(): (string | FileBasedTest)[];
+    abstract enumerateTestFiles(): string[];
 
     getTestFiles(): ReturnType<this["enumerateTestFiles"]> {
         const all = this.enumerateTestFiles();

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -51,9 +51,10 @@ export class CompilerBaselineRunner extends RunnerBase {
         return this.testSuiteName;
     }
 
+    private loadedTestFiles: CompilerFileBasedTest[] | undefined;
     public enumerateTestFiles() {
         // see also: `enumerateTestFiles` in tests/webTestServer.ts
-        return this.enumerateFiles(this.basePath, /\.tsx?$/, { recursive: true }).map(CompilerTest.getConfigurations);
+        return this.loadedTestFiles ??= this.enumerateFiles(this.basePath, /\.tsx?$/, { recursive: true }).map(CompilerTest.getConfigurations);
     }
 
     public initializeTests() {

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -51,10 +51,10 @@ export class CompilerBaselineRunner extends RunnerBase {
         return this.testSuiteName;
     }
 
-    private loadedTestFiles: CompilerFileBasedTest[] | undefined;
+    private testFiles: string[] | undefined;
     public enumerateTestFiles() {
         // see also: `enumerateTestFiles` in tests/webTestServer.ts
-        return this.loadedTestFiles ??= this.enumerateFiles(this.basePath, /\.tsx?$/, { recursive: true }).map(CompilerTest.getConfigurations);
+        return this.testFiles ??= this.enumerateFiles(this.basePath, /\.tsx?$/, { recursive: true });
     }
 
     public initializeTests() {
@@ -65,9 +65,8 @@ export class CompilerBaselineRunner extends RunnerBase {
 
             // this will set up a series of describe/it blocks to run between the setup and cleanup phases
             const files = this.tests.length > 0 ? this.tests : IO.enumerateTestFiles(this);
-            files.forEach(test => {
-                const file = typeof test === "string" ? test : test.file;
-                this.checkTestCodeOutput(vpath.normalizeSeparators(file), typeof test === "string" ? CompilerTest.getConfigurations(test) : test);
+            files.forEach(file => {
+                this.checkTestCodeOutput(vpath.normalizeSeparators(file), CompilerTest.getConfigurations(file));
             });
         });
     }

--- a/src/testRunner/fourslashRunner.ts
+++ b/src/testRunner/fourslashRunner.ts
@@ -41,8 +41,7 @@ export class FourSlashRunner extends RunnerBase {
         }
 
         describe(this.testSuiteName + " tests", () => {
-            this.tests.forEach(test => {
-                const file = typeof test === "string" ? test : test.file;
+            this.tests.forEach(file => {
                 describe(file, () => {
                     let fn = ts.normalizeSlashes(file);
                     const justName = fn.replace(/^.*[\\/]/, "");

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -217,8 +217,7 @@ export function start() {
         console.log("Discovering runner-based tests...");
         const discoverStart = +(new Date());
         for (const runner of runners) {
-            for (const test of runner.getTestFiles()) {
-                const file = typeof test === "string" ? test : test.file;
+            for (const file of runner.getTestFiles()) {
                 let size: number;
                 if (!perfData) {
                     try {

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -54,7 +54,7 @@ export class ProjectRunner extends Harness.RunnerBase {
         describe("projects tests", () => {
             const tests = this.tests.length === 0 ? this.enumerateTestFiles() : this.tests;
             for (const test of tests) {
-                this.runProjectTestCase(typeof test === "string" ? test : test.file);
+                this.runProjectTestCase(test);
             }
         });
     }

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -202,15 +202,36 @@ class ProjectTestCase {
             throw assert(false, "Testcase: " + testCaseFileName + " does not contain valid json format: " + e.message);
         }
 
-        const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false);
-        fs.mountSync(vpath.resolve(Harness.IO.getWorkspaceRoot(), "tests"), vpath.combine(vfs.srcFolder, "tests"), vfs.createResolver(Harness.IO));
-        fs.mkdirpSync(vpath.combine(vfs.srcFolder, testCase.projectRoot));
-        fs.chdir(vpath.combine(vfs.srcFolder, testCase.projectRoot));
-        fs.makeReadonly();
-
+        function makeFileSystem() {
+            const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false);
+            fs.mountSync(vpath.resolve(Harness.IO.getWorkspaceRoot(), "tests"), vpath.combine(vfs.srcFolder, "tests"), vfs.createResolver(Harness.IO));
+            fs.mkdirpSync(vpath.combine(vfs.srcFolder, testCase.projectRoot));
+            fs.chdir(vpath.combine(vfs.srcFolder, testCase.projectRoot));
+            fs.makeReadonly();
+            return fs;
+        }
+        let fs: vfs.FileSystem | undefined;
         return [
-            { name: `@module: commonjs`, payload: { testCase, moduleKind: ts.ModuleKind.CommonJS, vfs: fs } },
-            { name: `@module: amd`, payload: { testCase, moduleKind: ts.ModuleKind.AMD, vfs: fs } },
+            {
+                name: `@module: commonjs`,
+                payload: {
+                    testCase,
+                    moduleKind: ts.ModuleKind.CommonJS,
+                    get vfs() {
+                        return fs ??= makeFileSystem();
+                    },
+                },
+            },
+            {
+                name: `@module: amd`,
+                payload: {
+                    testCase,
+                    moduleKind: ts.ModuleKind.AMD,
+                    get vfs() {
+                        return fs ??= makeFileSystem();
+                    },
+                },
+            },
         ];
     }
 

--- a/src/testRunner/runner.ts
+++ b/src/testRunner/runner.ts
@@ -191,7 +191,6 @@ function handleTestConfig() {
                     case "fourslash-generated":
                         runners.push(new GeneratedFourslashRunner(FourSlash.FourSlashTestType.Native));
                         break;
-                        break;
                 }
             }
         }

--- a/src/testRunner/runner.ts
+++ b/src/testRunner/runner.ts
@@ -27,8 +27,7 @@ function runTests(runners: RunnerBase[]) {
         const dupes: [string, string][] = [];
         for (const runner of runners) {
             if (runner instanceof CompilerBaselineRunner || runner instanceof FourSlashRunner) {
-                for (const sf of runner.enumerateTestFiles()) {
-                    const full = typeof sf === "string" ? sf : sf.file;
+                for (const full of runner.enumerateTestFiles()) {
                     const base = vpath.basename(full).toLowerCase();
                     // allow existing dupes in fourslash/shims and fourslash/server
                     if (seen.has(base) && !/fourslash\/(shim|server)/.test(full)) {


### PR DESCRIPTION
Improvements to reduce fs calls during test discovery:

1. Use `opendirSync` to read the directory content. This reduces the need to call `fs.existsSync` and `fs.statSync`
2. Cache `enumerateTestFiles` result to avoid having to enumerating the files again
3. Delay creation of vfs for project tests (as creating the vfs also mounts real folders which also touch the file system)

Improvements in test discovery time (anecdotal):

1. Linux node 18 debug - ~1.4 seconds -> ~800ms
2. Windows 10 node 20 debug - 8s -> 2s

Performance of running all the tests does not appear to be impacted as the cost of test discovery is not a big percentage of running all tests and the work that si delayed will have to eventually be executed anyway.

Fixes #56790
