### PR TITLE
Switch release pipeline image

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -15,7 +15,7 @@ extends:
   parameters:
     pool:
       name: TypeScript-AzurePipelines-EO
-      image: 1ESPT-Mariner2.0
+      image: 1ESPT-Ubuntu22.04
       os: linux
 
     sdl:


### PR DESCRIPTION
Mariner failed to clone, but Windows didn't. So, try Ubuntu in case that works.