### PR TITLE
Do not remove binding alias in function declarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6225,16 +6225,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
     function hasVisibleDeclarations(symbol: Symbol, shouldComputeAliasToMakeVisible: boolean): SymbolVisibilityResult | undefined {
         let aliasesToMakeVisible: LateVisibilityPaintedStatement[] | undefined;
-        let bindingElementToMakeVisible: BindingElement | undefined;
         if (!every(filter(symbol.declarations, d => d.kind !== SyntaxKind.Identifier), getIsDeclarationVisible)) {
             return undefined;
         }
-        return { accessibility: SymbolAccessibility.Accessible, aliasesToMakeVisible, bindingElementToMakeVisible };
+        return { accessibility: SymbolAccessibility.Accessible, aliasesToMakeVisible };
 
         function getIsDeclarationVisible(declaration: Declaration) {
-            if (isBindingElement(declaration) && findAncestor(declaration, isParameter)) {
-                bindingElementToMakeVisible = declaration;
-            }
             if (!isDeclarationVisible(declaration)) {
                 // Mark the unexported alias as visible if its parent is visible
                 // because these kind of aliases can be used to name types in declaration file

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -46,12 +46,10 @@ import {
     factory,
     FileReference,
     filter,
-    findAncestor,
     flatMap,
     flatten,
     forEach,
     FunctionDeclaration,
-    FunctionExpression,
     FunctionTypeNode,
     GeneratedIdentifierFlags,
     GetAccessorDeclaration,
@@ -65,7 +63,6 @@ import {
     getLineAndCharacterOfPosition,
     getNameOfDeclaration,
     getNormalizedAbsolutePath,
-    getOriginalNode,
     getOriginalNodeId,
     getOutputPathsFor,
     getParseTreeNode,
@@ -115,8 +112,6 @@ import {
     isFunctionDeclaration,
     isFunctionLike,
     isGlobalScopeAugmentation,
-    isIdentifier,
-    isIdentifierANonContextualKeyword,
     isIdentifierText,
     isImportDeclaration,
     isImportEqualsDeclaration,
@@ -132,7 +127,6 @@ import {
     isModifier,
     isModuleDeclaration,
     isOmittedExpression,
-    isParameter,
     isPrivateIdentifier,
     isPropertySignature,
     isSemicolonClassElement,
@@ -154,7 +148,6 @@ import {
     isVarAwaitUsing,
     isVariableDeclaration,
     isVarUsing,
-    JSDocFunctionType,
     LateBoundDeclaration,
     LateVisibilityPaintedStatement,
     length,
@@ -185,7 +178,6 @@ import {
     pathContainsNodeModules,
     pathIsRelative,
     PropertyDeclaration,
-    PropertyName,
     PropertySignature,
     pushIfUnique,
     removeAllComments,
@@ -197,7 +189,6 @@ import {
     setOriginalNode,
     setParent,
     setTextRange,
-    SignatureDeclaration,
     some,
     SourceFile,
     startsWith,
@@ -268,7 +259,6 @@ export function transformDeclarations(context: TransformationContext) {
     let lateStatementReplacementMap: Map<NodeId, VisitResult<LateVisibilityPaintedStatement | ExportAssignment | undefined>>;
     let suppressNewDiagnosticContexts: boolean;
     let exportedModulesFromDeclarationEmit: Symbol[] | undefined;
-    const usedBindingElementAliases = new Map<Node, Map<Node, BindingName>>();
 
     const { factory } = context;
     const host = context.getEmitHost();
@@ -344,18 +334,6 @@ export function transformDeclarations(context: TransformationContext) {
                     }
                 }
             }
-            if (symbolAccessibilityResult.bindingElementToMakeVisible) {
-                const bindingElement = symbolAccessibilityResult.bindingElementToMakeVisible;
-                const parameter = findAncestor(bindingElement, isParameter);
-                Debug.assert(parameter !== undefined);
-                const parent = getOriginalNode(parameter.parent);
-                let aliases = usedBindingElementAliases.get(parent);
-                if (!aliases) {
-                    usedBindingElementAliases.set(parent, aliases = new Map());
-                }
-                aliases.set(getOriginalNode(bindingElement), bindingElement.name);
-            }
-
             // TODO: Do all these accessibility checks inside/after the first pass in the checker when declarations are enabled, if possible
         }
         else {
@@ -676,7 +654,7 @@ export function transformDeclarations(context: TransformationContext) {
         return ret;
     }
 
-    function filterBindingPatternInitializersAndRenamings(name: BindingName) {
+    function filterBindingPatternInitializers(name: BindingName) {
         if (name.kind === SyntaxKind.Identifier) {
             return name;
         }
@@ -698,189 +676,13 @@ export function transformDeclarations(context: TransformationContext) {
                 checkEntityNameVisibility(elem.propertyName.expression, enclosingDeclaration);
             }
 
-            if (elem.propertyName && isIdentifier(elem.propertyName) && isIdentifier(elem.name) && !isIdentifierANonContextualKeyword(elem.propertyName)) {
-                // Remove rename. We will add it back if it used.
-                return factory.updateBindingElement(
-                    elem,
-                    elem.dotDotDotToken,
-                    /*propertyName*/ undefined,
-                    elem.propertyName,
-                    shouldPrintWithInitializer(elem) ? elem.initializer : undefined,
-                );
-            }
-
             return factory.updateBindingElement(
                 elem,
                 elem.dotDotDotToken,
                 elem.propertyName,
-                filterBindingPatternInitializersAndRenamings(elem.name),
+                filterBindingPatternInitializers(elem.name),
                 shouldPrintWithInitializer(elem) ? elem.initializer : undefined,
             );
-        }
-    }
-    type SignatureDeclarationWithUsableBindingAliases = Exclude<SignatureDeclaration, JSDocFunctionType | FunctionExpression | IndexSignatureDeclaration>;
-    function ensureBindingAliasesInParameterList<T extends SignatureDeclarationWithUsableBindingAliases>(input: T, updatedNode: T): T;
-    function ensureBindingAliasesInParameterList(input: SignatureDeclarationWithUsableBindingAliases, updatedNode: SignatureDeclarationWithUsableBindingAliases) {
-        const original = getOriginalNode(input);
-        const params = updatedNode.parameters;
-        const aliases = usedBindingElementAliases.get(original);
-        if (!aliases) {
-            return updatedNode;
-        }
-        usedBindingElementAliases.delete(original);
-        const newParams = map(params, addUsedBindingPatternsToParameter);
-        const newParamsNodeArray = factory.createNodeArray(newParams, params.hasTrailingComma);
-        switch (updatedNode.kind) {
-            case SyntaxKind.MethodDeclaration:
-                return factory.updateMethodDeclaration(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    updatedNode.asteriskToken,
-                    updatedNode.name,
-                    updatedNode.questionToken,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                    updatedNode.body,
-                );
-            case SyntaxKind.Constructor:
-                return factory.updateConstructorDeclaration(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    newParamsNodeArray,
-                    updatedNode.body,
-                );
-            case SyntaxKind.GetAccessor:
-                return factory.updateGetAccessorDeclaration(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    updatedNode.name,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                    updatedNode.body,
-                );
-            case SyntaxKind.SetAccessor:
-                return factory.updateSetAccessorDeclaration(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    updatedNode.name,
-                    newParamsNodeArray,
-                    updatedNode.body,
-                );
-            case SyntaxKind.ArrowFunction:
-                return factory.updateArrowFunction(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                    updatedNode.equalsGreaterThanToken,
-                    updatedNode.body,
-                );
-            case SyntaxKind.FunctionDeclaration:
-                return factory.updateFunctionDeclaration(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    updatedNode.asteriskToken,
-                    updatedNode.name,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                    updatedNode.body,
-                );
-            case SyntaxKind.CallSignature:
-                return factory.updateCallSignature(
-                    updatedNode,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                );
-            case SyntaxKind.MethodSignature:
-                return factory.updateMethodSignature(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    updatedNode.name,
-                    updatedNode.questionToken,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                );
-
-            case SyntaxKind.ConstructSignature:
-                return factory.updateConstructSignature(
-                    updatedNode,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                );
-            case SyntaxKind.FunctionType:
-                return factory.updateFunctionTypeNode(
-                    updatedNode,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                );
-            case SyntaxKind.ConstructorType:
-                return factory.updateConstructorTypeNode(
-                    updatedNode,
-                    updatedNode.modifiers,
-                    updatedNode.typeParameters,
-                    newParamsNodeArray,
-                    updatedNode.type,
-                );
-            default:
-                Debug.assertNever(updatedNode);
-        }
-
-        function addUsedBindingPatternsToParameter(p: ParameterDeclaration): ParameterDeclaration {
-            return factory.updateParameterDeclaration(
-                p,
-                p.modifiers,
-                p.dotDotDotToken,
-                addUsedBindingPatternAliases(p.name),
-                p.questionToken,
-                p.type,
-                p.initializer,
-            );
-        }
-        function addUsedBindingPatternAliases(name: BindingName) {
-            if (name.kind === SyntaxKind.Identifier) {
-                return name;
-            }
-            else {
-                if (name.kind === SyntaxKind.ArrayBindingPattern) {
-                    return factory.updateArrayBindingPattern(name, visitNodes(name.elements, visitBindingElement, isArrayBindingElement));
-                }
-                else {
-                    return factory.updateObjectBindingPattern(name, visitNodes(name.elements, visitBindingElement, isBindingElement));
-                }
-            }
-
-            function visitBindingElement<T extends Node>(elem: T): T;
-            function visitBindingElement(elem: ArrayBindingElement): ArrayBindingElement {
-                if (elem.kind === SyntaxKind.OmittedExpression) {
-                    return elem;
-                }
-                const usedAlias = aliases!.get(getOriginalNode(elem));
-                // If alias is used and property name was removed by filterBindingPatternInitializersAndRenamings
-                // The alias can be preserved if it is a non contextual keyword.
-                if (usedAlias && !elem.propertyName) {
-                    return factory.updateBindingElement(
-                        elem,
-                        elem.dotDotDotToken,
-                        elem.name as PropertyName,
-                        usedAlias,
-                        elem.initializer,
-                    );
-                }
-                return factory.updateBindingElement(
-                    elem,
-                    elem.dotDotDotToken,
-                    elem.propertyName,
-                    addUsedBindingPatternAliases(elem.name),
-                    elem.initializer,
-                );
-            }
         }
     }
 
@@ -894,7 +696,7 @@ export function transformDeclarations(context: TransformationContext) {
             p,
             maskModifiers(factory, p, modifierMask),
             p.dotDotDotToken,
-            filterBindingPatternInitializersAndRenamings(p.name),
+            filterBindingPatternInitializers(p.name),
             resolver.isOptionalParameter(p) ? (p.questionToken || factory.createToken(SyntaxKind.QuestionToken)) : undefined,
             ensureType(p, type || p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
             ensureNoInitializer(p),
@@ -1333,24 +1135,18 @@ export function transformDeclarations(context: TransformationContext) {
                     return cleanup(factory.updateTypeReferenceNode(node, node.typeName, node.typeArguments));
                 }
                 case SyntaxKind.ConstructSignature:
-                    return cleanup(ensureBindingAliasesInParameterList(
+                    return cleanup(factory.updateConstructSignature(
                         input,
-                        factory.updateConstructSignature(
-                            input,
-                            ensureTypeParams(input, input.typeParameters),
-                            updateParamsList(input, input.parameters),
-                            ensureType(input, input.type),
-                        ),
+                        ensureTypeParams(input, input.typeParameters),
+                        updateParamsList(input, input.parameters),
+                        ensureType(input, input.type),
                     ));
                 case SyntaxKind.Constructor: {
                     // A constructor declaration may not have a type annotation
-                    const ctor = ensureBindingAliasesInParameterList(
-                        input,
-                        factory.createConstructorDeclaration(
-                            /*modifiers*/ ensureModifiers(input),
-                            updateParamsList(input, input.parameters, ModifierFlags.None),
-                            /*body*/ undefined,
-                        ),
+                    const ctor = factory.createConstructorDeclaration(
+                        /*modifiers*/ ensureModifiers(input),
+                        updateParamsList(input, input.parameters, ModifierFlags.None),
+                        /*body*/ undefined,
                     );
                     return cleanup(ctor);
                 }
@@ -1358,18 +1154,15 @@ export function transformDeclarations(context: TransformationContext) {
                     if (isPrivateIdentifier(input.name)) {
                         return cleanup(/*returnValue*/ undefined);
                     }
-                    const sig = ensureBindingAliasesInParameterList(
-                        input,
-                        factory.createMethodDeclaration(
-                            ensureModifiers(input),
-                            /*asteriskToken*/ undefined,
-                            input.name,
-                            input.questionToken,
-                            ensureTypeParams(input, input.typeParameters),
-                            updateParamsList(input, input.parameters),
-                            ensureType(input, input.type),
-                            /*body*/ undefined,
-                        ),
+                    const sig = factory.createMethodDeclaration(
+                        ensureModifiers(input),
+                        /*asteriskToken*/ undefined,
+                        input.name,
+                        input.questionToken,
+                        ensureTypeParams(input, input.typeParameters),
+                        updateParamsList(input, input.parameters),
+                        ensureType(input, input.type),
+                        /*body*/ undefined,
                     );
                     return cleanup(sig);
                 }
@@ -1378,31 +1171,25 @@ export function transformDeclarations(context: TransformationContext) {
                         return cleanup(/*returnValue*/ undefined);
                     }
                     const accessorType = getTypeAnnotationFromAllAccessorDeclarations(input, resolver.getAllAccessorDeclarations(input));
-                    return cleanup(ensureBindingAliasesInParameterList(
+                    return cleanup(factory.updateGetAccessorDeclaration(
                         input,
-                        factory.updateGetAccessorDeclaration(
-                            input,
-                            ensureModifiers(input),
-                            input.name,
-                            updateAccessorParamsList(input, hasEffectiveModifier(input, ModifierFlags.Private)),
-                            ensureType(input, accessorType),
-                            /*body*/ undefined,
-                        ),
+                        ensureModifiers(input),
+                        input.name,
+                        updateAccessorParamsList(input, hasEffectiveModifier(input, ModifierFlags.Private)),
+                        ensureType(input, accessorType),
+                        /*body*/ undefined,
                     ));
                 }
                 case SyntaxKind.SetAccessor: {
                     if (isPrivateIdentifier(input.name)) {
                         return cleanup(/*returnValue*/ undefined);
                     }
-                    return cleanup(ensureBindingAliasesInParameterList(
+                    return cleanup(factory.updateSetAccessorDeclaration(
                         input,
-                        factory.updateSetAccessorDeclaration(
-                            input,
-                            ensureModifiers(input),
-                            input.name,
-                            updateAccessorParamsList(input, hasEffectiveModifier(input, ModifierFlags.Private)),
-                            /*body*/ undefined,
-                        ),
+                        ensureModifiers(input),
+                        input.name,
+                        updateAccessorParamsList(input, hasEffectiveModifier(input, ModifierFlags.Private)),
+                        /*body*/ undefined,
                     ));
                 }
                 case SyntaxKind.PropertyDeclaration:
@@ -1432,29 +1219,25 @@ export function transformDeclarations(context: TransformationContext) {
                     if (isPrivateIdentifier(input.name)) {
                         return cleanup(/*returnValue*/ undefined);
                     }
-                    return cleanup(ensureBindingAliasesInParameterList(
+                    return cleanup(factory.updateMethodSignature(
                         input,
-                        factory.updateMethodSignature(
-                            input,
-                            ensureModifiers(input),
-                            input.name,
-                            input.questionToken,
-                            ensureTypeParams(input, input.typeParameters),
-                            updateParamsList(input, input.parameters),
-                            ensureType(input, input.type),
-                        ),
+                        ensureModifiers(input),
+                        input.name,
+                        input.questionToken,
+                        ensureTypeParams(input, input.typeParameters),
+                        updateParamsList(input, input.parameters),
+                        ensureType(input, input.type),
                     ));
                 }
                 case SyntaxKind.CallSignature: {
-                    return cleanup(ensureBindingAliasesInParameterList(
-                        input,
+                    return cleanup(
                         factory.updateCallSignature(
                             input,
                             ensureTypeParams(input, input.typeParameters),
                             updateParamsList(input, input.parameters),
                             ensureType(input, input.type),
                         ),
-                    ));
+                    );
                 }
                 case SyntaxKind.IndexSignature: {
                     return cleanup(factory.updateIndexSignature(
@@ -1495,26 +1278,20 @@ export function transformDeclarations(context: TransformationContext) {
                     return cleanup(factory.updateConditionalTypeNode(input, checkType, extendsType, trueType, falseType));
                 }
                 case SyntaxKind.FunctionType: {
-                    return cleanup(ensureBindingAliasesInParameterList(
+                    return cleanup(factory.updateFunctionTypeNode(
                         input,
-                        factory.updateFunctionTypeNode(
-                            input,
-                            visitNodes(input.typeParameters, visitDeclarationSubtree, isTypeParameterDeclaration),
-                            updateParamsList(input, input.parameters),
-                            Debug.checkDefined(visitNode(input.type, visitDeclarationSubtree, isTypeNode)),
-                        ),
+                        visitNodes(input.typeParameters, visitDeclarationSubtree, isTypeParameterDeclaration),
+                        updateParamsList(input, input.parameters),
+                        Debug.checkDefined(visitNode(input.type, visitDeclarationSubtree, isTypeNode)),
                     ));
                 }
                 case SyntaxKind.ConstructorType: {
-                    return cleanup(ensureBindingAliasesInParameterList(
+                    return cleanup(factory.updateConstructorTypeNode(
                         input,
-                        factory.updateConstructorTypeNode(
-                            input,
-                            ensureModifiers(input),
-                            visitNodes(input.typeParameters, visitDeclarationSubtree, isTypeParameterDeclaration),
-                            updateParamsList(input, input.parameters),
-                            Debug.checkDefined(visitNode(input.type, visitDeclarationSubtree, isTypeNode)),
-                        ),
+                        ensureModifiers(input),
+                        visitNodes(input.typeParameters, visitDeclarationSubtree, isTypeParameterDeclaration),
+                        updateParamsList(input, input.parameters),
+                        Debug.checkDefined(visitNode(input.type, visitDeclarationSubtree, isTypeNode)),
                     ));
                 }
                 case SyntaxKind.ImportType: {
@@ -1722,18 +1499,15 @@ export function transformDeclarations(context: TransformationContext) {
             }
             case SyntaxKind.FunctionDeclaration: {
                 // Generators lose their generator-ness, excepting their return type
-                const clean = cleanup(ensureBindingAliasesInParameterList(
+                const clean = cleanup(factory.updateFunctionDeclaration(
                     input,
-                    factory.updateFunctionDeclaration(
-                        input,
-                        ensureModifiers(input),
-                        /*asteriskToken*/ undefined,
-                        input.name,
-                        ensureTypeParams(input, input.typeParameters),
-                        updateParamsList(input, input.parameters),
-                        ensureType(input, input.type),
-                        /*body*/ undefined,
-                    ),
+                    ensureModifiers(input),
+                    /*asteriskToken*/ undefined,
+                    input.name,
+                    ensureTypeParams(input, input.typeParameters),
+                    updateParamsList(input, input.parameters),
+                    ensureType(input, input.type),
+                    /*body*/ undefined,
                 ));
                 if (clean && resolver.isExpandoFunctionDeclaration(input) && shouldEmitFunctionProperties(input)) {
                     const props = resolver.getPropertiesOfContainerFunction(input);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5592,7 +5592,6 @@ export type LateVisibilityPaintedStatement =
 /** @internal */
 export interface SymbolVisibilityResult {
     accessibility: SymbolAccessibility;
-    bindingElementToMakeVisible?: BindingElement;
     aliasesToMakeVisible?: LateVisibilityPaintedStatement[]; // aliases that need to have this symbol visible
     errorSymbolName?: string; // Optional symbol name that results in error
     errorNode?: Node; // optional node that results in error

--- a/tests/baselines/reference/declarationEmitBindingPatternsFunctionExpr.js
+++ b/tests/baselines/reference/declarationEmitBindingPatternsFunctionExpr.js
@@ -1,0 +1,43 @@
+//// [tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts] ////
+
+//// [declarationEmitBindingPatternsFunctionExpr.ts]
+type Named = { name: string }
+// Tempting to remove alias if unused 
+let notReferenced = ({ name: alias }: Named) => { }
+
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+const duplicateIndetifiers = ({ name: alias, name: alias2 }: Named) => { }
+const duplicateIndetifiers2 = (name: string, { name: alias }: Named) => { }
+const duplicateIndetifiers3 = ({ name: alias }: Named, { name: alias2 }: Named) => { }
+
+let value = "";
+// 2.Can change in meaning for typeof value if we remove alias
+const shadowedVariable = ({ value: alias }: { value: string }): typeof value => value;
+
+//// [declarationEmitBindingPatternsFunctionExpr.js]
+// Tempting to remove alias if unused 
+let notReferenced = ({ name: alias }) => { };
+// Resons we can't remove aliases that are not used in the function signature: 
+// 1.Causes duplicate identifier if we remove alias
+const duplicateIndetifiers = ({ name: alias, name: alias2 }) => { };
+const duplicateIndetifiers2 = (name, { name: alias }) => { };
+const duplicateIndetifiers3 = ({ name: alias }, { name: alias2 }) => { };
+let value = "";
+// 2.Can change in meaning for typeof value if we remove alias
+const shadowedVariable = ({ value: alias }) => value;
+
+
+//// [declarationEmitBindingPatternsFunctionExpr.d.ts]
+type Named = {
+    name: string;
+};
+declare let notReferenced: ({ name: alias }: Named) => void;
+declare const duplicateIndetifiers: ({ name: alias, name: alias2 }: Named) => void;
+declare const duplicateIndetifiers2: (name: string, { name: alias }: Named) => void;
+declare const duplicateIndetifiers3: ({ name: alias }: Named, { name: alias2 }: Named) => void;
+declare let value: string;
+declare const shadowedVariable: ({ value: alias }: {
+    value: string;
+}) => typeof value;

--- a/tests/baselines/reference/declarationEmitBindingPatternsFunctionExpr.symbols
+++ b/tests/baselines/reference/declarationEmitBindingPatternsFunctionExpr.symbols
@@ -1,0 +1,53 @@
+//// [tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts] ////
+
+=== declarationEmitBindingPatternsFunctionExpr.ts ===
+type Named = { name: string }
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 0))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 14))
+
+// Tempting to remove alias if unused 
+let notReferenced = ({ name: alias }: Named) => { }
+>notReferenced : Symbol(notReferenced, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 2, 3))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 2, 22))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 0))
+
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+const duplicateIndetifiers = ({ name: alias, name: alias2 }: Named) => { }
+>duplicateIndetifiers : Symbol(duplicateIndetifiers, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 7, 5))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 7, 31))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 14))
+>alias2 : Symbol(alias2, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 7, 44))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 0))
+
+const duplicateIndetifiers2 = (name: string, { name: alias }: Named) => { }
+>duplicateIndetifiers2 : Symbol(duplicateIndetifiers2, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 8, 5))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 8, 31))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 8, 46))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 0))
+
+const duplicateIndetifiers3 = ({ name: alias }: Named, { name: alias2 }: Named) => { }
+>duplicateIndetifiers3 : Symbol(duplicateIndetifiers3, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 9, 5))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 9, 32))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 0))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 14))
+>alias2 : Symbol(alias2, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 9, 56))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 0, 0))
+
+let value = "";
+>value : Symbol(value, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 11, 3))
+
+// 2.Can change in meaning for typeof value if we remove alias
+const shadowedVariable = ({ value: alias }: { value: string }): typeof value => value;
+>shadowedVariable : Symbol(shadowedVariable, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 13, 5))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 13, 45))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 13, 27))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 13, 45))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 11, 3))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsFunctionExpr.ts, 11, 3))
+

--- a/tests/baselines/reference/declarationEmitBindingPatternsFunctionExpr.types
+++ b/tests/baselines/reference/declarationEmitBindingPatternsFunctionExpr.types
@@ -1,0 +1,54 @@
+//// [tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts] ////
+
+=== declarationEmitBindingPatternsFunctionExpr.ts ===
+type Named = { name: string }
+>Named : { name: string; }
+>name : string
+
+// Tempting to remove alias if unused 
+let notReferenced = ({ name: alias }: Named) => { }
+>notReferenced : ({ name: alias }: Named) => void
+>({ name: alias }: Named) => { } : ({ name: alias }: Named) => void
+>name : any
+>alias : string
+
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+const duplicateIndetifiers = ({ name: alias, name: alias2 }: Named) => { }
+>duplicateIndetifiers : ({ name: alias, name: alias2 }: Named) => void
+>({ name: alias, name: alias2 }: Named) => { } : ({ name: alias, name: alias2 }: Named) => void
+>name : any
+>alias : string
+>name : any
+>alias2 : string
+
+const duplicateIndetifiers2 = (name: string, { name: alias }: Named) => { }
+>duplicateIndetifiers2 : (name: string, { name: alias }: Named) => void
+>(name: string, { name: alias }: Named) => { } : (name: string, { name: alias }: Named) => void
+>name : string
+>name : any
+>alias : string
+
+const duplicateIndetifiers3 = ({ name: alias }: Named, { name: alias2 }: Named) => { }
+>duplicateIndetifiers3 : ({ name: alias }: Named, { name: alias2 }: Named) => void
+>({ name: alias }: Named, { name: alias2 }: Named) => { } : ({ name: alias }: Named, { name: alias2 }: Named) => void
+>name : any
+>alias : string
+>name : any
+>alias2 : string
+
+let value = "";
+>value : string
+>"" : ""
+
+// 2.Can change in meaning for typeof value if we remove alias
+const shadowedVariable = ({ value: alias }: { value: string }): typeof value => value;
+>shadowedVariable : ({ value: alias }: {    value: string;}) => typeof value
+>({ value: alias }: { value: string }): typeof value => value : ({ value: alias }: {    value: string;}) => typeof value
+>value : any
+>alias : string
+>value : string
+>value : string
+>value : string
+

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.errors.txt
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.errors.txt
@@ -1,13 +1,25 @@
-declarationEmitBindingPatternsUnused.ts(85,35): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
-declarationEmitBindingPatternsUnused.ts(89,41): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
-declarationEmitBindingPatternsUnused.ts(95,11): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
-declarationEmitBindingPatternsUnused.ts(96,15): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
-declarationEmitBindingPatternsUnused.ts(97,16): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
-declarationEmitBindingPatternsUnused.ts(98,12): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
+declarationEmitBindingPatternsUnused.ts(95,35): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
+declarationEmitBindingPatternsUnused.ts(99,41): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
+declarationEmitBindingPatternsUnused.ts(105,11): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
+declarationEmitBindingPatternsUnused.ts(106,15): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
+declarationEmitBindingPatternsUnused.ts(107,16): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
+declarationEmitBindingPatternsUnused.ts(108,12): error TS2842: 'alias' is an unused renaming of 'name'. Did you intend to use it as a type annotation?
 
 
 ==== declarationEmitBindingPatternsUnused.ts (6 errors) ====
     type Named = { name: string }
+    
+    // Resons we can't remove aliases that are not used in the function signature: 
+    
+    // 1.Causes duplicate identifier if we remove alias
+    function duplicateIndetifiers({ name: alias, name: alias2 }: Named) { }
+    function duplicateIndetifiers2(name: string, { name: alias }: Named) { }
+    function duplicateIndetifiers3({ name: alias }: Named, { name: alias2 }: Named) { }
+    
+    let value = "";
+    // 2.Can change in meaning for typeof value if we remove alias
+    function shadowedVariable({ value: alias }: { value: string }): typeof value { return value }
+    
     function notReferenced({ name: alias }: Named) {
     
     }
@@ -15,8 +27,6 @@ declarationEmitBindingPatternsUnused.ts(98,12): error TS2842: 'alias' is an unus
     }
     function notReferencedArrayAlias([a, b, { name: alias }]: Named[]) {
     }
-    
-    
     
     function referencedInCode({ name: alias }: Named) {
         return alias;

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.js
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.js
@@ -2,6 +2,18 @@
 
 //// [declarationEmitBindingPatternsUnused.ts]
 type Named = { name: string }
+
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+function duplicateIndetifiers({ name: alias, name: alias2 }: Named) { }
+function duplicateIndetifiers2(name: string, { name: alias }: Named) { }
+function duplicateIndetifiers3({ name: alias }: Named, { name: alias2 }: Named) { }
+
+let value = "";
+// 2.Can change in meaning for typeof value if we remove alias
+function shadowedVariable({ value: alias }: { value: string }): typeof value { return value }
+
 function notReferenced({ name: alias }: Named) {
 
 }
@@ -9,8 +21,6 @@ function notReferencedNestedAlias({ p: { name: alias } }: { p: Named }) {
 }
 function notReferencedArrayAlias([a, b, { name: alias }]: Named[]) {
 }
-
-
 
 function referencedInCode({ name: alias }: Named) {
     return alias;
@@ -114,6 +124,14 @@ interface ReferencedInSignartureInterface {
 }
 
 //// [declarationEmitBindingPatternsUnused.js]
+// Resons we can't remove aliases that are not used in the function signature: 
+// 1.Causes duplicate identifier if we remove alias
+function duplicateIndetifiers({ name: alias, name: alias2 }) { }
+function duplicateIndetifiers2(name, { name: alias }) { }
+function duplicateIndetifiers3({ name: alias }, { name: alias2 }) { }
+let value = "";
+// 2.Can change in meaning for typeof value if we remove alias
+function shadowedVariable({ value: alias }) { return value; }
 function notReferenced({ name: alias }) {
 }
 function notReferencedNestedAlias({ p: { name: alias } }) {
@@ -191,12 +209,19 @@ let referencedInSignartureParamTypeCtorType;
 type Named = {
     name: string;
 };
-declare function notReferenced({ name }: Named): void;
-declare function notReferencedNestedAlias({ p: { name } }: {
+declare function duplicateIndetifiers({ name: alias, name: alias2 }: Named): void;
+declare function duplicateIndetifiers2(name: string, { name: alias }: Named): void;
+declare function duplicateIndetifiers3({ name: alias }: Named, { name: alias2 }: Named): void;
+declare let value: string;
+declare function shadowedVariable({ value: alias }: {
+    value: string;
+}): typeof value;
+declare function notReferenced({ name: alias }: Named): void;
+declare function notReferencedNestedAlias({ p: { name: alias } }: {
     p: Named;
 }): void;
-declare function notReferencedArrayAlias([a, b, { name }]: Named[]): void;
-declare function referencedInCode({ name }: Named): string;
+declare function notReferencedArrayAlias([a, b, { name: alias }]: Named[]): void;
+declare function referencedInCode({ name: alias }: Named): string;
 declare function referencedInSignarture({ name: alias }: Named): typeof alias;
 declare function referencedInSignartureKeyword({ function: alias }: {
     function: string;
@@ -210,14 +235,14 @@ declare function referencedNestedAlias({ p: { name: alias } }: {
 }): typeof alias;
 declare function referencedArrayAlias([a, b, { name: alias }]: Named[]): typeof alias;
 declare class NotReferencedClass {
-    constructor({ name }: Named);
-    set x({ name }: Named);
-    m({ name }: Named): void;
+    constructor({ name: alias }: Named);
+    set x({ name: alias }: Named);
+    m({ name: alias }: Named): void;
 }
 declare class ReferencedInCodeClas {
-    constructor({ name }: Named);
-    set x({ name }: Named);
-    m({ name }: Named): void;
+    constructor({ name: alias }: Named);
+    set x({ name: alias }: Named);
+    m({ name: alias }: Named): void;
 }
 declare class ReferencedInSignartureClass {
     constructor({ name: alias }: Named, p: typeof alias);
@@ -228,17 +253,17 @@ declare class ReferencedInSignartureClass {
     mRerturnTypeNested({ name: alias }: Named): NonNullable<typeof alias>;
     mParameter({ name: alias }: Named, p: typeof alias): any;
 }
-declare let notReferencedFnType: ({ name }: Named) => void;
+declare let notReferencedFnType: ({ name: alias }: Named) => void;
 declare let referencedInSignartureReturnTypeFnType: ({ name: alias }: Named) => typeof alias;
 declare let referencedInSignartureParamTypeFnType: ({ name: alias }: Named, p: typeof alias) => void;
-declare let notReferencedCtorType: new ({ name }: Named) => void;
+declare let notReferencedCtorType: new ({ name: alias }: Named) => void;
 declare let referencedInSignartureReturnTypeCtorType: new ({ name: alias }: Named) => typeof alias;
 declare let referencedInSignartureParamTypeCtorType: new ({ name: alias }: Named, p: typeof alias) => void;
 interface NotReferencedInterface {
-    ({ name }: Named): void;
-    new ({ name }: Named): void;
-    set x({ name }: Named);
-    m({ name }: Named): any;
+    ({ name: alias }: Named): void;
+    new ({ name: alias }: Named): void;
+    set x({ name: alias }: Named);
+    m({ name: alias }: Named): any;
 }
 interface ReferencedInSignartureInterface {
     ({ name: alias }: Named, p: typeof alias): void;

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.symbols
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.symbols
@@ -5,374 +5,411 @@ type Named = { name: string }
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
 
-function notReferenced({ name: alias }: Named) {
->notReferenced : Symbol(notReferenced, Decl(declarationEmitBindingPatternsUnused.ts, 0, 29))
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+function duplicateIndetifiers({ name: alias, name: alias2 }: Named) { }
+>duplicateIndetifiers : Symbol(duplicateIndetifiers, Decl(declarationEmitBindingPatternsUnused.ts, 0, 29))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 1, 24))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 5, 31))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
+>alias2 : Symbol(alias2, Decl(declarationEmitBindingPatternsUnused.ts, 5, 44))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
+
+function duplicateIndetifiers2(name: string, { name: alias }: Named) { }
+>duplicateIndetifiers2 : Symbol(duplicateIndetifiers2, Decl(declarationEmitBindingPatternsUnused.ts, 5, 71))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 6, 31))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 6, 46))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
+
+function duplicateIndetifiers3({ name: alias }: Named, { name: alias2 }: Named) { }
+>duplicateIndetifiers3 : Symbol(duplicateIndetifiers3, Decl(declarationEmitBindingPatternsUnused.ts, 6, 72))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 7, 32))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
+>alias2 : Symbol(alias2, Decl(declarationEmitBindingPatternsUnused.ts, 7, 56))
+>Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
+
+let value = "";
+>value : Symbol(value, Decl(declarationEmitBindingPatternsUnused.ts, 9, 3))
+
+// 2.Can change in meaning for typeof value if we remove alias
+function shadowedVariable({ value: alias }: { value: string }): typeof value { return value }
+>shadowedVariable : Symbol(shadowedVariable, Decl(declarationEmitBindingPatternsUnused.ts, 9, 15))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsUnused.ts, 11, 45))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 11, 27))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsUnused.ts, 11, 45))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsUnused.ts, 9, 3))
+>value : Symbol(value, Decl(declarationEmitBindingPatternsUnused.ts, 9, 3))
+
+function notReferenced({ name: alias }: Named) {
+>notReferenced : Symbol(notReferenced, Decl(declarationEmitBindingPatternsUnused.ts, 11, 93))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 13, 24))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
 }
 function notReferencedNestedAlias({ p: { name: alias } }: { p: Named }) {
->notReferencedNestedAlias : Symbol(notReferencedNestedAlias, Decl(declarationEmitBindingPatternsUnused.ts, 3, 1))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 4, 59))
+>notReferencedNestedAlias : Symbol(notReferencedNestedAlias, Decl(declarationEmitBindingPatternsUnused.ts, 15, 1))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 16, 59))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 4, 40))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 4, 59))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 16, 40))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 16, 59))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 }
 function notReferencedArrayAlias([a, b, { name: alias }]: Named[]) {
->notReferencedArrayAlias : Symbol(notReferencedArrayAlias, Decl(declarationEmitBindingPatternsUnused.ts, 5, 1))
->a : Symbol(a, Decl(declarationEmitBindingPatternsUnused.ts, 6, 34))
->b : Symbol(b, Decl(declarationEmitBindingPatternsUnused.ts, 6, 36))
+>notReferencedArrayAlias : Symbol(notReferencedArrayAlias, Decl(declarationEmitBindingPatternsUnused.ts, 17, 1))
+>a : Symbol(a, Decl(declarationEmitBindingPatternsUnused.ts, 18, 34))
+>b : Symbol(b, Decl(declarationEmitBindingPatternsUnused.ts, 18, 36))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 6, 41))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 18, 41))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 }
 
-
-
 function referencedInCode({ name: alias }: Named) {
->referencedInCode : Symbol(referencedInCode, Decl(declarationEmitBindingPatternsUnused.ts, 7, 1))
+>referencedInCode : Symbol(referencedInCode, Decl(declarationEmitBindingPatternsUnused.ts, 19, 1))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 11, 27))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 21, 27))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
     return alias;
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 11, 27))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 21, 27))
 }
 
 function referencedInSignarture({ name: alias }: Named): typeof alias {
->referencedInSignarture : Symbol(referencedInSignarture, Decl(declarationEmitBindingPatternsUnused.ts, 13, 1))
+>referencedInSignarture : Symbol(referencedInSignarture, Decl(declarationEmitBindingPatternsUnused.ts, 23, 1))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 15, 33))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 25, 33))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 15, 33))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 25, 33))
 
     return alias;
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 15, 33))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 25, 33))
 }
 
 function referencedInSignartureKeyword({ function: alias }: { function: string }): typeof alias {
->referencedInSignartureKeyword : Symbol(referencedInSignartureKeyword, Decl(declarationEmitBindingPatternsUnused.ts, 17, 1))
->function : Symbol(function, Decl(declarationEmitBindingPatternsUnused.ts, 19, 61))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 19, 40))
->function : Symbol(function, Decl(declarationEmitBindingPatternsUnused.ts, 19, 61))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 19, 40))
+>referencedInSignartureKeyword : Symbol(referencedInSignartureKeyword, Decl(declarationEmitBindingPatternsUnused.ts, 27, 1))
+>function : Symbol(function, Decl(declarationEmitBindingPatternsUnused.ts, 29, 61))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 29, 40))
+>function : Symbol(function, Decl(declarationEmitBindingPatternsUnused.ts, 29, 61))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 29, 40))
 
     return null!;
 }
 
 function referencedInInferredType({ name: alias }: Named) {
->referencedInInferredType : Symbol(referencedInInferredType, Decl(declarationEmitBindingPatternsUnused.ts, 21, 1))
+>referencedInInferredType : Symbol(referencedInInferredType, Decl(declarationEmitBindingPatternsUnused.ts, 31, 1))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 23, 35))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 33, 35))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
     type Named2 = { name: typeof alias }
->Named2 : Symbol(Named2, Decl(declarationEmitBindingPatternsUnused.ts, 23, 59))
->name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 24, 19))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 23, 35))
+>Named2 : Symbol(Named2, Decl(declarationEmitBindingPatternsUnused.ts, 33, 59))
+>name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 34, 19))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 33, 35))
 
     return null! as Named2
->Named2 : Symbol(Named2, Decl(declarationEmitBindingPatternsUnused.ts, 23, 59))
+>Named2 : Symbol(Named2, Decl(declarationEmitBindingPatternsUnused.ts, 33, 59))
 }
 
 function referencedInNestedFunction({ name: alias }: Named) {
->referencedInNestedFunction : Symbol(referencedInNestedFunction, Decl(declarationEmitBindingPatternsUnused.ts, 26, 1))
+>referencedInNestedFunction : Symbol(referencedInNestedFunction, Decl(declarationEmitBindingPatternsUnused.ts, 36, 1))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 28, 37))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 38, 37))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
     return function(p: typeof alias) {
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 29, 20))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 28, 37))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 39, 20))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 38, 37))
 
     }
 }
 
 function referencedNestedAlias({ p: { name: alias } }: { p: Named }): typeof alias {
->referencedNestedAlias : Symbol(referencedNestedAlias, Decl(declarationEmitBindingPatternsUnused.ts, 32, 1))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 34, 56))
+>referencedNestedAlias : Symbol(referencedNestedAlias, Decl(declarationEmitBindingPatternsUnused.ts, 42, 1))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 44, 56))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 34, 37))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 34, 56))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 44, 37))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 44, 56))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 34, 37))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 44, 37))
 
 	return alias;
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 34, 37))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 44, 37))
 }
 
 function referencedArrayAlias([a, b, { name: alias }]: Named[]): typeof alias {
->referencedArrayAlias : Symbol(referencedArrayAlias, Decl(declarationEmitBindingPatternsUnused.ts, 36, 1))
->a : Symbol(a, Decl(declarationEmitBindingPatternsUnused.ts, 38, 31))
->b : Symbol(b, Decl(declarationEmitBindingPatternsUnused.ts, 38, 33))
+>referencedArrayAlias : Symbol(referencedArrayAlias, Decl(declarationEmitBindingPatternsUnused.ts, 46, 1))
+>a : Symbol(a, Decl(declarationEmitBindingPatternsUnused.ts, 48, 31))
+>b : Symbol(b, Decl(declarationEmitBindingPatternsUnused.ts, 48, 33))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 38, 38))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 48, 38))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 38, 38))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 48, 38))
 
 	return alias;
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 38, 38))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 48, 38))
 }
 
 
 class NotReferencedClass {
->NotReferencedClass : Symbol(NotReferencedClass, Decl(declarationEmitBindingPatternsUnused.ts, 40, 1))
+>NotReferencedClass : Symbol(NotReferencedClass, Decl(declarationEmitBindingPatternsUnused.ts, 50, 1))
 
 	constructor({ name: alias }: Named) {
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 44, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 54, 14))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 	}
 	set x({ name: alias }: Named) {
->x : Symbol(NotReferencedClass.x, Decl(declarationEmitBindingPatternsUnused.ts, 45, 2))
+>x : Symbol(NotReferencedClass.x, Decl(declarationEmitBindingPatternsUnused.ts, 55, 2))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 46, 8))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 56, 8))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
         console.log(alias);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 46, 8))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 56, 8))
     }
 	m({ name: alias }: Named) {
->m : Symbol(NotReferencedClass.m, Decl(declarationEmitBindingPatternsUnused.ts, 48, 5))
+>m : Symbol(NotReferencedClass.m, Decl(declarationEmitBindingPatternsUnused.ts, 58, 5))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 49, 4))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 59, 4))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
         console.log(alias);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 49, 4))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 59, 4))
     }
 }
 
 class ReferencedInCodeClas {
->ReferencedInCodeClas : Symbol(ReferencedInCodeClas, Decl(declarationEmitBindingPatternsUnused.ts, 52, 1))
+>ReferencedInCodeClas : Symbol(ReferencedInCodeClas, Decl(declarationEmitBindingPatternsUnused.ts, 62, 1))
 
 	constructor({ name: alias }: Named) {
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 55, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 65, 14))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
 		console.log(alias);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 55, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 65, 14))
 	}
 	set x({ name: alias }: Named) {
->x : Symbol(ReferencedInCodeClas.x, Decl(declarationEmitBindingPatternsUnused.ts, 57, 2))
+>x : Symbol(ReferencedInCodeClas.x, Decl(declarationEmitBindingPatternsUnused.ts, 67, 2))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 58, 8))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 68, 8))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
         console.log(alias);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 58, 8))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 68, 8))
     }
 	m({ name: alias }: Named) {
->m : Symbol(ReferencedInCodeClas.m, Decl(declarationEmitBindingPatternsUnused.ts, 60, 5))
+>m : Symbol(ReferencedInCodeClas.m, Decl(declarationEmitBindingPatternsUnused.ts, 70, 5))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 61, 4))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 71, 4))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
         console.log(alias);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 61, 4))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 71, 4))
     }
 }
 
 class ReferencedInSignartureClass {
->ReferencedInSignartureClass : Symbol(ReferencedInSignartureClass, Decl(declarationEmitBindingPatternsUnused.ts, 64, 1))
+>ReferencedInSignartureClass : Symbol(ReferencedInSignartureClass, Decl(declarationEmitBindingPatternsUnused.ts, 74, 1))
 
 	constructor({ name: alias }: Named, p: typeof alias) {
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 67, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 77, 14))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 67, 36))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 67, 14))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 77, 36))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 77, 14))
 
 		console.log(alias);
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 67, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 77, 14))
 	}
 	set x({ name: alias }: Named & { o: typeof alias }) {
->x : Symbol(ReferencedInSignartureClass.x, Decl(declarationEmitBindingPatternsUnused.ts, 69, 2))
+>x : Symbol(ReferencedInSignartureClass.x, Decl(declarationEmitBindingPatternsUnused.ts, 79, 2))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 70, 8))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 80, 8))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->o : Symbol(o, Decl(declarationEmitBindingPatternsUnused.ts, 70, 33))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 70, 8))
+>o : Symbol(o, Decl(declarationEmitBindingPatternsUnused.ts, 80, 33))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 80, 8))
         
     }
 	mReturnType({ name: alias }: Named): typeof alias {
->mReturnType : Symbol(ReferencedInSignartureClass.mReturnType, Decl(declarationEmitBindingPatternsUnused.ts, 72, 5))
+>mReturnType : Symbol(ReferencedInSignartureClass.mReturnType, Decl(declarationEmitBindingPatternsUnused.ts, 82, 5))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 73, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 83, 14))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 73, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 83, 14))
 
         return null!
     }
 	mRerturnTypeNested({ name: alias }: Named): NonNullable<typeof alias> {
->mRerturnTypeNested : Symbol(ReferencedInSignartureClass.mRerturnTypeNested, Decl(declarationEmitBindingPatternsUnused.ts, 75, 5))
+>mRerturnTypeNested : Symbol(ReferencedInSignartureClass.mRerturnTypeNested, Decl(declarationEmitBindingPatternsUnused.ts, 85, 5))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 76, 21))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 86, 21))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 >NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 76, 21))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 86, 21))
 
         return null!
     }
     mParameter({ name: alias }: Named, p: typeof alias) {
->mParameter : Symbol(ReferencedInSignartureClass.mParameter, Decl(declarationEmitBindingPatternsUnused.ts, 78, 5))
+>mParameter : Symbol(ReferencedInSignartureClass.mParameter, Decl(declarationEmitBindingPatternsUnused.ts, 88, 5))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 79, 16))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 89, 16))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 79, 38))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 79, 16))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 89, 38))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 89, 16))
 
         return null!
     }
 }
 
 let notReferencedFnType: ({ name: alias }: Named) => void;
->notReferencedFnType : Symbol(notReferencedFnType, Decl(declarationEmitBindingPatternsUnused.ts, 84, 3))
+>notReferencedFnType : Symbol(notReferencedFnType, Decl(declarationEmitBindingPatternsUnused.ts, 94, 3))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 84, 27))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 94, 27))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
 let referencedInSignartureReturnTypeFnType: ({ name: alias }: Named) => typeof alias;
->referencedInSignartureReturnTypeFnType : Symbol(referencedInSignartureReturnTypeFnType, Decl(declarationEmitBindingPatternsUnused.ts, 85, 3))
+>referencedInSignartureReturnTypeFnType : Symbol(referencedInSignartureReturnTypeFnType, Decl(declarationEmitBindingPatternsUnused.ts, 95, 3))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 85, 46))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 95, 46))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 85, 46))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 95, 46))
 
 let referencedInSignartureParamTypeFnType: ({ name: alias }: Named, p: typeof alias) => void;
->referencedInSignartureParamTypeFnType : Symbol(referencedInSignartureParamTypeFnType, Decl(declarationEmitBindingPatternsUnused.ts, 86, 3))
+>referencedInSignartureParamTypeFnType : Symbol(referencedInSignartureParamTypeFnType, Decl(declarationEmitBindingPatternsUnused.ts, 96, 3))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 86, 45))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 96, 45))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 86, 67))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 86, 45))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 96, 67))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 96, 45))
 
 let notReferencedCtorType: new ({ name: alias }: Named) => void;
->notReferencedCtorType : Symbol(notReferencedCtorType, Decl(declarationEmitBindingPatternsUnused.ts, 88, 3))
+>notReferencedCtorType : Symbol(notReferencedCtorType, Decl(declarationEmitBindingPatternsUnused.ts, 98, 3))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 88, 33))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 98, 33))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
 let referencedInSignartureReturnTypeCtorType: new ({ name: alias }: Named) => typeof alias;
->referencedInSignartureReturnTypeCtorType : Symbol(referencedInSignartureReturnTypeCtorType, Decl(declarationEmitBindingPatternsUnused.ts, 89, 3))
+>referencedInSignartureReturnTypeCtorType : Symbol(referencedInSignartureReturnTypeCtorType, Decl(declarationEmitBindingPatternsUnused.ts, 99, 3))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 89, 52))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 99, 52))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 89, 52))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 99, 52))
 
 let referencedInSignartureParamTypeCtorType: new  ({ name: alias }: Named, p: typeof alias) => void;
->referencedInSignartureParamTypeCtorType : Symbol(referencedInSignartureParamTypeCtorType, Decl(declarationEmitBindingPatternsUnused.ts, 90, 3))
+>referencedInSignartureParamTypeCtorType : Symbol(referencedInSignartureParamTypeCtorType, Decl(declarationEmitBindingPatternsUnused.ts, 100, 3))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 90, 52))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 100, 52))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 90, 74))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 90, 52))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 100, 74))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 100, 52))
 
 
 interface NotReferencedInterface {
->NotReferencedInterface : Symbol(NotReferencedInterface, Decl(declarationEmitBindingPatternsUnused.ts, 90, 100))
+>NotReferencedInterface : Symbol(NotReferencedInterface, Decl(declarationEmitBindingPatternsUnused.ts, 100, 100))
 
 	({ name: alias }: Named): void
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 94, 3))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 104, 3))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
 	new ({ name: alias }: Named): void
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 95, 7))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 105, 7))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
 	set x({ name: alias }: Named);
->x : Symbol(NotReferencedInterface.x, Decl(declarationEmitBindingPatternsUnused.ts, 95, 35))
+>x : Symbol(NotReferencedInterface.x, Decl(declarationEmitBindingPatternsUnused.ts, 105, 35))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 96, 8))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 106, 8))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 
 	m({ name: alias }: Named);
->m : Symbol(NotReferencedInterface.m, Decl(declarationEmitBindingPatternsUnused.ts, 96, 31))
+>m : Symbol(NotReferencedInterface.m, Decl(declarationEmitBindingPatternsUnused.ts, 106, 31))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 97, 4))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 107, 4))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 }
 
 interface ReferencedInSignartureInterface {
->ReferencedInSignartureInterface : Symbol(ReferencedInSignartureInterface, Decl(declarationEmitBindingPatternsUnused.ts, 98, 1))
+>ReferencedInSignartureInterface : Symbol(ReferencedInSignartureInterface, Decl(declarationEmitBindingPatternsUnused.ts, 108, 1))
 
 	({ name: alias }: Named, p: typeof alias): void
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 101, 3))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 111, 3))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 101, 25))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 101, 3))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 111, 25))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 111, 3))
 
 	({ name: alias }: Named): typeof alias
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 102, 3))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 112, 3))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 102, 3))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 112, 3))
 	
 	new ({ name: alias }: Named, p: typeof alias): void
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 104, 7))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 114, 7))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 104, 29))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 104, 7))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 114, 29))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 114, 7))
 
 	new ({ name: alias }: Named): typeof alias
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 105, 7))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 115, 7))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 105, 7))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 115, 7))
 
 	set x({ name: alias }: Named & { o: typeof alias })
->x : Symbol(ReferencedInSignartureInterface.x, Decl(declarationEmitBindingPatternsUnused.ts, 105, 43))
+>x : Symbol(ReferencedInSignartureInterface.x, Decl(declarationEmitBindingPatternsUnused.ts, 115, 43))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 106, 8))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 116, 8))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->o : Symbol(o, Decl(declarationEmitBindingPatternsUnused.ts, 106, 33))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 106, 8))
+>o : Symbol(o, Decl(declarationEmitBindingPatternsUnused.ts, 116, 33))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 116, 8))
 
 	mReturnType({ name: alias }: Named): typeof alias;
->mReturnType : Symbol(ReferencedInSignartureInterface.mReturnType, Decl(declarationEmitBindingPatternsUnused.ts, 106, 52))
+>mReturnType : Symbol(ReferencedInSignartureInterface.mReturnType, Decl(declarationEmitBindingPatternsUnused.ts, 116, 52))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 107, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 117, 14))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 107, 14))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 117, 14))
 
 	mRerturnTypeNested({ name: alias }: Named): NonNullable<typeof alias>;
->mRerturnTypeNested : Symbol(ReferencedInSignartureInterface.mRerturnTypeNested, Decl(declarationEmitBindingPatternsUnused.ts, 107, 51))
+>mRerturnTypeNested : Symbol(ReferencedInSignartureInterface.mRerturnTypeNested, Decl(declarationEmitBindingPatternsUnused.ts, 117, 51))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 108, 21))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 118, 21))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
 >NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 108, 21))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 118, 21))
 
     mParameter({ name: alias }: Named, p: typeof alias);
->mParameter : Symbol(ReferencedInSignartureInterface.mParameter, Decl(declarationEmitBindingPatternsUnused.ts, 108, 71))
+>mParameter : Symbol(ReferencedInSignartureInterface.mParameter, Decl(declarationEmitBindingPatternsUnused.ts, 118, 71))
 >name : Symbol(name, Decl(declarationEmitBindingPatternsUnused.ts, 0, 14))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 109, 16))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 119, 16))
 >Named : Symbol(Named, Decl(declarationEmitBindingPatternsUnused.ts, 0, 0))
->p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 109, 38))
->alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 109, 16))
+>p : Symbol(p, Decl(declarationEmitBindingPatternsUnused.ts, 119, 38))
+>alias : Symbol(alias, Decl(declarationEmitBindingPatternsUnused.ts, 119, 16))
 }

--- a/tests/baselines/reference/declarationEmitBindingPatternsUnused.types
+++ b/tests/baselines/reference/declarationEmitBindingPatternsUnused.types
@@ -5,6 +5,42 @@ type Named = { name: string }
 >Named : { name: string; }
 >name : string
 
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+function duplicateIndetifiers({ name: alias, name: alias2 }: Named) { }
+>duplicateIndetifiers : ({ name: alias, name: alias2 }: Named) => void
+>name : any
+>alias : string
+>name : any
+>alias2 : string
+
+function duplicateIndetifiers2(name: string, { name: alias }: Named) { }
+>duplicateIndetifiers2 : (name: string, { name: alias }: Named) => void
+>name : string
+>name : any
+>alias : string
+
+function duplicateIndetifiers3({ name: alias }: Named, { name: alias2 }: Named) { }
+>duplicateIndetifiers3 : ({ name: alias }: Named, { name: alias2 }: Named) => void
+>name : any
+>alias : string
+>name : any
+>alias2 : string
+
+let value = "";
+>value : string
+>"" : ""
+
+// 2.Can change in meaning for typeof value if we remove alias
+function shadowedVariable({ value: alias }: { value: string }): typeof value { return value }
+>shadowedVariable : ({ value: alias }: {    value: string;}) => typeof value
+>value : any
+>alias : string
+>value : string
+>value : string
+>value : string
+
 function notReferenced({ name: alias }: Named) {
 >notReferenced : ({ name: alias }: Named) => void
 >name : any
@@ -25,8 +61,6 @@ function notReferencedArrayAlias([a, b, { name: alias }]: Named[]) {
 >name : any
 >alias : string
 }
-
-
 
 function referencedInCode({ name: alias }: Named) {
 >referencedInCode : ({ name: alias }: Named) => string

--- a/tests/baselines/reference/declarationEmitKeywordDestructuring.js
+++ b/tests/baselines/reference/declarationEmitKeywordDestructuring.js
@@ -88,21 +88,21 @@ declare function f2({ function: _function, ...rest }: P): {
     await: boolean;
     one: boolean;
 };
-declare function f3({ abstract, ...rest }: P): {
+declare function f3({ abstract: _abstract, ...rest }: P): {
     enum: boolean;
     function: boolean;
     async: boolean;
     await: boolean;
     one: boolean;
 };
-declare function f4({ async, ...rest }: P): {
+declare function f4({ async: _async, ...rest }: P): {
     enum: boolean;
     function: boolean;
     abstract: boolean;
     await: boolean;
     one: boolean;
 };
-declare function f5({ await, ...rest }: P): {
+declare function f5({ await: _await, ...rest }: P): {
     enum: boolean;
     function: boolean;
     abstract: boolean;

--- a/tests/baselines/reference/destructuringInFunctionType.js
+++ b/tests/baselines/reference/destructuringInFunctionType.js
@@ -54,7 +54,7 @@ type T3 = ([{
 }, {
     b: a;
 }]);
-type F3 = ([{ a }, { b }]: [{
+type F3 = ([{ a: b }, { b: a }]: [{
     a: any;
 }, {
     b: any;

--- a/tests/baselines/reference/paramterDestrcuturingDeclaration.js
+++ b/tests/baselines/reference/paramterDestrcuturingDeclaration.js
@@ -12,10 +12,10 @@ interface C {
 
 //// [paramterDestrcuturingDeclaration.d.ts]
 interface C {
-    ({ p }: {
+    ({ p: name }: {
         p: any;
     }): any;
-    new ({ p }: {
+    new ({ p: boolean }: {
         p: any;
     }): any;
 }

--- a/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.js
+++ b/tests/baselines/reference/renamingDestructuredPropertyInFunctionType.js
@@ -101,14 +101,14 @@ type O = {
     c: number;
 };
 type F1 = (arg: number) => any;
-type F2 = ({ a }: O) => any;
-type F3 = ({ a, b, c }: O) => any;
-type F4 = ({ a }: O) => any;
-type F5 = ({ a, b, c }: O) => any;
+type F2 = ({ a: string }: O) => any;
+type F3 = ({ a: string, b, c }: O) => any;
+type F4 = ({ a: string }: O) => any;
+type F5 = ({ a: string, b, c }: O) => any;
 type F6 = ({ a: string }: {
     a: any;
 }) => typeof string;
-type F7 = ({ a, b: number }: {
+type F7 = ({ a: string, b: number }: {
     a: any;
     b: any;
 }) => typeof number;
@@ -118,14 +118,14 @@ type F8 = ({ a, b: number }: {
 }) => typeof number;
 type F9 = ([a, b, c]: [any, any, any]) => void;
 type G1 = new (arg: number) => any;
-type G2 = new ({ a }: O) => any;
-type G3 = new ({ a, b, c }: O) => any;
-type G4 = new ({ a }: O) => any;
-type G5 = new ({ a, b, c }: O) => any;
+type G2 = new ({ a: string }: O) => any;
+type G3 = new ({ a: string, b, c }: O) => any;
+type G4 = new ({ a: string }: O) => any;
+type G5 = new ({ a: string, b, c }: O) => any;
 type G6 = new ({ a: string }: {
     a: any;
 }) => typeof string;
-type G7 = new ({ a, b: number }: {
+type G7 = new ({ a: string, b: number }: {
     a: any;
     b: any;
 }) => typeof number;
@@ -156,19 +156,19 @@ type G13 = new ({ [2]: string }: {
 }) => void;
 interface I {
     method1(arg: number): any;
-    method2({ a }: {
+    method2({ a: string }: {
         a: any;
     }): any;
     (arg: number): any;
-    ({ a }: {
+    ({ a: string }: {
         a: any;
     }): any;
     new (arg: number): any;
-    new ({ a }: {
+    new ({ a: string }: {
         a: any;
     }): any;
 }
-declare function f1({ a }: O): void;
+declare function f1({ a: string }: O): void;
 declare const f2: ({ a: string }: O) => void;
 declare const f3: ({ a: string, b, c }: O) => void;
 declare const f4: ({ a: string }: O) => string;
@@ -179,7 +179,7 @@ declare const obj1: {
 declare const obj2: {
     method({ a: string }: O): string;
 };
-declare function f6({ a }: O): void;
+declare function f6({ a: string }: O): void;
 declare const f7: ({ a: string, b, c }: O) => void;
 declare const f8: ({ "a": string }: O) => void;
 declare function f9({ 2: string }: {

--- a/tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts
+++ b/tests/cases/compiler/declarationEmitBindingPatternsFunctionExpr.ts
@@ -1,0 +1,18 @@
+// @declaration: true
+// @target: esnext
+// @skipLibCheck: false
+
+type Named = { name: string }
+// Tempting to remove alias if unused 
+let notReferenced = ({ name: alias }: Named) => { }
+
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+const duplicateIndetifiers = ({ name: alias, name: alias2 }: Named) => { }
+const duplicateIndetifiers2 = (name: string, { name: alias }: Named) => { }
+const duplicateIndetifiers3 = ({ name: alias }: Named, { name: alias2 }: Named) => { }
+
+let value = "";
+// 2.Can change in meaning for typeof value if we remove alias
+const shadowedVariable = ({ value: alias }: { value: string }): typeof value => value;

--- a/tests/cases/compiler/declarationEmitBindingPatternsUnused.ts
+++ b/tests/cases/compiler/declarationEmitBindingPatternsUnused.ts
@@ -3,6 +3,18 @@
 // @skipLibCheck: false
 
 type Named = { name: string }
+
+// Resons we can't remove aliases that are not used in the function signature: 
+
+// 1.Causes duplicate identifier if we remove alias
+function duplicateIndetifiers({ name: alias, name: alias2 }: Named) { }
+function duplicateIndetifiers2(name: string, { name: alias }: Named) { }
+function duplicateIndetifiers3({ name: alias }: Named, { name: alias2 }: Named) { }
+
+let value = "";
+// 2.Can change in meaning for typeof value if we remove alias
+function shadowedVariable({ value: alias }: { value: string }): typeof value { return value }
+
 function notReferenced({ name: alias }: Named) {
 
 }
@@ -10,8 +22,6 @@ function notReferencedNestedAlias({ p: { name: alias } }: { p: Named }) {
 }
 function notReferencedArrayAlias([a, b, { name: alias }]: Named[]) {
 }
-
-
 
 function referencedInCode({ name: alias }: Named) {
     return alias;


### PR DESCRIPTION
Revert change that removes binding aliases from declaration files. Doing this correctly implies doing a lot more work than previously anticipated. 

Fixes #56991
Fixes #56992
