### PR TITLE
fix(57451): Prevent self-imports when using the "Move to File" refactor

### DIFF
--- a/src/services/refactors/moveToFile.ts
+++ b/src/services/refactors/moveToFile.ts
@@ -18,6 +18,7 @@ import {
     ClassDeclaration,
     codefix,
     combinePaths,
+    Comparison,
     concatenate,
     contains,
     createModuleSpecifierResolutionHost,
@@ -52,12 +53,14 @@ import {
     getDirectoryPath,
     getLocaleSpecificMessage,
     getModifiers,
+    getNormalizedAbsolutePath,
     getPropertySymbolFromBindingElement,
     getQuotePreference,
     getRangesWhere,
     getRefactorContextSpan,
     getRelativePathFromFile,
     getSourceFileOfNode,
+    getStringComparer,
     getSynthesizedDeepClone,
     getTokenAtPosition,
     getUniqueName,
@@ -429,7 +432,12 @@ export function updateImportsInOtherFiles(
                 };
                 deleteUnusedImports(sourceFile, importNode, changes, shouldMove); // These will be changed to imports from the new file
 
-                const pathToTargetFileWithExtension = resolvePath(getDirectoryPath(oldFile.path), targetFileName);
+                const pathToTargetFileWithExtension = resolvePath(getDirectoryPath(getNormalizedAbsolutePath(oldFile.fileName, program.getCurrentDirectory())), targetFileName);
+
+                // no self-imports
+
+                if (getStringComparer(!program.useCaseSensitiveFileNames())(pathToTargetFileWithExtension, sourceFile.fileName) === Comparison.EqualTo) return;
+
                 const newModuleSpecifier = getModuleSpecifier(program.getCompilerOptions(), sourceFile, sourceFile.fileName, pathToTargetFileWithExtension, createModuleSpecifierResolutionHost(program, host));
                 const newImportDeclaration = filterImport(importNode, makeStringLiteral(newModuleSpecifier, quotePreference), shouldMove);
                 if (newImportDeclaration) changes.insertNodeAfter(sourceFile, statement, newImportDeclaration);
@@ -581,7 +589,7 @@ export function makeImportOrRequire(
     useEs6Imports: boolean,
     quotePreference: QuotePreference,
 ): AnyImportOrRequireStatement | undefined {
-    const pathToTargetFile = resolvePath(getDirectoryPath(sourceFile.path), targetFileNameWithExtension);
+    const pathToTargetFile = resolvePath(getDirectoryPath(getNormalizedAbsolutePath(sourceFile.fileName, program.getCurrentDirectory())), targetFileNameWithExtension);
     const pathToTargetFileWithCorrectExtension = getModuleSpecifier(program.getCompilerOptions(), sourceFile, sourceFile.fileName, pathToTargetFile, createModuleSpecifierResolutionHost(program, host));
 
     if (useEs6Imports) {

--- a/tests/cases/fourslash/moveToFile_noSelfImports1.ts
+++ b/tests/cases/fourslash/moveToFile_noSelfImports1.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: /bar.ts
+////import { y } from "./a";
+
+// @Filename: /a.ts
+////[|export const y = 1;|]
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts": "",
+
+        "/bar.ts": 
+`
+export const y = 1;
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/bar.ts" }
+});

--- a/tests/cases/fourslash/moveToFile_noSelfImports2.ts
+++ b/tests/cases/fourslash/moveToFile_noSelfImports2.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: /bar.ts
+////import { y, z } from "./a";
+
+// @Filename: /a.ts
+////[|export const y = 1;|]
+////export const z = 2;
+
+verify.moveToFile({
+    newFileContents: {
+        "/a.ts": "export const z = 2;",
+
+        "/bar.ts": 
+`import { z } from "./a";
+export const y = 1;
+`,
+    },
+    interactiveRefactorArguments: { targetFile: "/bar.ts" }
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `main` branch
* [x] You've successfully run `hereby runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #57451 
