### PR TITLE
chore: deprecate Node's getFullStart()

### DIFF
--- a/src/services/callHierarchy.ts
+++ b/src/services/callHierarchy.ts
@@ -424,7 +424,7 @@ export function createCallHierarchyItem(program: Program, node: CallHierarchyDec
     const containerName = getCallHierarchItemContainerName(node);
     const kind = getNodeKind(node);
     const kindModifiers = getNodeModifiers(node);
-    const span = createTextSpanFromBounds(skipTrivia(sourceFile.text, node.getFullStart(), /*stopAfterLineBreak*/ false, /*stopAtComments*/ true), node.getEnd());
+    const span = createTextSpanFromBounds(skipTrivia(sourceFile.text, node.pos, /*stopAfterLineBreak*/ false, /*stopAtComments*/ true), node.getEnd());
     const selectionSpan = createTextSpanFromBounds(name.pos, name.end);
     return { file: sourceFile.fileName, kind, kindModifiers, name: name.text, containerName, span, selectionSpan };
 }

--- a/src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts
+++ b/src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts
@@ -53,7 +53,7 @@ function doChanges(changes: textChanges.ChangeTracker, sourceFile: SourceFile, e
         heritageClauses[1].token === SyntaxKind.ImplementsKeyword
     ) {
         const implementsToken = heritageClauses[1].getFirstToken()!;
-        const implementsFullStart = implementsToken.getFullStart();
+        const implementsFullStart = implementsToken.pos;
         changes.replaceRange(sourceFile, { pos: implementsFullStart, end: implementsFullStart }, factory.createToken(SyntaxKind.CommaToken));
 
         // Rough heuristic: delete trailing whitespace after keyword so that it's not excessive.

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -5148,7 +5148,7 @@ function tryGetObjectLikeCompletionContainer(contextToken: Node | undefined, pos
 function getRelevantTokens(position: number, sourceFile: SourceFile): { contextToken: Node; previousToken: Node; } | { contextToken: undefined; previousToken: undefined; } {
     const previousToken = findPrecedingToken(position, sourceFile);
     if (previousToken && position <= previousToken.end && (isMemberName(previousToken) || isKeyword(previousToken.kind))) {
-        const contextToken = findPrecedingToken(previousToken.getFullStart(), sourceFile, /*startNode*/ undefined)!; // TODO: GH#18217
+        const contextToken = findPrecedingToken(previousToken.pos, sourceFile, /*startNode*/ undefined)!; // TODO: GH#18217
         return { contextToken, previousToken };
     }
     return { contextToken: previousToken as Node, previousToken: previousToken as Node };

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -879,7 +879,7 @@ function getTextSpan(node: Node, sourceFile: SourceFile, endNode?: Node): TextSp
         end -= 1;
     }
     if (endNode?.kind === SyntaxKind.CaseBlock) {
-        end = endNode.getFullStart();
+        end = endNode.pos;
     }
     return createTextSpanFromBounds(start, end);
 }

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -197,7 +197,7 @@ function groupByNewlineContiguous<T extends ImportDeclaration | ExportDeclaratio
 // a new group is created if an import/export includes at least two new line
 // new line from multi-line comment doesn't count
 function isNewGroup(sourceFile: SourceFile, decl: ImportDeclaration | ExportDeclaration, scanner: Scanner) {
-    const startPos = decl.getFullStart();
+    const startPos = decl.pos;
     const endPos = decl.getStart();
     scanner.setText(sourceFile.text, startPos, endPos - startPos);
 

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -331,10 +331,10 @@ function getOutliningSpanForNode(n: Node, sourceFile: SourceFile): OutliningSpan
     }
 
     function spanForArrowFunction(node: ArrowFunction): OutliningSpan | undefined {
-        if (isBlock(node.body) || isParenthesizedExpression(node.body) || positionsAreOnSameLine(node.body.getFullStart(), node.body.getEnd(), sourceFile)) {
+        if (isBlock(node.body) || isParenthesizedExpression(node.body) || positionsAreOnSameLine(node.body.pos, node.body.getEnd(), sourceFile)) {
             return undefined;
         }
-        const textSpan = createTextSpanFromBounds(node.body.getFullStart(), node.body.getEnd());
+        const textSpan = createTextSpanFromBounds(node.body.pos, node.body.getEnd());
         return createOutliningSpan(textSpan, OutliningSpanKind.Code, createTextSpanFromNode(node));
     }
 
@@ -397,7 +397,7 @@ function functionSpan(node: SignatureDeclaration, body: Block, sourceFile: Sourc
 }
 
 function spanBetweenTokens(openToken: Node, closeToken: Node, hintSpanNode: Node, sourceFile: SourceFile, autoCollapse = false, useFullStart = true): OutliningSpan {
-    const textSpan = createTextSpanFromBounds(useFullStart ? openToken.getFullStart() : openToken.getStart(sourceFile), closeToken.getEnd());
+    const textSpan = createTextSpanFromBounds(useFullStart ? openToken.pos : openToken.getStart(sourceFile), closeToken.getEnd());
     return createOutliningSpan(textSpan, OutliningSpanKind.Code, createTextSpanFromNode(hintSpanNode, sourceFile), autoCollapse);
 }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -561,6 +561,7 @@ class TokenOrIdentifierObject implements Node {
         return getTokenPosOfNode(this, sourceFile, includeJsDocComment);
     }
 
+    /** @deprecated use {@link pos} */
     public getFullStart(): number {
         return this.pos;
     }

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -253,7 +253,7 @@ function createJSSignatureHelpItems(argumentInfo: ArgumentListInfo, program: Pro
 }
 
 function containsPrecedingToken(startingToken: Node, sourceFile: SourceFile, container: Node) {
-    const pos = startingToken.getFullStart();
+    const pos = startingToken.pos;
     // There's a possibility that `startingToken.parent` contains only `startingToken` and
     // missing nodes, none of which are valid to be returned by `findPrecedingToken`. In that
     // case, the preceding token we want is actually higher up the tree—almost definitely the
@@ -601,7 +601,7 @@ function getApplicableSpanForArguments(argumentsList: Node, sourceFile: SourceFi
     //
     // The applicable span is from the first bar to the second bar (inclusive,
     // but not including parentheses)
-    const applicableSpanStart = argumentsList.getFullStart();
+    const applicableSpanStart = argumentsList.pos;
     const applicableSpanEnd = skipTrivia(sourceFile.text, argumentsList.getEnd(), /*stopAfterLineBreak*/ false);
     return createTextSpan(applicableSpanStart, applicableSpanEnd - applicableSpanStart);
 }

--- a/src/services/smartSelection.ts
+++ b/src/services/smartSelection.ts
@@ -51,7 +51,7 @@ import {
 /** @internal */
 export function getSmartSelectionRange(pos: number, sourceFile: SourceFile): SelectionRange {
     let selectionRange: SelectionRange = {
-        textSpan: createTextSpanFromBounds(sourceFile.getFullStart(), sourceFile.getEnd()),
+        textSpan: createTextSpanFromBounds(sourceFile.pos, sourceFile.getEnd()),
     };
 
     let parentNode: Node = sourceFile;
@@ -102,7 +102,7 @@ export function getSmartSelectionRange(pos: number, sourceFile: SourceFile): Sel
 
                 // Synthesize a stop for '${ ... }' since '${' and '}' actually belong to siblings.
                 if (isTemplateSpan(parentNode) && nextNode && isTemplateMiddleOrTemplateTail(nextNode)) {
-                    const start = node.getFullStart() - "${".length;
+                    const start = node.pos - "${".length;
                     const end = nextNode.getStart() + "}".length;
                     pushSelectionRange(start, end);
                 }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -369,7 +369,7 @@ function getAdjustedStartPosition(sourceFile: SourceFile, node: Node, options: C
             return getLineStartPositionForPosition(JSDocComments[0].pos, sourceFile);
         }
     }
-    const fullStart = node.getFullStart();
+    const fullStart = node.pos;
     const start = node.getStart(sourceFile);
     if (fullStart === start) {
         return start;
@@ -1063,7 +1063,7 @@ export class ChangeTracker {
                 // ###b,
                 //   c,
                 const nextNode = containingList[index + 1];
-                const startPos = skipWhitespacesAndLineBreaks(sourceFile.text, nextNode.getFullStart());
+                const startPos = skipWhitespacesAndLineBreaks(sourceFile.text, nextNode.pos);
 
                 // write separator and leading trivia of the next element as suffix
                 const suffix = `${tokenToString(nextToken.kind)}${sourceFile.text.substring(nextToken.end, startPos)}`;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -55,7 +55,7 @@ declare module "../compiler/types" {
         getStart(sourceFile?: SourceFile, includeJsDocComment?: boolean): number;
         /** @internal */
         getStart(sourceFile?: SourceFileLike, includeJsDocComment?: boolean): number; // eslint-disable-line @typescript-eslint/unified-signatures
-         /** @deprecated use {@link pos} */
+        /** @deprecated use {@link pos} */
         getFullStart(): number;
         getEnd(): number;
         getWidth(sourceFile?: SourceFileLike): number;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -55,6 +55,7 @@ declare module "../compiler/types" {
         getStart(sourceFile?: SourceFile, includeJsDocComment?: boolean): number;
         /** @internal */
         getStart(sourceFile?: SourceFileLike, includeJsDocComment?: boolean): number; // eslint-disable-line @typescript-eslint/unified-signatures
+         /** @deprecated use {@link pos} */
         getFullStart(): number;
         getEnd(): number;
         getWidth(sourceFile?: SourceFileLike): number;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1609,7 +1609,7 @@ function getTokenAtPositionWorker(sourceFile: SourceFile, position: number, allo
                 return Comparison.LessThan;
             }
 
-            const start = allowPositionInLeadingTrivia ? children[middle].getFullStart() : children[middle].getStart(sourceFile, /*includeJsDocComment*/ true);
+            const start = allowPositionInLeadingTrivia ? children[middle].pos : children[middle].getStart(sourceFile, /*includeJsDocComment*/ true);
             if (start > position) {
                 return Comparison.GreaterThan;
             }
@@ -1648,7 +1648,7 @@ function getTokenAtPositionWorker(sourceFile: SourceFile, position: number, allo
         if (end < position) {
             return false;
         }
-        start ??= allowPositionInLeadingTrivia ? node.getFullStart() : node.getStart(sourceFile, /*includeJsDocComment*/ true);
+        start ??= allowPositionInLeadingTrivia ? node.pos : node.getStart(sourceFile, /*includeJsDocComment*/ true);
         if (start > position) {
             // If this child begins after position, then all subsequent children will as well.
             return false;
@@ -1959,7 +1959,7 @@ export function isInsideJsxElement(sourceFile: SourceFile, position: number): bo
 export function findPrecedingMatchingToken(token: Node, matchingTokenKind: SyntaxKind.OpenBraceToken | SyntaxKind.OpenParenToken | SyntaxKind.OpenBracketToken, sourceFile: SourceFile) {
     const closeTokenText = tokenToString(token.kind)!;
     const matchingTokenText = tokenToString(matchingTokenKind);
-    const tokenFullStart = token.getFullStart();
+    const tokenFullStart = token.pos;
     // Text-scan based fast path - can be bamboozled by comments and other trivia, but often provides
     // a good, fast approximation without too much extra work in the cases where it fails.
     const bestGuessIndex = sourceFile.text.lastIndexOf(matchingTokenText, tokenFullStart);
@@ -1976,7 +1976,7 @@ export function findPrecedingMatchingToken(token: Node, matchingTokenKind: Synta
     const tokenKind = token.kind;
     let remainingMatchingTokens = 0;
     while (true) {
-        const preceding = findPrecedingToken(token.getFullStart(), sourceFile);
+        const preceding = findPrecedingToken(token.pos, sourceFile);
         if (!preceding) {
             return undefined;
         }
@@ -2054,9 +2054,9 @@ export function getPossibleTypeArgumentsInfo(tokenIn: Node | undefined, sourceFi
         switch (token.kind) {
             case SyntaxKind.LessThanToken:
                 // Found the beginning of the generic argument expression
-                token = findPrecedingToken(token.getFullStart(), sourceFile);
+                token = findPrecedingToken(token.pos, sourceFile);
                 if (token && token.kind === SyntaxKind.QuestionDotToken) {
-                    token = findPrecedingToken(token.getFullStart(), sourceFile);
+                    token = findPrecedingToken(token.pos, sourceFile);
                 }
                 if (!token || !isIdentifier(token)) return undefined;
                 if (!remainingLessThanTokens) {
@@ -2130,7 +2130,7 @@ export function getPossibleTypeArgumentsInfo(tokenIn: Node | undefined, sourceFi
                 return undefined;
         }
 
-        token = findPrecedingToken(token.getFullStart(), sourceFile);
+        token = findPrecedingToken(token.pos, sourceFile);
     }
 
     return undefined;
@@ -3256,7 +3256,7 @@ export function copyComments(sourceNode: Node, targetNode: Node) {
 }
 
 function hasLeadingLineBreak(node: Node, text: string) {
-    const start = node.getFullStart();
+    const start = node.pos;
     const end = node.getStart();
     for (let i = start; i < end; i++) {
         if (text.charCodeAt(i) === CharacterCodes.lineFeed) return true;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4816,6 +4816,7 @@ declare namespace ts {
         getChildAt(index: number, sourceFile?: SourceFile): Node;
         getChildren(sourceFile?: SourceFile): Node[];
         getStart(sourceFile?: SourceFile, includeJsDocComment?: boolean): number;
+        /** @deprecated use {@link pos} */
         getFullStart(): number;
         getEnd(): number;
         getWidth(sourceFile?: SourceFileLike): number;


### PR DESCRIPTION
Fixes #57053.

Marks the method as `@deprecated` in the `Node` interface and `TokenOrIdentifierObject` implementing class. Then replaces all find-all-references results from either to `.pos`.

Does not add the deprecation notice to the `NodeObject` class, since its `getFullStart()` also does a `this.assertHasRealPosition()`. Should that also be marked as deprecated?