### PR TITLE
Looser import/export elision blocking in visitElidableStatement

### DIFF
--- a/src/testRunner/unittests/customTransforms.ts
+++ b/src/testRunner/unittests/customTransforms.ts
@@ -164,4 +164,47 @@ describe("unittests:: customTransforms", () => {
             },
         ],
     }, { sourceMap: true, outFile: "source.js" });
+
+    emitsCorrectly("importDeclarationBeforeTransformElision", [
+        {
+            file: "a.ts",
+            text: "export type A = string;",
+        },
+        {
+            file: "index.ts",
+            text: "import { A } from './a.js';\nexport { A } from './a.js';",
+        },
+    ], {
+        before: [
+            context => {
+                const { factory } = context;
+                return (s: ts.SourceFile) => ts.visitEachChild(s, visitor, context);
+
+                function visitor(node: ts.Node): ts.Node {
+                    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier))
+                        return factory.updateImportDeclaration(
+                            node,
+                            node.modifiers,
+                            node.importClause,
+                            factory.createStringLiteral(node.moduleSpecifier.text),
+                            node.attributes
+                        );
+
+                    if (ts.isExportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier))
+                        return factory.updateExportDeclaration(
+                            node,
+                            node.modifiers,
+                            node.isTypeOnly,
+                            node.exportClause,
+                            factory.createStringLiteral(node.moduleSpecifier.text),
+                            node.attributes
+                        );
+                    return node;
+                }
+            }
+        ]
+    }, {
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.ESNext
+    });
 });

--- a/src/testRunner/unittests/customTransforms.ts
+++ b/src/testRunner/unittests/customTransforms.ts
@@ -181,30 +181,32 @@ describe("unittests:: customTransforms", () => {
                 return (s: ts.SourceFile) => ts.visitEachChild(s, visitor, context);
 
                 function visitor(node: ts.Node): ts.Node {
-                    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier))
+                    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
                         return factory.updateImportDeclaration(
                             node,
                             node.modifiers,
                             node.importClause,
                             factory.createStringLiteral(node.moduleSpecifier.text),
-                            node.attributes
+                            node.attributes,
                         );
+                    }
 
-                    if (ts.isExportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier))
+                    if (ts.isExportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
                         return factory.updateExportDeclaration(
                             node,
                             node.modifiers,
                             node.isTypeOnly,
                             node.exportClause,
                             factory.createStringLiteral(node.moduleSpecifier.text),
-                            node.attributes
+                            node.attributes,
                         );
+                    }
                     return node;
                 }
-            }
-        ]
+            },
+        ],
     }, {
         target: ts.ScriptTarget.ESNext,
-        module: ts.ModuleKind.ESNext
+        module: ts.ModuleKind.ESNext,
     });
 });

--- a/tests/baselines/reference/customTransforms/importDeclarationBeforeTransformElision.js
+++ b/tests/baselines/reference/customTransforms/importDeclarationBeforeTransformElision.js
@@ -1,0 +1,6 @@
+// [a.js]
+export {};
+
+
+// [index.js]
+export {};


### PR DESCRIPTION
This uses a slightly less restrictive elision blocking mechanism in `visitElidableStatement` such that we preserve import/export elision when a "before" transform updates an import or export declaration, so long as we are able to verify that the local bindings that we would have used to detect elision have not changed.

Fixes #40603
