### PR TITLE
Fix emit for `export { default } from ...` when both `importHelpers` and `esModuleInterop` are enabled

### DIFF
--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -68,6 +68,7 @@ import {
     map,
     MethodDeclaration,
     ModifierFlags,
+    NamedExportBindings,
     NamedImportBindings,
     NamespaceExport,
     Node,
@@ -108,14 +109,16 @@ export interface ExternalModuleInfo {
     hasExportStarsToExportValues: boolean; // whether this module contains export*
 }
 
-function containsDefaultReference(node: NamedImportBindings | undefined) {
+function containsDefaultReference(node: NamedImportBindings | NamedExportBindings | undefined) {
     if (!node) return false;
-    if (!isNamedImports(node)) return false;
+    if (!isNamedImports(node) && !isNamedExports(node)) return false;
     return some(node.elements, isNamedDefaultReference);
 }
 
-function isNamedDefaultReference(e: ImportSpecifier): boolean {
-    return e.propertyName !== undefined && e.propertyName.escapedText === InternalSymbolName.Default;
+function isNamedDefaultReference(e: ImportSpecifier | ExportSpecifier): boolean {
+    return e.propertyName !== undefined ?
+        e.propertyName.escapedText === InternalSymbolName.Default :
+        e.name.escapedText === InternalSymbolName.Default;
 }
 
 /** @internal */
@@ -214,6 +217,7 @@ export function collectExternalModuleInfo(context: TransformationContext, source
                         externalImports.push(node as ExportDeclaration);
                         if (isNamedExports((node as ExportDeclaration).exportClause!)) {
                             addExportedNamesForExportDeclaration(node as ExportDeclaration);
+                            hasImportDefault ||= containsDefaultReference((node as ExportDeclaration).exportClause);
                         }
                         else {
                             const name = ((node as ExportDeclaration).exportClause as NamespaceExport).name;

--- a/tests/baselines/reference/importHelpersNoEmitHelpersExportDefault.js
+++ b/tests/baselines/reference/importHelpersNoEmitHelpersExportDefault.js
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/importHelpersNoEmitHelpersExportDefault.ts] ////
+
+//// [main.ts]
+// https://github.com/microsoft/TypeScript/issues/40328
+export { default as A } from "./other";
+
+//// [main2.ts]
+export { default } from "./other";
+
+//// [other.ts]
+export default {};
+
+//// [tslib.d.ts]
+declare module "tslib" {
+    function __importDefault(m: any): void;
+}
+
+//// [other.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = {};
+//// [main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.A = void 0;
+var tslib_1 = require("tslib");
+// https://github.com/microsoft/TypeScript/issues/40328
+var other_1 = require("./other");
+Object.defineProperty(exports, "A", { enumerable: true, get: function () { return tslib_1.__importDefault(other_1).default; } });
+//// [main2.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = void 0;
+var tslib_1 = require("tslib");
+var other_1 = require("./other");
+Object.defineProperty(exports, "default", { enumerable: true, get: function () { return tslib_1.__importDefault(other_1).default; } });

--- a/tests/baselines/reference/nodeModulesAllowJsImportHelpersCollisions3(module=node16).js
+++ b/tests/baselines/reference/nodeModulesAllowJsImportHelpersCollisions3(module=node16).js
@@ -29,16 +29,14 @@ declare module "tslib" {
 
 //// [index.js]
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.baz = exports.foo = exports.default = void 0;
+var tslib_1 = require("tslib");
 // cjs format file
 var fs_1 = require("fs");
-Object.defineProperty(exports, "default", { enumerable: true, get: function () { return __importDefault(fs_1).default; } });
+Object.defineProperty(exports, "default", { enumerable: true, get: function () { return tslib_1.__importDefault(fs_1).default; } });
 var fs_2 = require("fs");
-Object.defineProperty(exports, "foo", { enumerable: true, get: function () { return __importDefault(fs_2).default; } });
+Object.defineProperty(exports, "foo", { enumerable: true, get: function () { return tslib_1.__importDefault(fs_2).default; } });
 var fs_3 = require("fs");
 Object.defineProperty(exports, "baz", { enumerable: true, get: function () { return fs_3.bar; } });
 //// [index.js]

--- a/tests/baselines/reference/nodeModulesAllowJsImportHelpersCollisions3(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesAllowJsImportHelpersCollisions3(module=nodenext).js
@@ -29,16 +29,14 @@ declare module "tslib" {
 
 //// [index.js]
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.baz = exports.foo = exports.default = void 0;
+var tslib_1 = require("tslib");
 // cjs format file
 var fs_1 = require("fs");
-Object.defineProperty(exports, "default", { enumerable: true, get: function () { return __importDefault(fs_1).default; } });
+Object.defineProperty(exports, "default", { enumerable: true, get: function () { return tslib_1.__importDefault(fs_1).default; } });
 var fs_2 = require("fs");
-Object.defineProperty(exports, "foo", { enumerable: true, get: function () { return __importDefault(fs_2).default; } });
+Object.defineProperty(exports, "foo", { enumerable: true, get: function () { return tslib_1.__importDefault(fs_2).default; } });
 var fs_3 = require("fs");
 Object.defineProperty(exports, "baz", { enumerable: true, get: function () { return fs_3.bar; } });
 //// [index.js]

--- a/tests/baselines/reference/nodeModulesImportHelpersCollisions3(module=node16).js
+++ b/tests/baselines/reference/nodeModulesImportHelpersCollisions3(module=node16).js
@@ -25,14 +25,12 @@ declare module "tslib" {
 
 //// [index.js]
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = void 0;
+var tslib_1 = require("tslib");
 // cjs format file
 var fs_1 = require("fs");
-Object.defineProperty(exports, "default", { enumerable: true, get: function () { return __importDefault(fs_1).default; } });
+Object.defineProperty(exports, "default", { enumerable: true, get: function () { return tslib_1.__importDefault(fs_1).default; } });
 //// [index.js]
 // esm format file
 export { default } from "fs";

--- a/tests/baselines/reference/nodeModulesImportHelpersCollisions3(module=nodenext).js
+++ b/tests/baselines/reference/nodeModulesImportHelpersCollisions3(module=nodenext).js
@@ -25,14 +25,12 @@ declare module "tslib" {
 
 //// [index.js]
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = void 0;
+var tslib_1 = require("tslib");
 // cjs format file
 var fs_1 = require("fs");
-Object.defineProperty(exports, "default", { enumerable: true, get: function () { return __importDefault(fs_1).default; } });
+Object.defineProperty(exports, "default", { enumerable: true, get: function () { return tslib_1.__importDefault(fs_1).default; } });
 //// [index.js]
 // esm format file
 export { default } from "fs";

--- a/tests/cases/compiler/importHelpersNoEmitHelpersExportDefault.ts
+++ b/tests/cases/compiler/importHelpersNoEmitHelpersExportDefault.ts
@@ -1,0 +1,21 @@
+// @target: es5
+// @module: commonjs
+// @importHelpers: true
+// @noEmitHelpers: true
+// @esModuleInterop: true
+// @noTypesAndSymbols: true
+
+// @filename: main.ts
+// https://github.com/microsoft/TypeScript/issues/40328
+export { default as A } from "./other";
+
+// @filename: main2.ts
+export { default } from "./other";
+
+// @filename: other.ts
+export default {};
+
+// @filename: tslib.d.ts
+declare module "tslib" {
+    function __importDefault(m: any): void;
+}


### PR DESCRIPTION
Fixes #40328
