### PR TITLE
Give suggestion for @types/bun when Bun global is not found

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26192,6 +26192,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 return compilerOptions.types
                     ? Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashnode_and_then_add_node_to_the_types_field_in_your_tsconfig
                     : Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashnode;
+            case "Bun":
+                return compilerOptions.types
+                    ? Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_bun_Try_npm_i_save_dev_types_Slashbun_and_then_add_bun_to_the_types_field_in_your_tsconfig
+                    : Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_bun_Try_npm_i_save_dev_types_Slashbun;
             case "Map":
             case "Set":
             case "Promise":

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26194,8 +26194,8 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     : Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_node_Try_npm_i_save_dev_types_Slashnode;
             case "Bun":
                 return compilerOptions.types
-                    ? Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_bun_Try_npm_i_save_dev_types_Slashbun_and_then_add_bun_to_the_types_field_in_your_tsconfig
-                    : Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_bun_Try_npm_i_save_dev_types_Slashbun;
+                    ? Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_Bun_Try_npm_i_save_dev_types_Slashbun_and_then_add_bun_to_the_types_field_in_your_tsconfig
+                    : Diagnostics.Cannot_find_name_0_Do_you_need_to_install_type_definitions_for_Bun_Try_npm_i_save_dev_types_Slashbun;
             case "Map":
             case "Set":
             case "Promise":

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3735,6 +3735,14 @@
         "category": "Error",
         "code": 2866
     },
+    "Cannot find name '{0}'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun`.": {
+        "category": "Error",
+        "code": 2867
+    },
+    "Cannot find name '{0}'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.": {
+        "category": "Error",
+        "code": 2868
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3735,11 +3735,11 @@
         "category": "Error",
         "code": 2866
     },
-    "Cannot find name '{0}'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun`.": {
+    "Cannot find name '{0}'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun`.": {
         "category": "Error",
         "code": 2867
     },
-    "Cannot find name '{0}'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.": {
+    "Cannot find name '{0}'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.": {
         "category": "Error",
         "code": 2868
     },

--- a/tests/baselines/reference/typingsSuggestionBun1.errors.txt
+++ b/tests/baselines/reference/typingsSuggestionBun1.errors.txt
@@ -1,4 +1,4 @@
-a.ts(1,14): error TS2304: Cannot find name 'Bun'.
+a.ts(1,14): error TS2868: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.
 
 
 ==== tsconfig.json (0 errors) ====
@@ -7,5 +7,5 @@ a.ts(1,14): error TS2304: Cannot find name 'Bun'.
 ==== a.ts (1 errors) ====
     const file = Bun.file("/a.ts");
                  ~~~
-!!! error TS2304: Cannot find name 'Bun'.
+!!! error TS2868: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.
     

--- a/tests/baselines/reference/typingsSuggestionBun1.errors.txt
+++ b/tests/baselines/reference/typingsSuggestionBun1.errors.txt
@@ -1,0 +1,11 @@
+a.ts(1,14): error TS2304: Cannot find name 'Bun'.
+
+
+==== tsconfig.json (0 errors) ====
+    { "compilerOptions": {"types": []} }
+    
+==== a.ts (1 errors) ====
+    const file = Bun.file("/a.ts");
+                 ~~~
+!!! error TS2304: Cannot find name 'Bun'.
+    

--- a/tests/baselines/reference/typingsSuggestionBun1.errors.txt
+++ b/tests/baselines/reference/typingsSuggestionBun1.errors.txt
@@ -1,4 +1,4 @@
-a.ts(1,14): error TS2868: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.
+a.ts(1,14): error TS2868: Cannot find name 'Bun'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.
 
 
 ==== tsconfig.json (0 errors) ====
@@ -7,5 +7,5 @@ a.ts(1,14): error TS2868: Cannot find name 'Bun'. Do you need to install type de
 ==== a.ts (1 errors) ====
     const file = Bun.file("/a.ts");
                  ~~~
-!!! error TS2868: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.
+!!! error TS2868: Cannot find name 'Bun'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun` and then add 'bun' to the types field in your tsconfig.
     

--- a/tests/baselines/reference/typingsSuggestionBun1.js
+++ b/tests/baselines/reference/typingsSuggestionBun1.js
@@ -1,0 +1,8 @@
+//// [tests/cases/conformance/typings/typingsSuggestionBun1.ts] ////
+
+//// [a.ts]
+const file = Bun.file("/a.ts");
+
+
+//// [a.js]
+var file = Bun.file("/a.ts");

--- a/tests/baselines/reference/typingsSuggestionBun1.symbols
+++ b/tests/baselines/reference/typingsSuggestionBun1.symbols
@@ -1,0 +1,6 @@
+//// [tests/cases/conformance/typings/typingsSuggestionBun1.ts] ////
+
+=== a.ts ===
+const file = Bun.file("/a.ts");
+>file : Symbol(file, Decl(a.ts, 0, 5))
+

--- a/tests/baselines/reference/typingsSuggestionBun1.types
+++ b/tests/baselines/reference/typingsSuggestionBun1.types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/typings/typingsSuggestionBun1.ts] ////
+
+=== a.ts ===
+const file = Bun.file("/a.ts");
+>file : any
+>Bun.file("/a.ts") : any
+>Bun.file : any
+>Bun : any
+>file : any
+>"/a.ts" : "/a.ts"
+

--- a/tests/baselines/reference/typingsSuggestionBun2.errors.txt
+++ b/tests/baselines/reference/typingsSuggestionBun2.errors.txt
@@ -1,4 +1,4 @@
-a.ts(1,14): error TS2867: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun`.
+a.ts(1,14): error TS2867: Cannot find name 'Bun'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun`.
 
 
 ==== tsconfig.json (0 errors) ====
@@ -7,5 +7,5 @@ a.ts(1,14): error TS2867: Cannot find name 'Bun'. Do you need to install type de
 ==== a.ts (1 errors) ====
     const file = Bun.file("/a.ts");
                  ~~~
-!!! error TS2867: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun`.
+!!! error TS2867: Cannot find name 'Bun'. Do you need to install type definitions for Bun? Try `npm i --save-dev @types/bun`.
     

--- a/tests/baselines/reference/typingsSuggestionBun2.errors.txt
+++ b/tests/baselines/reference/typingsSuggestionBun2.errors.txt
@@ -1,0 +1,11 @@
+a.ts(1,14): error TS2304: Cannot find name 'Bun'.
+
+
+==== tsconfig.json (0 errors) ====
+    { "compilerOptions": {} }
+    
+==== a.ts (1 errors) ====
+    const file = Bun.file("/a.ts");
+                 ~~~
+!!! error TS2304: Cannot find name 'Bun'.
+    

--- a/tests/baselines/reference/typingsSuggestionBun2.errors.txt
+++ b/tests/baselines/reference/typingsSuggestionBun2.errors.txt
@@ -1,4 +1,4 @@
-a.ts(1,14): error TS2304: Cannot find name 'Bun'.
+a.ts(1,14): error TS2867: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun`.
 
 
 ==== tsconfig.json (0 errors) ====
@@ -7,5 +7,5 @@ a.ts(1,14): error TS2304: Cannot find name 'Bun'.
 ==== a.ts (1 errors) ====
     const file = Bun.file("/a.ts");
                  ~~~
-!!! error TS2304: Cannot find name 'Bun'.
+!!! error TS2867: Cannot find name 'Bun'. Do you need to install type definitions for bun? Try `npm i --save-dev @types/bun`.
     

--- a/tests/baselines/reference/typingsSuggestionBun2.js
+++ b/tests/baselines/reference/typingsSuggestionBun2.js
@@ -1,0 +1,8 @@
+//// [tests/cases/conformance/typings/typingsSuggestionBun2.ts] ////
+
+//// [a.ts]
+const file = Bun.file("/a.ts");
+
+
+//// [a.js]
+var file = Bun.file("/a.ts");

--- a/tests/baselines/reference/typingsSuggestionBun2.symbols
+++ b/tests/baselines/reference/typingsSuggestionBun2.symbols
@@ -1,0 +1,6 @@
+//// [tests/cases/conformance/typings/typingsSuggestionBun2.ts] ////
+
+=== a.ts ===
+const file = Bun.file("/a.ts");
+>file : Symbol(file, Decl(a.ts, 0, 5))
+

--- a/tests/baselines/reference/typingsSuggestionBun2.types
+++ b/tests/baselines/reference/typingsSuggestionBun2.types
@@ -1,0 +1,11 @@
+//// [tests/cases/conformance/typings/typingsSuggestionBun2.ts] ////
+
+=== a.ts ===
+const file = Bun.file("/a.ts");
+>file : any
+>Bun.file("/a.ts") : any
+>Bun.file : any
+>Bun : any
+>file : any
+>"/a.ts" : "/a.ts"
+

--- a/tests/cases/conformance/typings/typingsSuggestionBun1.ts
+++ b/tests/cases/conformance/typings/typingsSuggestionBun1.ts
@@ -1,0 +1,5 @@
+// @filename: tsconfig.json
+{ "compilerOptions": {"types": []} }
+
+// @filename: a.ts
+const file = Bun.file("/a.ts");

--- a/tests/cases/conformance/typings/typingsSuggestionBun2.ts
+++ b/tests/cases/conformance/typings/typingsSuggestionBun2.ts
@@ -1,0 +1,5 @@
+// @filename: tsconfig.json
+{ "compilerOptions": {} }
+
+// @filename: a.ts
+const file = Bun.file("/a.ts");


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67827 will introduce `@types/bun`. This PR makes TypeScript aware of the global `Bun` name, suggesting the types package now that its name is settled.

I thought we had something similar for modules such that we could see `bun:` prefixed modules and also suggest the types, but I think I was wrong.