### PR TITLE
Use 'export * from' for public API instead of 'export ='

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -2,6 +2,7 @@
 import {
     CancelToken,
 } from "@esfx/canceltoken";
+import assert from "assert";
 import chalk from "chalk";
 import chokidar from "chokidar";
 import esbuild from "esbuild";
@@ -41,7 +42,6 @@ import {
     readJson,
     rimraf,
 } from "./scripts/build/utils.mjs";
-import assert from "assert";
 
 /** @typedef {ReturnType<typeof task>} Task */
 void 0;

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -2,7 +2,6 @@ import {
     Debug,
     LogLevel,
 } from "./_namespaces/ts";
-import * as ts from "./_namespaces/ts";
 
 // enable deprecation logging
 declare const console: any;
@@ -23,4 +22,4 @@ if (typeof console !== "undefined") {
     };
 }
 
-export = ts;
+export * from "./_namespaces/ts";


### PR DESCRIPTION
In #57133, I noticed that the emit for `export =` is actually worse for our bundle by a good bit; if we use `export * from`, things are less nested and smaller. Nothing changes for the public API as far as I'm aware.