### PR TITLE
fix(57386): Invalid use of 'eval' when defining a namespaced eval function

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2563,7 +2563,7 @@ function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
     }
 
     function checkStrictModeFunctionName(node: FunctionLikeDeclaration) {
-        if (inStrictMode) {
+        if (inStrictMode && !(node.flags & NodeFlags.Ambient)) {
             // It is a SyntaxError if the identifier eval or arguments appears within a FormalParameterList of a strict mode FunctionDeclaration or FunctionExpression (13.1))
             checkStrictModeEvalOrArguments(node, node.name);
         }

--- a/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.symbols
+++ b/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.symbols
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts] ////
+
+=== /a.d.ts ===
+declare global {
+>global : Symbol(global, Decl(a.d.ts, 0, 0))
+
+    export namespace ns {
+>ns : Symbol(ns, Decl(a.d.ts, 0, 16))
+
+        export function eval(): void;
+>eval : Symbol(eval, Decl(a.d.ts, 1, 25))
+
+        export function arguments(): void;
+>arguments : Symbol(arguments, Decl(a.d.ts, 2, 37))
+    }
+}
+export {}
+

--- a/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.symbols
+++ b/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.symbols
@@ -14,5 +14,12 @@ declare global {
 >arguments : Symbol(arguments, Decl(a.d.ts, 2, 37))
     }
 }
+
+declare function eval(): void;
+>eval : Symbol(eval, Decl(a.d.ts, 5, 1))
+
+declare function arguments(): void;
+>arguments : Symbol(arguments, Decl(a.d.ts, 7, 30))
+
 export {}
 

--- a/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.types
+++ b/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.types
@@ -14,5 +14,12 @@ declare global {
 >arguments : () => void
     }
 }
+
+declare function eval(): void;
+>eval : () => void
+
+declare function arguments(): void;
+>arguments : () => void
+
 export {}
 

--- a/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.types
+++ b/tests/baselines/reference/evalOrArgumentsInDeclarationFunctions.types
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts] ////
+
+=== /a.d.ts ===
+declare global {
+>global : typeof global
+
+    export namespace ns {
+>ns : typeof ns
+
+        export function eval(): void;
+>eval : () => void
+
+        export function arguments(): void;
+>arguments : () => void
+    }
+}
+export {}
+

--- a/tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts
+++ b/tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts
@@ -1,0 +1,8 @@
+// @filename: /a.d.ts
+declare global {
+    export namespace ns {
+        export function eval(): void;
+        export function arguments(): void;
+    }
+}
+export {}

--- a/tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts
+++ b/tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts
@@ -5,4 +5,8 @@ declare global {
         export function arguments(): void;
     }
 }
+
+declare function eval(): void;
+declare function arguments(): void;
+
 export {}


### PR DESCRIPTION
Fixes #57386