### PR TITLE
Disable fail-fast in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - '20'


### PR DESCRIPTION
I don't really see a reason to make tests fail fast in our case; especially if we expand out the suite to more runtimes and OSs.