### PR TITLE
Fix unnecessary non-null assertions caught by newer ts-eslint

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7825,7 +7825,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     if (context.tracker.canTrackSymbol && isComputedPropertyName(node) && isLateBindableName(node)) {
                         trackComputedName(node.expression, context.enclosingDeclaration, context);
                     }
-                    let visited = visitEachChild(node, elideInitializerAndSetEmitFlags, /*context*/ undefined, /*nodesVisitor*/ undefined, elideInitializerAndSetEmitFlags)!;
+                    let visited = visitEachChild(node, elideInitializerAndSetEmitFlags, /*context*/ undefined, /*nodesVisitor*/ undefined, elideInitializerAndSetEmitFlags);
                     if (isBindingElement(visited)) {
                         visited = factory.updateBindingElement(
                             visited,
@@ -32629,7 +32629,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // Find the first enclosing class that has the declaring classes of the protected constituents
         // of the property as base classes
         let enclosingClass = forEachEnclosingClass(location, enclosingDeclaration => {
-            const enclosingClass = getDeclaredTypeOfSymbol(getSymbolOfDeclaration(enclosingDeclaration)!) as InterfaceType;
+            const enclosingClass = getDeclaredTypeOfSymbol(getSymbolOfDeclaration(enclosingDeclaration)) as InterfaceType;
             return isClassDerivedFromDeclaringClasses(enclosingClass, prop, writing);
         });
         // A protected property is accessible if the property is within the declaring class or classes derived from it
@@ -36278,7 +36278,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             return getTypeOfSymbol(symbol);
         }
         else {
-            const symbol = getSymbolOfDeclaration(container)!;
+            const symbol = getSymbolOfDeclaration(container);
             return getTypeOfSymbol(symbol);
         }
     }
@@ -40068,7 +40068,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // TypeScript 1.0 spec (April 2014)
         // 3.7.4: An object type can contain at most one string index signature and one numeric index signature.
         // 8.5: A class declaration can have at most one string index member declaration and one numeric index member declaration
-        const indexSymbol = getIndexSymbol(getSymbolOfDeclaration(node)!);
+        const indexSymbol = getIndexSymbol(getSymbolOfDeclaration(node));
         if (indexSymbol?.declarations) {
             const indexSignatureMap = new Map<TypeId, { type: Type; declarations: IndexSignatureDeclaration[]; }>();
             for (const declaration of (indexSymbol.declarations as IndexSignatureDeclaration[])) {
@@ -41025,7 +41025,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                 case SyntaxKind.NamespaceImport:
                 case SyntaxKind.ImportClause:
                     let result = DeclarationSpaces.None;
-                    const target = resolveAlias(getSymbolOfDeclaration(d as ImportEqualsDeclaration | NamespaceImport | ImportClause | ExportAssignment | BinaryExpression)!);
+                    const target = resolveAlias(getSymbolOfDeclaration(d as ImportEqualsDeclaration | NamespaceImport | ImportClause | ExportAssignment | BinaryExpression));
                     forEach(target.declarations, d => {
                         result |= getDeclarationSpaces(d);
                     });
@@ -47539,7 +47539,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
 
         if (isDeclarationNameOrImportPropertyName(node)) {
             // This is a declaration, call getSymbolOfNode
-            const parentSymbol = getSymbolOfDeclaration(parent as Declaration)!;
+            const parentSymbol = getSymbolOfDeclaration(parent as Declaration);
             return isImportOrExportSpecifier(node.parent) && node.parent.propertyName === node
                 ? getImmediateAliasedSymbol(parentSymbol)
                 : parentSymbol;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3068,7 +3068,7 @@ export function createPrinter(printerOptions: PrinterOptions = {}, handlers: Pri
             // If the number will be printed verbatim and it doesn't already contain a dot or an exponent indicator, add one
             // if the expression doesn't have any comments that will be emitted.
             return !(expression.numericLiteralFlags & TokenFlags.WithSpecifier)
-                && !text.includes(tokenToString(SyntaxKind.DotToken)!)
+                && !text.includes(tokenToString(SyntaxKind.DotToken))
                 && !text.includes(String.fromCharCode(CharacterCodes.E))
                 && !text.includes(String.fromCharCode(CharacterCodes.e));
         }

--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -175,7 +175,7 @@ export class SessionClient implements LanguageService {
         let foundResponseMessage = false;
         let response!: T;
         while (!foundResponseMessage) {
-            const lastMessage = this.messages.dequeue()!;
+            const lastMessage = this.messages.dequeue();
             Debug.assert(!!lastMessage, "Did not receive any responses.");
             const responseBody = extractMessage(lastMessage);
             try {
@@ -842,7 +842,7 @@ export class SessionClient implements LanguageService {
 
         const request = this.processRequest<protocol.GetMoveToRefactoringFileSuggestionsRequest>(protocol.CommandTypes.GetMoveToRefactoringFileSuggestions, args);
         const response = this.processResponse<protocol.GetMoveToRefactoringFileSuggestions>(request);
-        return { newFileName: response.body?.newFileName, files: response.body?.files }!;
+        return { newFileName: response.body?.newFileName, files: response.body?.files };
     }
 
     getEditsForRefactor(

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5369,7 +5369,7 @@ function getContextualKeywords(
             && tokenLine === currentLine
         ) {
             entries.push({
-                name: tokenToString(SyntaxKind.AssertKeyword)!,
+                name: tokenToString(SyntaxKind.AssertKeyword),
                 kind: ScriptElementKind.keyword,
                 kindModifiers: ScriptElementKindModifier.none,
                 sortText: SortText.GlobalsOrKeywords,

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -327,7 +327,7 @@ export function createDocumentRegistryInternal(useCaseSensitiveFileNames?: boole
             // the script snapshot.  If so, update it appropriately.  Otherwise, we can just
             // return it as is.
             if (entry.sourceFile.version !== version) {
-                entry.sourceFile = updateLanguageServiceSourceFile(entry.sourceFile, scriptSnapshot, version, scriptSnapshot.getChangeRange(entry.sourceFile.scriptSnapshot!)); // TODO: GH#18217
+                entry.sourceFile = updateLanguageServiceSourceFile(entry.sourceFile, scriptSnapshot, version, scriptSnapshot.getChangeRange(entry.sourceFile.scriptSnapshot)); // TODO: GH#18217
                 if (externalCache) {
                     externalCache.setDocument(keyWithMode, path, entry.sourceFile);
                 }

--- a/src/services/documentRegistry.ts
+++ b/src/services/documentRegistry.ts
@@ -327,7 +327,7 @@ export function createDocumentRegistryInternal(useCaseSensitiveFileNames?: boole
             // the script snapshot.  If so, update it appropriately.  Otherwise, we can just
             // return it as is.
             if (entry.sourceFile.version !== version) {
-                entry.sourceFile = updateLanguageServiceSourceFile(entry.sourceFile, scriptSnapshot, version, scriptSnapshot.getChangeRange(entry.sourceFile.scriptSnapshot)); // TODO: GH#18217
+                entry.sourceFile = updateLanguageServiceSourceFile(entry.sourceFile, scriptSnapshot, version, scriptSnapshot.getChangeRange(entry.sourceFile.scriptSnapshot));
                 if (externalCache) {
                     externalCache.setDocument(keyWithMode, path, entry.sourceFile);
                 }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1958,7 +1958,7 @@ export function isInsideJsxElement(sourceFile: SourceFile, position: number): bo
 /** @internal */
 export function findPrecedingMatchingToken(token: Node, matchingTokenKind: SyntaxKind.OpenBraceToken | SyntaxKind.OpenParenToken | SyntaxKind.OpenBracketToken, sourceFile: SourceFile) {
     const closeTokenText = tokenToString(token.kind)!;
-    const matchingTokenText = tokenToString(matchingTokenKind)!;
+    const matchingTokenText = tokenToString(matchingTokenKind);
     const tokenFullStart = token.getFullStart();
     // Text-scan based fast path - can be bamboozled by comments and other trivia, but often provides
     // a good, fast approximation without too much extra work in the cases where it fails.

--- a/src/testRunner/unittests/helpers/baseline.ts
+++ b/src/testRunner/unittests/helpers/baseline.ts
@@ -355,7 +355,7 @@ export function baselineBuildInfo(
     if (!buildInfoPath || !sys.writtenFiles!.has(toPathWithSystem(sys, buildInfoPath))) return;
     if (!sys.fileExists(buildInfoPath)) return;
 
-    const buildInfo = ts.getBuildInfo(buildInfoPath, (originalReadCall || sys.readFile).call(sys, buildInfoPath, "utf8")!);
+    const buildInfo = ts.getBuildInfo(buildInfoPath, (originalReadCall || sys.readFile).call(sys, buildInfoPath, "utf8"));
     if (!buildInfo) return sys.writeFile(`${buildInfoPath}.baseline.txt`, "Error reading valid buildinfo file");
     generateBuildInfoProgramBaseline(sys, buildInfoPath, buildInfo);
 

--- a/src/testRunner/unittests/tsbuild/outFile.ts
+++ b/src/testRunner/unittests/tsbuild/outFile.ts
@@ -608,7 +608,7 @@ ${internal} enum internalEnum { a, b, c }`,
                     fs.writeFileSync(
                         "/src/third/tsconfig.json",
                         jsonToReadableText({
-                            ...JSON.parse(fs.readFileSync("/src/third/tsconfig.json", "utf-8")!),
+                            ...JSON.parse(fs.readFileSync("/src/third/tsconfig.json", "utf-8")),
                             references: [{ path: "../second", prepend: true }],
                         }),
                     );

--- a/src/testRunner/unittests/typeParameterIsPossiblyReferenced.ts
+++ b/src/testRunner/unittests/typeParameterIsPossiblyReferenced.ts
@@ -32,7 +32,7 @@ describe("unittests :: internalApi :: typeParameterIsPossiblyReferenced", () => 
             .type as ts.TypeQueryNode // typeof a
         ;
         const typeParameterDecl = (file.statements[0] as ts.FunctionDeclaration).typeParameters![0]; // T in f<T>
-        const typeParameter = checker.getTypeAtLocation(typeParameterDecl)! as ts.TypeParameter;
+        const typeParameter = checker.getTypeAtLocation(typeParameterDecl) as ts.TypeParameter;
         const isReferenced = checker.isTypeParameterPossiblyReferenced(typeParameter, typeQueryNode);
         assert.ok(isReferenced, "Type parameter is referenced in type query node");
     });


### PR DESCRIPTION
After https://github.com/typescript-eslint/typescript-eslint/pull/8143, typescript-eslint catches even more of these unnecessary non-null assertions. Linting will fail with newer versions until this is merged (so package-lock bumps will be stopped as that checks tests/lint).