### PR TITLE
Remove use of deprecated context.parserServices

### DIFF
--- a/scripts/eslint/rules/argument-trivia.cjs
+++ b/scripts/eslint/rules/argument-trivia.cjs
@@ -177,8 +177,8 @@ module.exports = createRule({
             }
 
             const getSignature = memoize(() => {
-                if (context.parserServices?.program) {
-                    const parserServices = ESLintUtils.getParserServices(context);
+                const parserServices = ESLintUtils.getParserServices(context, /*allowWithoutFullTypeInformation*/ true);
+                if (parserServices.program) {
                     const checker = parserServices.program.getTypeChecker();
                     const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
                     return checker.getResolvedSignature(tsNode);


### PR DESCRIPTION
`context.parserServices` is deprecated and will be removed in eslint v9; switch to using `ESLintUtils.getParserServices`.