### PR TITLE
Update typescript devDep to latest nightly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "playwright": "^1.38.0",
                 "source-map-support": "^0.5.21",
                 "tslib": "^2.5.0",
-                "typescript": "5.4.0-dev.20231206",
+                "typescript": "5.4.0-dev.20240119",
                 "which": "^2.0.2"
             },
             "engines": {
@@ -3909,9 +3909,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.0-dev.20231206",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231206.tgz",
-            "integrity": "sha512-bKJ5+3jwj4qTzNg7C97rCVLgyyYuzjYh/Pf0zlpOyyq9vpI3TVLO09d1gQ8jS5M+BSLONojTijei0KHmFoBezw==",
+            "version": "5.4.0-dev.20240119",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20240119.tgz",
+            "integrity": "sha512-I+Uge2+WNFs91q42WVrqTwxmq3NQwQlrL0MLora9zXhizbsKIGApE7LGcEJIbG+0yk6gpDilGaDH1pU4VUAKzw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -6805,9 +6805,9 @@
             }
         },
         "typescript": {
-            "version": "5.4.0-dev.20231206",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20231206.tgz",
-            "integrity": "sha512-bKJ5+3jwj4qTzNg7C97rCVLgyyYuzjYh/Pf0zlpOyyq9vpI3TVLO09d1gQ8jS5M+BSLONojTijei0KHmFoBezw==",
+            "version": "5.4.0-dev.20240119",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.0-dev.20240119.tgz",
+            "integrity": "sha512-I+Uge2+WNFs91q42WVrqTwxmq3NQwQlrL0MLora9zXhizbsKIGApE7LGcEJIbG+0yk6gpDilGaDH1pU4VUAKzw==",
             "dev": true
         },
         "typical": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "playwright": "^1.38.0",
         "source-map-support": "^0.5.21",
         "tslib": "^2.5.0",
-        "typescript": "5.4.0-dev.20231206",
+        "typescript": "5.4.0-dev.20240119",
         "which": "^2.0.2"
     },
     "overrides": {

--- a/scripts/dtsBundler.mjs
+++ b/scripts/dtsBundler.mjs
@@ -40,16 +40,6 @@ console.log(`Bundling ${entrypoint} to ${output} and ${internalOutput}`);
 const newLineKind = ts.NewLineKind.LineFeed;
 const newLine = newLineKind === ts.NewLineKind.LineFeed ? "\n" : "\r\n";
 
-/** @type {(node: ts.Node) => node is ts.DeclarationStatement} */
-function isDeclarationStatement(node) {
-    return /** @type {any} */ (ts).isDeclarationStatement(node);
-}
-
-/** @type {(node: ts.Node) => boolean} */
-function isInternalDeclaration(node) {
-    return /** @type {any} */ (ts).isInternalDeclaration(node, node.getSourceFile());
-}
-
 /**
  * @param {ts.VariableDeclaration} node
  * @returns {ts.VariableStatement}
@@ -71,14 +61,11 @@ function getDeclarationStatement(node) {
     if (ts.isVariableDeclaration(node)) {
         return getParentVariableStatement(node);
     }
-    else if (isDeclarationStatement(node)) {
+    else if (ts.isDeclarationStatement(node)) {
         return node;
     }
     return undefined;
 }
-
-/** @type {ts.TransformationContext} */
-const nullTransformationContext = /** @type {any} */ (ts).nullTransformationContext;
 
 const program = ts.createProgram([entrypoint], { target: ts.ScriptTarget.ES5 });
 
@@ -207,7 +194,7 @@ function containsPublicAPI(symbol) {
 
         for (const decl of symbol.declarations) {
             const statement = getDeclarationStatement(decl);
-            if (statement && !isInternalDeclaration(statement)) {
+            if (statement && !ts.isInternalDeclaration(statement)) {
                 return true;
             }
         }
@@ -264,17 +251,10 @@ function isNonLocalAlias(symbol, excludes = ts.SymbolFlags.Value | ts.SymbolFlag
 
 /**
  * @param {ts.Symbol} symbol
- */
-function resolveAlias(symbol) {
-    return typeChecker.getAliasedSymbol(symbol);
-}
-
-/**
- * @param {ts.Symbol} symbol
  * @param {boolean | undefined} [dontResolveAlias]
  */
 function resolveSymbol(symbol, dontResolveAlias = undefined) {
-    return !dontResolveAlias && isNonLocalAlias(symbol) ? resolveAlias(symbol) : symbol;
+    return !dontResolveAlias && isNonLocalAlias(symbol) ? typeChecker.getAliasedSymbol(symbol) : symbol;
 }
 
 /**
@@ -282,7 +262,7 @@ function resolveSymbol(symbol, dontResolveAlias = undefined) {
  * @returns {ts.Symbol}
  */
 function getMergedSymbol(symbol) {
-    return /** @type {any} */ (typeChecker).getMergedSymbol(symbol);
+    return typeChecker.getMergedSymbol(symbol);
 }
 
 /**
@@ -309,19 +289,11 @@ function symbolsConflict(s1, s2) {
 }
 
 /**
- * @param {ts.Node} node
- * @returns {boolean}
- */
-function isPartOfTypeNode(node) {
-    return /** @type {any} */ (ts).isPartOfTypeNode(node);
-}
-
-/**
  * @param {ts.Statement} decl
  */
 function verifyMatchingSymbols(decl) {
     ts.visitEachChild(decl, /** @type {(node: ts.Node) => ts.Node} */ function visit(node) {
-        if (ts.isIdentifier(node) && isPartOfTypeNode(node)) {
+        if (ts.isIdentifier(node) && ts.isPartOfTypeNode(node)) {
             if (ts.isQualifiedName(node.parent) && node !== node.parent.left) {
                 return node;
             }
@@ -347,8 +319,8 @@ function verifyMatchingSymbols(decl) {
             }
         }
 
-        return ts.visitEachChild(node, visit, nullTransformationContext);
-    }, nullTransformationContext);
+        return ts.visitEachChild(node, visit, /*context*/ undefined);
+    }, /*context*/ undefined);
 }
 
 /**
@@ -397,20 +369,20 @@ function emitAsNamespace(name, moduleSymbol) {
 
             verifyMatchingSymbols(statement);
 
-            const isInternal = isInternalDeclaration(statement);
+            const isInternal = ts.isInternalDeclaration(statement);
             if (!isInternal) {
                 const publicStatement = ts.visitEachChild(statement, node => {
                     // No @internal comments in the public API.
-                    if (isInternalDeclaration(node)) {
+                    if (ts.isInternalDeclaration(node)) {
                         return undefined;
                     }
                     return removeDeclareConstExport(node);
-                }, nullTransformationContext);
+                }, /*context*/ undefined);
 
                 writeNode(publicStatement, sourceFile, WriteTarget.Public);
             }
 
-            const internalStatement = ts.visitEachChild(statement, removeDeclareConstExport, nullTransformationContext);
+            const internalStatement = ts.visitEachChild(statement, removeDeclareConstExport, /*context*/ undefined);
 
             writeNode(internalStatement, sourceFile, WriteTarget.Internal);
         }

--- a/src/cancellationToken/cancellationToken.ts
+++ b/src/cancellationToken/cancellationToken.ts
@@ -60,7 +60,7 @@ function createCancellationToken(args: string[]): ServerCancellationToken {
     }
     else {
         return {
-            isCancellationRequested: () => pipeExists(cancellationPipeName!), // TODO: GH#18217
+            isCancellationRequested: () => pipeExists(cancellationPipeName), // TODO: GH#18217
             setRequest: (_requestId: number): void => void 0,
             resetRequest: (_requestId: number): void => void 0,
         };

--- a/src/cancellationToken/cancellationToken.ts
+++ b/src/cancellationToken/cancellationToken.ts
@@ -60,7 +60,7 @@ function createCancellationToken(args: string[]): ServerCancellationToken {
     }
     else {
         return {
-            isCancellationRequested: () => pipeExists(cancellationPipeName), // TODO: GH#18217
+            isCancellationRequested: () => pipeExists(cancellationPipeName),
             setRequest: (_requestId: number): void => void 0,
             resetRequest: (_requestId: number): void => void 0,
         };

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3569,7 +3569,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     (meaning & SymbolFlags.BlockScopedVariable ||
                         ((meaning & SymbolFlags.Class || meaning & SymbolFlags.Enum) && (meaning & SymbolFlags.Value) === SymbolFlags.Value))
                 ) {
-                    const exportOrLocalSymbol = getExportSymbolOfValueSymbolIfExported(result!);
+                    const exportOrLocalSymbol = getExportSymbolOfValueSymbolIfExported(result);
                     if (exportOrLocalSymbol.flags & SymbolFlags.BlockScopedVariable || exportOrLocalSymbol.flags & SymbolFlags.Class || exportOrLocalSymbol.flags & SymbolFlags.Enum) {
                         checkResolvedBlockScopedVariable(exportOrLocalSymbol, errorLocation);
                     }

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1295,7 +1295,7 @@ function createModuleOrTypeReferenceResolutionCache<T>(
         ...nonRelativeNameResolutionCache,
         clear,
         update,
-        getPackageJsonInfoCache: () => packageJsonInfoCache!,
+        getPackageJsonInfoCache: () => packageJsonInfoCache,
         clearAllExceptPackageJsonInfoCache,
         optionsToRedirectsKey,
     };

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2523,7 +2523,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
                 moduleNames,
                 newSourceFile,
                 resolutions,
-                (name, mode) => oldProgram!.getResolvedModule(newSourceFile, name, mode),
+                (name, mode) => oldProgram.getResolvedModule(newSourceFile, name, mode),
                 moduleResolutionIsEqualTo,
                 moduleResolutionNameAndModeGetter,
             );
@@ -2580,7 +2580,7 @@ export function createProgram(rootNamesOrOptions: readonly string[] | CreateProg
             }
             if (oldFile.path === path) {
                 // Set the file as found during node modules search if it was found that way in old progra,
-                if (oldProgram!.isSourceFileFromExternalLibrary(oldFile)) {
+                if (oldProgram.isSourceFileFromExternalLibrary(oldFile)) {
                     sourceFilesFoundSearchingNodeModules.set(oldFile.path, true);
                 }
                 return;

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -2641,6 +2641,6 @@ export function isInternalDeclaration(node: Node, sourceFile?: SourceFile) {
     }
     const leadingCommentRanges = parseTreeNode && getLeadingCommentRangesOfNode(parseTreeNode, sourceFile);
     return !!forEach(leadingCommentRanges, range => {
-        return hasInternalAnnotation(range, sourceFile!);
+        return hasInternalAnnotation(range, sourceFile);
     });
 }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -953,12 +953,12 @@ function createWatchFactoryHostUsingWatchEvents(service: ProjectService, canUseW
         callbacks.add(callback);
         return {
             close() {
-                const callbacks = idToCallbacks.get(id!);
+                const callbacks = idToCallbacks.get(id);
                 if (!callbacks?.delete(callback)) return;
                 if (callbacks.size) return;
-                idToCallbacks.delete(id!);
+                idToCallbacks.delete(id);
                 pathToId.delete(key);
-                service.eventHandler!({ eventName: CloseFileWatcherEvent, data: { id: id! } });
+                service.eventHandler!({ eventName: CloseFileWatcherEvent, data: { id } });
             },
         };
     }
@@ -3899,7 +3899,7 @@ export class ProjectService {
         for (const project of arrayFrom(this.configuredProjects.values())) {
             // If this project has potential project reference for any of the project we are loading ancestor tree for
             // load this project first
-            if (forEachPotentialProjectReference(project, potentialRefPath => forProjects!.has(potentialRefPath))) {
+            if (forEachPotentialProjectReference(project, potentialRefPath => forProjects.has(potentialRefPath))) {
                 updateProjectIfDirty(project);
             }
             this.ensureProjectChildren(project, forProjects, seenProjects);

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -2391,7 +2391,7 @@ export namespace Core {
             // If we have a 'super' container, we must have an enclosing class.
             // Now make sure the owning class is the same as the search-space
             // and has the same static qualifier as the original 'super's owner.
-            return container && isStatic(container) === !!staticFlag && container.parent.symbol === searchSpaceNode!.symbol ? nodeEntry(node) : undefined;
+            return container && isStatic(container) === !!staticFlag && container.parent.symbol === searchSpaceNode.symbol ? nodeEntry(node) : undefined;
         });
 
         return [{ definition: { type: DefinitionKind.Symbol, symbol: searchSpaceNode.symbol }, references }];


### PR DESCRIPTION
This exposes a few places where the new closure narrowing improved things, and also allows `dtsBundler.mjs` to shed _most_ of its internal API use.