### PR TITLE
Make JSDoc parsing slow again for perf testing

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2290,6 +2290,11 @@ export function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean
     }
 
     function shouldParseJSDoc() {
+        // eslint-disable-next-line no-constant-condition
+        if (1 === 1) {
+            return true;
+        }
+
         switch (jsDocParsingMode) {
             case JSDocParsingMode.ParseAll:
                 return true;


### PR DESCRIPTION
Just a quick check to force JSDoc parsing again to test new perf stuff.
