### PR TITLE
Expand anti-parent-barrel auto-import heuristic to all moduleResolution modes

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -1054,13 +1054,11 @@ function compareModuleSpecifiers(
 // This is a simple heuristic to try to avoid creating an import cycle with a barrel re-export.
 // E.g., do not `import { Foo } from ".."` when you could `import { Foo } from "../Foo"`.
 // This can produce false positives or negatives if re-exports cross into sibling directories
-// (e.g. `export * from "../whatever"`) or are not named "index" (we don't even try to consider
-// this if we're in a resolution mode where you can't drop trailing "/index" from paths).
+// (e.g. `export * from "../whatever"`) or are not named "index".
 function isFixPossiblyReExportingImportingFile(fix: ImportFixWithModuleSpecifier, importingFile: SourceFile, compilerOptions: CompilerOptions, toPath: (fileName: string) => Path): boolean {
     if (
         fix.isReExport &&
         fix.exportInfo?.moduleFileName &&
-        getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.Node10 &&
         isIndexFileName(fix.exportInfo.moduleFileName)
     ) {
         const reExportDir = toPath(getDirectoryPath(fix.exportInfo.moduleFileName));

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -97,7 +97,6 @@ import {
     mapDefined,
     memoizeOne,
     ModuleKind,
-    ModuleResolutionKind,
     moduleResolutionUsesNodeModules,
     moduleSpecifiers,
     MultiMap,

--- a/tests/cases/fourslash/importNameCodeFix_barrelExport4.ts
+++ b/tests/cases/fourslash/importNameCodeFix_barrelExport4.ts
@@ -1,0 +1,30 @@
+/// <reference path="fourslash.ts" />
+
+// @module: preserve
+// @moduleResolution: bundler
+
+// @Filename: /foo/a.ts
+//// export const A = 0;
+
+// @Filename: /foo/b.ts
+//// export {};
+//// A/*sibling*/
+
+// @Filename: /foo/index.ts
+//// export * from "./a";
+//// export * from "./b";
+
+// @Filename: /index.ts
+//// export * from "./foo";
+//// export * from "./src";
+
+// @Filename: /src/a.ts
+//// export {};
+//// A/*parent*/
+
+// @Filename: /src/index.ts
+//// export * from "./a";
+
+// Module specifiers made up of only "." and ".." components are deprioritized
+verify.importFixModuleSpecifiers("sibling", ["./a", ".", ".."]);
+verify.importFixModuleSpecifiers("parent", ["../foo", "../foo/a", ".."]);

--- a/tests/cases/fourslash/importNameCodeFix_barrelExport5.ts
+++ b/tests/cases/fourslash/importNameCodeFix_barrelExport5.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @module: nodenext
+
+// @Filename: /package.json
+//// { "type": "module" }
+
+// @Filename: /foo/a.ts
+//// export const A = 0;
+
+// @Filename: /foo/b.ts
+//// export {};
+//// A/*sibling*/
+
+// @Filename: /foo/index.ts
+//// export * from "./a.js";
+//// export * from "./b.js";
+
+// @Filename: /index.ts
+//// export * from "./foo/index.js";
+//// export * from "./src/index.js";
+
+// @Filename: /src/a.ts
+//// export {};
+//// A/*parent*/
+
+// @Filename: /src/index.ts
+//// export * from "./a.js";
+
+verify.importFixModuleSpecifiers("sibling", ["./a.js", "./index.js", "../index.js"]);
+verify.importFixModuleSpecifiers("parent", ["../foo/a.js", "../foo/index.js", "../index.js"]);


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes https://github.com/microsoft/TypeScript/issues/45953#issuecomment-1766430380
