### PR TITLE
Add an extra test case related to control flow of element access using non-const variable

### DIFF
--- a/tests/baselines/reference/controlFlowElementAccessNoCrash1.symbols
+++ b/tests/baselines/reference/controlFlowElementAccessNoCrash1.symbols
@@ -1,0 +1,81 @@
+//// [tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts] ////
+
+=== controlFlowElementAccessNoCrash1.ts ===
+interface TestTscEdit {
+>TestTscEdit : Symbol(TestTscEdit, Decl(controlFlowElementAccessNoCrash1.ts, 0, 0))
+
+  caption: string;
+>caption : Symbol(TestTscEdit.caption, Decl(controlFlowElementAccessNoCrash1.ts, 0, 23))
+
+  commandLineArgs?: readonly string[];
+>commandLineArgs : Symbol(TestTscEdit.commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 1, 18))
+}
+
+interface TestTscCompile {
+>TestTscCompile : Symbol(TestTscCompile, Decl(controlFlowElementAccessNoCrash1.ts, 3, 1))
+
+  subScenario: string;
+>subScenario : Symbol(TestTscCompile.subScenario, Decl(controlFlowElementAccessNoCrash1.ts, 5, 26))
+
+  commandLineArgs: readonly string[];
+>commandLineArgs : Symbol(TestTscCompile.commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 6, 22))
+}
+
+interface VerifyTscEditDiscrepanciesInput {
+>VerifyTscEditDiscrepanciesInput : Symbol(VerifyTscEditDiscrepanciesInput, Decl(controlFlowElementAccessNoCrash1.ts, 8, 1))
+
+  index: number;
+>index : Symbol(VerifyTscEditDiscrepanciesInput.index, Decl(controlFlowElementAccessNoCrash1.ts, 10, 43))
+
+  edits: readonly TestTscEdit[];
+>edits : Symbol(VerifyTscEditDiscrepanciesInput.edits, Decl(controlFlowElementAccessNoCrash1.ts, 11, 16))
+>TestTscEdit : Symbol(TestTscEdit, Decl(controlFlowElementAccessNoCrash1.ts, 0, 0))
+
+  commandLineArgs: TestTscCompile["commandLineArgs"];
+>commandLineArgs : Symbol(VerifyTscEditDiscrepanciesInput.commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 12, 32))
+>TestTscCompile : Symbol(TestTscCompile, Decl(controlFlowElementAccessNoCrash1.ts, 3, 1))
+}
+
+function testTscCompile(input: TestTscCompile) {}
+>testTscCompile : Symbol(testTscCompile, Decl(controlFlowElementAccessNoCrash1.ts, 14, 1))
+>input : Symbol(input, Decl(controlFlowElementAccessNoCrash1.ts, 16, 24))
+>TestTscCompile : Symbol(TestTscCompile, Decl(controlFlowElementAccessNoCrash1.ts, 3, 1))
+
+function verifyTscEditDiscrepancies({
+>verifyTscEditDiscrepancies : Symbol(verifyTscEditDiscrepancies, Decl(controlFlowElementAccessNoCrash1.ts, 16, 49))
+
+  index,
+>index : Symbol(index, Decl(controlFlowElementAccessNoCrash1.ts, 18, 37))
+
+  edits,
+>edits : Symbol(edits, Decl(controlFlowElementAccessNoCrash1.ts, 19, 8))
+
+  commandLineArgs,
+>commandLineArgs : Symbol(commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 20, 8))
+
+}: VerifyTscEditDiscrepanciesInput) {
+>VerifyTscEditDiscrepanciesInput : Symbol(VerifyTscEditDiscrepanciesInput, Decl(controlFlowElementAccessNoCrash1.ts, 8, 1))
+
+  const { caption } = edits[index];
+>caption : Symbol(caption, Decl(controlFlowElementAccessNoCrash1.ts, 23, 9))
+>edits : Symbol(edits, Decl(controlFlowElementAccessNoCrash1.ts, 19, 8))
+>index : Symbol(index, Decl(controlFlowElementAccessNoCrash1.ts, 18, 37))
+
+  testTscCompile({
+>testTscCompile : Symbol(testTscCompile, Decl(controlFlowElementAccessNoCrash1.ts, 14, 1))
+
+    subScenario: caption,
+>subScenario : Symbol(subScenario, Decl(controlFlowElementAccessNoCrash1.ts, 24, 18))
+>caption : Symbol(caption, Decl(controlFlowElementAccessNoCrash1.ts, 23, 9))
+
+    commandLineArgs: edits[index].commandLineArgs || commandLineArgs,
+>commandLineArgs : Symbol(commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 25, 25))
+>edits[index].commandLineArgs : Symbol(TestTscEdit.commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 1, 18))
+>edits : Symbol(edits, Decl(controlFlowElementAccessNoCrash1.ts, 19, 8))
+>index : Symbol(index, Decl(controlFlowElementAccessNoCrash1.ts, 18, 37))
+>commandLineArgs : Symbol(TestTscEdit.commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 1, 18))
+>commandLineArgs : Symbol(commandLineArgs, Decl(controlFlowElementAccessNoCrash1.ts, 20, 8))
+
+  });
+}
+

--- a/tests/baselines/reference/controlFlowElementAccessNoCrash1.types
+++ b/tests/baselines/reference/controlFlowElementAccessNoCrash1.types
@@ -1,0 +1,75 @@
+//// [tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts] ////
+
+=== controlFlowElementAccessNoCrash1.ts ===
+interface TestTscEdit {
+  caption: string;
+>caption : string
+
+  commandLineArgs?: readonly string[];
+>commandLineArgs : readonly string[] | undefined
+}
+
+interface TestTscCompile {
+  subScenario: string;
+>subScenario : string
+
+  commandLineArgs: readonly string[];
+>commandLineArgs : readonly string[]
+}
+
+interface VerifyTscEditDiscrepanciesInput {
+  index: number;
+>index : number
+
+  edits: readonly TestTscEdit[];
+>edits : readonly TestTscEdit[]
+
+  commandLineArgs: TestTscCompile["commandLineArgs"];
+>commandLineArgs : readonly string[]
+}
+
+function testTscCompile(input: TestTscCompile) {}
+>testTscCompile : (input: TestTscCompile) => void
+>input : TestTscCompile
+
+function verifyTscEditDiscrepancies({
+>verifyTscEditDiscrepancies : ({ index, edits, commandLineArgs, }: VerifyTscEditDiscrepanciesInput) => void
+
+  index,
+>index : number
+
+  edits,
+>edits : readonly TestTscEdit[]
+
+  commandLineArgs,
+>commandLineArgs : readonly string[]
+
+}: VerifyTscEditDiscrepanciesInput) {
+  const { caption } = edits[index];
+>caption : string
+>edits[index] : TestTscEdit
+>edits : readonly TestTscEdit[]
+>index : number
+
+  testTscCompile({
+>testTscCompile({    subScenario: caption,    commandLineArgs: edits[index].commandLineArgs || commandLineArgs,  }) : void
+>testTscCompile : (input: TestTscCompile) => void
+>{    subScenario: caption,    commandLineArgs: edits[index].commandLineArgs || commandLineArgs,  } : { subScenario: string; commandLineArgs: readonly string[]; }
+
+    subScenario: caption,
+>subScenario : string
+>caption : string
+
+    commandLineArgs: edits[index].commandLineArgs || commandLineArgs,
+>commandLineArgs : readonly string[]
+>edits[index].commandLineArgs || commandLineArgs : readonly string[]
+>edits[index].commandLineArgs : readonly string[] | undefined
+>edits[index] : TestTscEdit
+>edits : readonly TestTscEdit[]
+>index : number
+>commandLineArgs : readonly string[] | undefined
+>commandLineArgs : readonly string[]
+
+  });
+}
+

--- a/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
@@ -1,0 +1,32 @@
+// @strict: true
+// @noEmit: true
+
+interface TestTscEdit {
+  caption: string;
+  commandLineArgs?: readonly string[];
+}
+
+interface TestTscCompile {
+  subScenario: string;
+  commandLineArgs: readonly string[];
+}
+
+interface VerifyTscEditDiscrepanciesInput {
+  index: number;
+  edits: readonly TestTscEdit[];
+  commandLineArgs: TestTscCompile["commandLineArgs"];
+}
+
+function testTscCompile(input: TestTscCompile) {}
+
+function verifyTscEditDiscrepancies({
+  index,
+  edits,
+  commandLineArgs,
+}: VerifyTscEditDiscrepanciesInput) {
+  const { caption } = edits[index];
+  testTscCompile({
+    subScenario: caption,
+    commandLineArgs: edits[index].commandLineArgs || commandLineArgs,
+  });
+}


### PR DESCRIPTION
Just an extra test case. I discovered this case after breaking `self-check` [here](https://github.com/microsoft/TypeScript/pull/56392) without failing any test case. The mentioned PR is just an experiment at this point so I think it's worth pulling this test case separately as a regression test for the future