### PR TITLE
Fix scripts/errorCheck.mjs

### DIFF
--- a/scripts/errorCheck.mjs
+++ b/scripts/errorCheck.mjs
@@ -28,7 +28,7 @@ async function checkErrorBaselines() {
             const msg = keys.filter(k => messages[k].code === errCode)[0];
             messages[msg].seen = true;
         }
-    };
+    }
 
     console.log("== List of errors not present in baselines ==");
     let count = 0;

--- a/scripts/errorCheck.mjs
+++ b/scripts/errorCheck.mjs
@@ -19,18 +19,16 @@ async function checkErrorBaselines() {
 
     const files = (await fsPromises.readdir(baseDir)).filter(f => f.endsWith(".errors.txt"));
 
-    files.forEach(f => {
-        fs.readFile(baseDir + f, "utf-8", (err, baseline) => {
-            if (err) throw err;
+    for (const f of files) {
+        const baseline = fs.readFileSync(baseDir + f, "utf-8");
 
-            let g;
-            while (g = errRegex.exec(baseline)) {
-                const errCode = +g[1];
-                const msg = keys.filter(k => messages[k].code === errCode)[0];
-                messages[msg].seen = true;
-            }
-        });
-    });
+        let g;
+        while (g = errRegex.exec(baseline)) {
+            const errCode = +g[1];
+            const msg = keys.filter(k => messages[k].code === errCode)[0];
+            messages[msg].seen = true;
+        }
+    };
 
     console.log("== List of errors not present in baselines ==");
     let count = 0;


### PR DESCRIPTION
It wasn't waiting till the baseline files were done reading before running the `seen` check.

Fixed by changing readFile -> readFileSync. readFile in a script is basically always a bug!

Running the script shows an astounding 1069 / 1987 errors do not have baselines.