### PR TITLE
Consider dtsBundler.mjs mod time in `hereby dts`

### DIFF
--- a/Herebyfile.mjs
+++ b/Herebyfile.mjs
@@ -159,13 +159,15 @@ export const cleanSrc = task({
     run: () => cleanProject("src"),
 });
 
+const dtsBundlerPath = "./scripts/dtsBundler.mjs";
+
 /**
  * @param {string} entrypoint
  * @param {string} output
  */
 async function runDtsBundler(entrypoint, output) {
     await exec(process.execPath, [
-        "./scripts/dtsBundler.mjs",
+        dtsBundlerPath,
         "--entrypoint",
         entrypoint,
         "--output",
@@ -392,7 +394,7 @@ export const dtsServices = task({
     description: "Bundles typescript.d.ts",
     dependencies: [buildServices],
     run: async () => {
-        if (needsUpdate("./built/local/typescript/tsconfig.tsbuildinfo", ["./built/local/typescript.d.ts", "./built/local/typescript.internal.d.ts"])) {
+        if (needsUpdate(["./built/local/typescript/tsconfig.tsbuildinfo", dtsBundlerPath], ["./built/local/typescript.d.ts", "./built/local/typescript.internal.d.ts"])) {
             await runDtsBundler("./built/local/typescript/typescript.d.ts", "./built/local/typescript.d.ts");
         }
     },


### PR DESCRIPTION
I had meant to fix this ages ago; if we modify the bundler script, then we want to regenerate the declaration files.