### PR TITLE
Fix isolatedModules check for export assignments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -46384,11 +46384,12 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
                     );
                 }
 
-                if (!isIllegalExportDefaultInCJS && getIsolatedModules(compilerOptions) && !(sym.flags & SymbolFlags.Value)) {
+                if (!isIllegalExportDefaultInCJS && !(node.flags & NodeFlags.Ambient) && getIsolatedModules(compilerOptions) && !(sym.flags & SymbolFlags.Value)) {
+                    const nonLocalMeanings = getSymbolFlags(sym, /*excludeTypeOnlyMeanings*/ false, /*excludeLocalMeanings*/ true);
                     if (
                         sym.flags & SymbolFlags.Alias
-                        && resolveAlias(sym) !== unknownSymbol
-                        && getSymbolFlags(sym, /*excludeTypeOnlyMeanings*/ false, /*excludeLocalMeanings*/ true) & SymbolFlags.Type
+                        && nonLocalMeanings & SymbolFlags.Type
+                        && !(nonLocalMeanings & SymbolFlags.Value)
                         && (!typeOnlyDeclaration || getSourceFileOfNode(typeOnlyDeclaration) !== getSourceFileOfNode(node))
                     ) {
                         // import { SomeType } from "./someModule";

--- a/tests/baselines/reference/exportDeclaration(isolatedmodules=true).errors.txt
+++ b/tests/baselines/reference/exportDeclaration(isolatedmodules=true).errors.txt
@@ -1,5 +1,5 @@
 /b.ts(3,5): error TS1362: 'A' cannot be used as a value because it was exported using 'export type'.
-/d.ts(2,10): error TS1291: 'A' resolves to a type and must be marked type-only in this file before re-exporting when 'isolatedModules' is enabled. Consider using 'import type' where 'A' is imported.
+/d.ts(2,10): error TS1289: 'A' resolves to a type-only declaration and must be marked type-only in this file before re-exporting when 'isolatedModules' is enabled. Consider using 'import type' where 'A' is imported.
 
 
 ==== /a.ts (0 errors) ====
@@ -22,4 +22,5 @@
     import { A } from './a';
     export = A;
              ~
-!!! error TS1291: 'A' resolves to a type and must be marked type-only in this file before re-exporting when 'isolatedModules' is enabled. Consider using 'import type' where 'A' is imported.
+!!! error TS1289: 'A' resolves to a type-only declaration and must be marked type-only in this file before re-exporting when 'isolatedModules' is enabled. Consider using 'import type' where 'A' is imported.
+!!! related TS1377 /a.ts:2:15: 'A' was exported here.

--- a/tests/cases/compiler/isolatedModulesReExportAlias.ts
+++ b/tests/cases/compiler/isolatedModulesReExportAlias.ts
@@ -1,0 +1,25 @@
+// @isolatedModules: true
+// @noEmit: true
+// @noTypesAndSymbols: true
+
+// @Filename: /events.d.ts
+declare module "events" {
+  interface EventEmitterOptions {
+    captureRejections?: boolean;
+  }
+  class EventEmitter {
+    constructor(options?: EventEmitterOptions);
+  }
+  export = EventEmitter;
+}
+declare module "node:events" {
+  import events = require("events");
+  export = events;
+}
+
+// @Filename: /moreEvents.ts
+import events = require("events");
+export = events;
+
+// @Filename: /boo.ts
+// Bad test runner (ignores stuff when last file contains the string r-e-q-u-i-r-e)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #57136 

Originally added in #55097, this was missing both the non-ambient check and a check that the resolved symbol has no value meaning:

- We only issue isolatedModules errors on non-ambient code, because the goal of all isolatedModules errors to ensure that code can be transpiled to JS. Ambient code produces no JS, so it’s exempt from checks.
- These errors are only supposed to occur when some re-export (`events` in the test and linked issue) resolves to something that doesn’t really exist at runtime (i.e., something that’s only a type, or something whose value meaning comes from a type-only import/export). The point is it needs to be easy for a transpiler to tell whether the re-export should be emitted or not—if it resolves to something real, it can and must be emitted; otherwise, it must be marked as type-only somewhere in the file so it can be removed.
  
  To try to determine if `events` resolved to anything real, the implementation was only checking that the re-export resolves to something with a type meaning before issuing an error. But `events` has both a value meaning and a type meaning (since it’s a namespace that contains one value and two types). So the implementation needed to check that the resolved symbol doesn’t _also_ have a value meaning in order to issue an error.