### PR TITLE
Add missing members to array of objects in quickfix

### DIFF
--- a/tests/cases/fourslash/codeFixAddMissingProperties30.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties30.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+////interface A {
+////    a: number;
+////    b: string;
+////}
+////function f(_obj: A[]): string {
+////    return "";
+////}
+////[|f([{}])|]
+
+debugger;
+verify.codeFix({
+    index: 0,
+    description: ts.Diagnostics.Add_missing_properties.message,
+    newRangeContent:
+`f([{
+    a: 0,
+    b: ""
+}])`,
+});

--- a/tests/cases/fourslash/codeFixAddMissingProperties31.ts
+++ b/tests/cases/fourslash/codeFixAddMissingProperties31.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+////interface A {
+////    a: number;
+////    b: string;
+////}
+////interface B {
+////    c: A[];
+////}
+////[|const b: B[] = [{c: [{}]}]|]
+
+debugger;
+verify.codeFix({
+    index: 0,
+    description: ts.Diagnostics.Add_missing_properties.message,
+    newRangeContent:
+`const b: B[] = [{c: [{
+    a: 0,
+    b: ""
+}]}]`,
+});


### PR DESCRIPTION
If an object with missing properties is part of an array, then the token where the error occurs is an OpenBraceToken, which was not handled by the quickfix.

The correct type is available on the parent ObjectLiteralExpression.

Note that the ObjectLiteralExpression does not have a `text` property, so place the `identifier` string for deduplication on the InfoKind.ObjectLiteral structure.

The added test cases were failing on the main branch.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #57142
