### PR TITLE
Skip parent error when reporting JSX excess property checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21711,10 +21711,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                                 const suggestionSymbol = getSuggestedSymbolForNonexistentJSXAttribute(propName, errorTarget);
                                 const suggestion = suggestionSymbol ? symbolToString(suggestionSymbol) : undefined;
                                 if (suggestion) {
-                                    reportError(Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, propName, typeToString(errorTarget), suggestion);
+                                    reportParentSkippedError(Diagnostics.Property_0_does_not_exist_on_type_1_Did_you_mean_2, propName, typeToString(errorTarget), suggestion);
                                 }
                                 else {
-                                    reportError(Diagnostics.Property_0_does_not_exist_on_type_1, propName, typeToString(errorTarget));
+                                    reportParentSkippedError(Diagnostics.Property_0_does_not_exist_on_type_1, propName, typeToString(errorTarget));
                                 }
                             }
                             else {

--- a/tests/baselines/reference/checkJsxChildrenProperty15.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty15.errors.txt
@@ -1,9 +1,6 @@
-file.tsx(10,17): error TS2322: Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'children' does not exist on type 'IntrinsicAttributes'.
-file.tsx(11,13): error TS2322: Type '{ children: Element; key: string; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'children' does not exist on type 'IntrinsicAttributes'.
-file.tsx(12,13): error TS2322: Type '{ children: Element[]; key: string; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'children' does not exist on type 'IntrinsicAttributes'.
+file.tsx(10,17): error TS2339: Property 'children' does not exist on type 'IntrinsicAttributes'.
+file.tsx(11,13): error TS2339: Property 'children' does not exist on type 'IntrinsicAttributes'.
+file.tsx(12,13): error TS2339: Property 'children' does not exist on type 'IntrinsicAttributes'.
 
 
 ==== file.tsx (3 errors) ====
@@ -18,14 +15,11 @@ file.tsx(12,13): error TS2322: Type '{ children: Element[]; key: string; }' is n
     // Not OK (excess children)
     const k3 = <Tag children={<div></div>} />;
                     ~~~~~~~~
-!!! error TS2322: Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'children' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'children' does not exist on type 'IntrinsicAttributes'.
     const k4 = <Tag key="1"><div></div></Tag>;
                 ~~~
-!!! error TS2322: Type '{ children: Element; key: string; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'children' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'children' does not exist on type 'IntrinsicAttributes'.
     const k5 = <Tag key="1"><div></div><div></div></Tag>;
                 ~~~
-!!! error TS2322: Type '{ children: Element[]; key: string; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'children' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'children' does not exist on type 'IntrinsicAttributes'.
     

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,35 +1,25 @@
 file.tsx(27,64): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-    Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-      Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+    Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-    Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-      Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+    Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 file.tsx(28,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-    Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-      Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+    Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-    Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-      Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
+    Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
 file.tsx(29,43): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-    Type '{ extra: true; goTo: string; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-      Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+    Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-    Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-      Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+    Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 file.tsx(30,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-    Type '{ goTo: string; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-      Property 'goTo' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+    Property 'goTo' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-    Type '{ goTo: "home"; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-      Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-file.tsx(33,65): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
-file.tsx(36,44): error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+    Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+file.tsx(33,65): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+file.tsx(36,44): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 
 
 ==== file.tsx (6 errors) ====
@@ -63,48 +53,38 @@ file.tsx(36,44): error TS2322: Type '{ extra: true; goTo: "home"; }' is not assi
                                                                    ~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-!!! error TS2769:     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-!!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+!!! error TS2769:     Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
 !!! error TS2769:   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-!!! error TS2769:     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2769:     Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
                 ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-!!! error TS2769:     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-!!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+!!! error TS2769:     Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
 !!! error TS2769:   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-!!! error TS2769:     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2769:       Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2769:     Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "contact"
                                               ~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-!!! error TS2769:     Type '{ extra: true; goTo: string; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-!!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+!!! error TS2769:     Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
 !!! error TS2769:   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-!!! error TS2769:     Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2769:     Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b4 = <MainButton goTo="home" extra />;  // goTo has type "home" | "contact"
                 ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
-!!! error TS2769:     Type '{ goTo: string; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-!!! error TS2769:       Property 'goTo' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+!!! error TS2769:     Property 'goTo' does not exist on type 'IntrinsicAttributes & ButtonProps'.
 !!! error TS2769:   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
-!!! error TS2769:     Type '{ goTo: "home"; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2769:     Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     
     export function NoOverload(buttonProps: ButtonProps): JSX.Element { return undefined }
     const c1 = <NoOverload  {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type any
                                                                     ~~~~~
-!!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
     
     export function NoOverload1(linkProps: LinkProps): JSX.Element { return undefined }
     const d1 = <NoOverload1 {...{goTo:"home"}} extra  />;  // goTo has type "home" | "contact"
                                                ~~~~~
-!!! error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     

--- a/tests/baselines/reference/excessiveStackDepthFlatArray.errors.txt
+++ b/tests/baselines/reference/excessiveStackDepthFlatArray.errors.txt
@@ -1,5 +1,4 @@
-index.tsx(35,13): error TS2322: Type '{ key: string; }' is not assignable to type 'HTMLAttributes<HTMLLIElement>'.
-  Property 'key' does not exist on type 'HTMLAttributes<HTMLLIElement>'.
+index.tsx(35,13): error TS2339: Property 'key' does not exist on type 'HTMLAttributes<HTMLLIElement>'.
 
 
 ==== index.tsx (1 errors) ====
@@ -39,8 +38,7 @@ index.tsx(35,13): error TS2322: Type '{ key: string; }' is not assignable to typ
           {categories.map((category) => (
             <li key={category}>{category}</li> // Error about 'key' only
                 ~~~
-!!! error TS2322: Type '{ key: string; }' is not assignable to type 'HTMLAttributes<HTMLLIElement>'.
-!!! error TS2322:   Property 'key' does not exist on type 'HTMLAttributes<HTMLLIElement>'.
+!!! error TS2339: Property 'key' does not exist on type 'HTMLAttributes<HTMLLIElement>'.
           ))}
         </ul>
       );

--- a/tests/baselines/reference/jsxElementType.errors.txt
+++ b/tests/baselines/reference/jsxElementType.errors.txt
@@ -1,18 +1,13 @@
 jsxElementType.tsx(34,2): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.
-jsxElementType.tsx(36,16): error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-  Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+jsxElementType.tsx(36,16): error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
 jsxElementType.tsx(40,2): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.
-jsxElementType.tsx(42,15): error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-  Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+jsxElementType.tsx(42,15): error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
 jsxElementType.tsx(46,2): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.
-jsxElementType.tsx(48,15): error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-  Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+jsxElementType.tsx(48,15): error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
 jsxElementType.tsx(52,2): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.
-jsxElementType.tsx(54,14): error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-  Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+jsxElementType.tsx(54,14): error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
 jsxElementType.tsx(59,2): error TS2741: Property 'title' is missing in type '{}' but required in type '{ title: string; }'.
-jsxElementType.tsx(61,16): error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-  Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+jsxElementType.tsx(61,16): error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
 jsxElementType.tsx(70,2): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<{ title: string; }>): RenderStringClass', gave the following error.
     Property 'title' is missing in type '{}' but required in type 'Readonly<{ title: string; }>'.
@@ -20,11 +15,9 @@ jsxElementType.tsx(70,2): error TS2769: No overload matches this call.
     Property 'title' is missing in type '{}' but required in type 'Readonly<{ title: string; }>'.
 jsxElementType.tsx(72,20): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<{ title: string; }>): RenderStringClass', gave the following error.
-    Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
-      Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
+    Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
   Overload 2 of 2, '(props: { title: string; }, context?: any): RenderStringClass', gave the following error.
-    Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
-      Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
+    Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
 jsxElementType.tsx(78,1): error TS2339: Property 'boop' does not exist on type 'JSX.IntrinsicElements'.
 jsxElementType.tsx(79,1): error TS2339: Property 'my-undeclared-custom-element' does not exist on type 'JSX.IntrinsicElements'.
 jsxElementType.tsx(91,2): error TS2786: 'ReactNativeFlatList' cannot be used as a JSX component.
@@ -34,10 +27,8 @@ jsxElementType.tsx(91,2): error TS2786: 'ReactNativeFlatList' cannot be used as 
 jsxElementType.tsx(95,11): error TS2322: Type '{}' is not assignable to type 'LibraryManagedAttributes<T, {}>'.
 jsxElementType.tsx(98,2): error TS2304: Cannot find name 'Unresolved'.
 jsxElementType.tsx(99,2): error TS2304: Cannot find name 'Unresolved'.
-jsxElementType.tsx(110,6): error TS2322: Type '{ b: string; }' is not assignable to type '{ a: string; }'.
-  Property 'b' does not exist on type '{ a: string; }'.
-jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is not assignable to type '{ a: string; }'.
-  Property 'b' does not exist on type '{ a: string; }'.
+jsxElementType.tsx(110,6): error TS2339: Property 'b' does not exist on type '{ a: string; }'.
+jsxElementType.tsx(111,19): error TS2339: Property 'b' does not exist on type '{ a: string; }'.
 
 
 ==== jsxElementType.tsx (20 errors) ====
@@ -81,8 +72,7 @@ jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is no
     <RenderElement title="react" />;
     <RenderElement excessProp />;
                    ~~~~~~~~~~
-!!! error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-!!! error TS2322:   Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+!!! error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
     
     const RenderString = ({ title }: { title: string }) => title;
     Component = RenderString;
@@ -93,8 +83,7 @@ jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is no
     <RenderString title="react" />;
     <RenderString excessProp />;
                   ~~~~~~~~~~
-!!! error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-!!! error TS2322:   Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+!!! error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
     
     const RenderNumber = ({ title }: { title: string }) => title.length;
     Component = RenderNumber;
@@ -105,8 +94,7 @@ jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is no
     <RenderNumber title="react" />;
     <RenderNumber excessProp />;
                   ~~~~~~~~~~
-!!! error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-!!! error TS2322:   Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+!!! error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
     
     const RenderArray = ({ title }: { title: string }) => [title];
     Component = RenderArray;
@@ -117,8 +105,7 @@ jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is no
     <RenderArray title="react" />;
     <RenderArray excessProp />;
                  ~~~~~~~~~~
-!!! error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-!!! error TS2322:   Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+!!! error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
     
     // React Server Component
     const RenderPromise = async ({ title }: { title: string }) => "react";
@@ -130,8 +117,7 @@ jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is no
     <RenderPromise title="react" />;
     <RenderPromise excessProp />;
                    ~~~~~~~~~~
-!!! error TS2322: Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & { title: string; }'.
-!!! error TS2322:   Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
+!!! error TS2339: Property 'excessProp' does not exist on type 'IntrinsicAttributes & { title: string; }'.
     
     // Class components still work
     class RenderStringClass extends React.Component<{ title: string }> {
@@ -154,11 +140,9 @@ jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is no
                        ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<{ title: string; }>): RenderStringClass', gave the following error.
-!!! error TS2769:     Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
-!!! error TS2769:       Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
+!!! error TS2769:     Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
 !!! error TS2769:   Overload 2 of 2, '(props: { title: string; }, context?: any): RenderStringClass', gave the following error.
-!!! error TS2769:     Type '{ excessProp: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
-!!! error TS2769:       Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
+!!! error TS2769:     Property 'excessProp' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RenderStringClass> & Readonly<{ children?: ReactNode; }> & Readonly<{ title: string; }>'.
     
     // Host element types still work
     <div />;
@@ -213,10 +197,8 @@ jsxElementType.tsx(111,19): error TS2322: Type '{ a: string; b: string; }' is no
     <a:b a="accepted" />;
     <a:b b="rejected" />;
          ~
-!!! error TS2322: Type '{ b: string; }' is not assignable to type '{ a: string; }'.
-!!! error TS2322:   Property 'b' does not exist on type '{ a: string; }'.
+!!! error TS2339: Property 'b' does not exist on type '{ a: string; }'.
     <a:b a="accepted" b="rejected" />;
                       ~
-!!! error TS2322: Type '{ a: string; b: string; }' is not assignable to type '{ a: string; }'.
-!!! error TS2322:   Property 'b' does not exist on type '{ a: string; }'.
+!!! error TS2339: Property 'b' does not exist on type '{ a: string; }'.
     

--- a/tests/baselines/reference/jsxNamespacePrefixIntrinsics.errors.txt
+++ b/tests/baselines/reference/jsxNamespacePrefixIntrinsics.errors.txt
@@ -1,8 +1,6 @@
 jsxNamespacePrefixIntrinsics.tsx(15,18): error TS2339: Property 'element' does not exist on type 'JSX.IntrinsicElements'.
-jsxNamespacePrefixIntrinsics.tsx(16,30): error TS2322: Type '{ attribute: string; }' is not assignable to type '{ "ns:attribute": string; }'.
-  Property 'attribute' does not exist on type '{ "ns:attribute": string; }'. Did you mean '"ns:attribute"'?
-jsxNamespacePrefixIntrinsics.tsx(17,30): error TS2322: Type '{ "ns:invalid": string; }' is not assignable to type '{ "ns:attribute": string; }'.
-  Property 'ns:invalid' does not exist on type '{ "ns:attribute": string; }'.
+jsxNamespacePrefixIntrinsics.tsx(16,30): error TS2551: Property 'attribute' does not exist on type '{ "ns:attribute": string; }'. Did you mean '"ns:attribute"'?
+jsxNamespacePrefixIntrinsics.tsx(17,30): error TS2339: Property 'ns:invalid' does not exist on type '{ "ns:attribute": string; }'.
 
 
 ==== jsxNamespacePrefixIntrinsics.tsx (3 errors) ====
@@ -25,10 +23,8 @@ jsxNamespacePrefixIntrinsics.tsx(17,30): error TS2322: Type '{ "ns:invalid": str
 !!! error TS2339: Property 'element' does not exist on type 'JSX.IntrinsicElements'.
     const invalid2 = <ns:element attribute="nope" />;
                                  ~~~~~~~~~
-!!! error TS2322: Type '{ attribute: string; }' is not assignable to type '{ "ns:attribute": string; }'.
-!!! error TS2322:   Property 'attribute' does not exist on type '{ "ns:attribute": string; }'. Did you mean '"ns:attribute"'?
+!!! error TS2551: Property 'attribute' does not exist on type '{ "ns:attribute": string; }'. Did you mean '"ns:attribute"'?
     const invalid3 = <ns:element ns:invalid="nope" />;
                                  ~~~~~~~~~~
-!!! error TS2322: Type '{ "ns:invalid": string; }' is not assignable to type '{ "ns:attribute": string; }'.
-!!! error TS2322:   Property 'ns:invalid' does not exist on type '{ "ns:attribute": string; }'.
+!!! error TS2339: Property 'ns:invalid' does not exist on type '{ "ns:attribute": string; }'.
     

--- a/tests/baselines/reference/spellingSuggestionJSXAttribute.errors.txt
+++ b/tests/baselines/reference/spellingSuggestionJSXAttribute.errors.txt
@@ -1,29 +1,19 @@
-spellingSuggestionJSXAttribute.tsx(8,4): error TS2322: Type '{ class: string; }' is not assignable to type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
-  Property 'class' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'. Did you mean 'className'?
-spellingSuggestionJSXAttribute.tsx(9,4): error TS2322: Type '{ for: string; }' is not assignable to type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
-  Property 'for' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
-spellingSuggestionJSXAttribute.tsx(10,8): error TS2322: Type '{ for: string; }' is not assignable to type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'.
-  Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
-spellingSuggestionJSXAttribute.tsx(11,8): error TS2322: Type '{ for: string; class: string; }' is not assignable to type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'.
-  Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
+spellingSuggestionJSXAttribute.tsx(8,4): error TS2551: Property 'class' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'. Did you mean 'className'?
+spellingSuggestionJSXAttribute.tsx(9,4): error TS2339: Property 'for' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
+spellingSuggestionJSXAttribute.tsx(10,8): error TS2551: Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
+spellingSuggestionJSXAttribute.tsx(11,8): error TS2551: Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
 spellingSuggestionJSXAttribute.tsx(12,9): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<{ className?: string; htmlFor?: string; }>): MyComp', gave the following error.
-    Type '{ class: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-      Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
+    Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
   Overload 2 of 2, '(props: { className?: string; htmlFor?: string; }, context?: any): MyComp', gave the following error.
-    Type '{ class: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-      Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
-spellingSuggestionJSXAttribute.tsx(13,10): error TS2322: Type '{ class: string; }' is not assignable to type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'.
-  Property 'class' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'className'?
+    Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
+spellingSuggestionJSXAttribute.tsx(13,10): error TS2551: Property 'class' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'className'?
 spellingSuggestionJSXAttribute.tsx(14,9): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<{ className?: string; htmlFor?: string; }>): MyComp', gave the following error.
-    Type '{ for: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-      Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
+    Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
   Overload 2 of 2, '(props: { className?: string; htmlFor?: string; }, context?: any): MyComp', gave the following error.
-    Type '{ for: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-      Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
-spellingSuggestionJSXAttribute.tsx(15,10): error TS2322: Type '{ for: string; }' is not assignable to type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'.
-  Property 'for' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'htmlFor'?
+    Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
+spellingSuggestionJSXAttribute.tsx(15,10): error TS2551: Property 'for' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'htmlFor'?
 
 
 ==== spellingSuggestionJSXAttribute.tsx (8 errors) ====
@@ -36,44 +26,34 @@ spellingSuggestionJSXAttribute.tsx(15,10): error TS2322: Type '{ for: string; }'
     class MyComp extends React.Component<{ className?: string, htmlFor?: string }> { }
     <a class="" />;
        ~~~~~
-!!! error TS2322: Type '{ class: string; }' is not assignable to type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
-!!! error TS2322:   Property 'class' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'. Did you mean 'className'?
+!!! error TS2551: Property 'class' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'. Did you mean 'className'?
     <a for="" />; // should have no fix
        ~~~
-!!! error TS2322: Type '{ for: string; }' is not assignable to type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
-!!! error TS2322:   Property 'for' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
+!!! error TS2339: Property 'for' does not exist on type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
     <label for="" />;
            ~~~
-!!! error TS2322: Type '{ for: string; }' is not assignable to type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'.
-!!! error TS2322:   Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
+!!! error TS2551: Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
     <label for="" class="" />;
            ~~~
-!!! error TS2322: Type '{ for: string; class: string; }' is not assignable to type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'.
-!!! error TS2322:   Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
+!!! error TS2551: Property 'for' does not exist on type 'DetailedHTMLProps<LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>'. Did you mean 'htmlFor'?
     <MyComp class="" />;
             ~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<{ className?: string; htmlFor?: string; }>): MyComp', gave the following error.
-!!! error TS2769:     Type '{ class: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-!!! error TS2769:       Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
+!!! error TS2769:     Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
 !!! error TS2769:   Overload 2 of 2, '(props: { className?: string; htmlFor?: string; }, context?: any): MyComp', gave the following error.
-!!! error TS2769:     Type '{ class: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-!!! error TS2769:       Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
+!!! error TS2769:     Property 'class' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'className'?
     <MyComp2 class="" />;
              ~~~~~
-!!! error TS2322: Type '{ class: string; }' is not assignable to type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'.
-!!! error TS2322:   Property 'class' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'className'?
+!!! error TS2551: Property 'class' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'className'?
     <MyComp for="" />;
             ~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<{ className?: string; htmlFor?: string; }>): MyComp', gave the following error.
-!!! error TS2769:     Type '{ for: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-!!! error TS2769:       Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
+!!! error TS2769:     Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
 !!! error TS2769:   Overload 2 of 2, '(props: { className?: string; htmlFor?: string; }, context?: any): MyComp', gave the following error.
-!!! error TS2769:     Type '{ for: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'.
-!!! error TS2769:       Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
+!!! error TS2769:     Property 'for' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp> & Readonly<{ children?: ReactNode; }> & Readonly<{ className?: string; htmlFor?: string; }>'. Did you mean 'htmlFor'?
     <MyComp2 for="" />;
              ~~~
-!!! error TS2322: Type '{ for: string; }' is not assignable to type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'.
-!!! error TS2322:   Property 'for' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'htmlFor'?
+!!! error TS2551: Property 'for' does not exist on type 'IntrinsicAttributes & { className?: string; htmlFor?: string; }'. Did you mean 'htmlFor'?
     

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-incremental.js
@@ -199,8 +199,7 @@ Input::
 
 
 Output::
-[96mindex.tsx[0m:[93m1[0m:[93m31[0m - [91merror[0m[90m TS2322: [0mType '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.
-  Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?
+[96mindex.tsx[0m:[93m1[0m:[93m31[0m - [91merror[0m[90m TS2551: [0mProperty 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?
 
 [7m1[0m export const App = () => <div propA={true}></div>;
 [7m [0m [91m                              ~~~~~[0m
@@ -226,7 +225,7 @@ exports.App = App;
 
 
 //// [/users/username/projects/project/tsconfig.tsbuildinfo]
-{"program":{"fileNames":["../../../../a/lib/lib.d.ts","./node_modules/preact/jsx-runtime/index.d.ts","./index.tsx"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",{"version":"-14760199789-export const App = () => <div propA={true}></div>;","signature":"-8162467991-export declare const App: () => import(\"preact/jsx-runtime\").JSX.Element;\n"}],"root":[3],"options":{"jsx":4,"jsxImportSource":"preact","module":1},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,[3,[{"file":"./index.tsx","start":30,"length":5,"code":2322,"category":1,"messageText":{"messageText":"Type '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.","category":1,"code":2322,"next":[{"messageText":"Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?","category":1,"code":2551}]}}]],2]},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../../../../a/lib/lib.d.ts","./node_modules/preact/jsx-runtime/index.d.ts","./index.tsx"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",{"version":"-14760199789-export const App = () => <div propA={true}></div>;","signature":"-8162467991-export declare const App: () => import(\"preact/jsx-runtime\").JSX.Element;\n"}],"root":[3],"options":{"jsx":4,"jsxImportSource":"preact","module":1},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,[3,[{"file":"./index.tsx","start":30,"length":5,"code":2551,"category":1,"messageText":"Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?"}]],2]},"version":"FakeTSVersion"}
 
 //// [/users/username/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -294,20 +293,9 @@ exports.App = App;
             "file": "./index.tsx",
             "start": 30,
             "length": 5,
-            "code": 2322,
+            "code": 2551,
             "category": 1,
-            "messageText": {
-              "messageText": "Type '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.",
-              "category": 1,
-              "code": 2322,
-              "next": [
-                {
-                  "messageText": "Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?",
-                  "category": 1,
-                  "code": 2551
-                }
-              ]
-            }
+            "messageText": "Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?"
           }
         ]
       ],
@@ -315,7 +303,7 @@ exports.App = App;
     ]
   },
   "version": "FakeTSVersion",
-  "size": 1640
+  "size": 1470
 }
 
 

--- a/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
+++ b/tests/baselines/reference/tscWatch/incremental/jsxImportSource-option-changed-watch.js
@@ -256,8 +256,7 @@ Output::
 >> Screen clear
 [[90m12:00:50 AM[0m] Starting compilation in watch mode...
 
-[96mindex.tsx[0m:[93m1[0m:[93m31[0m - [91merror[0m[90m TS2322: [0mType '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.
-  Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?
+[96mindex.tsx[0m:[93m1[0m:[93m31[0m - [91merror[0m[90m TS2551: [0mProperty 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?
 
 [7m1[0m export const App = () => <div propA={true}></div>;
 [7m [0m [91m                              ~~~~~[0m
@@ -282,7 +281,7 @@ exports.App = App;
 
 
 //// [/users/username/projects/project/tsconfig.tsbuildinfo]
-{"program":{"fileNames":["../../../../a/lib/lib.d.ts","./node_modules/preact/jsx-runtime/index.d.ts","./index.tsx"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",{"version":"-14760199789-export const App = () => <div propA={true}></div>;","signature":"-8162467991-export declare const App: () => import(\"preact/jsx-runtime\").JSX.Element;\n"}],"root":[3],"options":{"jsx":4,"jsxImportSource":"preact","module":1},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,[3,[{"file":"./index.tsx","start":30,"length":5,"code":2322,"category":1,"messageText":{"messageText":"Type '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.","category":1,"code":2322,"next":[{"messageText":"Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?","category":1,"code":2551}]}}]],2]},"version":"FakeTSVersion"}
+{"program":{"fileNames":["../../../../a/lib/lib.d.ts","./node_modules/preact/jsx-runtime/index.d.ts","./index.tsx"],"fileInfos":[{"version":"3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };","affectsGlobalScope":true},"-17896129664-export namespace JSX {\n    interface Element {}\n    interface IntrinsicElements {\n        div: {\n            propB?: boolean;\n        };\n    }\n}\nexport function jsx(...args: any[]): void;\nexport function jsxs(...args: any[]): void;\nexport const Fragment: unique symbol;\n",{"version":"-14760199789-export const App = () => <div propA={true}></div>;","signature":"-8162467991-export declare const App: () => import(\"preact/jsx-runtime\").JSX.Element;\n"}],"root":[3],"options":{"jsx":4,"jsxImportSource":"preact","module":1},"fileIdsList":[[2]],"referencedMap":[[3,1]],"exportedModulesMap":[[3,1]],"semanticDiagnosticsPerFile":[1,[3,[{"file":"./index.tsx","start":30,"length":5,"code":2551,"category":1,"messageText":"Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?"}]],2]},"version":"FakeTSVersion"}
 
 //// [/users/username/projects/project/tsconfig.tsbuildinfo.readable.baseline.txt]
 {
@@ -350,20 +349,9 @@ exports.App = App;
             "file": "./index.tsx",
             "start": 30,
             "length": 5,
-            "code": 2322,
+            "code": 2551,
             "category": 1,
-            "messageText": {
-              "messageText": "Type '{ propA: boolean; }' is not assignable to type '{ propB?: boolean; }'.",
-              "category": 1,
-              "code": 2322,
-              "next": [
-                {
-                  "messageText": "Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?",
-                  "category": 1,
-                  "code": 2551
-                }
-              ]
-            }
+            "messageText": "Property 'propA' does not exist on type '{ propB?: boolean; }'. Did you mean 'propB'?"
           }
         ]
       ],
@@ -371,7 +359,7 @@ exports.App = App;
     ]
   },
   "version": "FakeTSVersion",
-  "size": 1640
+  "size": 1470
 }
 
 

--- a/tests/baselines/reference/tsxAttributeResolution1.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution1.errors.txt
@@ -1,11 +1,8 @@
 file.tsx(23,8): error TS2322: Type 'string' is not assignable to type 'number'.
-file.tsx(24,8): error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
-  Property 'y' does not exist on type 'Attribs1'.
-file.tsx(25,8): error TS2322: Type '{ y: string; }' is not assignable to type 'Attribs1'.
-  Property 'y' does not exist on type 'Attribs1'.
+file.tsx(24,8): error TS2339: Property 'y' does not exist on type 'Attribs1'.
+file.tsx(25,8): error TS2339: Property 'y' does not exist on type 'Attribs1'.
 file.tsx(26,8): error TS2322: Type 'string' is not assignable to type 'number'.
-file.tsx(27,8): error TS2322: Type '{ var: string; }' is not assignable to type 'Attribs1'.
-  Property 'var' does not exist on type 'Attribs1'.
+file.tsx(27,8): error TS2339: Property 'var' does not exist on type 'Attribs1'.
 file.tsx(29,2): error TS2741: Property 'reqd' is missing in type '{}' but required in type '{ reqd: string; }'.
 file.tsx(30,8): error TS2322: Type 'number' is not assignable to type 'string'.
 
@@ -39,20 +36,17 @@ file.tsx(30,8): error TS2322: Type 'number' is not assignable to type 'string'.
 !!! related TS6500 file.tsx:10:2: The expected type comes from property 'x' which is declared here on type 'Attribs1'
     <test1 y={0} />; // Error, no property "y"
            ~
-!!! error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
+!!! error TS2339: Property 'y' does not exist on type 'Attribs1'.
     <test1 y="foo" />; // Error, no property "y"
            ~
-!!! error TS2322: Type '{ y: string; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
+!!! error TS2339: Property 'y' does not exist on type 'Attribs1'.
     <test1 x="32" />; // Error, "32" is not number
            ~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
 !!! related TS6500 file.tsx:10:2: The expected type comes from property 'x' which is declared here on type 'Attribs1'
     <test1 var="10" />; // Error, no 'var' property
            ~~~
-!!! error TS2322: Type '{ var: string; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Property 'var' does not exist on type 'Attribs1'.
+!!! error TS2339: Property 'var' does not exist on type 'Attribs1'.
     
     <test2 />; // Error, missing reqd
      ~~~~~

--- a/tests/baselines/reference/tsxAttributeResolution11.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution11.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(11,22): error TS2322: Type '{ bar: string; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
-  Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
+file.tsx(11,22): error TS2339: Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
 
 
 ==== react.d.ts (0 errors) ====
@@ -28,7 +27,6 @@ file.tsx(11,22): error TS2322: Type '{ bar: string; }' is not assignable to type
     // Should be an OK
     var x = <MyComponent bar='world' />;
                          ~~~
-!!! error TS2322: Type '{ bar: string; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
-!!! error TS2322:   Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
+!!! error TS2339: Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
     
     

--- a/tests/baselines/reference/tsxAttributeResolution15.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution15.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(11,21): error TS2322: Type '{ prop1: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
-  Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+file.tsx(11,21): error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
 file.tsx(14,39): error TS2532: Object is possibly 'undefined'.
 
 
@@ -16,8 +15,7 @@ file.tsx(14,39): error TS2532: Object is possibly 'undefined'.
     // Error
     let a = <BigGreeter prop1="hello" />
                         ~~~~~
-!!! error TS2322: Type '{ prop1: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+!!! error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
     
     // OK
     let b = <BigGreeter ref={(input) => { this.textInput = input; }} />

--- a/tests/baselines/reference/tsxElementResolution11.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution11.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(17,7): error TS2322: Type '{ x: number; }' is not assignable to type '{ q?: number; }'.
-  Property 'x' does not exist on type '{ q?: number; }'.
+file.tsx(17,7): error TS2339: Property 'x' does not exist on type '{ q?: number; }'.
 
 
 ==== file.tsx (1 errors) ====
@@ -21,8 +20,7 @@ file.tsx(17,7): error TS2322: Type '{ x: number; }' is not assignable to type '{
     var Obj2: Obj2type;
     <Obj2 x={10} />; // Error
           ~
-!!! error TS2322: Type '{ x: number; }' is not assignable to type '{ q?: number; }'.
-!!! error TS2322:   Property 'x' does not exist on type '{ q?: number; }'.
+!!! error TS2339: Property 'x' does not exist on type '{ q?: number; }'.
     
     interface Obj3type {
     	new(n: string): { x: number; };

--- a/tests/baselines/reference/tsxElementResolution3.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution3.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(12,7): error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
-  Property 'w' does not exist on type '{ n: string; }'.
+file.tsx(12,7): error TS2339: Property 'w' does not exist on type '{ n: string; }'.
 
 
 ==== file.tsx (1 errors) ====
@@ -16,5 +15,4 @@ file.tsx(12,7): error TS2322: Type '{ w: string; }' is not assignable to type '{
     // Error
     <span w='err' />;
           ~
-!!! error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
-!!! error TS2322:   Property 'w' does not exist on type '{ n: string; }'.
+!!! error TS2339: Property 'w' does not exist on type '{ n: string; }'.

--- a/tests/baselines/reference/tsxElementResolution4.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution4.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(16,7): error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
-  Property 'q' does not exist on type '{ m: string; }'.
+file.tsx(16,7): error TS2339: Property 'q' does not exist on type '{ m: string; }'.
 
 
 ==== file.tsx (1 errors) ====
@@ -20,6 +19,5 @@ file.tsx(16,7): error TS2322: Type '{ q: string; }' is not assignable to type '{
     // Error
     <span q='' />;
           ~
-!!! error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
-!!! error TS2322:   Property 'q' does not exist on type '{ m: string; }'.
+!!! error TS2339: Property 'q' does not exist on type '{ m: string; }'.
     

--- a/tests/baselines/reference/tsxLibraryManagedAttributes.errors.txt
+++ b/tests/baselines/reference/tsxLibraryManagedAttributes.errors.txt
@@ -1,23 +1,19 @@
 tsxLibraryManagedAttributes.tsx(55,12): error TS2322: Type '{ foo: number; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
   Type '{ foo: number; }' is missing the following properties from type '{ bar: ReactNode | null | undefined; baz: string; }': bar, baz
-tsxLibraryManagedAttributes.tsx(57,41): error TS2322: Type '{ bar: string; baz: string; bat: string; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
-  Property 'bat' does not exist on type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
+tsxLibraryManagedAttributes.tsx(57,41): error TS2339: Property 'bat' does not exist on type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
 tsxLibraryManagedAttributes.tsx(59,42): error TS2322: Type 'null' is not assignable to type 'string'.
 tsxLibraryManagedAttributes.tsx(69,26): error TS2322: Type 'string' is not assignable to type 'number'.
 tsxLibraryManagedAttributes.tsx(71,35): error TS2322: Type 'null' is not assignable to type 'ReactNode'.
-tsxLibraryManagedAttributes.tsx(80,38): error TS2322: Type '{ foo: number; bar: string; }' is not assignable to type 'Defaultize<{}, { foo: number; }>'.
-  Property 'bar' does not exist on type 'Defaultize<{}, { foo: number; }>'.
+tsxLibraryManagedAttributes.tsx(80,38): error TS2339: Property 'bar' does not exist on type 'Defaultize<{}, { foo: number; }>'.
 tsxLibraryManagedAttributes.tsx(81,29): error TS2322: Type 'string' is not assignable to type 'number'.
 tsxLibraryManagedAttributes.tsx(98,12): error TS2322: Type '{ foo: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
   Type '{ foo: string; }' is missing the following properties from type '{ bar: ReactNode | null | undefined; baz: number; }': bar, baz
-tsxLibraryManagedAttributes.tsx(100,56): error TS2322: Type '{ bar: string; baz: number; bat: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
-  Property 'bat' does not exist on type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
+tsxLibraryManagedAttributes.tsx(100,56): error TS2339: Property 'bat' does not exist on type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
 tsxLibraryManagedAttributes.tsx(102,57): error TS2322: Type 'null' is not assignable to type 'number'.
 tsxLibraryManagedAttributes.tsx(111,46): error TS2322: Type 'number' is not assignable to type 'string'.
 tsxLibraryManagedAttributes.tsx(112,46): error TS2322: Type 'null' is not assignable to type 'string'.
 tsxLibraryManagedAttributes.tsx(113,57): error TS2322: Type 'null' is not assignable to type 'ReactNode'.
-tsxLibraryManagedAttributes.tsx(122,58): error TS2322: Type '{ foo: string; bar: string; }' is not assignable to type 'Defaultize<FooProps, { foo: string; }>'.
-  Property 'bar' does not exist on type 'Defaultize<FooProps, { foo: string; }>'.
+tsxLibraryManagedAttributes.tsx(122,58): error TS2339: Property 'bar' does not exist on type 'Defaultize<FooProps, { foo: string; }>'.
 tsxLibraryManagedAttributes.tsx(123,49): error TS2322: Type 'number' is not assignable to type 'string'.
 
 
@@ -83,8 +79,7 @@ tsxLibraryManagedAttributes.tsx(123,49): error TS2322: Type 'number' is not assi
     const c = <Component bar="yes" baz="yeah" />;
     const d = <Component bar="yes" baz="yo" bat="ohno" />; // Error, baz not a valid prop
                                             ~~~
-!!! error TS2322: Type '{ bar: string; baz: string; bat: string; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
-!!! error TS2322:   Property 'bat' does not exist on type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
+!!! error TS2339: Property 'bat' does not exist on type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
     const e = <Component foo={12} bar={null} baz="cool" />; // bar is nullable/undefinable since it's not marked `isRequired`
     const f = <Component foo={12} bar="yeah" baz={null} />; // Error, baz is _not_ nullable/undefinable since it's marked `isRequired`
                                              ~~~
@@ -117,8 +112,7 @@ tsxLibraryManagedAttributes.tsx(123,49): error TS2322: Type 'number' is not assi
     const k = <JustDefaultProps foo={12} />;
     const l = <JustDefaultProps foo={12} bar="ok" />; // error, no prop named bar
                                          ~~~
-!!! error TS2322: Type '{ foo: number; bar: string; }' is not assignable to type 'Defaultize<{}, { foo: number; }>'.
-!!! error TS2322:   Property 'bar' does not exist on type 'Defaultize<{}, { foo: number; }>'.
+!!! error TS2339: Property 'bar' does not exist on type 'Defaultize<{}, { foo: number; }>'.
     const m = <JustDefaultProps foo="no" />; // error, wrong type
                                 ~~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
@@ -146,8 +140,7 @@ tsxLibraryManagedAttributes.tsx(123,49): error TS2322: Type 'number' is not assi
     const p = <BothWithSpecifiedGeneric bar="yes" baz={12} />;
     const q = <BothWithSpecifiedGeneric bar="yes" baz={12} bat="ohno" />; // Error, baz not a valid prop
                                                            ~~~
-!!! error TS2322: Type '{ bar: string; baz: number; bat: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
-!!! error TS2322:   Property 'bat' does not exist on type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
+!!! error TS2339: Property 'bat' does not exist on type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
     const r = <BothWithSpecifiedGeneric foo="no" bar={null} baz={0} />; // bar is nullable/undefinable since it's not marked `isRequired`
     const s = <BothWithSpecifiedGeneric foo="eh" bar="yeah" baz={null} />; // Error, baz is _not_ nullable/undefinable since it's marked `isRequired`
                                                             ~~~
@@ -182,8 +175,7 @@ tsxLibraryManagedAttributes.tsx(123,49): error TS2322: Type 'number' is not assi
     const x = <JustDefaultPropsWithSpecifiedGeneric foo="eh" />;
     const y = <JustDefaultPropsWithSpecifiedGeneric foo="no" bar="ok" />; // error, no prop named bar
                                                              ~~~
-!!! error TS2322: Type '{ foo: string; bar: string; }' is not assignable to type 'Defaultize<FooProps, { foo: string; }>'.
-!!! error TS2322:   Property 'bar' does not exist on type 'Defaultize<FooProps, { foo: string; }>'.
+!!! error TS2339: Property 'bar' does not exist on type 'Defaultize<FooProps, { foo: string; }>'.
     const z = <JustDefaultPropsWithSpecifiedGeneric foo={12} />; // error, wrong type
                                                     ~~~
 !!! error TS2322: Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution14.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution14.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(11,38): error TS2322: Type '{ Property1: true; property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
-  Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'. Did you mean 'property1'?
+file.tsx(11,38): error TS2551: Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'. Did you mean 'property1'?
 
 
 ==== file.tsx (1 errors) ====
@@ -15,8 +14,7 @@ file.tsx(11,38): error TS2322: Type '{ Property1: true; property1: string; prope
             // Error extra property
             <AnotherComponent {...props} Property1/>
                                          ~~~~~~~~~
-!!! error TS2322: Type '{ Property1: true; property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
-!!! error TS2322:   Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'. Did you mean 'property1'?
+!!! error TS2551: Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'. Did you mean 'property1'?
         );
     }
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -5,8 +5,7 @@ file.tsx(22,21): error TS2322: Type 'true' is not assignable to type '"2"'.
 file.tsx(23,10): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
   Types of property 'x' are incompatible.
     Type 'number' is not assignable to type 'string'.
-file.tsx(24,40): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'. Did you mean 'x'?
+file.tsx(24,40): error TS2551: Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'. Did you mean 'x'?
 
 
 ==== file.tsx (6 errors) ====
@@ -49,5 +48,4 @@ file.tsx(24,40): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not a
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.
     let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
                                            ~
-!!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'. Did you mean 'x'?
+!!! error TS2551: Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'. Did you mean 'x'?

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,29 +1,23 @@
 file.tsx(12,22): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
-    Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes'.
-      Property 'extraProp' does not exist on type 'IntrinsicAttributes'.
+    Property 'extraProp' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
-    Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-      Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+    Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 file.tsx(13,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
-    Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes'.
-      Property 'yy' does not exist on type 'IntrinsicAttributes'.
+    Property 'yy' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Property 'yy1' is missing in type '{ yy: number; }' but required in type '{ yy: number; yy1: string; }'.
 file.tsx(14,31): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
-    Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes'.
-      Property 'yy1' does not exist on type 'IntrinsicAttributes'.
+    Property 'yy1' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Type 'boolean' is not assignable to type 'string'.
 file.tsx(16,31): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
-    Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes'.
-      Property 'y1' does not exist on type 'IntrinsicAttributes'.
+    Property 'y1' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
-    Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-      Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+    Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 file.tsx(17,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ yy: boolean; yy1: string; }' has no properties in common with type 'IntrinsicAttributes'.
@@ -40,8 +34,7 @@ file.tsx(25,13): error TS2769: No overload matches this call.
     Property 'yy' is missing in type '{ "extra-data": true; }' but required in type '{ yy: string; direction?: number; }'.
 file.tsx(26,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(j: { "extra-data": string; }): Element', gave the following error.
-    Type '{ yy: string; direction: string; }' is not assignable to type 'IntrinsicAttributes & { "extra-data": string; }'.
-      Property 'yy' does not exist on type 'IntrinsicAttributes & { "extra-data": string; }'.
+    Property 'yy' does not exist on type 'IntrinsicAttributes & { "extra-data": string; }'.
   Overload 2 of 2, '(n: { yy: string; direction?: number; }): Element', gave the following error.
     Type 'string' is not assignable to type 'number'.
 file.tsx(33,13): error TS2769: No overload matches this call.
@@ -53,25 +46,21 @@ file.tsx(33,13): error TS2769: No overload matches this call.
     Type 'string' is not assignable to type 'boolean'.
 file.tsx(34,13): error TS2769: No overload matches this call.
   Overload 1 of 3, '(a: { y1?: string; y2?: number; }): Element', gave the following error.
-    Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
-      Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
+    Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
   Overload 2 of 3, '(a: { y1?: string; y2?: number; children: Element; }): Element', gave the following error.
-    Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; children: Element; }'.
-      Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; children: Element; }'.
+    Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; children: Element; }'.
   Overload 3 of 3, '(a: { y1: boolean; y2?: number; y3: boolean; }): Element', gave the following error.
     Type 'string' is not assignable to type 'boolean'.
 file.tsx(35,13): error TS2769: No overload matches this call.
   Overload 1 of 3, '(a: { y1?: string; y2?: number; }): Element', gave the following error.
-    Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
-      Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
+    Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
   Overload 2 of 3, '(a: { y1?: string; y2?: number; children: Element; }): Element', gave the following error.
     Type 'string' is not assignable to type 'Element'.
   Overload 3 of 3, '(a: { y1: boolean; y2?: number; y3: boolean; }): Element', gave the following error.
     Type 'string' is not assignable to type 'boolean'.
 file.tsx(36,13): error TS2769: No overload matches this call.
   Overload 1 of 3, '(a: { y1?: string; y2?: number; }): Element', gave the following error.
-    Type '{ children: string; y1: string; y2: number; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
-      Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
+    Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
   Overload 2 of 3, '(a: { y1?: string; y2?: number; children: Element; }): Element', gave the following error.
     'TestingOptional' components don't accept text as child elements. Text in JSX has the type 'string', but the expected type of 'children' is 'Element'.
   Overload 3 of 3, '(a: { y1: boolean; y2?: number; y3: boolean; }): Element', gave the following error.
@@ -94,17 +83,14 @@ file.tsx(36,13): error TS2769: No overload matches this call.
                          ~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
-!!! error TS2769:     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2769:       Property 'extraProp' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2769:     Property 'extraProp' does not exist on type 'IntrinsicAttributes'.
 !!! error TS2769:   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
-!!! error TS2769:     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2769:       Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+!!! error TS2769:     Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
                 ~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
-!!! error TS2769:     Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2769:       Property 'yy' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2769:     Property 'yy' does not exist on type 'IntrinsicAttributes'.
 !!! error TS2769:   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
 !!! error TS2769:     Property 'yy1' is missing in type '{ yy: number; }' but required in type '{ yy: number; yy1: string; }'.
 !!! related TS2728 file.tsx:3:43: 'yy1' is declared here.
@@ -112,8 +98,7 @@ file.tsx(36,13): error TS2769: No overload matches this call.
                                   ~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
-!!! error TS2769:     Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2769:       Property 'yy1' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2769:     Property 'yy1' does not exist on type 'IntrinsicAttributes'.
 !!! error TS2769:   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
 !!! error TS2769:     Type 'boolean' is not assignable to type 'string'.
 !!! related TS6500 file.tsx:3:43: The expected type comes from property 'yy1' which is declared here on type 'IntrinsicAttributes & { yy: number; yy1: string; }'
@@ -122,11 +107,9 @@ file.tsx(36,13): error TS2769: No overload matches this call.
                                   ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
-!!! error TS2769:     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2769:       Property 'y1' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2769:     Property 'y1' does not exist on type 'IntrinsicAttributes'.
 !!! error TS2769:   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
-!!! error TS2769:     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2769:       Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+!!! error TS2769:     Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
                 ~~~~~~~~
 !!! error TS2769: No overload matches this call.
@@ -157,8 +140,7 @@ file.tsx(36,13): error TS2769: No overload matches this call.
                 ~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(j: { "extra-data": string; }): Element', gave the following error.
-!!! error TS2769:     Type '{ yy: string; direction: string; }' is not assignable to type 'IntrinsicAttributes & { "extra-data": string; }'.
-!!! error TS2769:       Property 'yy' does not exist on type 'IntrinsicAttributes & { "extra-data": string; }'.
+!!! error TS2769:     Property 'yy' does not exist on type 'IntrinsicAttributes & { "extra-data": string; }'.
 !!! error TS2769:   Overload 2 of 2, '(n: { yy: string; direction?: number; }): Element', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'number'.
 !!! related TS6500 file.tsx:22:50: The expected type comes from property 'direction' which is declared here on type 'IntrinsicAttributes & { yy: string; direction?: number; }'
@@ -184,11 +166,9 @@ file.tsx(36,13): error TS2769: No overload matches this call.
                 ~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(a: { y1?: string; y2?: number; }): Element', gave the following error.
-!!! error TS2769:     Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
-!!! error TS2769:       Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
+!!! error TS2769:     Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
 !!! error TS2769:   Overload 2 of 3, '(a: { y1?: string; y2?: number; children: Element; }): Element', gave the following error.
-!!! error TS2769:     Type '{ y1: string; y2: number; y3: true; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; children: Element; }'.
-!!! error TS2769:       Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; children: Element; }'.
+!!! error TS2769:     Property 'y3' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; children: Element; }'.
 !!! error TS2769:   Overload 3 of 3, '(a: { y1: boolean; y2?: number; y3: boolean; }): Element', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'boolean'.
 !!! related TS6500 file.tsx:30:38: The expected type comes from property 'y1' which is declared here on type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'
@@ -196,8 +176,7 @@ file.tsx(36,13): error TS2769: No overload matches this call.
                 ~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(a: { y1?: string; y2?: number; }): Element', gave the following error.
-!!! error TS2769:     Type '{ y1: string; y2: number; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
-!!! error TS2769:       Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
+!!! error TS2769:     Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
 !!! error TS2769:   Overload 2 of 3, '(a: { y1?: string; y2?: number; children: Element; }): Element', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'Element'.
 !!! error TS2769:   Overload 3 of 3, '(a: { y1: boolean; y2?: number; y3: boolean; }): Element', gave the following error.
@@ -208,8 +187,7 @@ file.tsx(36,13): error TS2769: No overload matches this call.
                 ~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(a: { y1?: string; y2?: number; }): Element', gave the following error.
-!!! error TS2769:     Type '{ children: string; y1: string; y2: number; }' is not assignable to type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
-!!! error TS2769:       Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
+!!! error TS2769:     Property 'children' does not exist on type 'IntrinsicAttributes & { y1?: string; y2?: number; }'.
 !!! error TS2769:   Overload 2 of 3, '(a: { y1?: string; y2?: number; children: Element; }): Element', gave the following error.
 !!! error TS2769:     'TestingOptional' components don't accept text as child elements. Text in JSX has the type 'string', but the expected type of 'children' is 'Element'.
 !!! error TS2769:   Overload 3 of 3, '(a: { y1: boolean; y2?: number; y3: boolean; }): Element', gave the following error.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,13 +1,10 @@
 file.tsx(48,13): error TS2769: No overload matches this call.
   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
-    Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-      Property 'to' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+    Property 'to' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 3, '(linkProps: LinkProps): Element', gave the following error.
-    Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-      Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
+    Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
   Overload 3 of 3, '(hyphenProps: HyphenProps): Element', gave the following error.
-    Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-      Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+    Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
 file.tsx(54,51): error TS2769: No overload matches this call.
   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
     Type 'number' is not assignable to type 'string'.
@@ -85,14 +82,11 @@ file.tsx(56,13): error TS2769: No overload matches this call.
                 ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
-!!! error TS2769:     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-!!! error TS2769:       Property 'to' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+!!! error TS2769:     Property 'to' does not exist on type 'IntrinsicAttributes & ButtonProps'.
 !!! error TS2769:   Overload 2 of 3, '(linkProps: LinkProps): Element', gave the following error.
-!!! error TS2769:     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2769:       Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2769:     Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2769:   Overload 3 of 3, '(hyphenProps: HyphenProps): Element', gave the following error.
-!!! error TS2769:     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2769:       Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2769:     Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
 !!! related TS2793 file.tsx:38:17: The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
     const b2 = <MainButton {...{to: "10000"}} {...obj2} />;  // extra property

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -1,13 +1,9 @@
-file.tsx(19,16): error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-  Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'. Did you mean 'name'?
+file.tsx(19,16): error TS2551: Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'. Did you mean 'name'?
 file.tsx(27,15): error TS2322: Type 'number' is not assignable to type 'string'.
-file.tsx(29,15): error TS2322: Type '{ naaaaaaame: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-  Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+file.tsx(29,15): error TS2339: Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
 file.tsx(34,10): error TS2741: Property '"prop-name"' is missing in type '{ "extra-prop-name": string; }' but required in type '{ "prop-name": string; }'.
-file.tsx(37,23): error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'prop1' does not exist on type 'IntrinsicAttributes'.
-file.tsx(38,24): error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'ref' does not exist on type 'IntrinsicAttributes'.
+file.tsx(37,23): error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes'.
+file.tsx(38,24): error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes'.
 file.tsx(41,16): error TS1005: ',' expected.
 file.tsx(45,11): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes'.
 
@@ -33,8 +29,7 @@ file.tsx(45,11): error TS2559: Type '{ prop1: boolean; }' has no properties in c
     // Error
     let b = <Greet naaame='world' />;
                    ~~~~~~
-!!! error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-!!! error TS2322:   Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'. Did you mean 'name'?
+!!! error TS2551: Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'. Did you mean 'name'?
     
     // OK
     let c = <Meet />;
@@ -48,8 +43,7 @@ file.tsx(45,11): error TS2559: Type '{ prop1: boolean; }' has no properties in c
     // Error
     let f = <Meet naaaaaaame='no' />;
                   ~~~~~~~~~~
-!!! error TS2322: Type '{ naaaaaaame: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-!!! error TS2322:   Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+!!! error TS2339: Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     
     // OK
     let g = <MeetAndGreet prop-name="Bob" />;
@@ -62,12 +56,10 @@ file.tsx(45,11): error TS2559: Type '{ prop1: boolean; }' has no properties in c
     // Error
     let i = <EmptyPropSFC prop1 />
                           ~~~~~
-!!! error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes'.
     let i1 = <EmptyPropSFC ref={x => x.greeting.substr(10)} />
                            ~~~
-!!! error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes'.
     
     let o = {
         prop1: true;

--- a/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(19,16): error TS2322: Type '{ ref: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-  Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+file.tsx(19,16): error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
 file.tsx(25,42): error TS2551: Property 'subtr' does not exist on type 'string'. Did you mean 'substr'?
 file.tsx(27,33): error TS2339: Property 'notARealProperty' does not exist on type 'BigGreeter'.
 file.tsx(35,26): error TS2339: Property 'propertyNotOnHtmlDivElement' does not exist on type 'HTMLDivElement'.
@@ -26,8 +25,7 @@ file.tsx(35,26): error TS2339: Property 'propertyNotOnHtmlDivElement' does not e
     // Error - not allowed to specify 'ref' on SFCs
     let c = <Greet ref="myRef" />;
                    ~~~
-!!! error TS2322: Type '{ ref: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-!!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+!!! error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     
     
     // OK - ref is valid for classes

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
@@ -1,7 +1,6 @@
 file.tsx(9,15): error TS2769: No overload matches this call.
   Overload 1 of 3, '(): Element', gave the following error.
-    Type '{ a: number; }' is not assignable to type 'IntrinsicAttributes'.
-      Property 'a' does not exist on type 'IntrinsicAttributes'.
+    Property 'a' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 3, '(attr: { b: unknown; a: string; "ignore-prop": boolean; }): Element', gave the following error.
     Type 'number' is not assignable to type 'string'.
   Overload 3 of 3, '(attr: { b: unknown; a: number; }): Element', gave the following error.
@@ -30,8 +29,7 @@ file.tsx(10,15): error TS2769: No overload matches this call.
                   ~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(): Element', gave the following error.
-!!! error TS2769:     Type '{ a: number; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2769:       Property 'a' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2769:     Property 'a' does not exist on type 'IntrinsicAttributes'.
 !!! error TS2769:   Overload 2 of 3, '(attr: { b: unknown; a: string; "ignore-prop": boolean; }): Element', gave the following error.
 !!! error TS2769:     Type 'number' is not assignable to type 'string'.
 !!! error TS2769:   Overload 3 of 3, '(attr: { b: unknown; a: number; }): Element', gave the following error.

--- a/tests/baselines/reference/tsxUnionElementType4.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType4.errors.txt
@@ -1,8 +1,6 @@
 file.tsx(32,17): error TS2322: Type 'boolean' is not assignable to type 'never'.
-file.tsx(33,21): error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-  Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-file.tsx(34,22): error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
-  Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
+file.tsx(33,21): error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+file.tsx(34,22): error TS2339: Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
 
 
 ==== file.tsx (3 errors) ====
@@ -43,10 +41,8 @@ file.tsx(34,22): error TS2322: Type '{ prop: true; }' is not assignable to type 
 !!! related TS6500 file.tsx:3:36: The expected type comes from property 'x' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC1 | RC2> & { x: number; } & { children?: ReactNode; } & { x: string; } & { children?: ReactNode; }'
     let b = <PartRCComp x={10} />
                         ~
-!!! error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+!!! error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
     let c = <EmptyRCComp prop />;
                          ~~~~
-!!! error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
+!!! error TS2339: Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
     

--- a/tests/baselines/reference/tsxUnionElementType6.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType6.errors.txt
@@ -1,5 +1,4 @@
-file.tsx(18,23): error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'x' does not exist on type 'IntrinsicAttributes'.
+file.tsx(18,23): error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes'.
 file.tsx(19,27): error TS2322: Type 'string' is not assignable to type 'boolean'.
 file.tsx(20,10): error TS2741: Property 'x' is missing in type '{}' but required in type '{ x: boolean; }'.
 file.tsx(21,10): error TS2741: Property 'x' is missing in type '{ "data-prop": true; }' but required in type '{ x: boolean; }'.
@@ -25,8 +24,7 @@ file.tsx(21,10): error TS2741: Property 'x' is missing in type '{ "data-prop": t
     // Error
     let a = <EmptySFCComp x />;
                           ~
-!!! error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'x' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes'.
     let b = <SFC2AndEmptyComp x="hi" />;
                               ~
 !!! error TS2322: Type 'string' is not assignable to type 'boolean'.


### PR DESCRIPTION
This is just a small extension of https://github.com/microsoft/TypeScript/pull/55152 since that PR didn't touch the JSX-related codepath. cc @RyanCavanaugh 
