### PR TITLE
Make generic arrays indexable by `numericStringType`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -40252,7 +40252,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Check if we're indexing with a numeric type and if either object or index types
         // is a generic type with a constraint that has a numeric index signature.
         const apparentObjectType = getApparentType(objectType);
-        if (getIndexInfoOfType(apparentObjectType, numberType) && isTypeAssignableToKind(indexType, TypeFlags.NumberLike)) {
+        if (getIndexInfoOfType(apparentObjectType, numberType) && isApplicableIndexType(indexType, numberType)) {
             return type;
         }
         if (isGenericObjectType(objectType)) {

--- a/tests/baselines/reference/typeParameterConstrainedToArrayIndexableByNumericStringType.symbols
+++ b/tests/baselines/reference/typeParameterConstrainedToArrayIndexableByNumericStringType.symbols
@@ -1,0 +1,46 @@
+//// [tests/cases/compiler/typeParameterConstrainedToArrayIndexableByNumericStringType.ts] ////
+
+=== typeParameterConstrainedToArrayIndexableByNumericStringType.ts ===
+// https://github.com/microsoft/TypeScript/issues/56823
+
+declare function test1<A extends unknown[]>(arr: A): A[`${number}`];
+>test1 : Symbol(test1, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 0, 0))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 2, 23))
+>arr : Symbol(arr, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 2, 44))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 2, 23))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 2, 23))
+
+const res1 = test1([1, 2, 3]);
+>res1 : Symbol(res1, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 3, 5))
+>test1 : Symbol(test1, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 0, 0))
+
+declare function test2<A extends [unknown, unknown]>(arr: A): A[`${number}`];
+>test2 : Symbol(test2, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 3, 30))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 5, 23))
+>arr : Symbol(arr, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 5, 53))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 5, 23))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 5, 23))
+
+const res2 = test2([1, 'foo']);
+>res2 : Symbol(res2, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 6, 5))
+>test2 : Symbol(test2, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 3, 30))
+
+declare function test3<A extends [unknown, unknown, ...unknown[]]>(arr: A): A[`${number}`];
+>test3 : Symbol(test3, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 6, 31))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 8, 23))
+>arr : Symbol(arr, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 8, 67))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 8, 23))
+>A : Symbol(A, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 8, 23))
+
+const res3 = test3([1, 'foo', true]);
+>res3 : Symbol(res3, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 9, 5))
+>test3 : Symbol(test3, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 6, 31))
+
+declare const tuple1: [number, string, ...boolean[]];
+>tuple1 : Symbol(tuple1, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 10, 13))
+
+const res4 = test3(tuple1);
+>res4 : Symbol(res4, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 11, 5))
+>test3 : Symbol(test3, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 6, 31))
+>tuple1 : Symbol(tuple1, Decl(typeParameterConstrainedToArrayIndexableByNumericStringType.ts, 10, 13))
+

--- a/tests/baselines/reference/typeParameterConstrainedToArrayIndexableByNumericStringType.types
+++ b/tests/baselines/reference/typeParameterConstrainedToArrayIndexableByNumericStringType.types
@@ -1,0 +1,52 @@
+//// [tests/cases/compiler/typeParameterConstrainedToArrayIndexableByNumericStringType.ts] ////
+
+=== typeParameterConstrainedToArrayIndexableByNumericStringType.ts ===
+// https://github.com/microsoft/TypeScript/issues/56823
+
+declare function test1<A extends unknown[]>(arr: A): A[`${number}`];
+>test1 : <A extends unknown[]>(arr: A) => A[`${number}`]
+>arr : A
+
+const res1 = test1([1, 2, 3]);
+>res1 : number
+>test1([1, 2, 3]) : number
+>test1 : <A extends unknown[]>(arr: A) => A[`${number}`]
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+
+declare function test2<A extends [unknown, unknown]>(arr: A): A[`${number}`];
+>test2 : <A extends [unknown, unknown]>(arr: A) => A[`${number}`]
+>arr : A
+
+const res2 = test2([1, 'foo']);
+>res2 : string | number
+>test2([1, 'foo']) : string | number
+>test2 : <A extends [unknown, unknown]>(arr: A) => A[`${number}`]
+>[1, 'foo'] : [number, string]
+>1 : 1
+>'foo' : "foo"
+
+declare function test3<A extends [unknown, unknown, ...unknown[]]>(arr: A): A[`${number}`];
+>test3 : <A extends [unknown, unknown, ...unknown[]]>(arr: A) => A[`${number}`]
+>arr : A
+
+const res3 = test3([1, 'foo', true]);
+>res3 : string | number | boolean
+>test3([1, 'foo', true]) : string | number | boolean
+>test3 : <A extends [unknown, unknown, ...unknown[]]>(arr: A) => A[`${number}`]
+>[1, 'foo', true] : [number, string, true]
+>1 : 1
+>'foo' : "foo"
+>true : true
+
+declare const tuple1: [number, string, ...boolean[]];
+>tuple1 : [number, string, ...boolean[]]
+
+const res4 = test3(tuple1);
+>res4 : string | number | boolean
+>test3(tuple1) : string | number | boolean
+>test3 : <A extends [unknown, unknown, ...unknown[]]>(arr: A) => A[`${number}`]
+>tuple1 : [number, string, ...boolean[]]
+

--- a/tests/cases/compiler/typeParameterConstrainedToArrayIndexableByNumericStringType.ts
+++ b/tests/cases/compiler/typeParameterConstrainedToArrayIndexableByNumericStringType.ts
@@ -1,0 +1,15 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/56823
+
+declare function test1<A extends unknown[]>(arr: A): A[`${number}`];
+const res1 = test1([1, 2, 3]);
+
+declare function test2<A extends [unknown, unknown]>(arr: A): A[`${number}`];
+const res2 = test2([1, 'foo']);
+
+declare function test3<A extends [unknown, unknown, ...unknown[]]>(arr: A): A[`${number}`];
+const res3 = test3([1, 'foo', true]);
+declare const tuple1: [number, string, ...boolean[]];
+const res4 = test3(tuple1);


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/56823