### PR TITLE
Deprioritize declaration emit paths from baseUrl containing node_modules

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -437,7 +437,16 @@ function computeModuleSpecifiers(
                 redirectPathsSpecifiers = append(redirectPathsSpecifiers, local);
             }
             else if (pathIsBareSpecifier(local)) {
-                pathsSpecifiers = append(pathsSpecifiers, local);
+                if (pathContainsNodeModules(local)) {
+                    // We could be in this branch due to inappropriate use of `baseUrl`, not intentional `paths`
+                    // usage. It's impossible to reason about where to prioritize baseUrl-generated module
+                    // specifiers, but if they contain `/node_modules/`, they're going to trigger a portability
+                    // error, so *at least* don't prioritize those.
+                    relativeSpecifiers = append(relativeSpecifiers, local);
+                }
+                else {
+                    pathsSpecifiers = append(pathsSpecifiers, local);
+                }
             }
             else if (forAutoImport || !importedFileIsInNodeModules || modulePath.isInNodeModules) {
                 // Why this extra conditional, not just an `else`? If some path to the file contained

--- a/tests/baselines/reference/declarationEmitMonorepoBaseUrl.js
+++ b/tests/baselines/reference/declarationEmitMonorepoBaseUrl.js
@@ -1,0 +1,63 @@
+//// [tests/cases/compiler/declarationEmitMonorepoBaseUrl.ts] ////
+
+//// [package.json]
+{
+  "name": "@babel/parser",
+  "version": "7.23.6",
+  "main": "./lib/index.js",
+  "types": "./typings/babel-parser.d.ts"
+}
+
+//// [babel-parser.d.ts]
+export declare function createPlugin(): PluginConfig;
+export declare class PluginConfig {}
+
+//// [package.json]
+{
+  "name": "@vue/compiler-core",
+  "version": "3.0.0",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@babel/parser": "^7.0.0"
+  }
+}
+
+//// [package.json]
+{
+  "name": "@vue/compiler-sfc",
+  "version": "3.0.0",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@babel/parser": "^7.0.0",
+    "@vue/compiler-core": "^3.0.0"
+  }
+}
+
+//// [index.ts]
+import { PluginConfig } from "@babel/parser";
+
+//// [index.ts]
+import { createPlugin } from "@babel/parser";
+export function resolveParserPlugins() {
+  return [createPlugin()];
+}
+
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveParserPlugins = void 0;
+const parser_1 = require("@babel/parser");
+function resolveParserPlugins() {
+    return [(0, parser_1.createPlugin)()];
+}
+exports.resolveParserPlugins = resolveParserPlugins;
+
+
+//// [index.d.ts]
+export {};
+//// [index.d.ts]
+export declare function resolveParserPlugins(): import("@babel/parser").PluginConfig[];

--- a/tests/cases/compiler/declarationEmitMonorepoBaseUrl.ts
+++ b/tests/cases/compiler/declarationEmitMonorepoBaseUrl.ts
@@ -1,0 +1,57 @@
+// @noTypesAndSymbols: true
+
+// @Filename: /tsconfig.json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "declaration": true,
+    "outDir": "temp",
+    "baseUrl": "."
+  }
+}
+
+// @Filename: /node_modules/.pnpm/@babel+parser@7.23.6/node_modules/@babel/parser/package.json
+{
+  "name": "@babel/parser",
+  "version": "7.23.6",
+  "main": "./lib/index.js",
+  "types": "./typings/babel-parser.d.ts"
+}
+
+// @Filename: /node_modules/.pnpm/@babel+parser@7.23.6/node_modules/@babel/parser/typings/babel-parser.d.ts
+export declare function createPlugin(): PluginConfig;
+export declare class PluginConfig {}
+
+// @Filename: /packages/compiler-core/package.json
+{
+  "name": "@vue/compiler-core",
+  "version": "3.0.0",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@babel/parser": "^7.0.0"
+  }
+}
+
+// @Filename: /packages/compiler-core/src/index.ts
+import { PluginConfig } from "@babel/parser";
+
+// @Filename: /packages/compiler-sfc/package.json
+{
+  "name": "@vue/compiler-sfc",
+  "version": "3.0.0",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@babel/parser": "^7.0.0",
+    "@vue/compiler-core": "^3.0.0"
+  }
+}
+
+// @Filename: /packages/compiler-sfc/src/index.ts
+import { createPlugin } from "@babel/parser";
+export function resolveParserPlugins() {
+  return [createPlugin()];
+}
+
+// @link: /node_modules/.pnpm/@babel+parser@7.23.6/node_modules/@babel/parser -> /node_modules/@babel/parser
+// @link: /node_modules/.pnpm/@babel+parser@7.23.6/node_modules/@babel/parser -> /packages/compiler-core/node_modules/@babel/parser
+// @link: /node_modules/.pnpm/@babel+parser@7.23.6/node_modules/@babel/parser -> /packages/compiler-sfc/node_modules/@babel/parser


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes `error TS2742: The inferred type of 'resolveParserPlugins' cannot be named without a reference to 'packages/compiler-core/node_modules/@babel/parser/typings/babel-parser'. This is likely not portable. A type annotation is necessary.` reported in #57117. (It bisected to #55015, though it’s not clear why, and doesn’t seem like that PR directly introduced the buggy behavior.)

Also worth noting that Vue should almost certainly not be using `baseUrl` at all.