### PR TITLE
Fix release branch creation

### DIFF
--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/new-release-branch.yaml
@@ -35,7 +35,7 @@ jobs:
           sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' src/compiler/corePublic.ts
           sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' tests/baselines/reference/api/typescript.d.ts
           sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' tests/baselines/reference/api/tsserverlibrary.d.ts
-          sed -i -e 's/const version\(: string\)\{0,1\} = `${versionMajorMinor}.0-.*`/const version = `${versionMajorMinor}.0-${{ github.event.client_payload.core_tag || 'dev' }}`/g' src/compiler/corePublic.ts
+          sed -i -e 's/const version\(: string\)\{0,1\} = .*;/const version = "${{ github.event.client_payload.package_version }}" as string;/g' src/compiler/corePublic.ts
           npm ci
           npm install # update package-lock.json to ensure the version bump is included
           npx hereby LKG


### PR DESCRIPTION
Setting the version to a string literal fails CI because we (now, as of some previous release) figure out the actual interpolated literal and emit it. The intent is that our `d.ts` file has `const version: string`.

Just copy the code over from the `set-version` pipeline. The difference between the two pipelines is now just:

```diff
diff --git a/.github/workflows/new-release-branch.yaml b/.github/workflows/set-version.yaml
index 7e7a41ce50..cf490ad79d 100644
--- a/.github/workflows/new-release-branch.yaml
+++ b/.github/workflows/set-version.yaml
@@ -1,8 +1,8 @@
-name: New Release Branch
+name: Set branch version
 
 on:
   repository_dispatch:
-    types: [new-release-branch]
+    types: [set-version]
 
 permissions:
   contents: read
@@ -16,12 +16,10 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          filter: blob:none # https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
-          fetch-depth: 0 # Default is 1; need to set to 0 to get the benefits of blob:none.
+          ref: ${{ github.event.client_payload.branch_name }}
           token: ${{ secrets.TS_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
       - run: |
@@ -29,8 +27,14 @@ jobs:
           # corepack enable npm
           npm install -g $(jq -r '.packageManager' < package.json)
           npm --version
+      # notably, this is essentially the same script as `new-release-branch.yaml` (with fewer inputs), but it assumes the branch already exists
+      # do note that executing the transform below will prevent the `configurePrerelease` script from running on the source, as it makes the
+      # `version` identifier no longer match the regex it uses
+      # required client_payload members:
+      # branch_name - the target branch
+      # package_version - the full version string (eg, `3.9.1-rc` or `3.9.2`)
+      # core_major_minor - the major.minor pair associated with the desired package_version (eg, `3.9` for `3.9.3`)
       - run: |
-          git checkout -b ${{ github.event.client_payload.branch_name }}
           sed -i -e 's/"version": ".*"/"version": "${{ github.event.client_payload.package_version }}"/g' package.json
           sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' src/compiler/corePublic.ts
           sed -i -e 's/const versionMajorMinor = ".*"/const versionMajorMinor = "${{ github.event.client_payload.core_major_minor }}"/g' tests/baselines/reference/api/typescript.d.ts
@@ -49,4 +53,4 @@ jobs:
           git config user.email "typescriptbot@microsoft.com"
           git config user.name "TypeScript Bot"
           git commit -m 'Bump version to ${{ github.event.client_payload.package_version }} and LKG'
-          git push --set-upstream origin ${{ github.event.client_payload.branch_name }}
+          git push
```

They could be merged together, as they really just do the same thing.

See also https://github.com/microsoft/typescript-bot-test-triggerer/blob/master/GithubCommentReader/index.js#L437