### PR TITLE
Copy and paste ImportAttribute/ImportAttributes to old names

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3663,11 +3663,27 @@ export interface ImportClause extends NamedDeclaration {
 /** @deprecated */
 export type AssertionKey = ImportAttributeName;
 
-/** @deprecated */
-export interface AssertEntry extends ImportAttribute {}
+// The following two types are copied and pasted versions of ImportAttribute and ImportAttributes,
+// preserved for backwards compatibility with downstream users which "patch" our public API
+// like `interface AssertEntry extends Node {}` to ensure both are available.
+// Eventually, these should be removed.
 
 /** @deprecated */
-export interface AssertClause extends ImportAttributes {}
+export interface AssertEntry extends Node {
+    readonly kind: SyntaxKind.AssertEntry;
+    readonly parent: AssertClause;
+    readonly name: ImportAttributeName;
+    readonly value: Expression;
+}
+
+/** @deprecated */
+export interface AssertClause extends Node {
+    readonly token: SyntaxKind.WithKeyword | SyntaxKind.AssertKeyword;
+    readonly kind: SyntaxKind.AssertClause;
+    readonly parent: ImportDeclaration | ExportDeclaration;
+    readonly elements: NodeArray<AssertEntry>;
+    readonly multiLine?: boolean;
+}
 
 export type ImportAttributeName = Identifier | StringLiteral;
 

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -6021,10 +6021,19 @@ declare namespace ts {
     /** @deprecated */
     type AssertionKey = ImportAttributeName;
     /** @deprecated */
-    interface AssertEntry extends ImportAttribute {
+    interface AssertEntry extends Node {
+        readonly kind: SyntaxKind.AssertEntry;
+        readonly parent: AssertClause;
+        readonly name: ImportAttributeName;
+        readonly value: Expression;
     }
     /** @deprecated */
-    interface AssertClause extends ImportAttributes {
+    interface AssertClause extends Node {
+        readonly token: SyntaxKind.WithKeyword | SyntaxKind.AssertKeyword;
+        readonly kind: SyntaxKind.AssertClause;
+        readonly parent: ImportDeclaration | ExportDeclaration;
+        readonly elements: NodeArray<AssertEntry>;
+        readonly multiLine?: boolean;
     }
     type ImportAttributeName = Identifier | StringLiteral;
     interface ImportAttribute extends Node {


### PR DESCRIPTION
Fixes #56954

Rather than including an `@ts-ignore` in our API, instead copy and paste the old declarations back into the file so that downstream users can still have interfaces of the same shape as `<5.2`. The two are structurally compatible.
