### PR TITLE
Add missing types for parameters of BigIntConstructor (#57283)

### DIFF
--- a/src/lib/es2020.bigint.d.ts
+++ b/src/lib/es2020.bigint.d.ts
@@ -103,7 +103,7 @@ interface BigInt {
 }
 
 interface BigIntConstructor {
-    (value: bigint | boolean | number | string): bigint;
+    (value: bigint | BigInt | boolean | Boolean | number | Number | string | String): bigint;
     readonly prototype: BigInt;
 
     /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #57283
