### PR TITLE
Set NODE_ENV to development and not testing in launch template

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -38,7 +38,7 @@
                 "0"
             ],
             "env": {
-                "NODE_ENV": "testing"
+                "NODE_ENV": "development"
             },
             "outFiles": [
                 "${workspaceFolder}/built/**/*.js",


### PR DESCRIPTION
All of our "is this development time" checks in the codebase look for `development` and not `testing` as the NODE_ENV.

