### PR TITLE
Remove `missingType` when inferring from properties in EOPT

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26182,7 +26182,10 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             for (const targetProp of properties) {
                 const sourceProp = getPropertyOfType(source, targetProp.escapedName);
                 if (sourceProp && !some(sourceProp.declarations, hasSkipDirectInferenceFlag)) {
-                    inferFromTypes(getTypeOfSymbol(sourceProp), getTypeOfSymbol(targetProp));
+                    inferFromTypes(
+                        removeMissingType(getTypeOfSymbol(sourceProp), !!(sourceProp.flags & SymbolFlags.Optional)),
+                        removeMissingType(getTypeOfSymbol(targetProp), !!(targetProp.flags & SymbolFlags.Optional)),
+                    );
                 }
             }
         }
@@ -30577,7 +30580,7 @@ export function createTypeChecker(host: TypeCheckerHost): TypeChecker {
             else if (t.flags & TypeFlags.StructuredType) {
                 const prop = getPropertyOfType(t, name);
                 if (prop) {
-                    return isCircularMappedProperty(prop) ? undefined : removeMissingType(getTypeOfSymbol(prop), !!(prop && prop.flags & SymbolFlags.Optional));
+                    return isCircularMappedProperty(prop) ? undefined : removeMissingType(getTypeOfSymbol(prop), !!(prop.flags & SymbolFlags.Optional));
                 }
                 if (isTupleType(t) && isNumericLiteralName(name) && +name >= 0) {
                     const restType = getElementTypeOfSliceOfTupleType(t, t.target.fixedLength, /*endSkipCount*/ 0, /*writing*/ false, /*noReductions*/ true);

--- a/tests/baselines/reference/inferenceExactOptionalProperties1.symbols
+++ b/tests/baselines/reference/inferenceExactOptionalProperties1.symbols
@@ -1,0 +1,10 @@
+//// [tests/cases/compiler/inferenceExactOptionalProperties1.ts] ////
+
+=== inferenceExactOptionalProperties1.ts ===
+type Test1 = { prop?: never } extends { prop?: infer T } ? T : false; // never
+>Test1 : Symbol(Test1, Decl(inferenceExactOptionalProperties1.ts, 0, 0))
+>prop : Symbol(prop, Decl(inferenceExactOptionalProperties1.ts, 0, 14))
+>prop : Symbol(prop, Decl(inferenceExactOptionalProperties1.ts, 0, 39))
+>T : Symbol(T, Decl(inferenceExactOptionalProperties1.ts, 0, 52))
+>T : Symbol(T, Decl(inferenceExactOptionalProperties1.ts, 0, 52))
+

--- a/tests/baselines/reference/inferenceExactOptionalProperties1.types
+++ b/tests/baselines/reference/inferenceExactOptionalProperties1.types
@@ -1,0 +1,9 @@
+//// [tests/cases/compiler/inferenceExactOptionalProperties1.ts] ////
+
+=== inferenceExactOptionalProperties1.ts ===
+type Test1 = { prop?: never } extends { prop?: infer T } ? T : false; // never
+>Test1 : never
+>prop : undefined
+>prop : T | undefined
+>false : false
+

--- a/tests/baselines/reference/inferenceExactOptionalProperties2.errors.txt
+++ b/tests/baselines/reference/inferenceExactOptionalProperties2.errors.txt
@@ -1,0 +1,79 @@
+inferenceExactOptionalProperties2.ts(64,11): error TS2345: Argument of type '"alarm"' is not assignable to parameter of type '"counter"'.
+
+
+==== inferenceExactOptionalProperties2.ts (1 errors) ====
+    type Values<T> = T[keyof T];
+    
+    type EventObject = {
+      type: string;
+    };
+    
+    interface ActorLogic<TEvent extends EventObject> {
+      transition: (ev: TEvent) => unknown;
+    }
+    
+    type UnknownActorLogic = ActorLogic<never>;
+    
+    interface ProvidedActor {
+      src: string;
+      logic: UnknownActorLogic;
+    }
+    
+    interface ActionFunction<TActor extends ProvidedActor> {
+      (): void;
+      _out_TActor?: TActor;
+    }
+    
+    interface AssignAction<TActor extends ProvidedActor> {
+      (): void;
+      _out_TActor?: TActor;
+    }
+    
+    interface MachineConfig<TActor extends ProvidedActor> {
+      entry?: ActionFunction<TActor>;
+    }
+    
+    declare function assign<TActor extends ProvidedActor>(
+      _: (spawn: (actor: TActor["src"]) => void) => {},
+    ): AssignAction<TActor>;
+    
+    type ToProvidedActor<TActors extends Record<string, UnknownActorLogic>> =
+      Values<{
+        [K in keyof TActors & string]: {
+          src: K;
+          logic: TActors[K];
+        };
+      }>;
+    
+    declare function setup<
+      TActors extends Record<string, UnknownActorLogic> = {},
+    >(implementations?: {
+      actors?: { [K in keyof TActors]: TActors[K] };
+    }): {
+      createMachine: <
+        const TConfig extends MachineConfig<ToProvidedActor<TActors>>,
+      >(
+        config: TConfig,
+      ) => void;
+    };
+    
+    declare const counterLogic: ActorLogic<{ type: "INCREMENT" }>;
+    
+    // example usage
+    setup({
+      actors: { counter: counterLogic },
+    }).createMachine({
+      entry: assign((spawn) => {
+        spawn("counter"); // ok
+        spawn("alarm"); // error
+              ~~~~~~~
+!!! error TS2345: Argument of type '"alarm"' is not assignable to parameter of type '"counter"'.
+        return {};
+      }),
+    });
+    
+    // no provided actors, `assign` should still work
+    setup().createMachine({
+      entry: assign(() => ({})),
+    });
+    

--- a/tests/baselines/reference/inferenceExactOptionalProperties2.symbols
+++ b/tests/baselines/reference/inferenceExactOptionalProperties2.symbols
@@ -1,0 +1,197 @@
+//// [tests/cases/compiler/inferenceExactOptionalProperties2.ts] ////
+
+=== inferenceExactOptionalProperties2.ts ===
+type Values<T> = T[keyof T];
+>Values : Symbol(Values, Decl(inferenceExactOptionalProperties2.ts, 0, 0))
+>T : Symbol(T, Decl(inferenceExactOptionalProperties2.ts, 0, 12))
+>T : Symbol(T, Decl(inferenceExactOptionalProperties2.ts, 0, 12))
+>T : Symbol(T, Decl(inferenceExactOptionalProperties2.ts, 0, 12))
+
+type EventObject = {
+>EventObject : Symbol(EventObject, Decl(inferenceExactOptionalProperties2.ts, 0, 28))
+
+  type: string;
+>type : Symbol(type, Decl(inferenceExactOptionalProperties2.ts, 2, 20))
+
+};
+
+interface ActorLogic<TEvent extends EventObject> {
+>ActorLogic : Symbol(ActorLogic, Decl(inferenceExactOptionalProperties2.ts, 4, 2))
+>TEvent : Symbol(TEvent, Decl(inferenceExactOptionalProperties2.ts, 6, 21))
+>EventObject : Symbol(EventObject, Decl(inferenceExactOptionalProperties2.ts, 0, 28))
+
+  transition: (ev: TEvent) => unknown;
+>transition : Symbol(ActorLogic.transition, Decl(inferenceExactOptionalProperties2.ts, 6, 50))
+>ev : Symbol(ev, Decl(inferenceExactOptionalProperties2.ts, 7, 15))
+>TEvent : Symbol(TEvent, Decl(inferenceExactOptionalProperties2.ts, 6, 21))
+}
+
+type UnknownActorLogic = ActorLogic<never>;
+>UnknownActorLogic : Symbol(UnknownActorLogic, Decl(inferenceExactOptionalProperties2.ts, 8, 1))
+>ActorLogic : Symbol(ActorLogic, Decl(inferenceExactOptionalProperties2.ts, 4, 2))
+
+interface ProvidedActor {
+>ProvidedActor : Symbol(ProvidedActor, Decl(inferenceExactOptionalProperties2.ts, 10, 43))
+
+  src: string;
+>src : Symbol(ProvidedActor.src, Decl(inferenceExactOptionalProperties2.ts, 12, 25))
+
+  logic: UnknownActorLogic;
+>logic : Symbol(ProvidedActor.logic, Decl(inferenceExactOptionalProperties2.ts, 13, 14))
+>UnknownActorLogic : Symbol(UnknownActorLogic, Decl(inferenceExactOptionalProperties2.ts, 8, 1))
+}
+
+interface ActionFunction<TActor extends ProvidedActor> {
+>ActionFunction : Symbol(ActionFunction, Decl(inferenceExactOptionalProperties2.ts, 15, 1))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 17, 25))
+>ProvidedActor : Symbol(ProvidedActor, Decl(inferenceExactOptionalProperties2.ts, 10, 43))
+
+  (): void;
+  _out_TActor?: TActor;
+>_out_TActor : Symbol(ActionFunction._out_TActor, Decl(inferenceExactOptionalProperties2.ts, 18, 11))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 17, 25))
+}
+
+interface AssignAction<TActor extends ProvidedActor> {
+>AssignAction : Symbol(AssignAction, Decl(inferenceExactOptionalProperties2.ts, 20, 1))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 22, 23))
+>ProvidedActor : Symbol(ProvidedActor, Decl(inferenceExactOptionalProperties2.ts, 10, 43))
+
+  (): void;
+  _out_TActor?: TActor;
+>_out_TActor : Symbol(AssignAction._out_TActor, Decl(inferenceExactOptionalProperties2.ts, 23, 11))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 22, 23))
+}
+
+interface MachineConfig<TActor extends ProvidedActor> {
+>MachineConfig : Symbol(MachineConfig, Decl(inferenceExactOptionalProperties2.ts, 25, 1))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 27, 24))
+>ProvidedActor : Symbol(ProvidedActor, Decl(inferenceExactOptionalProperties2.ts, 10, 43))
+
+  entry?: ActionFunction<TActor>;
+>entry : Symbol(MachineConfig.entry, Decl(inferenceExactOptionalProperties2.ts, 27, 55))
+>ActionFunction : Symbol(ActionFunction, Decl(inferenceExactOptionalProperties2.ts, 15, 1))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 27, 24))
+}
+
+declare function assign<TActor extends ProvidedActor>(
+>assign : Symbol(assign, Decl(inferenceExactOptionalProperties2.ts, 29, 1))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 31, 24))
+>ProvidedActor : Symbol(ProvidedActor, Decl(inferenceExactOptionalProperties2.ts, 10, 43))
+
+  _: (spawn: (actor: TActor["src"]) => void) => {},
+>_ : Symbol(_, Decl(inferenceExactOptionalProperties2.ts, 31, 54))
+>spawn : Symbol(spawn, Decl(inferenceExactOptionalProperties2.ts, 32, 6))
+>actor : Symbol(actor, Decl(inferenceExactOptionalProperties2.ts, 32, 14))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 31, 24))
+
+): AssignAction<TActor>;
+>AssignAction : Symbol(AssignAction, Decl(inferenceExactOptionalProperties2.ts, 20, 1))
+>TActor : Symbol(TActor, Decl(inferenceExactOptionalProperties2.ts, 31, 24))
+
+type ToProvidedActor<TActors extends Record<string, UnknownActorLogic>> =
+>ToProvidedActor : Symbol(ToProvidedActor, Decl(inferenceExactOptionalProperties2.ts, 33, 24))
+>TActors : Symbol(TActors, Decl(inferenceExactOptionalProperties2.ts, 35, 21))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>UnknownActorLogic : Symbol(UnknownActorLogic, Decl(inferenceExactOptionalProperties2.ts, 8, 1))
+
+  Values<{
+>Values : Symbol(Values, Decl(inferenceExactOptionalProperties2.ts, 0, 0))
+
+    [K in keyof TActors & string]: {
+>K : Symbol(K, Decl(inferenceExactOptionalProperties2.ts, 37, 5))
+>TActors : Symbol(TActors, Decl(inferenceExactOptionalProperties2.ts, 35, 21))
+
+      src: K;
+>src : Symbol(src, Decl(inferenceExactOptionalProperties2.ts, 37, 36))
+>K : Symbol(K, Decl(inferenceExactOptionalProperties2.ts, 37, 5))
+
+      logic: TActors[K];
+>logic : Symbol(logic, Decl(inferenceExactOptionalProperties2.ts, 38, 13))
+>TActors : Symbol(TActors, Decl(inferenceExactOptionalProperties2.ts, 35, 21))
+>K : Symbol(K, Decl(inferenceExactOptionalProperties2.ts, 37, 5))
+
+    };
+  }>;
+
+declare function setup<
+>setup : Symbol(setup, Decl(inferenceExactOptionalProperties2.ts, 41, 5))
+
+  TActors extends Record<string, UnknownActorLogic> = {},
+>TActors : Symbol(TActors, Decl(inferenceExactOptionalProperties2.ts, 43, 23))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>UnknownActorLogic : Symbol(UnknownActorLogic, Decl(inferenceExactOptionalProperties2.ts, 8, 1))
+
+>(implementations?: {
+>implementations : Symbol(implementations, Decl(inferenceExactOptionalProperties2.ts, 45, 2))
+
+  actors?: { [K in keyof TActors]: TActors[K] };
+>actors : Symbol(actors, Decl(inferenceExactOptionalProperties2.ts, 45, 21))
+>K : Symbol(K, Decl(inferenceExactOptionalProperties2.ts, 46, 14))
+>TActors : Symbol(TActors, Decl(inferenceExactOptionalProperties2.ts, 43, 23))
+>TActors : Symbol(TActors, Decl(inferenceExactOptionalProperties2.ts, 43, 23))
+>K : Symbol(K, Decl(inferenceExactOptionalProperties2.ts, 46, 14))
+
+}): {
+  createMachine: <
+>createMachine : Symbol(createMachine, Decl(inferenceExactOptionalProperties2.ts, 47, 5))
+
+    const TConfig extends MachineConfig<ToProvidedActor<TActors>>,
+>TConfig : Symbol(TConfig, Decl(inferenceExactOptionalProperties2.ts, 48, 18))
+>MachineConfig : Symbol(MachineConfig, Decl(inferenceExactOptionalProperties2.ts, 25, 1))
+>ToProvidedActor : Symbol(ToProvidedActor, Decl(inferenceExactOptionalProperties2.ts, 33, 24))
+>TActors : Symbol(TActors, Decl(inferenceExactOptionalProperties2.ts, 43, 23))
+
+  >(
+    config: TConfig,
+>config : Symbol(config, Decl(inferenceExactOptionalProperties2.ts, 50, 4))
+>TConfig : Symbol(TConfig, Decl(inferenceExactOptionalProperties2.ts, 48, 18))
+
+  ) => void;
+};
+
+declare const counterLogic: ActorLogic<{ type: "INCREMENT" }>;
+>counterLogic : Symbol(counterLogic, Decl(inferenceExactOptionalProperties2.ts, 55, 13))
+>ActorLogic : Symbol(ActorLogic, Decl(inferenceExactOptionalProperties2.ts, 4, 2))
+>type : Symbol(type, Decl(inferenceExactOptionalProperties2.ts, 55, 40))
+
+// example usage
+setup({
+>setup({  actors: { counter: counterLogic },}).createMachine : Symbol(createMachine, Decl(inferenceExactOptionalProperties2.ts, 47, 5))
+>setup : Symbol(setup, Decl(inferenceExactOptionalProperties2.ts, 41, 5))
+
+  actors: { counter: counterLogic },
+>actors : Symbol(actors, Decl(inferenceExactOptionalProperties2.ts, 58, 7))
+>counter : Symbol(counter, Decl(inferenceExactOptionalProperties2.ts, 59, 11))
+>counterLogic : Symbol(counterLogic, Decl(inferenceExactOptionalProperties2.ts, 55, 13))
+
+}).createMachine({
+>createMachine : Symbol(createMachine, Decl(inferenceExactOptionalProperties2.ts, 47, 5))
+
+  entry: assign((spawn) => {
+>entry : Symbol(entry, Decl(inferenceExactOptionalProperties2.ts, 60, 18))
+>assign : Symbol(assign, Decl(inferenceExactOptionalProperties2.ts, 29, 1))
+>spawn : Symbol(spawn, Decl(inferenceExactOptionalProperties2.ts, 61, 17))
+
+    spawn("counter"); // ok
+>spawn : Symbol(spawn, Decl(inferenceExactOptionalProperties2.ts, 61, 17))
+
+    spawn("alarm"); // error
+>spawn : Symbol(spawn, Decl(inferenceExactOptionalProperties2.ts, 61, 17))
+
+    return {};
+  }),
+});
+
+// no provided actors, `assign` should still work
+setup().createMachine({
+>setup().createMachine : Symbol(createMachine, Decl(inferenceExactOptionalProperties2.ts, 47, 5))
+>setup : Symbol(setup, Decl(inferenceExactOptionalProperties2.ts, 41, 5))
+>createMachine : Symbol(createMachine, Decl(inferenceExactOptionalProperties2.ts, 47, 5))
+
+  entry: assign(() => ({})),
+>entry : Symbol(entry, Decl(inferenceExactOptionalProperties2.ts, 69, 23))
+>assign : Symbol(assign, Decl(inferenceExactOptionalProperties2.ts, 29, 1))
+
+});
+

--- a/tests/baselines/reference/inferenceExactOptionalProperties2.types
+++ b/tests/baselines/reference/inferenceExactOptionalProperties2.types
@@ -1,0 +1,158 @@
+//// [tests/cases/compiler/inferenceExactOptionalProperties2.ts] ////
+
+=== inferenceExactOptionalProperties2.ts ===
+type Values<T> = T[keyof T];
+>Values : Values<T>
+
+type EventObject = {
+>EventObject : { type: string; }
+
+  type: string;
+>type : string
+
+};
+
+interface ActorLogic<TEvent extends EventObject> {
+  transition: (ev: TEvent) => unknown;
+>transition : (ev: TEvent) => unknown
+>ev : TEvent
+}
+
+type UnknownActorLogic = ActorLogic<never>;
+>UnknownActorLogic : ActorLogic<never>
+
+interface ProvidedActor {
+  src: string;
+>src : string
+
+  logic: UnknownActorLogic;
+>logic : UnknownActorLogic
+}
+
+interface ActionFunction<TActor extends ProvidedActor> {
+  (): void;
+  _out_TActor?: TActor;
+>_out_TActor : TActor | undefined
+}
+
+interface AssignAction<TActor extends ProvidedActor> {
+  (): void;
+  _out_TActor?: TActor;
+>_out_TActor : TActor | undefined
+}
+
+interface MachineConfig<TActor extends ProvidedActor> {
+  entry?: ActionFunction<TActor>;
+>entry : ActionFunction<TActor> | undefined
+}
+
+declare function assign<TActor extends ProvidedActor>(
+>assign : <TActor extends ProvidedActor>(_: (spawn: (actor: TActor["src"]) => void) => {}) => AssignAction<TActor>
+
+  _: (spawn: (actor: TActor["src"]) => void) => {},
+>_ : (spawn: (actor: TActor["src"]) => void) => {}
+>spawn : (actor: TActor["src"]) => void
+>actor : TActor["src"]
+
+): AssignAction<TActor>;
+
+type ToProvidedActor<TActors extends Record<string, UnknownActorLogic>> =
+>ToProvidedActor : ToProvidedActor<TActors>
+
+  Values<{
+    [K in keyof TActors & string]: {
+      src: K;
+>src : K
+
+      logic: TActors[K];
+>logic : TActors[K]
+
+    };
+  }>;
+
+declare function setup<
+>setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; } | undefined) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>>(config: TConfig) => void; }
+
+  TActors extends Record<string, UnknownActorLogic> = {},
+>(implementations?: {
+>implementations : { actors?: { [K in keyof TActors]: TActors[K]; }; } | undefined
+
+  actors?: { [K in keyof TActors]: TActors[K] };
+>actors : { [K in keyof TActors]: TActors[K]; } | undefined
+
+}): {
+  createMachine: <
+>createMachine : <const TConfig extends MachineConfig<ToProvidedActor<TActors>>>(config: TConfig) => void
+
+    const TConfig extends MachineConfig<ToProvidedActor<TActors>>,
+  >(
+    config: TConfig,
+>config : TConfig
+
+  ) => void;
+};
+
+declare const counterLogic: ActorLogic<{ type: "INCREMENT" }>;
+>counterLogic : ActorLogic<{ type: "INCREMENT"; }>
+>type : "INCREMENT"
+
+// example usage
+setup({
+>setup({  actors: { counter: counterLogic },}).createMachine({  entry: assign((spawn) => {    spawn("counter"); // ok    spawn("alarm"); // error    return {};  }),}) : void
+>setup({  actors: { counter: counterLogic },}).createMachine : <const TConfig extends MachineConfig<{ src: "counter"; logic: ActorLogic<{ type: "INCREMENT"; }>; }>>(config: TConfig) => void
+>setup({  actors: { counter: counterLogic },}) : { createMachine: <const TConfig extends MachineConfig<{ src: "counter"; logic: ActorLogic<{ type: "INCREMENT"; }>; }>>(config: TConfig) => void; }
+>setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; } | undefined) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>>(config: TConfig) => void; }
+>{  actors: { counter: counterLogic },} : { actors: { counter: ActorLogic<{ type: "INCREMENT"; }>; }; }
+
+  actors: { counter: counterLogic },
+>actors : { counter: ActorLogic<{ type: "INCREMENT"; }>; }
+>{ counter: counterLogic } : { counter: ActorLogic<{ type: "INCREMENT"; }>; }
+>counter : ActorLogic<{ type: "INCREMENT"; }>
+>counterLogic : ActorLogic<{ type: "INCREMENT"; }>
+
+}).createMachine({
+>createMachine : <const TConfig extends MachineConfig<{ src: "counter"; logic: ActorLogic<{ type: "INCREMENT"; }>; }>>(config: TConfig) => void
+>{  entry: assign((spawn) => {    spawn("counter"); // ok    spawn("alarm"); // error    return {};  }),} : { entry: AssignAction<{ src: "counter"; logic: ActorLogic<{ type: "INCREMENT"; }>; }>; }
+
+  entry: assign((spawn) => {
+>entry : AssignAction<{ src: "counter"; logic: ActorLogic<{ type: "INCREMENT"; }>; }>
+>assign((spawn) => {    spawn("counter"); // ok    spawn("alarm"); // error    return {};  }) : AssignAction<{ src: "counter"; logic: ActorLogic<{ type: "INCREMENT"; }>; }>
+>assign : <TActor extends ProvidedActor>(_: (spawn: (actor: TActor["src"]) => void) => {}) => AssignAction<TActor>
+>(spawn) => {    spawn("counter"); // ok    spawn("alarm"); // error    return {};  } : (spawn: (actor: "counter") => void) => {}
+>spawn : (actor: "counter") => void
+
+    spawn("counter"); // ok
+>spawn("counter") : void
+>spawn : (actor: "counter") => void
+>"counter" : "counter"
+
+    spawn("alarm"); // error
+>spawn("alarm") : void
+>spawn : (actor: "counter") => void
+>"alarm" : "alarm"
+
+    return {};
+>{} : {}
+
+  }),
+});
+
+// no provided actors, `assign` should still work
+setup().createMachine({
+>setup().createMachine({  entry: assign(() => ({})),}) : void
+>setup().createMachine : <const TConfig extends MachineConfig<never>>(config: TConfig) => void
+>setup() : { createMachine: <const TConfig extends MachineConfig<never>>(config: TConfig) => void; }
+>setup : <TActors extends Record<string, UnknownActorLogic> = {}>(implementations?: { actors?: { [K in keyof TActors]: TActors[K]; }; } | undefined) => { createMachine: <const TConfig extends MachineConfig<ToProvidedActor<TActors>>>(config: TConfig) => void; }
+>createMachine : <const TConfig extends MachineConfig<never>>(config: TConfig) => void
+>{  entry: assign(() => ({})),} : { entry: AssignAction<never>; }
+
+  entry: assign(() => ({})),
+>entry : AssignAction<never>
+>assign(() => ({})) : AssignAction<never>
+>assign : <TActor extends ProvidedActor>(_: (spawn: (actor: TActor["src"]) => void) => {}) => AssignAction<TActor>
+>() => ({}) : () => {}
+>({}) : {}
+>{} : {}
+
+});
+

--- a/tests/cases/compiler/inferenceExactOptionalProperties1.ts
+++ b/tests/cases/compiler/inferenceExactOptionalProperties1.ts
@@ -1,0 +1,5 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true
+// @noEmit: true
+
+type Test1 = { prop?: never } extends { prop?: infer T } ? T : false; // never

--- a/tests/cases/compiler/inferenceExactOptionalProperties2.ts
+++ b/tests/cases/compiler/inferenceExactOptionalProperties2.ts
@@ -1,0 +1,76 @@
+// @strict: true
+// @exactOptionalPropertyTypes: true
+// @noEmit: true
+
+type Values<T> = T[keyof T];
+
+type EventObject = {
+  type: string;
+};
+
+interface ActorLogic<TEvent extends EventObject> {
+  transition: (ev: TEvent) => unknown;
+}
+
+type UnknownActorLogic = ActorLogic<never>;
+
+interface ProvidedActor {
+  src: string;
+  logic: UnknownActorLogic;
+}
+
+interface ActionFunction<TActor extends ProvidedActor> {
+  (): void;
+  _out_TActor?: TActor;
+}
+
+interface AssignAction<TActor extends ProvidedActor> {
+  (): void;
+  _out_TActor?: TActor;
+}
+
+interface MachineConfig<TActor extends ProvidedActor> {
+  entry?: ActionFunction<TActor>;
+}
+
+declare function assign<TActor extends ProvidedActor>(
+  _: (spawn: (actor: TActor["src"]) => void) => {},
+): AssignAction<TActor>;
+
+type ToProvidedActor<TActors extends Record<string, UnknownActorLogic>> =
+  Values<{
+    [K in keyof TActors & string]: {
+      src: K;
+      logic: TActors[K];
+    };
+  }>;
+
+declare function setup<
+  TActors extends Record<string, UnknownActorLogic> = {},
+>(implementations?: {
+  actors?: { [K in keyof TActors]: TActors[K] };
+}): {
+  createMachine: <
+    const TConfig extends MachineConfig<ToProvidedActor<TActors>>,
+  >(
+    config: TConfig,
+  ) => void;
+};
+
+declare const counterLogic: ActorLogic<{ type: "INCREMENT" }>;
+
+// example usage
+setup({
+  actors: { counter: counterLogic },
+}).createMachine({
+  entry: assign((spawn) => {
+    spawn("counter"); // ok
+    spawn("alarm"); // error
+    return {};
+  }),
+});
+
+// no provided actors, `assign` should still work
+setup().createMachine({
+  entry: assign(() => ({})),
+});


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/57446