### PR TITLE
Update .dprint.jsonc

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -56,7 +56,7 @@
     ],
     // Note: if adding new languages, make sure settings.template.json is updated too.
     "plugins": [
-        "https://plugins.dprint.dev/typescript-0.88.9.wasm",
+        "https://plugins.dprint.dev/typescript-0.88.10.wasm",
         "https://plugins.dprint.dev/json-0.19.1.wasm",
         "https://plugins.dprint.dev/prettier-0.35.0.json@0df49c4d878bb1051af2fa1d1f69ba6400f4b78633f49baa1f38954a6fd32b40"
     ]


### PR DESCRIPTION
Ensure .dprint.jsonc is up to date by changing https://plugins.dprint.dev/typescript-0.88.9.wasm to https://plugins.dprint.dev/typescript-0.88.10.wasm