### PR TITLE
fix(56475): Hyperlink in quick info generated by @link jumps to import statement for named or default imports, not symbol definition

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2977,10 +2977,11 @@ export function buildLinkParts(link: JSDocLink | JSDocLinkCode | JSDocLinkPlain,
     }
     else {
         const symbol = checker?.getSymbolAtLocation(link.name);
+        const targetSymbol = symbol && checker ? getSymbolTarget(symbol, checker) : undefined;
         const suffix = findLinkNameEnd(link.text);
         const name = getTextOfNode(link.name) + link.text.slice(0, suffix);
         const text = skipSeparatorFromLinkText(link.text.slice(suffix));
-        const decl = symbol?.valueDeclaration || symbol?.declarations?.[0];
+        const decl = targetSymbol?.valueDeclaration || targetSymbol?.declarations?.[0];
         if (decl) {
             parts.push(linkNamePart(name, decl));
             if (text) parts.push(linkTextPart(text));

--- a/tests/baselines/reference/jsdocLink3.baseline
+++ b/tests/baselines/reference/jsdocLink3.baseline
@@ -83,10 +83,10 @@
           "text": "C",
           "kind": "linkName",
           "target": {
-            "fileName": "/module1.ts",
+            "fileName": "/jsdocLink3.ts",
             "textSpan": {
-              "start": 9,
-              "length": 1
+              "start": 0,
+              "length": 18
             }
           }
         },
@@ -111,10 +111,10 @@
               "text": "C",
               "kind": "linkName",
               "target": {
-                "fileName": "/module1.ts",
+                "fileName": "/jsdocLink3.ts",
                 "textSpan": {
-                  "start": 9,
-                  "length": 1
+                  "start": 0,
+                  "length": 18
                 }
               }
             },
@@ -134,10 +134,10 @@
               "text": "C()",
               "kind": "linkName",
               "target": {
-                "fileName": "/module1.ts",
+                "fileName": "/jsdocLink3.ts",
                 "textSpan": {
-                  "start": 9,
-                  "length": 1
+                  "start": 0,
+                  "length": 18
                 }
               }
             },
@@ -157,10 +157,10 @@
               "text": "C",
               "kind": "linkName",
               "target": {
-                "fileName": "/module1.ts",
+                "fileName": "/jsdocLink3.ts",
                 "textSpan": {
-                  "start": 9,
-                  "length": 1
+                  "start": 0,
+                  "length": 18
                 }
               }
             },
@@ -205,10 +205,10 @@
               "text": "C",
               "kind": "linkName",
               "target": {
-                "fileName": "/module1.ts",
+                "fileName": "/jsdocLink3.ts",
                 "textSpan": {
-                  "start": 9,
-                  "length": 1
+                  "start": 0,
+                  "length": 18
                 }
               }
             },

--- a/tests/baselines/reference/jsdocLink6.baseline
+++ b/tests/baselines/reference/jsdocLink6.baseline
@@ -1,0 +1,114 @@
+// === QuickInfo ===
+=== /b.ts ===
+// import A, { B } from "./a";
+// /**
+//  * {@link A}
+//  * {@link B}
+//  */
+// export default function f() { }
+//                         ^
+// | ----------------------------------------------------------------------
+// | function f(): void
+// | {@link A}
+// | {@link B}
+// | ----------------------------------------------------------------------
+
+[
+  {
+    "marker": {
+      "fileName": "/b.ts",
+      "position": 86,
+      "name": ""
+    },
+    "item": {
+      "kind": "function",
+      "kindModifiers": "export",
+      "textSpan": {
+        "start": 86,
+        "length": 1
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "f",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "void",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "A",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/a.ts",
+            "textSpan": {
+              "start": 0,
+              "length": 31
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        },
+        {
+          "text": "\n",
+          "kind": "text"
+        },
+        {
+          "text": "{@link ",
+          "kind": "link"
+        },
+        {
+          "text": "B",
+          "kind": "linkName",
+          "target": {
+            "fileName": "/a.ts",
+            "textSpan": {
+              "start": 32,
+              "length": 23
+            }
+          }
+        },
+        {
+          "text": "}",
+          "kind": "link"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/fourslash/jsdocLink6.ts
+++ b/tests/cases/fourslash/jsdocLink6.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: /a.ts
+////export default function A() { }
+////export function B() { };
+
+// @Filename: /b.ts
+////import A, { B } from "./a";
+
+/////**
+//// * {@link A}
+//// * {@link B}
+//// */
+////export default function /**/f() { }
+
+verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #56475