### PR TITLE
Replace only local type parameters with `any` when creating `prototype` property type of a class

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10701,7 +10701,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
         // the type of which is an instantiation of the class type with type Any supplied as a type argument for each type parameter.
         // It is an error to explicitly declare a static property member with the name 'prototype'.
         const classType = getDeclaredTypeOfSymbol(getParentOfSymbol(prototype)!) as InterfaceType;
-        return classType.typeParameters ? createTypeReference(classType as GenericType, map(classType.typeParameters, _ => anyType)) : classType;
+        return classType.localTypeParameters ? createTypeReference(classType as GenericType, concatenate(classType.outerTypeParameters, map(classType.localTypeParameters, _ => anyType))) : classType;
     }
 
     // Return the type of the given property in the given type, or undefined if no such property exists

--- a/tests/baselines/reference/accessorsOverrideProperty9.types
+++ b/tests/baselines/reference/accessorsOverrideProperty9.types
@@ -70,7 +70,7 @@ function ApiItemContainerMixin<TBaseClass extends IApiItemConstructor>(
   }
 
   return MixedClass;
->MixedClass : ((abstract new (...args: any[]) => MixedClass) & { prototype: ApiItemContainerMixin<any>.MixedClass; }) & TBaseClass
+>MixedClass : ((abstract new (...args: any[]) => MixedClass) & { prototype: MixedClass; }) & TBaseClass
 }
 
 // Subclass inheriting from mixin

--- a/tests/baselines/reference/amdDeclarationEmitNoExtraDeclare.types
+++ b/tests/baselines/reference/amdDeclarationEmitNoExtraDeclare.types
@@ -25,7 +25,7 @@ export function Configurable<T extends Constructor<{}>>(base: T): T {
 >base : T
 
     return class extends base {
->class extends base {        constructor(...args: any[]) {            super(...args);        }    } : { new (...args: any[]): (Anonymous class); prototype: Configurable<any>.(Anonymous class); } & T
+>class extends base {        constructor(...args: any[]) {            super(...args);        }    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >base : {}
 
         constructor(...args: any[]) {

--- a/tests/baselines/reference/anonClassDeclarationEmitIsAnon.types
+++ b/tests/baselines/reference/anonClassDeclarationEmitIsAnon.types
@@ -23,11 +23,11 @@ export type Constructor<T = {}> = new (...args: any[]) => T;
 >args : any[]
 
 export function Timestamped<TBase extends Constructor>(Base: TBase) {
->Timestamped : <TBase extends Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
+>Timestamped : <TBase extends Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >Base : TBase
 
     return class extends Base {
->class extends Base {        timestamp = Date.now();    } : { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
+>class extends Base {        timestamp = Date.now();    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >Base : {}
 
         timestamp = Date.now();
@@ -43,7 +43,7 @@ export function Timestamped<TBase extends Constructor>(Base: TBase) {
 === index.ts ===
 import { wrapClass, Timestamped } from "./wrapClass";
 >wrapClass : (param: any) => typeof Wrapped
->Timestamped : <TBase extends import("wrapClass").Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
+>Timestamped : <TBase extends import("wrapClass").Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 
 export default wrapClass(0);
 >wrapClass(0) : typeof Wrapped
@@ -63,12 +63,12 @@ export class User {
 export class TimestampedUser extends Timestamped(User) {
 >TimestampedUser : TimestampedUser
 >Timestamped(User) : Timestamped<typeof User>.(Anonymous class) & User
->Timestamped : <TBase extends import("wrapClass").Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
+>Timestamped : <TBase extends import("wrapClass").Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >User : typeof User
 
     constructor() {
         super();
 >super() : void
->super : { new (...args: any[]): Timestamped<typeof User>.(Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & typeof User
+>super : { new (...args: any[]): Timestamped<typeof User>.(Anonymous class); prototype: Timestamped<typeof User>.(Anonymous class); } & typeof User
     }
 }

--- a/tests/baselines/reference/baseConstraintOfDecorator.types
+++ b/tests/baselines/reference/baseConstraintOfDecorator.types
@@ -44,8 +44,8 @@ export function classExtender2<TFunction extends new (...args: string[]) => MyCl
 >args : any[]
 
     return class decoratorFunc extends superClass {
->class decoratorFunc extends superClass {        constructor(...args: any[]) {            super(...args);            _instanceModifier(this, args);        }    } : { new (...args: any[]): decoratorFunc; prototype: classExtender2<any>.decoratorFunc; } & TFunction
->decoratorFunc : { new (...args: any[]): decoratorFunc; prototype: classExtender2<any>.decoratorFunc; } & TFunction
+>class decoratorFunc extends superClass {        constructor(...args: any[]) {            super(...args);            _instanceModifier(this, args);        }    } : { new (...args: any[]): decoratorFunc; prototype: decoratorFunc; } & TFunction
+>decoratorFunc : { new (...args: any[]): decoratorFunc; prototype: decoratorFunc; } & TFunction
 >superClass : MyClass
 
         constructor(...args: any[]) {

--- a/tests/baselines/reference/declarationEmitLocalClassDeclarationMixin.types
+++ b/tests/baselines/reference/declarationEmitLocalClassDeclarationMixin.types
@@ -5,7 +5,7 @@ interface Constructor<C> { new (...args: any[]): C; }
 >args : any[]
 
 function mixin<B extends Constructor<{}>>(Base: B) {
->mixin : <B extends Constructor<{}>>(Base: B) => { new (...args: any[]): PrivateMixed; prototype: mixin<any>.PrivateMixed; } & B
+>mixin : <B extends Constructor<{}>>(Base: B) => { new (...args: any[]): PrivateMixed; prototype: PrivateMixed; } & B
 >Base : B
 
     class PrivateMixed extends Base {
@@ -17,7 +17,7 @@ function mixin<B extends Constructor<{}>>(Base: B) {
 >2 : 2
     }
     return PrivateMixed;
->PrivateMixed : { new (...args: any[]): PrivateMixed; prototype: mixin<any>.PrivateMixed; } & B
+>PrivateMixed : { new (...args: any[]): PrivateMixed; prototype: PrivateMixed; } & B
 }
 
 export class Unmixed {
@@ -29,13 +29,13 @@ export class Unmixed {
 }
 
 export const Mixed = mixin(Unmixed);
->Mixed : { new (...args: any[]): mixin<typeof Unmixed>.PrivateMixed; prototype: mixin<any>.PrivateMixed; } & typeof Unmixed
->mixin(Unmixed) : { new (...args: any[]): mixin<typeof Unmixed>.PrivateMixed; prototype: mixin<any>.PrivateMixed; } & typeof Unmixed
->mixin : <B extends Constructor<{}>>(Base: B) => { new (...args: any[]): PrivateMixed; prototype: mixin<any>.PrivateMixed; } & B
+>Mixed : { new (...args: any[]): mixin<typeof Unmixed>.PrivateMixed; prototype: mixin<typeof Unmixed>.PrivateMixed; } & typeof Unmixed
+>mixin(Unmixed) : { new (...args: any[]): mixin<typeof Unmixed>.PrivateMixed; prototype: mixin<typeof Unmixed>.PrivateMixed; } & typeof Unmixed
+>mixin : <B extends Constructor<{}>>(Base: B) => { new (...args: any[]): PrivateMixed; prototype: PrivateMixed; } & B
 >Unmixed : typeof Unmixed
 
 function Filter<C extends Constructor<{}>>(ctor: C) {
->Filter : <C extends Constructor<{}>>(ctor: C) => ((abstract new (...args: any[]) => FilterMixin) & { prototype: Filter<any>.FilterMixin; }) & C
+>Filter : <C extends Constructor<{}>>(ctor: C) => ((abstract new (...args: any[]) => FilterMixin) & { prototype: FilterMixin; }) & C
 >ctor : C
 
     abstract class FilterMixin extends ctor {
@@ -52,13 +52,13 @@ function Filter<C extends Constructor<{}>>(ctor: C) {
 >12 : 12
     }
     return FilterMixin;
->FilterMixin : ((abstract new (...args: any[]) => FilterMixin) & { prototype: Filter<any>.FilterMixin; }) & C
+>FilterMixin : ((abstract new (...args: any[]) => FilterMixin) & { prototype: FilterMixin; }) & C
 }
 
 export class FilteredThing extends Filter(Unmixed) {
 >FilteredThing : FilteredThing
 >Filter(Unmixed) : Filter<typeof Unmixed>.FilterMixin & Unmixed
->Filter : <C extends Constructor<{}>>(ctor: C) => ((abstract new (...args: any[]) => FilterMixin) & { prototype: Filter<any>.FilterMixin; }) & C
+>Filter : <C extends Constructor<{}>>(ctor: C) => ((abstract new (...args: any[]) => FilterMixin) & { prototype: FilterMixin; }) & C
 >Unmixed : typeof Unmixed
 
     match(path: string) {

--- a/tests/baselines/reference/declarationEmitPrivateNameCausesError.types
+++ b/tests/baselines/reference/declarationEmitPrivateNameCausesError.types
@@ -8,12 +8,12 @@ const IGNORE_EXTRA_VARIABLES = Symbol(); //Notice how this is unexported
 
 //This is exported
 export function ignoreExtraVariables<CtorT extends {new(...args:any[]):{}}> (ctor : CtorT) {
->ignoreExtraVariables : <CtorT extends new (...args: any[]) => {}>(ctor: CtorT) => { new (...args: any[]): (Anonymous class); prototype: ignoreExtraVariables<any>.(Anonymous class); } & CtorT
+>ignoreExtraVariables : <CtorT extends new (...args: any[]) => {}>(ctor: CtorT) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & CtorT
 >args : any[]
 >ctor : CtorT
 
     return class extends ctor {
->class extends ctor {        [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used    } : { new (...args: any[]): (Anonymous class); prototype: ignoreExtraVariables<any>.(Anonymous class); } & CtorT
+>class extends ctor {        [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & CtorT
 >ctor : {}
 
         [IGNORE_EXTRA_VARIABLES] = true; //An unexported constant is used

--- a/tests/baselines/reference/doubleMixinConditionalTypeBaseClassWorks.types
+++ b/tests/baselines/reference/doubleMixinConditionalTypeBaseClassWorks.types
@@ -6,30 +6,30 @@ type Constructor = new (...args: any[]) => {};
 >args : any[]
 
 const Mixin1 = <C extends Constructor>(Base: C) => class extends Base { private _fooPrivate: {}; }
->Mixin1 : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & C
-><C extends Constructor>(Base: C) => class extends Base { private _fooPrivate: {}; } : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & C
+>Mixin1 : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
+><C extends Constructor>(Base: C) => class extends Base { private _fooPrivate: {}; } : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
 >Base : C
->class extends Base { private _fooPrivate: {}; } : { new (...args: any[]): (Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & C
+>class extends Base { private _fooPrivate: {}; } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
 >Base : {}
 >_fooPrivate : {}
 
 type FooConstructor = typeof Mixin1 extends (a: Constructor) => infer Cls ? Cls : never;
->FooConstructor : { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & Constructor
->Mixin1 : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & C
+>FooConstructor : { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<Constructor>.(Anonymous class); } & Constructor
+>Mixin1 : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
 >a : Constructor
 
 const Mixin2 = <C extends FooConstructor>(Base: C) => class extends Base {};
->Mixin2 : <C extends { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: Mixin2<any>.(Anonymous class); } & C
-><C extends FooConstructor>(Base: C) => class extends Base {} : <C extends { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: Mixin2<any>.(Anonymous class); } & C
+>Mixin2 : <C extends { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<Constructor>.(Anonymous class); } & Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
+><C extends FooConstructor>(Base: C) => class extends Base {} : <C extends { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<Constructor>.(Anonymous class); } & Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
 >Base : C
->class extends Base {} : { new (...args: any[]): (Anonymous class); prototype: Mixin2<any>.(Anonymous class); } & C
+>class extends Base {} : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
 >Base : Mixin1<Constructor>.(Anonymous class)
 
 class C extends Mixin2(Mixin1(Object)) {}
 >C : C
->Mixin2(Mixin1(Object)) : Mixin2<{ new (...args: any[]): Mixin1<ObjectConstructor>.(Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & ObjectConstructor>.(Anonymous class) & Mixin1<ObjectConstructor>.(Anonymous class) & Object
->Mixin2 : <C extends { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: Mixin2<any>.(Anonymous class); } & C
->Mixin1(Object) : { new (...args: any[]): Mixin1<ObjectConstructor>.(Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & ObjectConstructor
->Mixin1 : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: Mixin1<any>.(Anonymous class); } & C
+>Mixin2(Mixin1(Object)) : Mixin2<{ new (...args: any[]): Mixin1<ObjectConstructor>.(Anonymous class); prototype: Mixin1<ObjectConstructor>.(Anonymous class); } & ObjectConstructor>.(Anonymous class) & Mixin1<ObjectConstructor>.(Anonymous class) & Object
+>Mixin2 : <C extends { new (...args: any[]): Mixin1<Constructor>.(Anonymous class); prototype: Mixin1<Constructor>.(Anonymous class); } & Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
+>Mixin1(Object) : { new (...args: any[]): Mixin1<ObjectConstructor>.(Anonymous class); prototype: Mixin1<ObjectConstructor>.(Anonymous class); } & ObjectConstructor
+>Mixin1 : <C extends Constructor>(Base: C) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & C
 >Object : ObjectConstructor
 

--- a/tests/baselines/reference/emitClassExpressionInDeclarationFile.types
+++ b/tests/baselines/reference/emitClassExpressionInDeclarationFile.types
@@ -43,11 +43,11 @@ export type Constructor<T> = new(...args: any[]) => T;
 >args : any[]
 
 export function WithTags<T extends Constructor<FooItem>>(Base: T) {
->WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithTags<any>.(Anonymous class); getTags(): void; } & T
+>WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); getTags(): void; } & T
 >Base : T
 
     return class extends Base {
->class extends Base {        static getTags(): void { }        tags(): void { }    } : { new (...args: any[]): (Anonymous class); prototype: WithTags<any>.(Anonymous class); getTags(): void; } & T
+>class extends Base {        static getTags(): void { }        tags(): void { }    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); getTags(): void; } & T
 >Base : FooItem
 
         static getTags(): void { }
@@ -61,7 +61,7 @@ export function WithTags<T extends Constructor<FooItem>>(Base: T) {
 export class Test extends WithTags(FooItem) {}
 >Test : Test
 >WithTags(FooItem) : WithTags<typeof FooItem>.(Anonymous class) & FooItem
->WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithTags<any>.(Anonymous class); getTags(): void; } & T
+>WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); getTags(): void; } & T
 >FooItem : typeof FooItem
 
 const test = new Test();

--- a/tests/baselines/reference/emitClassExpressionInDeclarationFile2.types
+++ b/tests/baselines/reference/emitClassExpressionInDeclarationFile2.types
@@ -41,11 +41,11 @@ export type Constructor<T> = new(...args: any[]) => T;
 >args : any[]
 
 export function WithTags<T extends Constructor<FooItem>>(Base: T) {
->WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithTags<any>.(Anonymous class); getTags(): void; } & T
+>WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); getTags(): void; } & T
 >Base : T
 
     return class extends Base {
->class extends Base {        static getTags(): void { }        tags(): void { }    } : { new (...args: any[]): (Anonymous class); prototype: WithTags<any>.(Anonymous class); getTags(): void; } & T
+>class extends Base {        static getTags(): void { }        tags(): void { }    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); getTags(): void; } & T
 >Base : FooItem
 
         static getTags(): void { }
@@ -59,7 +59,7 @@ export function WithTags<T extends Constructor<FooItem>>(Base: T) {
 export class Test extends WithTags(FooItem) {}
 >Test : Test
 >WithTags(FooItem) : WithTags<typeof FooItem>.(Anonymous class) & FooItem
->WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithTags<any>.(Anonymous class); getTags(): void; } & T
+>WithTags : <T extends Constructor<FooItem>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); getTags(): void; } & T
 >FooItem : typeof FooItem
 
 const test = new Test();

--- a/tests/baselines/reference/exportClassExtendingIntersection.types
+++ b/tests/baselines/reference/exportClassExtendingIntersection.types
@@ -29,7 +29,7 @@ export function MyMixin<T extends Constructor<MyBaseClass<any>>>(base: T): T & C
 >base : T
 
     return class extends base {
->class extends base {        mixinProperty: string;    } : { new (...args: any[]): (Anonymous class); prototype: MyMixin<any>.(Anonymous class); } & T
+>class extends base {        mixinProperty: string;    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >base : MyBaseClass<any>
 
         mixinProperty: string;

--- a/tests/baselines/reference/mixinAbstractClasses.2.types
+++ b/tests/baselines/reference/mixinAbstractClasses.2.types
@@ -22,7 +22,7 @@ function Mixin<TBaseClass extends abstract new (...args: any) => any>(baseClass:
         }
     }
     return MixinClass;
->MixinClass : { new (...args: any): MixinClass; prototype: Mixin<any>.MixinClass; } & TBaseClass
+>MixinClass : { new (...args: any): MixinClass; prototype: MixinClass; } & TBaseClass
 }
 
 abstract class AbstractBase {

--- a/tests/baselines/reference/mixinAbstractClasses.types
+++ b/tests/baselines/reference/mixinAbstractClasses.types
@@ -21,7 +21,7 @@ function Mixin<TBaseClass extends abstract new (...args: any) => any>(baseClass:
         }
     }
     return MixinClass;
->MixinClass : ((abstract new (...args: any) => MixinClass) & { prototype: Mixin<any>.MixinClass; }) & TBaseClass
+>MixinClass : ((abstract new (...args: any) => MixinClass) & { prototype: MixinClass; }) & TBaseClass
 }
 
 class ConcreteBase {

--- a/tests/baselines/reference/mixinAbstractClassesReturnTypeInference.types
+++ b/tests/baselines/reference/mixinAbstractClassesReturnTypeInference.types
@@ -14,7 +14,7 @@ abstract class AbstractBase {
 }
 
 function Mixin2<TBase extends abstract new (...args: any[]) => any>(baseClass: TBase) {
->Mixin2 : <TBase extends abstract new (...args: any[]) => any>(baseClass: TBase) => ((abstract new (...args: any[]) => MixinClass) & { prototype: Mixin2<any>.MixinClass; staticMixinMethod(): void; }) & TBase
+>Mixin2 : <TBase extends abstract new (...args: any[]) => any>(baseClass: TBase) => ((abstract new (...args: any[]) => MixinClass) & { prototype: MixinClass; staticMixinMethod(): void; }) & TBase
 >args : any[]
 >baseClass : TBase
 
@@ -31,13 +31,13 @@ function Mixin2<TBase extends abstract new (...args: any[]) => any>(baseClass: T
 >staticMixinMethod : () => void
     }
     return MixinClass;
->MixinClass : ((abstract new (...args: any[]) => MixinClass) & { prototype: Mixin2<any>.MixinClass; staticMixinMethod(): void; }) & TBase
+>MixinClass : ((abstract new (...args: any[]) => MixinClass) & { prototype: MixinClass; staticMixinMethod(): void; }) & TBase
 }
 
 class DerivedFromAbstract2 extends Mixin2(AbstractBase) {
 >DerivedFromAbstract2 : DerivedFromAbstract2
 >Mixin2(AbstractBase) : Mixin2<typeof AbstractBase>.MixinClass & AbstractBase
->Mixin2 : <TBase extends abstract new (...args: any[]) => any>(baseClass: TBase) => ((abstract new (...args: any[]) => MixinClass) & { prototype: Mixin2<any>.MixinClass; staticMixinMethod(): void; }) & TBase
+>Mixin2 : <TBase extends abstract new (...args: any[]) => any>(baseClass: TBase) => ((abstract new (...args: any[]) => MixinClass) & { prototype: MixinClass; staticMixinMethod(): void; }) & TBase
 >AbstractBase : typeof AbstractBase
 
     abstractBaseMethod() {}

--- a/tests/baselines/reference/mixinClassesAnnotated.types
+++ b/tests/baselines/reference/mixinClassesAnnotated.types
@@ -42,7 +42,7 @@ const Printable = <T extends Constructor<Base>>(superClass: T): Constructor<Prin
 >message : string
 
     class extends superClass {
->class extends superClass {        static message = "hello";        print() {            const output = this.x + "," + this.y;        }    } : { new (...args: any[]): (Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & T
+>class extends superClass {        static message = "hello";        print() {            const output = this.x + "," + this.y;        }    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); message: string; } & T
 >superClass : Base
 
         static message = "hello";
@@ -100,7 +100,7 @@ function Tagged<T extends Constructor<{}>>(superClass: T): Constructor<Tagged> &
         }
     }
     return C;
->C : { new (...args: any[]): C; prototype: Tagged<any>.C; } & T
+>C : { new (...args: any[]): C; prototype: C; } & T
 }
 
 const Thing1 = Tagged(Derived);

--- a/tests/baselines/reference/mixinClassesAnonymous.types
+++ b/tests/baselines/reference/mixinClassesAnonymous.types
@@ -31,10 +31,10 @@ class Derived extends Base {
 }
 
 const Printable = <T extends Constructor<Base>>(superClass: T) => class extends superClass {
->Printable : <T extends Constructor<Base>>(superClass: T) => { new (...args: any[]): (Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & T
-><T extends Constructor<Base>>(superClass: T) => class extends superClass {    static message = "hello";    print() {        const output = this.x + "," + this.y;    }} : <T extends Constructor<Base>>(superClass: T) => { new (...args: any[]): (Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & T
+>Printable : <T extends Constructor<Base>>(superClass: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); message: string; } & T
+><T extends Constructor<Base>>(superClass: T) => class extends superClass {    static message = "hello";    print() {        const output = this.x + "," + this.y;    }} : <T extends Constructor<Base>>(superClass: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); message: string; } & T
 >superClass : T
->class extends superClass {    static message = "hello";    print() {        const output = this.x + "," + this.y;    }} : { new (...args: any[]): (Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & T
+>class extends superClass {    static message = "hello";    print() {        const output = this.x + "," + this.y;    }} : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); message: string; } & T
 >superClass : Base
 
     static message = "hello";
@@ -59,7 +59,7 @@ const Printable = <T extends Constructor<Base>>(superClass: T) => class extends 
 }
 
 function Tagged<T extends Constructor<{}>>(superClass: T) {
->Tagged : <T extends Constructor<{}>>(superClass: T) => { new (...args: any[]): C; prototype: Tagged<any>.C; } & T
+>Tagged : <T extends Constructor<{}>>(superClass: T) => { new (...args: any[]): C; prototype: C; } & T
 >superClass : T
 
     class C extends superClass {
@@ -87,26 +87,26 @@ function Tagged<T extends Constructor<{}>>(superClass: T) {
         }
     }
     return C;
->C : { new (...args: any[]): C; prototype: Tagged<any>.C; } & T
+>C : { new (...args: any[]): C; prototype: C; } & T
 }
 
 const Thing1 = Tagged(Derived);
->Thing1 : { new (...args: any[]): Tagged<typeof Derived>.C; prototype: Tagged<any>.C; } & typeof Derived
->Tagged(Derived) : { new (...args: any[]): Tagged<typeof Derived>.C; prototype: Tagged<any>.C; } & typeof Derived
->Tagged : <T extends Constructor<{}>>(superClass: T) => { new (...args: any[]): C; prototype: Tagged<any>.C; } & T
+>Thing1 : { new (...args: any[]): Tagged<typeof Derived>.C; prototype: Tagged<typeof Derived>.C; } & typeof Derived
+>Tagged(Derived) : { new (...args: any[]): Tagged<typeof Derived>.C; prototype: Tagged<typeof Derived>.C; } & typeof Derived
+>Tagged : <T extends Constructor<{}>>(superClass: T) => { new (...args: any[]): C; prototype: C; } & T
 >Derived : typeof Derived
 
 const Thing2 = Tagged(Printable(Derived));
->Thing2 : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<any>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived
->Tagged(Printable(Derived)) : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<any>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived
->Tagged : <T extends Constructor<{}>>(superClass: T) => { new (...args: any[]): C; prototype: Tagged<any>.C; } & T
->Printable(Derived) : { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived
->Printable : <T extends Constructor<Base>>(superClass: T) => { new (...args: any[]): (Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & T
+>Thing2 : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived
+>Tagged(Printable(Derived)) : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived
+>Tagged : <T extends Constructor<{}>>(superClass: T) => { new (...args: any[]): C; prototype: C; } & T
+>Printable(Derived) : { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived
+>Printable : <T extends Constructor<Base>>(superClass: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); message: string; } & T
 >Derived : typeof Derived
 
 Thing2.message;
 >Thing2.message : string
->Thing2 : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<any>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived
+>Thing2 : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived
 >message : string
 
 function f1() {
@@ -115,7 +115,7 @@ function f1() {
     const thing = new Thing1(1, 2, 3);
 >thing : Tagged<typeof Derived>.C & Derived
 >new Thing1(1, 2, 3) : Tagged<typeof Derived>.C & Derived
->Thing1 : { new (...args: any[]): Tagged<typeof Derived>.C; prototype: Tagged<any>.C; } & typeof Derived
+>Thing1 : { new (...args: any[]): Tagged<typeof Derived>.C; prototype: Tagged<typeof Derived>.C; } & typeof Derived
 >1 : 1
 >2 : 2
 >3 : 3
@@ -135,40 +135,40 @@ function f2() {
 >f2 : () => void
 
     const thing = new Thing2(1, 2, 3);
->thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
->new Thing2(1, 2, 3) : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
->Thing2 : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<any>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived
+>thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
+>new Thing2(1, 2, 3) : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
+>Thing2 : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived
 >1 : 1
 >2 : 2
 >3 : 3
 
     thing.x;
 >thing.x : number
->thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
+>thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
 >x : number
 
     thing._tag;
 >thing._tag : string
->thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
+>thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
 >_tag : string
 
     thing.print();
 >thing.print() : void
 >thing.print : () => void
->thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
+>thing : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
 >print : () => void
 }
 
 class Thing3 extends Thing2 {
 >Thing3 : Thing3
->Thing2 : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
+>Thing2 : Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C & Printable<typeof Derived>.(Anonymous class) & Derived
 
     constructor(tag: string) {
 >tag : string
 
         super(10, 20, 30);
 >super(10, 20, 30) : void
->super : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<any>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<any>.(Anonymous class); message: string; } & typeof Derived
+>super : { new (...args: any[]): Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; prototype: Tagged<{ new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived>.C; } & { new (...args: any[]): Printable<typeof Derived>.(Anonymous class); prototype: Printable<typeof Derived>.(Anonymous class); message: string; } & typeof Derived
 >10 : 10
 >20 : 20
 >30 : 30
@@ -194,12 +194,12 @@ class Thing3 extends Thing2 {
 // Repro from #13805
 
 const Timestamped = <CT extends Constructor<object>>(Base: CT) => {
->Timestamped : <CT extends Constructor<object>>(Base: CT) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & CT
-><CT extends Constructor<object>>(Base: CT) => {    return class extends Base {        timestamp = new Date();    };} : <CT extends Constructor<object>>(Base: CT) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & CT
+>Timestamped : <CT extends Constructor<object>>(Base: CT) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & CT
+><CT extends Constructor<object>>(Base: CT) => {    return class extends Base {        timestamp = new Date();    };} : <CT extends Constructor<object>>(Base: CT) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & CT
 >Base : CT
 
     return class extends Base {
->class extends Base {        timestamp = new Date();    } : { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & CT
+>class extends Base {        timestamp = new Date();    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & CT
 >Base : object
 
         timestamp = new Date();

--- a/tests/baselines/reference/mixinIntersectionIsValidbaseType.types
+++ b/tests/baselines/reference/mixinIntersectionIsValidbaseType.types
@@ -15,32 +15,32 @@ export interface Initable {
  * Plain mixin where the superclass must be Initable
  */
 export const Serializable = <K extends Constructor<Initable> & Initable>(
->Serializable : <K extends Constructor<Initable> & Initable>(SuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
-><K extends Constructor<Initable> & Initable>(    SuperClass: K) => {    const LocalMixin = (InnerSuperClass: K) => {        return class SerializableLocal extends InnerSuperClass {        }    };    let ResultClass = LocalMixin(SuperClass);    return ResultClass;} : <K extends Constructor<Initable> & Initable>(SuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
+>Serializable : <K extends Constructor<Initable> & Initable>(SuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
+><K extends Constructor<Initable> & Initable>(    SuperClass: K) => {    const LocalMixin = (InnerSuperClass: K) => {        return class SerializableLocal extends InnerSuperClass {        }    };    let ResultClass = LocalMixin(SuperClass);    return ResultClass;} : <K extends Constructor<Initable> & Initable>(SuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
 
     SuperClass: K
 >SuperClass : K
 
 ) => {
     const LocalMixin = (InnerSuperClass: K) => {
->LocalMixin : (InnerSuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
->(InnerSuperClass: K) => {        return class SerializableLocal extends InnerSuperClass {        }    } : (InnerSuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
+>LocalMixin : (InnerSuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
+>(InnerSuperClass: K) => {        return class SerializableLocal extends InnerSuperClass {        }    } : (InnerSuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
 >InnerSuperClass : K
 
         return class SerializableLocal extends InnerSuperClass {
->class SerializableLocal extends InnerSuperClass {        } : { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
->SerializableLocal : { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
+>class SerializableLocal extends InnerSuperClass {        } : { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
+>SerializableLocal : { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
 >InnerSuperClass : Initable
         }
     };
     let ResultClass = LocalMixin(SuperClass);
->ResultClass : { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
->LocalMixin(SuperClass) : { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
->LocalMixin : (InnerSuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
+>ResultClass : { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
+>LocalMixin(SuperClass) : { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
+>LocalMixin : (InnerSuperClass: K) => { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
 >SuperClass : K
 
     return ResultClass;
->ResultClass : { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K
+>ResultClass : { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K
 
 };
 
@@ -50,19 +50,19 @@ const AMixin = <K extends Constructor<Initable> & Initable>(SuperClass: K) => {
 >SuperClass : K
 
     let SomeHowOkay = class A extends SuperClass {
->SomeHowOkay : { new (...args: any[]): A; prototype: AMixin<any>.A; init(...args: any[]): void; } & K
->class A extends SuperClass {    } : { new (...args: any[]): A; prototype: AMixin<any>.A; init(...args: any[]): void; } & K
->A : { new (...args: any[]): A; prototype: AMixin<any>.A; init(...args: any[]): void; } & K
+>SomeHowOkay : { new (...args: any[]): A; prototype: A; init(...args: any[]): void; } & K
+>class A extends SuperClass {    } : { new (...args: any[]): A; prototype: A; init(...args: any[]): void; } & K
+>A : { new (...args: any[]): A; prototype: A; init(...args: any[]): void; } & K
 >SuperClass : Initable
 
     };
 
     let SomeHowNotOkay = class A extends Serializable(SuperClass) {
->SomeHowNotOkay : { new (...args: any[]): A; prototype: AMixin<any>.A; init(...args: any[]): void; } & K
->class A extends Serializable(SuperClass) {    } : { new (...args: any[]): A; prototype: AMixin<any>.A; init(...args: any[]): void; } & K
->A : { new (...args: any[]): A; prototype: AMixin<any>.A; init(...args: any[]): void; } & K
+>SomeHowNotOkay : { new (...args: any[]): A; prototype: A; init(...args: any[]): void; } & K
+>class A extends Serializable(SuperClass) {    } : { new (...args: any[]): A; prototype: A; init(...args: any[]): void; } & K
+>A : { new (...args: any[]): A; prototype: A; init(...args: any[]): void; } & K
 >Serializable(SuperClass) : Serializable<K>.SerializableLocal & Initable
->Serializable : <K_1 extends Constructor<Initable> & Initable>(SuperClass: K_1) => { new (...args: any[]): SerializableLocal; prototype: Serializable<any>.SerializableLocal; init(...args: any[]): void; } & K_1
+>Serializable : <K_1 extends Constructor<Initable> & Initable>(SuperClass: K_1) => { new (...args: any[]): SerializableLocal; prototype: SerializableLocal; init(...args: any[]): void; } & K_1
 >SuperClass : K
 
     };

--- a/tests/baselines/reference/mixinOverMappedTypeNoCrash.types
+++ b/tests/baselines/reference/mixinOverMappedTypeNoCrash.types
@@ -39,5 +39,5 @@ function cloneClass<T extends Constructor<{}>>(OriginalClass: T): T {
         }
     }
     return AnotherOriginalClass
->AnotherOriginalClass : { new (...args: any[]): AnotherOriginalClass; prototype: cloneClass<any>.AnotherOriginalClass; } & T
+>AnotherOriginalClass : { new (...args: any[]): AnotherOriginalClass; prototype: AnotherOriginalClass; } & T
 }

--- a/tests/baselines/reference/mixinPrivateAndProtected.errors.txt
+++ b/tests/baselines/reference/mixinPrivateAndProtected.errors.txt
@@ -7,17 +7,17 @@ mixinPrivateAndProtected.ts(50,4): error TS2339: Property 'ptd' does not exist o
 mixinPrivateAndProtected.ts(51,4): error TS2339: Property 'pvt' does not exist on type 'never'.
   The intersection 'mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
 mixinPrivateAndProtected.ts(53,5): error TS2339: Property 'pb' does not exist on type 'never'.
-  The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+  The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
 mixinPrivateAndProtected.ts(54,5): error TS2339: Property 'ptd' does not exist on type 'never'.
-  The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+  The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
 mixinPrivateAndProtected.ts(55,5): error TS2339: Property 'pvt' does not exist on type 'never'.
-  The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+  The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
 mixinPrivateAndProtected.ts(57,6): error TS2339: Property 'pb' does not exist on type 'never'.
-  The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+  The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
 mixinPrivateAndProtected.ts(58,6): error TS2339: Property 'ptd' does not exist on type 'never'.
-  The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+  The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
 mixinPrivateAndProtected.ts(59,6): error TS2339: Property 'pvt' does not exist on type 'never'.
-  The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+  The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
 
 
 ==== mixinPrivateAndProtected.ts (11 errors) ====
@@ -89,28 +89,28 @@ mixinPrivateAndProtected.ts(59,6): error TS2339: Property 'pvt' does not exist o
     abc.pb.toFixed();
         ~~
 !!! error TS2339: Property 'pb' does not exist on type 'never'.
-!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
     abc.ptd.toFixed();  // Error
         ~~~
 !!! error TS2339: Property 'ptd' does not exist on type 'never'.
-!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
     abc.pvt.toFixed();  // Error
         ~~~
 !!! error TS2339: Property 'pvt' does not exist on type 'never'.
-!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
     
     ab2c.pb.toFixed();
          ~~
 !!! error TS2339: Property 'pb' does not exist on type 'never'.
-!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
     ab2c.ptd.toFixed(); // Error
          ~~~
 !!! error TS2339: Property 'ptd' does not exist on type 'never'.
-!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
     ab2c.pvt.toFixed(); // Error
          ~~~
 !!! error TS2339: Property 'pvt' does not exist on type 'never'.
-!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
+!!! error TS2339:   The intersection 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' was reduced to 'never' because property 'pvt' exists in multiple constituents and is private in some.
     
     // Repro from #13924
     

--- a/tests/baselines/reference/mixinPrivateAndProtected.types
+++ b/tests/baselines/reference/mixinPrivateAndProtected.types
@@ -24,11 +24,11 @@ class A {
 }
 
 function mixB<T extends Constructor<{}>>(Cls: T) {
->mixB : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: mixB<any>.(Anonymous class); } & T
+>mixB : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Cls : T
 
     return class extends Cls {
->class extends Cls {        protected ptd: number = 10;        private pvt: number = 0;    } : { new (...args: any[]): (Anonymous class); prototype: mixB<any>.(Anonymous class); } & T
+>class extends Cls {        protected ptd: number = 10;        private pvt: number = 0;    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Cls : {}
 
         protected ptd: number = 10;
@@ -43,11 +43,11 @@ function mixB<T extends Constructor<{}>>(Cls: T) {
 }
 
 function mixB2<T extends Constructor<A>>(Cls: T) {
->mixB2 : <T extends Constructor<A>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: mixB2<any>.(Anonymous class); } & T
+>mixB2 : <T extends Constructor<A>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Cls : T
 
     return class extends Cls {
->class extends Cls {        protected ptd: number = 10;    } : { new (...args: any[]): (Anonymous class); prototype: mixB2<any>.(Anonymous class); } & T
+>class extends Cls {        protected ptd: number = 10;    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Cls : A
 
         protected ptd: number = 10;
@@ -59,23 +59,23 @@ function mixB2<T extends Constructor<A>>(Cls: T) {
 
 const
     AB = mixB(A),
->AB : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A
->mixB(A) : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A
->mixB : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: mixB<any>.(Anonymous class); } & T
+>AB : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A
+>mixB(A) : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A
+>mixB : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >A : typeof A
 
     AB2 = mixB2(A);
->AB2 : { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A
->mixB2(A) : { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A
->mixB2 : <T extends Constructor<A>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: mixB2<any>.(Anonymous class); } & T
+>AB2 : { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A
+>mixB2(A) : { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A
+>mixB2 : <T extends Constructor<A>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >A : typeof A
 
 function mixC<T extends Constructor<{}>>(Cls: T) {
->mixC : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: mixC<any>.(Anonymous class); } & T
+>mixC : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Cls : T
 
     return class extends Cls {
->class extends Cls {        protected ptd: number = 100;        private pvt: number = 0;    } : { new (...args: any[]): (Anonymous class); prototype: mixC<any>.(Anonymous class); } & T
+>class extends Cls {        protected ptd: number = 100;        private pvt: number = 0;    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Cls : {}
 
         protected ptd: number = 100;
@@ -91,16 +91,16 @@ function mixC<T extends Constructor<{}>>(Cls: T) {
 
 const
     AB2C = mixC(AB2),
->AB2C : { new (...args: any[]): mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<any>.(Anonymous class); } & { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A
->mixC(AB2) : { new (...args: any[]): mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<any>.(Anonymous class); } & { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A
->mixC : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: mixC<any>.(Anonymous class); } & T
->AB2 : { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A
+>AB2C : { new (...args: any[]): mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); } & { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A
+>mixC(AB2) : { new (...args: any[]): mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); } & { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A
+>mixC : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
+>AB2 : { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A
 
     ABC = mixC(AB);
->ABC : { new (...args: any[]): mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<any>.(Anonymous class); } & { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A
->mixC(AB) : { new (...args: any[]): mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<any>.(Anonymous class); } & { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A
->mixC : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: mixC<any>.(Anonymous class); } & T
->AB : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A
+>ABC : { new (...args: any[]): mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); } & { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A
+>mixC(AB) : { new (...args: any[]): mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); } & { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A
+>mixC : <T extends Constructor<{}>>(Cls: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
+>AB : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A
 
 const
     a = new A(),
@@ -111,17 +111,17 @@ const
     ab = new AB(),
 >ab : never
 >new AB() : never
->AB : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A
+>AB : { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A
 
     abc = new ABC(),
 >abc : never
 >new ABC() : never
->ABC : { new (...args: any[]): mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<any>.(Anonymous class); } & { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A
+>ABC : { new (...args: any[]): mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); } & { new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<typeof A>.(Anonymous class); } & typeof A
 
     ab2c = new AB2C();
 >ab2c : never
 >new AB2C() : never
->AB2C : { new (...args: any[]): mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<any>.(Anonymous class); } & { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A
+>AB2C : { new (...args: any[]): mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); prototype: mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A>.(Anonymous class); } & { new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<typeof A>.(Anonymous class); } & typeof A
 
 a.pb.toFixed();
 >a.pb.toFixed() : string
@@ -235,11 +235,11 @@ class Person {
 }
 
 function PersonMixin<T extends Constructor<Person>>(Base: T) {
->PersonMixin : <T extends Constructor<Person>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: PersonMixin<any>.(Anonymous class); } & T
+>PersonMixin : <T extends Constructor<Person>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Base : T
 
 	return class extends Base {
->class extends Base {		constructor(...args: any[]) {			super(...args);		}		myProtectedFunction() {			super.myProtectedFunction();			// do more things		}	} : { new (...args: any[]): (Anonymous class); prototype: PersonMixin<any>.(Anonymous class); } & T
+>class extends Base {		constructor(...args: any[]) {			super(...args);		}		myProtectedFunction() {			super.myProtectedFunction();			// do more things		}	} : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Base : Person
 
 		constructor(...args: any[]) {
@@ -269,7 +269,7 @@ function PersonMixin<T extends Constructor<Person>>(Base: T) {
 class Customer extends PersonMixin(Person) {
 >Customer : Customer
 >PersonMixin(Person) : PersonMixin<typeof Person>.(Anonymous class) & Person
->PersonMixin : <T extends Constructor<Person>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: PersonMixin<any>.(Anonymous class); } & T
+>PersonMixin : <T extends Constructor<Person>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Person : typeof Person
 
 	accountBalance: number;

--- a/tests/baselines/reference/mixingApparentTypeOverrides.types
+++ b/tests/baselines/reference/mixingApparentTypeOverrides.types
@@ -6,11 +6,11 @@ type Constructor<T> = new(...args: any[]) => T;
 >args : any[]
 
 function Tagged<T extends Constructor<{}>>(Base: T) {
->Tagged : <T extends Constructor<{}>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: Tagged<any>.(Anonymous class); } & T
+>Tagged : <T extends Constructor<{}>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Base : T
 
   return class extends Base {
->class extends Base {    _tag: string;    constructor(...args: any[]) {      super(...args);      this._tag = "";    }  } : { new (...args: any[]): (Anonymous class); prototype: Tagged<any>.(Anonymous class); } & T
+>class extends Base {    _tag: string;    constructor(...args: any[]) {      super(...args);      this._tag = "";    }  } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Base : {}
 
     _tag: string;
@@ -49,7 +49,7 @@ class A {
 class B extends Tagged(A) {
 >B : B
 >Tagged(A) : Tagged<typeof A>.(Anonymous class) & A
->Tagged : <T extends Constructor<{}>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: Tagged<any>.(Anonymous class); } & T
+>Tagged : <T extends Constructor<{}>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >A : typeof A
 
   toString () { // Should not be an error

--- a/tests/baselines/reference/narrowTypeByInstanceofAnonymousConstructor1.symbols
+++ b/tests/baselines/reference/narrowTypeByInstanceofAnonymousConstructor1.symbols
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/narrowTypeByInstanceofAnonymousConstructor1.ts] ////
+
+=== narrowTypeByInstanceofAnonymousConstructor1.ts ===
+// https://github.com/microsoft/TypeScript/issues/57317
+
+function MakeClass<T>(someStuff: T) {
+>MakeClass : Symbol(MakeClass, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 0, 0))
+>T : Symbol(T, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 2, 19))
+>someStuff : Symbol(someStuff, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 2, 22))
+>T : Symbol(T, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 2, 19))
+
+  return class {
+    someStuff = someStuff;
+>someStuff : Symbol((Anonymous class).someStuff, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 3, 16))
+>someStuff : Symbol(someStuff, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 2, 22))
+
+  };
+}
+
+const MadeClassNumber = MakeClass(123);
+>MadeClassNumber : Symbol(MadeClassNumber, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 8, 5))
+>MakeClass : Symbol(MakeClass, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 0, 0))
+
+declare const someInstance: unknown;
+>someInstance : Symbol(someInstance, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 10, 13))
+
+if (someInstance instanceof MadeClassNumber) {
+>someInstance : Symbol(someInstance, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 10, 13))
+>MadeClassNumber : Symbol(MadeClassNumber, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 8, 5))
+
+  someInstance.someStuff;
+>someInstance.someStuff : Symbol((Anonymous class).someStuff, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 3, 16))
+>someInstance : Symbol(someInstance, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 10, 13))
+>someStuff : Symbol((Anonymous class).someStuff, Decl(narrowTypeByInstanceofAnonymousConstructor1.ts, 3, 16))
+}
+

--- a/tests/baselines/reference/narrowTypeByInstanceofAnonymousConstructor1.types
+++ b/tests/baselines/reference/narrowTypeByInstanceofAnonymousConstructor1.types
@@ -1,0 +1,39 @@
+//// [tests/cases/compiler/narrowTypeByInstanceofAnonymousConstructor1.ts] ////
+
+=== narrowTypeByInstanceofAnonymousConstructor1.ts ===
+// https://github.com/microsoft/TypeScript/issues/57317
+
+function MakeClass<T>(someStuff: T) {
+>MakeClass : <T>(someStuff: T) => typeof (Anonymous class)
+>someStuff : T
+
+  return class {
+>class {    someStuff = someStuff;  } : typeof (Anonymous class)
+
+    someStuff = someStuff;
+>someStuff : T
+>someStuff : T
+
+  };
+}
+
+const MadeClassNumber = MakeClass(123);
+>MadeClassNumber : typeof (Anonymous class)
+>MakeClass(123) : typeof (Anonymous class)
+>MakeClass : <T>(someStuff: T) => typeof (Anonymous class)
+>123 : 123
+
+declare const someInstance: unknown;
+>someInstance : unknown
+
+if (someInstance instanceof MadeClassNumber) {
+>someInstance instanceof MadeClassNumber : boolean
+>someInstance : unknown
+>MadeClassNumber : typeof (Anonymous class)
+
+  someInstance.someStuff;
+>someInstance.someStuff : number
+>someInstance : MakeClass<number>.(Anonymous class)
+>someStuff : number
+}
+

--- a/tests/baselines/reference/noCrashOnMixin.types
+++ b/tests/baselines/reference/noCrashOnMixin.types
@@ -18,11 +18,11 @@ type Constructor<T = {}> = new (...args: any[]) => T;
 >args : any[]
 
 function Mixin<TBase extends Constructor>(Base: TBase) {
->Mixin : <TBase extends Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Mixin<any>.(Anonymous class); } & TBase
+>Mixin : <TBase extends Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >Base : TBase
 
     return class extends Base {
->class extends Base {    } : { new (...args: any[]): (Anonymous class); prototype: Mixin<any>.(Anonymous class); } & TBase
+>class extends Base {    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >Base : {}
 
     };
@@ -35,7 +35,7 @@ class Empty {
 class CrashTrigger extends Mixin(Empty) {
 >CrashTrigger : CrashTrigger
 >Mixin(Empty) : Mixin<typeof Empty>.(Anonymous class) & Empty
->Mixin : <TBase extends Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Mixin<any>.(Anonymous class); } & TBase
+>Mixin : <TBase extends Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >Empty : typeof Empty
 
     public trigger() {

--- a/tests/baselines/reference/overrideBaseIntersectionMethod.types
+++ b/tests/baselines/reference/overrideBaseIntersectionMethod.types
@@ -8,10 +8,10 @@ type Constructor<T> = new (...args: any[]) => T;
 >args : any[]
 
 const WithLocation = <T extends Constructor<Point>>(Base: T) => class extends Base {
->WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
-><T extends Constructor<Point>>(Base: T) => class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
+><T extends Constructor<Point>>(Base: T) => class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Base : T
->class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>class extends Base {  getLocation(): [number, number] {    const [x,y] = super.getLocation();    return [this.x | x, this.y | y];  }} : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Base : Point
 
   getLocation(): [number, number] {
@@ -60,7 +60,7 @@ class Point {
 class Foo extends WithLocation(Point) {
 >Foo : Foo
 >WithLocation(Point) : WithLocation<typeof Point>.(Anonymous class) & Point
->WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: WithLocation<any>.(Anonymous class); } & T
+>WithLocation : <T extends Constructor<Point>>(Base: T) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & T
 >Point : typeof Point
 
   calculate() {

--- a/tests/baselines/reference/typeAliasFunctionTypeSharedSymbol.types
+++ b/tests/baselines/reference/typeAliasFunctionTypeSharedSymbol.types
@@ -4,25 +4,25 @@
 // Repro from comment in #21496
 
 function Mixin<TBase extends {new (...args: any[]): {}}>(Base: TBase) {
->Mixin : <TBase extends new (...args: any[]) => {}>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Mixin<any>.(Anonymous class); } & TBase
+>Mixin : <TBase extends new (...args: any[]) => {}>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >args : any[]
 >Base : TBase
 
     return class extends Base {
->class extends Base {    } : { new (...args: any[]): (Anonymous class); prototype: Mixin<any>.(Anonymous class); } & TBase
+>class extends Base {    } : { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 >Base : {}
 
     };
 }
 
 type Mixin = ReturnTypeOf<typeof Mixin>
->Mixin : { new (...args: any[]): Mixin<new (...args: any[]) => {}>.(Anonymous class); prototype: Mixin<any>.(Anonymous class); } & (new (...args: any[]) => {})
->Mixin : <TBase extends new (...args: any[]) => {}>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Mixin<any>.(Anonymous class); } & TBase
+>Mixin : { new (...args: any[]): Mixin<new (...args: any[]) => {}>.(Anonymous class); prototype: Mixin<new (...args: any[]) => {}>.(Anonymous class); } & (new (...args: any[]) => {})
+>Mixin : <TBase extends new (...args: any[]) => {}>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: (Anonymous class); } & TBase
 
 type ReturnTypeOf<V> = V extends (...args: any[])=>infer R ? R : never;
 >ReturnTypeOf : ReturnTypeOf<V>
 >args : any[]
 
 type Crashes = number & Mixin;
->Crashes : number & { new (...args: any[]): Mixin<new (...args: any[]) => {}>.(Anonymous class); prototype: Mixin<any>.(Anonymous class); } & (new (...args: any[]) => {})
+>Crashes : number & { new (...args: any[]): Mixin<new (...args: any[]) => {}>.(Anonymous class); prototype: Mixin<new (...args: any[]) => {}>.(Anonymous class); } & (new (...args: any[]) => {})
 

--- a/tests/cases/compiler/narrowTypeByInstanceofAnonymousConstructor1.ts
+++ b/tests/cases/compiler/narrowTypeByInstanceofAnonymousConstructor1.ts
@@ -1,0 +1,17 @@
+// @strict: true
+// @noEmit: true
+
+// https://github.com/microsoft/TypeScript/issues/57317
+
+function MakeClass<T>(someStuff: T) {
+  return class {
+    someStuff = someStuff;
+  };
+}
+
+const MadeClassNumber = MakeClass(123);
+
+declare const someInstance: unknown;
+if (someInstance instanceof MadeClassNumber) {
+  someInstance.someStuff;
+}

--- a/tests/cases/fourslash/quickInfoTemplateTag.ts
+++ b/tests/cases/fourslash/quickInfoTemplateTag.ts
@@ -16,6 +16,6 @@
 verify.quickInfoAt("",
 `function myMixin<T extends new (...args: any[]) => any>(cls: T): {
     new (...args: any[]): (Anonymous class);
-    prototype: myMixin<any>.(Anonymous class);
+    prototype: (Anonymous class);
 } & T`,
 "Doc");


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/57317
this is different from https://github.com/microsoft/TypeScript/pull/49863 - that PR likely still has a bug that I'm fixing here because it would replace the outer type parameter with its constraint