### PR TITLE
style(es5): Remove `"` symbol for `prototype` on `RegExpConstructor`

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1008,7 +1008,7 @@ interface RegExpConstructor {
     new (pattern: string, flags?: string): RegExp;
     (pattern: RegExp | string): RegExp;
     (pattern: string, flags?: string): RegExp;
-    readonly "prototype": RegExp;
+    readonly prototype: RegExp;
 
     // Non-standard extensions
     /** @deprecated A legacy feature for browser compatibility */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

the `"` symbol here is not necessary for `prototype` property on `RegExpConstructor` interface

and, in this file, no other `prototype` property also use the `"` symbol, this is quite inconsistent

