### PR TITLE
Avoid creating redundant substitution types in non-generic contexts

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16173,7 +16173,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
     }
 
     function getSubstitutionType(baseType: Type, constraint: Type) {
-        return constraint.flags & TypeFlags.AnyOrUnknown || constraint === baseType || baseType.flags & TypeFlags.Any ?
+        return constraint.flags & TypeFlags.AnyOrUnknown || constraint === baseType || baseType.flags & TypeFlags.Any || !isGenericType(constraint) && !isGenericType(baseType) && isTypeAssignableTo(baseType, constraint) ?
             baseType :
             getOrCreateSubstitutionType(baseType, constraint);
     }

--- a/tests/baselines/reference/nonGenericIndexedAccessInConditionalTrueBranch1.symbols
+++ b/tests/baselines/reference/nonGenericIndexedAccessInConditionalTrueBranch1.symbols
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/nonGenericIndexedAccessInConditionalTrueBranch1.ts] ////
+
+=== nonGenericIndexedAccessInConditionalTrueBranch1.ts ===
+// https://github.com/microsoft/TypeScript/issues/57109
+
+type A = {
+>A : Symbol(A, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 0, 0))
+
+  k: symbol;
+>k : Symbol(k, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 2, 10))
+
+};
+
+type B = "k" extends keyof A ? A["k"] : never;
+>B : Symbol(B, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 4, 2))
+>A : Symbol(A, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 0, 0))
+>A : Symbol(A, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 0, 0))
+
+type C = {
+>C : Symbol(C, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 6, 46))
+
+  k: symbol;
+>k : Symbol(k, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 8, 10))
+
+  other: boolean;
+>other : Symbol(other, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 9, 12))
+
+};
+
+type D = "k" extends keyof C ? C["k"] : never;
+>D : Symbol(D, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 11, 2))
+>C : Symbol(C, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 6, 46))
+>C : Symbol(C, Decl(nonGenericIndexedAccessInConditionalTrueBranch1.ts, 6, 46))
+

--- a/tests/baselines/reference/nonGenericIndexedAccessInConditionalTrueBranch1.types
+++ b/tests/baselines/reference/nonGenericIndexedAccessInConditionalTrueBranch1.types
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/nonGenericIndexedAccessInConditionalTrueBranch1.ts] ////
+
+=== nonGenericIndexedAccessInConditionalTrueBranch1.ts ===
+// https://github.com/microsoft/TypeScript/issues/57109
+
+type A = {
+>A : { k: symbol; }
+
+  k: symbol;
+>k : symbol
+
+};
+
+type B = "k" extends keyof A ? A["k"] : never;
+>B : symbol
+
+type C = {
+>C : { k: symbol; other: boolean; }
+
+  k: symbol;
+>k : symbol
+
+  other: boolean;
+>other : boolean
+
+};
+
+type D = "k" extends keyof C ? C["k"] : never;
+>D : symbol
+

--- a/tests/cases/compiler/nonGenericIndexedAccessInConditionalTrueBranch1.ts
+++ b/tests/cases/compiler/nonGenericIndexedAccessInConditionalTrueBranch1.ts
@@ -1,0 +1,17 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/57109
+
+type A = {
+  k: symbol;
+};
+
+type B = "k" extends keyof A ? A["k"] : never;
+
+type C = {
+  k: symbol;
+  other: boolean;
+};
+
+type D = "k" extends keyof C ? C["k"] : never;


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/57109
