### PR TITLE
Treat `switch (typeof x)` as exhaustive when all cases are handled for unconstrained type parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -37014,7 +37014,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             if (!witnesses) {
                 return false;
             }
-            const operandConstraint = getBaseConstraintOrType(checkExpressionCached((node.expression as TypeOfExpression).expression));
+            const operandConstraint = getBaseConstraintOfType(checkExpressionCached((node.expression as TypeOfExpression).expression)) || unknownType;
             // Get the not-equal flags for all handled cases.
             const notEqualFacts = getNotEqualFactsFromTypeofSwitch(0, 0, witnesses);
             if (operandConstraint.flags & TypeFlags.AnyOrUnknown) {

--- a/tests/baselines/reference/exhaustiveSwitchTypeofUnconstrainedTypeParameter.symbols
+++ b/tests/baselines/reference/exhaustiveSwitchTypeofUnconstrainedTypeParameter.symbols
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts] ////
+
+=== exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts ===
+// https://github.com/microsoft/TypeScript/issues/56786
+
+function checkAll<T>(something: T): T {
+>checkAll : Symbol(checkAll, Decl(exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts, 0, 0))
+>T : Symbol(T, Decl(exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts, 2, 18))
+>something : Symbol(something, Decl(exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts, 2, 21))
+>T : Symbol(T, Decl(exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts, 2, 18))
+>T : Symbol(T, Decl(exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts, 2, 18))
+
+  switch (typeof something) {
+>something : Symbol(something, Decl(exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts, 2, 21))
+
+    case "number":
+    case "bigint":
+    case "boolean":
+    case "symbol":
+    case "undefined":
+    case "function":
+    case "object":
+    case "string":
+      return something;
+>something : Symbol(something, Decl(exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts, 2, 21))
+  }
+}
+

--- a/tests/baselines/reference/exhaustiveSwitchTypeofUnconstrainedTypeParameter.types
+++ b/tests/baselines/reference/exhaustiveSwitchTypeofUnconstrainedTypeParameter.types
@@ -1,0 +1,42 @@
+//// [tests/cases/compiler/exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts] ////
+
+=== exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts ===
+// https://github.com/microsoft/TypeScript/issues/56786
+
+function checkAll<T>(something: T): T {
+>checkAll : <T>(something: T) => T
+>something : T
+
+  switch (typeof something) {
+>typeof something : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>something : T
+
+    case "number":
+>"number" : "number"
+
+    case "bigint":
+>"bigint" : "bigint"
+
+    case "boolean":
+>"boolean" : "boolean"
+
+    case "symbol":
+>"symbol" : "symbol"
+
+    case "undefined":
+>"undefined" : "undefined"
+
+    case "function":
+>"function" : "function"
+
+    case "object":
+>"object" : "object"
+
+    case "string":
+>"string" : "string"
+
+      return something;
+>something : (T & number) | (T & bigint) | (T & boolean) | (T & symbol) | (T & undefined) | (T & Function) | (T & object) | (T & null) | (T & string)
+  }
+}
+

--- a/tests/cases/compiler/exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts
+++ b/tests/cases/compiler/exhaustiveSwitchTypeofUnconstrainedTypeParameter.ts
@@ -1,0 +1,18 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/56786
+
+function checkAll<T>(something: T): T {
+  switch (typeof something) {
+    case "number":
+    case "bigint":
+    case "boolean":
+    case "symbol":
+    case "undefined":
+    case "function":
+    case "object":
+    case "string":
+      return something;
+  }
+}


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/56786