### PR TITLE
Check `autoImportExcludePatterns` against symlink paths

### DIFF
--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -8,6 +8,7 @@ import {
     createMultiMap,
     Debug,
     emptyArray,
+    ensureTrailingDirectorySeparator,
     findIndex,
     firstDefined,
     forEachAncestorDirectory,
@@ -43,6 +44,7 @@ import {
     nodeModulesPathPart,
     PackageJsonImportFilter,
     Path,
+    pathContainsNodeModules,
     Program,
     skipAlias,
     skipOuterExpressions,
@@ -427,12 +429,12 @@ export function forEachExternalModuleToImportFrom(
         return pattern ? getRegexFromPattern(pattern, useCaseSensitiveFileNames) : undefined;
     });
 
-    forEachExternalModule(program.getTypeChecker(), program.getSourceFiles(), excludePatterns, (module, file) => cb(module, file, program, /*isFromPackageJson*/ false));
+    forEachExternalModule(program.getTypeChecker(), program.getSourceFiles(), excludePatterns, host, (module, file) => cb(module, file, program, /*isFromPackageJson*/ false));
     const autoImportProvider = useAutoImportProvider && host.getPackageJsonAutoImportProvider?.();
     if (autoImportProvider) {
         const start = timestamp();
         const checker = program.getTypeChecker();
-        forEachExternalModule(autoImportProvider.getTypeChecker(), autoImportProvider.getSourceFiles(), excludePatterns, (module, file) => {
+        forEachExternalModule(autoImportProvider.getTypeChecker(), autoImportProvider.getSourceFiles(), excludePatterns, host, (module, file) => {
             if (file && !program.getSourceFile(file.fileName) || !file && !checker.resolveName(module.name, /*location*/ undefined, SymbolFlags.Module, /*excludeGlobals*/ false)) {
                 // The AutoImportProvider filters files already in the main program out of its *root* files,
                 // but non-root files can still be present in both programs, and already in the export info map
@@ -445,15 +447,32 @@ export function forEachExternalModuleToImportFrom(
     }
 }
 
-function forEachExternalModule(checker: TypeChecker, allSourceFiles: readonly SourceFile[], excludePatterns: readonly RegExp[] | undefined, cb: (module: Symbol, sourceFile: SourceFile | undefined) => void) {
-    const isExcluded = excludePatterns && ((fileName: string) => excludePatterns.some(p => p.test(fileName)));
+function forEachExternalModule(checker: TypeChecker, allSourceFiles: readonly SourceFile[], excludePatterns: readonly RegExp[] | undefined, host: LanguageServiceHost, cb: (module: Symbol, sourceFile: SourceFile | undefined) => void) {
+    const realpathsWithSymlinks = host.getSymlinkCache?.().getSymlinkedDirectoriesByRealpath();
+    const isExcluded = excludePatterns && (({ fileName, path }: SourceFile) => {
+        if (excludePatterns.some(p => p.test(fileName))) return true;
+        if (realpathsWithSymlinks?.size && pathContainsNodeModules(fileName)) {
+            let dir = getDirectoryPath(fileName);
+            let dirPath = getDirectoryPath(path);
+            while (dirPath !== "/") {
+                const symlinks = realpathsWithSymlinks.get(ensureTrailingDirectorySeparator(dirPath));
+                if (symlinks) {
+                    return symlinks.some(s => excludePatterns.some(p => p.test(fileName.replace(dir, s))));
+                }
+                dir = getDirectoryPath(dir);
+                dirPath = getDirectoryPath(dirPath);
+            }
+        }
+        return false;
+    });
+
     for (const ambient of checker.getAmbientModules()) {
-        if (!ambient.name.includes("*") && !(excludePatterns && ambient.declarations?.every(d => isExcluded!(d.getSourceFile().fileName)))) {
+        if (!ambient.name.includes("*") && !(excludePatterns && ambient.declarations?.every(d => isExcluded!(d.getSourceFile())))) {
             cb(ambient, /*sourceFile*/ undefined);
         }
     }
     for (const sourceFile of allSourceFiles) {
-        if (isExternalOrCommonJsModule(sourceFile) && !isExcluded?.(sourceFile.fileName)) {
+        if (isExternalOrCommonJsModule(sourceFile) && !isExcluded?.(sourceFile)) {
             cb(checker.getMergedSymbol(sourceFile.symbol), sourceFile);
         }
     }

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -453,15 +453,13 @@ function forEachExternalModule(checker: TypeChecker, allSourceFiles: readonly So
         if (excludePatterns.some(p => p.test(fileName))) return true;
         if (realpathsWithSymlinks?.size && pathContainsNodeModules(fileName)) {
             let dir = getDirectoryPath(fileName);
-            let dirPath = getDirectoryPath(path);
-            while (dirPath !== "/") {
+            return forEachAncestorDirectory(getDirectoryPath(path), dirPath => {
                 const symlinks = realpathsWithSymlinks.get(ensureTrailingDirectorySeparator(dirPath));
                 if (symlinks) {
                     return symlinks.some(s => excludePatterns.some(p => p.test(fileName.replace(dir, s))));
                 }
                 dir = getDirectoryPath(dir);
-                dirPath = getDirectoryPath(dirPath);
-            }
+            }) ?? false;
         }
         return false;
     });

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportFileExcludePatterns1.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportFileExcludePatterns1.js
@@ -22,7 +22,7 @@ export * from "./clients/s3";
 { "name": "aws-sdk", "version": "2.0.0", "main": "index.js" }
 
 //// [/project/package.json]
-{ "dependencies": "aws-sdk" }
+{ "dependencies": { "aws-sdk": "*" } }
 
 
 Info seq  [hh:mm:ss:mss] request:
@@ -113,12 +113,34 @@ Info seq  [hh:mm:ss:mss] 	Files (4)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/package.json 250 undefined WatchType: package.json file
+Info seq  [hh:mm:ss:mss] AutoImportProviderProject: found 1 root files in 1 dependencies in * ms
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/aws-sdk/index.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/autoImportProviderProject1*
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/aws-sdk/package.json 2000 undefined Project: /dev/null/autoImportProviderProject1* WatchType: File location affecting resolution
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/aws-sdk/clients/s3.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/autoImportProviderProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/autoImportProviderProject1*' (AutoImportProvider)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	/project/node_modules/aws-sdk/clients/s3.d.ts Text-1 "export declare class S3 {}"
+	/project/node_modules/aws-sdk/index.d.ts Text-1 "export * from \"./clients/s3\";"
+
+
+	node_modules/aws-sdk/clients/s3.d.ts
+	  Imported via "./clients/s3" from file 'node_modules/aws-sdk/index.d.ts' with packageId 'aws-sdk/clients/s3.d.ts@2.0.0'
+	node_modules/aws-sdk/index.d.ts
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
 Info seq  [hh:mm:ss:mss] 	Files (4)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
 Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/autoImportProviderProject1*' (AutoImportProvider)
+Info seq  [hh:mm:ss:mss] 	Files (2)
 
 Info seq  [hh:mm:ss:mss] -----------------------------------------------
 Info seq  [hh:mm:ss:mss] Open files: 
@@ -134,6 +156,12 @@ watchedFiles::
   {"pollingInterval":500}
 /lib.decorators.legacy.d.ts:
   {"pollingInterval":500}
+/project/node_modules/aws-sdk/clients/s3.d.ts: *new*
+  {"pollingInterval":500}
+/project/node_modules/aws-sdk/index.d.ts: *new*
+  {"pollingInterval":500}
+/project/node_modules/aws-sdk/package.json: *new*
+  {"pollingInterval":2000}
 /project/package.json: *new*
   {"pollingInterval":250}
 
@@ -984,6 +1012,7 @@ Info seq  [hh:mm:ss:mss] request:
       },
       "command": "getCodeFixes"
     }
+Info seq  [hh:mm:ss:mss] forEachExternalModuleToImportFrom autoImportProvider: *
 Info seq  [hh:mm:ss:mss] response:
     {
       "seq": 0,

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportFileExcludePatterns_symlinks.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportFileExcludePatterns_symlinks.js
@@ -1,0 +1,1049 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/typesMap.json" doesn't exist
+//// [/lib.d.ts]
+lib.d.ts-Text
+
+//// [/lib.decorators.d.ts]
+lib.decorators.d.ts-Text
+
+//// [/lib.decorators.legacy.d.ts]
+lib.decorators.legacy.d.ts-Text
+
+//// [/project/index.ts]
+ServerRuntimeMetaFunction
+
+//// [/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/index.d.ts]
+export declare function ServerRuntimeMetaFunction(): void;
+
+//// [/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/package.json]
+{
+  "name": "@remix-run/server-runtime",
+  "version": "0.0.0",
+  "main": "index.js"
+}
+
+//// [/project/node_modules/@remix-run/server-runtime] symlink(/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package)
+//// [/project/package.json]
+{ "dependencies": { "@remix-run/server-runtime": "*" } }
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "arguments": {
+        "file": "/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/package.json"
+      },
+      "command": "open"
+    }
+Info seq  [hh:mm:ss:mss] Search path: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package
+Info seq  [hh:mm:ss:mss] For info: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/package.json :: No config files found.
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.legacy.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: /project/node_modules/.store/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: /project/node_modules/.store/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/package.json SVC-1-0 "{\n  \"name\": \"@remix-run/server-runtime\",\n  \"version\": \"0.0.0\",\n  \"main\": \"index.js\"\n}"
+
+
+	../../../../../lib.d.ts
+	  Default library for target 'es5'
+	../../../../../lib.decorators.d.ts
+	  Library referenced via 'decorators' from file '../../../../../lib.d.ts'
+	../../../../../lib.decorators.legacy.d.ts
+	  Library referenced via 'decorators.legacy' from file '../../../../../lib.d.ts'
+	package.json
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/package.json ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+After Request
+watchedFiles::
+/lib.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.legacy.d.ts: *new*
+  {"pollingInterval":500}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/jsconfig.json: *new*
+  {"pollingInterval":2000}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/jsconfig.json: *new*
+  {"pollingInterval":2000}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/tsconfig.json: *new*
+  {"pollingInterval":2000}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/tsconfig.json: *new*
+  {"pollingInterval":2000}
+
+watchedDirectoriesRecursive::
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/node_modules/@types: *new*
+  {}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/node_modules/@types: *new*
+  {}
+/project/node_modules/.store/node_modules/@types: *new*
+  {}
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 1,
+      "type": "request",
+      "arguments": {
+        "file": "/project/index.ts"
+      },
+      "command": "open"
+    }
+Info seq  [hh:mm:ss:mss] Search path: /project
+Info seq  [hh:mm:ss:mss] For info: /project/index.ts :: No config files found.
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	/project/index.ts SVC-1-0 "ServerRuntimeMetaFunction"
+
+
+	../lib.d.ts
+	  Default library for target 'es5'
+	../lib.decorators.d.ts
+	  Library referenced via 'decorators' from file '../lib.d.ts'
+	../lib.decorators.legacy.d.ts
+	  Library referenced via 'decorators.legacy' from file '../lib.d.ts'
+	index.ts
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/package.json 250 undefined WatchType: package.json file
+Info seq  [hh:mm:ss:mss] AutoImportProviderProject: found 1 root files in 1 dependencies in * ms
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/index.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/autoImportProviderProject1*
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/autoImportProviderProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/autoImportProviderProject1*' (AutoImportProvider)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+	/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/index.d.ts Text-1 "export declare function ServerRuntimeMetaFunction(): void;"
+
+
+	node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/index.d.ts
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/autoImportProviderProject1*' (AutoImportProvider)
+Info seq  [hh:mm:ss:mss] 	Files (1)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/package.json ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 	FileName: /project/index.ts ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject2*
+After Request
+watchedFiles::
+/lib.d.ts:
+  {"pollingInterval":500}
+/lib.decorators.d.ts:
+  {"pollingInterval":500}
+/lib.decorators.legacy.d.ts:
+  {"pollingInterval":500}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/jsconfig.json:
+  {"pollingInterval":2000}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/index.d.ts: *new*
+  {"pollingInterval":500}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/jsconfig.json:
+  {"pollingInterval":2000}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/tsconfig.json:
+  {"pollingInterval":2000}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/tsconfig.json:
+  {"pollingInterval":2000}
+/project/package.json: *new*
+  {"pollingInterval":250}
+
+watchedDirectoriesRecursive::
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/node_modules/@types:
+  {}
+/project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/node_modules/@types:
+  {}
+/project/node_modules/.store/node_modules/@types:
+  {}
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 2,
+      "type": "request",
+      "arguments": {
+        "preferences": {
+          "includeCompletionsForModuleExports": true,
+          "autoImportFileExcludePatterns": [
+            "/**/@remix-run/server-runtime"
+          ]
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 2,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 3,
+      "type": "request",
+      "arguments": {
+        "file": "/project/index.ts",
+        "line": 1,
+        "offset": 26
+      },
+      "command": "completionInfo"
+    }
+Info seq  [hh:mm:ss:mss] getCompletionData: Get current token: *
+Info seq  [hh:mm:ss:mss] getCompletionData: Is inside comment: *
+Info seq  [hh:mm:ss:mss] getCompletionData: Get previous token: *
+Info seq  [hh:mm:ss:mss] getCompletionData: Semantic work: *
+Info seq  [hh:mm:ss:mss] getCompletionsAtPosition: getCompletionEntriesFromSymbols: *
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "completionInfo",
+      "request_seq": 3,
+      "success": true,
+      "body": {
+        "flags": 0,
+        "isGlobalCompletion": true,
+        "isMemberCompletion": false,
+        "isNewIdentifierLocation": false,
+        "optionalReplacementSpan": {
+          "start": {
+            "line": 1,
+            "offset": 1
+          },
+          "end": {
+            "line": 1,
+            "offset": 26
+          }
+        },
+        "entries": [
+          {
+            "name": "abstract",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "any",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "ArrayBuffer",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "as",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "asserts",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "async",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "await",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "bigint",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "boolean",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Boolean",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "break",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "case",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "catch",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "class",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "const",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "continue",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "DataView",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Date",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "debugger",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "declare",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "decodeURI",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "decodeURIComponent",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "default",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "delete",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "do",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "else",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "encodeURI",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "encodeURIComponent",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "enum",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Error",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "eval",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "EvalError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "export",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "extends",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "false",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "finally",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Float32Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Float64Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "for",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "function",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Function",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "globalThis",
+            "kind": "module",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "if",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "implements",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "import",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "in",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "infer",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Infinity",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "instanceof",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Int16Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Int32Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Int8Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "interface",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Intl",
+            "kind": "module",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "isFinite",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "isNaN",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "JSON",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "keyof",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "let",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Math",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "module",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "namespace",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "NaN",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "never",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "new",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "null",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "number",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Number",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "object",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Object",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "package",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "parseFloat",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "parseInt",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "RangeError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "readonly",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "ReferenceError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "RegExp",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "return",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "satisfies",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "string",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "String",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "super",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "switch",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "symbol",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "SyntaxError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "this",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "throw",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "true",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "try",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "type",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "TypeError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "typeof",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint16Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint32Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint8Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint8ClampedArray",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "undefined",
+            "kind": "var",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "unique",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "unknown",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "URIError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "var",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "void",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "while",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "with",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "yield",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "escape",
+            "kind": "function",
+            "kindModifiers": "deprecated,declare",
+            "sortText": "z15"
+          },
+          {
+            "name": "unescape",
+            "kind": "function",
+            "kindModifiers": "deprecated,declare",
+            "sortText": "z15"
+          }
+        ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 4,
+      "type": "request",
+      "arguments": {
+        "preferences": {
+          "autoImportFileExcludePatterns": [
+            "/**/@remix-run/server-runtime"
+          ]
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 4,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 5,
+      "type": "request",
+      "arguments": {
+        "preferences": {
+          "autoImportFileExcludePatterns": [
+            "/**/@remix-run/server-runtime"
+          ]
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 5,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 6,
+      "type": "request",
+      "arguments": {
+        "file": "/project/index.ts",
+        "includeLinePosition": true
+      },
+      "command": "syntacticDiagnosticsSync"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "syntacticDiagnosticsSync",
+      "request_seq": 6,
+      "success": true,
+      "body": []
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 7,
+      "type": "request",
+      "arguments": {
+        "file": "/project/index.ts",
+        "includeLinePosition": true
+      },
+      "command": "semanticDiagnosticsSync"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "semanticDiagnosticsSync",
+      "request_seq": 7,
+      "success": true,
+      "body": [
+        {
+          "message": "Cannot find name 'ServerRuntimeMetaFunction'.",
+          "start": 0,
+          "length": 25,
+          "category": "error",
+          "code": 2304,
+          "startLocation": {
+            "line": 1,
+            "offset": 1
+          },
+          "endLocation": {
+            "line": 1,
+            "offset": 26
+          }
+        }
+      ]
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 8,
+      "type": "request",
+      "arguments": {
+        "file": "/project/index.ts",
+        "includeLinePosition": true
+      },
+      "command": "suggestionDiagnosticsSync"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "suggestionDiagnosticsSync",
+      "request_seq": 8,
+      "success": true,
+      "body": []
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 9,
+      "type": "request",
+      "arguments": {
+        "file": "/project/index.ts",
+        "startLine": 1,
+        "startOffset": 1,
+        "endLine": 1,
+        "endOffset": 26,
+        "errorCodes": [
+          2304
+        ]
+      },
+      "command": "getCodeFixes"
+    }
+Info seq  [hh:mm:ss:mss] forEachExternalModuleToImportFrom autoImportProvider: *
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "getCodeFixes",
+      "request_seq": 9,
+      "success": true,
+      "body": []
+    }

--- a/tests/baselines/reference/tsserver/fourslashServer/autoImportFileExcludePatterns_symlinks2.js
+++ b/tests/baselines/reference/tsserver/fourslashServer/autoImportFileExcludePatterns_symlinks2.js
@@ -1,0 +1,1111 @@
+currentDirectory:: / useCaseSensitiveFileNames: false
+Info seq  [hh:mm:ss:mss] Provided types map file "/typesMap.json" doesn't exist
+//// [/lib.d.ts]
+lib.d.ts-Text
+
+//// [/lib.decorators.d.ts]
+lib.decorators.d.ts-Text
+
+//// [/lib.decorators.legacy.d.ts]
+lib.decorators.legacy.d.ts-Text
+
+//// [c:/project/index.ts]
+ServerRuntimeMetaFunction
+
+//// [c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/index.d.ts]
+export {};
+
+//// [c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/package.json]
+{ "name": "aws-sdk", "version": "2.0.0", "main": "index.js" }
+
+//// [c:/project/node_modules/@remix-run/server-runtime/index.d.ts]
+export declare function ServerRuntimeMetaFunction(): void;
+
+//// [c:/project/node_modules/@remix-run/server-runtime/package.json]
+{
+  "name": "@remix-run/server-runtime",
+  "version": "0.0.0",
+  "main": "index.js"
+}
+
+//// [c:/project/node_modules/aws-sdk] symlink(c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package)
+//// [c:/project/package.json]
+{ "dependencies": { "aws-sdk": "*", "@remix-run/server-runtime": "*" } }
+
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 0,
+      "type": "request",
+      "arguments": {
+        "file": "c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/package.json"
+      },
+      "command": "open"
+    }
+Info seq  [hh:mm:ss:mss] Search path: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package
+Info seq  [hh:mm:ss:mss] For info: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/package.json :: No config files found.
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/tsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/jsconfig.json 2000 undefined WatchType: Config file for the inferred project root
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules 1 undefined Project: /dev/null/inferredProject1* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: /lib.decorators.legacy.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject1* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/package.json SVC-1-0 "{ \"name\": \"aws-sdk\", \"version\": \"2.0.0\", \"main\": \"index.js\" }"
+
+
+	/lib.d.ts
+	  Default library for target 'es5'
+	/lib.decorators.d.ts
+	  Library referenced via 'decorators' from file '/lib.d.ts'
+	/lib.decorators.legacy.d.ts
+	  Library referenced via 'decorators.legacy' from file '/lib.d.ts'
+	package.json
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/package.json ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+After Request
+watchedFiles::
+/lib.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.d.ts: *new*
+  {"pollingInterval":500}
+/lib.decorators.legacy.d.ts: *new*
+  {"pollingInterval":500}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/jsconfig.json: *new*
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/jsconfig.json: *new*
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/tsconfig.json: *new*
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/tsconfig.json: *new*
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/jsconfig.json: *new*
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/tsconfig.json: *new*
+  {"pollingInterval":2000}
+c:/project/node_modules/jsconfig.json: *new*
+  {"pollingInterval":2000}
+c:/project/node_modules/tsconfig.json: *new*
+  {"pollingInterval":2000}
+
+watchedDirectoriesRecursive::
+c:/project/node_modules: *new*
+  {}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/node_modules/@types: *new*
+  {}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules: *new*
+  {}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules/@types: *new*
+  {}
+c:/project/node_modules/.store/node_modules/@types: *new*
+  {}
+c:/project/node_modules/@types: *new*
+  {}
+c:/project/node_modules/node_modules/@types: *new*
+  {}
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 1,
+      "type": "request",
+      "arguments": {
+        "file": "c:/project/index.ts"
+      },
+      "command": "open"
+    }
+Info seq  [hh:mm:ss:mss] Search path: c:/project
+Info seq  [hh:mm:ss:mss] For info: c:/project/index.ts :: No config files found.
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/inferredProject2*
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules 1 undefined Project: /dev/null/inferredProject2* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules 1 undefined Project: /dev/null/inferredProject2* WatchType: Failed Lookup Locations
+Info seq  [hh:mm:ss:mss] DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Elapsed:: *ms DirectoryWatcher:: Added:: WatchInfo: c:/project/node_modules/@types 1 undefined Project: /dev/null/inferredProject2* WatchType: Type roots
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/inferredProject2* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+	/lib.d.ts Text-1 lib.d.ts-Text
+	/lib.decorators.d.ts Text-1 lib.decorators.d.ts-Text
+	/lib.decorators.legacy.d.ts Text-1 lib.decorators.legacy.d.ts-Text
+	c:/project/index.ts SVC-1-0 "ServerRuntimeMetaFunction"
+
+
+	/lib.d.ts
+	  Default library for target 'es5'
+	/lib.decorators.d.ts
+	  Library referenced via 'decorators' from file '/lib.d.ts'
+	/lib.decorators.legacy.d.ts
+	  Library referenced via 'decorators.legacy' from file '/lib.d.ts'
+	index.ts
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/package.json 250 undefined WatchType: package.json file
+Info seq  [hh:mm:ss:mss] AutoImportProviderProject: found 2 root files in 2 dependencies in * ms
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/index.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] FileWatcher:: Added:: WatchInfo: c:/project/node_modules/@remix-run/server-runtime/index.d.ts 500 undefined WatchType: Closed Script info
+Info seq  [hh:mm:ss:mss] Starting updateGraphWorker: Project: /dev/null/autoImportProviderProject1*
+Info seq  [hh:mm:ss:mss] Finishing updateGraphWorker: Project: /dev/null/autoImportProviderProject1* Version: 1 structureChanged: true structureIsReused:: Not Elapsed:: *ms
+Info seq  [hh:mm:ss:mss] Project '/dev/null/autoImportProviderProject1*' (AutoImportProvider)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+	c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/index.d.ts Text-1 "export {};"
+	c:/project/node_modules/@remix-run/server-runtime/index.d.ts Text-1 "export declare function ServerRuntimeMetaFunction(): void;"
+
+
+	node_modules/.store/aws-sdk-virtual-adfe098/package/index.d.ts
+	  Root file specified for compilation
+	node_modules/@remix-run/server-runtime/index.d.ts
+	  Root file specified for compilation
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject1*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/inferredProject2*' (Inferred)
+Info seq  [hh:mm:ss:mss] 	Files (4)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Project '/dev/null/autoImportProviderProject1*' (AutoImportProvider)
+Info seq  [hh:mm:ss:mss] 	Files (2)
+
+Info seq  [hh:mm:ss:mss] -----------------------------------------------
+Info seq  [hh:mm:ss:mss] Open files: 
+Info seq  [hh:mm:ss:mss] 	FileName: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/package.json ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject1*
+Info seq  [hh:mm:ss:mss] 	FileName: c:/project/index.ts ProjectRootPath: undefined
+Info seq  [hh:mm:ss:mss] 		Projects: /dev/null/inferredProject2*
+After Request
+watchedFiles::
+/lib.d.ts:
+  {"pollingInterval":500}
+/lib.decorators.d.ts:
+  {"pollingInterval":500}
+/lib.decorators.legacy.d.ts:
+  {"pollingInterval":500}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/jsconfig.json:
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/index.d.ts: *new*
+  {"pollingInterval":500}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/jsconfig.json:
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/tsconfig.json:
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/tsconfig.json:
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/jsconfig.json:
+  {"pollingInterval":2000}
+c:/project/node_modules/.store/tsconfig.json:
+  {"pollingInterval":2000}
+c:/project/node_modules/@remix-run/server-runtime/index.d.ts: *new*
+  {"pollingInterval":500}
+c:/project/node_modules/jsconfig.json:
+  {"pollingInterval":2000}
+c:/project/node_modules/tsconfig.json:
+  {"pollingInterval":2000}
+c:/project/package.json: *new*
+  {"pollingInterval":250}
+
+watchedDirectoriesRecursive::
+c:/project/node_modules:
+  {}
+  {} *new*
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/node_modules/@types:
+  {}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules:
+  {}
+c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/node_modules/@types:
+  {}
+c:/project/node_modules/.store/node_modules/@types:
+  {}
+c:/project/node_modules/@types:
+  {}
+  {} *new*
+c:/project/node_modules/node_modules/@types:
+  {}
+
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 2,
+      "type": "request",
+      "arguments": {
+        "preferences": {
+          "includeCompletionsForModuleExports": true,
+          "autoImportFileExcludePatterns": [
+            "c:/**/@remix-run/server-runtime"
+          ]
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 2,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 3,
+      "type": "request",
+      "arguments": {
+        "file": "c:/project/index.ts",
+        "line": 1,
+        "offset": 26
+      },
+      "command": "completionInfo"
+    }
+Info seq  [hh:mm:ss:mss] getCompletionData: Get current token: *
+Info seq  [hh:mm:ss:mss] getCompletionData: Is inside comment: *
+Info seq  [hh:mm:ss:mss] getCompletionData: Get previous token: *
+Info seq  [hh:mm:ss:mss] getCompletionData: Semantic work: *
+Info seq  [hh:mm:ss:mss] getCompletionsAtPosition: getCompletionEntriesFromSymbols: *
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "completionInfo",
+      "request_seq": 3,
+      "success": true,
+      "body": {
+        "flags": 0,
+        "isGlobalCompletion": true,
+        "isMemberCompletion": false,
+        "isNewIdentifierLocation": false,
+        "optionalReplacementSpan": {
+          "start": {
+            "line": 1,
+            "offset": 1
+          },
+          "end": {
+            "line": 1,
+            "offset": 26
+          }
+        },
+        "entries": [
+          {
+            "name": "abstract",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "any",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "ArrayBuffer",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "as",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "asserts",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "async",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "await",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "bigint",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "boolean",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Boolean",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "break",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "case",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "catch",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "class",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "const",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "continue",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "DataView",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Date",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "debugger",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "declare",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "decodeURI",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "decodeURIComponent",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "default",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "delete",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "do",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "else",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "encodeURI",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "encodeURIComponent",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "enum",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Error",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "eval",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "EvalError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "export",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "extends",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "false",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "finally",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Float32Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Float64Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "for",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "function",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Function",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "globalThis",
+            "kind": "module",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "if",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "implements",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "import",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "in",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "infer",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Infinity",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "instanceof",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Int16Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Int32Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Int8Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "interface",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Intl",
+            "kind": "module",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "isFinite",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "isNaN",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "JSON",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "keyof",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "let",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Math",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "module",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "namespace",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "NaN",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "never",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "new",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "null",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "number",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Number",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "object",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Object",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "package",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "parseFloat",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "parseInt",
+            "kind": "function",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "RangeError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "readonly",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "ReferenceError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "RegExp",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "return",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "satisfies",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "string",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "String",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "super",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "switch",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "symbol",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "SyntaxError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "this",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "throw",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "true",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "try",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "type",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "TypeError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "typeof",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint16Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint32Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint8Array",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "Uint8ClampedArray",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "undefined",
+            "kind": "var",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "unique",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "unknown",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "URIError",
+            "kind": "var",
+            "kindModifiers": "declare",
+            "sortText": "15"
+          },
+          {
+            "name": "var",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "void",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "while",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "with",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "yield",
+            "kind": "keyword",
+            "kindModifiers": "",
+            "sortText": "15"
+          },
+          {
+            "name": "escape",
+            "kind": "function",
+            "kindModifiers": "deprecated,declare",
+            "sortText": "z15"
+          },
+          {
+            "name": "unescape",
+            "kind": "function",
+            "kindModifiers": "deprecated,declare",
+            "sortText": "z15"
+          }
+        ]
+      }
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 4,
+      "type": "request",
+      "arguments": {
+        "preferences": {
+          "autoImportFileExcludePatterns": [
+            "c:/**/@remix-run/server-runtime"
+          ]
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 4,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 5,
+      "type": "request",
+      "arguments": {
+        "preferences": {
+          "autoImportFileExcludePatterns": [
+            "c:/**/@remix-run/server-runtime"
+          ]
+        }
+      },
+      "command": "configure"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "configure",
+      "request_seq": 5,
+      "success": true
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 6,
+      "type": "request",
+      "arguments": {
+        "file": "c:/project/index.ts",
+        "includeLinePosition": true
+      },
+      "command": "syntacticDiagnosticsSync"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "syntacticDiagnosticsSync",
+      "request_seq": 6,
+      "success": true,
+      "body": []
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 7,
+      "type": "request",
+      "arguments": {
+        "file": "c:/project/index.ts",
+        "includeLinePosition": true
+      },
+      "command": "semanticDiagnosticsSync"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "semanticDiagnosticsSync",
+      "request_seq": 7,
+      "success": true,
+      "body": [
+        {
+          "message": "Cannot find name 'ServerRuntimeMetaFunction'.",
+          "start": 0,
+          "length": 25,
+          "category": "error",
+          "code": 2304,
+          "startLocation": {
+            "line": 1,
+            "offset": 1
+          },
+          "endLocation": {
+            "line": 1,
+            "offset": 26
+          }
+        }
+      ]
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 8,
+      "type": "request",
+      "arguments": {
+        "file": "c:/project/index.ts",
+        "includeLinePosition": true
+      },
+      "command": "suggestionDiagnosticsSync"
+    }
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "suggestionDiagnosticsSync",
+      "request_seq": 8,
+      "success": true,
+      "body": []
+    }
+Info seq  [hh:mm:ss:mss] request:
+    {
+      "seq": 9,
+      "type": "request",
+      "arguments": {
+        "file": "c:/project/index.ts",
+        "startLine": 1,
+        "startOffset": 1,
+        "endLine": 1,
+        "endOffset": 26,
+        "errorCodes": [
+          2304
+        ]
+      },
+      "command": "getCodeFixes"
+    }
+Info seq  [hh:mm:ss:mss] forEachExternalModuleToImportFrom autoImportProvider: *
+Info seq  [hh:mm:ss:mss] response:
+    {
+      "seq": 0,
+      "type": "response",
+      "command": "getCodeFixes",
+      "request_seq": 9,
+      "success": true,
+      "body": []
+    }

--- a/tests/cases/fourslash/server/autoImportFileExcludePatterns1.ts
+++ b/tests/cases/fourslash/server/autoImportFileExcludePatterns1.ts
@@ -12,7 +12,7 @@
 //// export declare class S3 {}
 
 // @Filename: /project/package.json
-//// { "dependencies": "aws-sdk" }
+//// { "dependencies": { "aws-sdk": "*" } }
 
 // @Filename: /project/index.ts
 //// S3/**/

--- a/tests/cases/fourslash/server/autoImportFileExcludePatterns_symlinks.ts
+++ b/tests/cases/fourslash/server/autoImportFileExcludePatterns_symlinks.ts
@@ -1,0 +1,34 @@
+/// <reference path="../fourslash.ts"/>
+
+// @module: commonjs
+
+// @Filename: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/package.json
+//// {
+////   "name": "@remix-run/server-runtime",
+////   "version": "0.0.0",
+////   "main": "index.js"
+//// }
+
+// @Filename: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package/index.d.ts
+//// export declare function ServerRuntimeMetaFunction(): void;
+
+// @Filename: /project/package.json
+//// { "dependencies": { "@remix-run/server-runtime": "*" } }
+
+// @link: /project/node_modules/.store/@remix-run-server-runtime-virtual-c72daf0d/package -> /project/node_modules/@remix-run/server-runtime
+
+// @Filename: /project/index.ts
+//// ServerRuntimeMetaFunction/**/
+
+const autoImportFileExcludePatterns = ["/**/@remix-run/server-runtime"];
+
+verify.completions({
+  marker: "",
+  excludes: "ServerRuntimeMetaFunction",
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    autoImportFileExcludePatterns,
+  }
+});
+
+verify.importFixAtPosition([], /*errorCode*/ undefined, { autoImportFileExcludePatterns });

--- a/tests/cases/fourslash/server/autoImportFileExcludePatterns_symlinks2.ts
+++ b/tests/cases/fourslash/server/autoImportFileExcludePatterns_symlinks2.ts
@@ -1,0 +1,40 @@
+/// <reference path="../fourslash.ts"/>
+
+// @module: commonjs
+
+// @Filename: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/package.json
+//// { "name": "aws-sdk", "version": "2.0.0", "main": "index.js" }
+
+// @Filename: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package/index.d.ts
+//// export {};
+
+// @Filename: c:/project/node_modules/@remix-run/server-runtime/package.json
+//// {
+////   "name": "@remix-run/server-runtime",
+////   "version": "0.0.0",
+////   "main": "index.js"
+//// }
+
+// @Filename: c:/project/node_modules/@remix-run/server-runtime/index.d.ts
+//// export declare function ServerRuntimeMetaFunction(): void;
+
+// @Filename: c:/project/package.json
+//// { "dependencies": { "aws-sdk": "*", "@remix-run/server-runtime": "*" } }
+
+// @link: c:/project/node_modules/.store/aws-sdk-virtual-adfe098/package -> c:/project/node_modules/aws-sdk
+
+// @Filename: c:/project/index.ts
+//// ServerRuntimeMetaFunction/**/
+
+const autoImportFileExcludePatterns = ["c:/**/@remix-run/server-runtime"];
+
+verify.completions({
+  marker: "",
+  excludes: "ServerRuntimeMetaFunction",
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    autoImportFileExcludePatterns,
+  }
+});
+
+verify.importFixAtPosition([], /*errorCode*/ undefined, { autoImportFileExcludePatterns });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

The `autoImportExcludePatterns` entry was `@remix-run/server-runtime`, but yarn mangles the realpath of that package to `@remix-run-server-runtime-{hash}`. We need to see if some filename is actually the realpath of a symlinked directory, and check the exclude patterns against the symlink locations too.

Fixes #55111
