### PR TITLE
Accept decimal strings in Intl.NumberFormat

### DIFF
--- a/src/lib/es2023.intl.d.ts
+++ b/src/lib/es2023.intl.d.ts
@@ -28,7 +28,9 @@ declare namespace Intl {
     }
 
     interface NumberFormat {
-        formatRange(start: number | bigint, end: number | bigint): string;
-        formatRangeToParts(start: number | bigint, end: number | bigint): NumberRangeFormatPart[];
+        format(value: number | bigint | `${number}`): string;
+        formatToParts(value: number | bigint | `${number}`): NumberFormatPart[];
+        formatRange(start: number | bigint | `${number}`, end: number | bigint | `${number}`): string;
+        formatRangeToParts(start: number | bigint | `${number}`, end: number | bigint | `${number}`): NumberRangeFormatPart[];
     }
 }

--- a/src/lib/es2023.intl.d.ts
+++ b/src/lib/es2023.intl.d.ts
@@ -27,10 +27,12 @@ declare namespace Intl {
         source: "startRange" | "endRange" | "shared";
     }
 
+    type StringNumericLiteral = `${number}` | "Infinity" | "-Infinity" | "+Infinity";
+
     interface NumberFormat {
-        format(value: number | bigint | `${number}`): string;
-        formatToParts(value: number | bigint | `${number}`): NumberFormatPart[];
-        formatRange(start: number | bigint | `${number}`, end: number | bigint | `${number}`): string;
-        formatRangeToParts(start: number | bigint | `${number}`, end: number | bigint | `${number}`): NumberRangeFormatPart[];
+        format(value: number | bigint | StringNumericLiteral): string;
+        formatToParts(value: number | bigint | StringNumericLiteral): NumberFormatPart[];
+        formatRange(start: number | bigint | StringNumericLiteral, end: number | bigint | StringNumericLiteral): string;
+        formatRangeToParts(start: number | bigint | StringNumericLiteral, end: number | bigint | StringNumericLiteral): NumberRangeFormatPart[];
     }
 }

--- a/tests/baselines/reference/intlNumberFormatES2023.js
+++ b/tests/baselines/reference/intlNumberFormatES2023.js
@@ -28,6 +28,9 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 new Intl.NumberFormat('en-GB').format('-12.3E-4');
 new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
 new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
+new Intl.NumberFormat('en-GB').format('Infinity');
+new Intl.NumberFormat('en-GB').format('-Infinity');
+new Intl.NumberFormat('en-GB').format('+Infinity');
 
 
 //// [intlNumberFormatES2023.js]
@@ -53,3 +56,6 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 new Intl.NumberFormat('en-GB').format('-12.3E-4');
 new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
 new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
+new Intl.NumberFormat('en-GB').format('Infinity');
+new Intl.NumberFormat('en-GB').format('-Infinity');
+new Intl.NumberFormat('en-GB').format('+Infinity');

--- a/tests/baselines/reference/intlNumberFormatES2023.js
+++ b/tests/baselines/reference/intlNumberFormatES2023.js
@@ -24,6 +24,11 @@ new Intl.NumberFormat('en-GB').formatRange(10n, 1000n);
 new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000)[0];
 new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 
+// Arbitrary-precision string arguments
+new Intl.NumberFormat('en-GB').format('-12.3E-4');
+new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
+new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
+
 
 //// [intlNumberFormatES2023.js]
 "use strict";
@@ -44,3 +49,7 @@ new Intl.NumberFormat('en-GB').formatRange(10, 100);
 new Intl.NumberFormat('en-GB').formatRange(10n, 1000n);
 new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000)[0];
 new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
+// Arbitrary-precision string arguments
+new Intl.NumberFormat('en-GB').format('-12.3E-4');
+new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
+new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');

--- a/tests/baselines/reference/intlNumberFormatES2023.symbols
+++ b/tests/baselines/reference/intlNumberFormatES2023.symbols
@@ -87,3 +87,25 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 >NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
 >formatRangeToParts : Symbol(Intl.NumberFormat.formatRangeToParts, Decl(lib.es2023.intl.d.ts, --, --))
 
+// Arbitrary-precision string arguments
+new Intl.NumberFormat('en-GB').format('-12.3E-4');
+>new Intl.NumberFormat('en-GB').format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+
+new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
+>new Intl.NumberFormat('en-GB').formatRange : Symbol(Intl.NumberFormat.formatRange, Decl(lib.es2023.intl.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>formatRange : Symbol(Intl.NumberFormat.formatRange, Decl(lib.es2023.intl.d.ts, --, --))
+
+new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
+>new Intl.NumberFormat('en-GB').formatRangeToParts : Symbol(Intl.NumberFormat.formatRangeToParts, Decl(lib.es2023.intl.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>formatRangeToParts : Symbol(Intl.NumberFormat.formatRangeToParts, Decl(lib.es2023.intl.d.ts, --, --))
+

--- a/tests/baselines/reference/intlNumberFormatES2023.symbols
+++ b/tests/baselines/reference/intlNumberFormatES2023.symbols
@@ -109,3 +109,24 @@ new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
 >NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
 >formatRangeToParts : Symbol(Intl.NumberFormat.formatRangeToParts, Decl(lib.es2023.intl.d.ts, --, --))
 
+new Intl.NumberFormat('en-GB').format('Infinity');
+>new Intl.NumberFormat('en-GB').format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+
+new Intl.NumberFormat('en-GB').format('-Infinity');
+>new Intl.NumberFormat('en-GB').format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+
+new Intl.NumberFormat('en-GB').format('+Infinity');
+>new Intl.NumberFormat('en-GB').format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl.NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>Intl : Symbol(Intl, Decl(lib.es5.d.ts, --, --), Decl(lib.es2016.intl.d.ts, --, --), Decl(lib.es2017.intl.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2019.intl.d.ts, --, --) ... and 5 more)
+>NumberFormat : Symbol(Intl.NumberFormat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2018.intl.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+>format : Symbol(Intl.NumberFormat.format, Decl(lib.es5.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2023.intl.d.ts, --, --))
+

--- a/tests/baselines/reference/intlNumberFormatES2023.types
+++ b/tests/baselines/reference/intlNumberFormatES2023.types
@@ -158,8 +158,8 @@ new Intl.NumberFormat('en-GB', { useGrouping: 'always' });
 new Intl.NumberFormat('en-GB').formatRange(10, 100);
 >new Intl.NumberFormat('en-GB').formatRange(10, 100) : string
 >                                                    : ^^^^^^
->new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
->                                           : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => string
+>                                           : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -170,8 +170,8 @@ new Intl.NumberFormat('en-GB').formatRange(10, 100);
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
->            : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRange : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => string
+>            : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10 : 10
 >   : ^^
 >100 : 100
@@ -180,8 +180,8 @@ new Intl.NumberFormat('en-GB').formatRange(10, 100);
 new Intl.NumberFormat('en-GB').formatRange(10n, 1000n);
 >new Intl.NumberFormat('en-GB').formatRange(10n, 1000n) : string
 >                                                       : ^^^^^^
->new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
->                                           : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => string
+>                                           : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -192,8 +192,8 @@ new Intl.NumberFormat('en-GB').formatRange(10n, 1000n);
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
->            : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRange : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => string
+>            : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10n : 10n
 >    : ^^^
 >1000n : 1000n
@@ -204,8 +204,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000)[0];
 >                                                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000) : Intl.NumberRangeFormatPart[]
 >                                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
->                                                  : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => Intl.NumberRangeFormatPart[]
+>                                                  : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -216,8 +216,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000)[0];
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
->                   : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRangeToParts : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => Intl.NumberRangeFormatPart[]
+>                   : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10 : 10
 >   : ^^
 >1000 : 1000
@@ -230,8 +230,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 >                                                                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n) : Intl.NumberRangeFormatPart[]
 >                                                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
->                                                  : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => Intl.NumberRangeFormatPart[]
+>                                                  : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -242,8 +242,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
->                   : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRangeToParts : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => Intl.NumberRangeFormatPart[]
+>                   : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10n : 10n
 >    : ^^^
 >1000n : 1000n
@@ -254,36 +254,125 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 // Arbitrary-precision string arguments
 new Intl.NumberFormat('en-GB').format('-12.3E-4');
 >new Intl.NumberFormat('en-GB').format('-12.3E-4') : string
->new Intl.NumberFormat('en-GB').format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | `${number}`): string; }
+>                                                  : ^^^^^^
+>new Intl.NumberFormat('en-GB').format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>                                      : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >Intl : typeof Intl
+>     : ^^^^^^^^^^^
 >NumberFormat : Intl.NumberFormatConstructor
+>             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
->format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | `${number}`): string; }
+>        : ^^^^^^^
+>format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>       : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'-12.3E-4' : "-12.3E-4"
+>           : ^^^^^^^^^^
 
 new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
 >new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8') : string
->new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>                                                             : ^^^^^^
+>new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => string
+>                                           : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >Intl : typeof Intl
+>     : ^^^^^^^^^^^
 >NumberFormat : Intl.NumberFormatConstructor
+>             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
->formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>        : ^^^^^^^
+>formatRange : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => string
+>            : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'123.4' : "123.4"
+>        : ^^^^^^^
 >'567.8' : "567.8"
+>        : ^^^^^^^
 
 new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
 >new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8') : Intl.NumberRangeFormatPart[]
->new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>                                                                     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => Intl.NumberRangeFormatPart[]
+>                                                  : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >Intl : typeof Intl
+>     : ^^^^^^^^^^^
 >NumberFormat : Intl.NumberFormatConstructor
+>             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
->formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>        : ^^^^^^^
+>formatRangeToParts : (start: number | bigint | Intl.StringNumericLiteral, end: number | bigint | Intl.StringNumericLiteral) => Intl.NumberRangeFormatPart[]
+>                   : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'123E-4' : "123E-4"
+>         : ^^^^^^^^
 >'567E8' : "567E8"
+>        : ^^^^^^^
+
+new Intl.NumberFormat('en-GB').format('Infinity');
+>new Intl.NumberFormat('en-GB').format('Infinity') : string
+>                                                  : ^^^^^^
+>new Intl.NumberFormat('en-GB').format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>                                      : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>                               : ^^^^^^^^^^^^^^^^^
+>Intl.NumberFormat : Intl.NumberFormatConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Intl : typeof Intl
+>     : ^^^^^^^^^^^
+>NumberFormat : Intl.NumberFormatConstructor
+>             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'en-GB' : "en-GB"
+>        : ^^^^^^^
+>format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>       : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'Infinity' : "Infinity"
+>           : ^^^^^^^^^^
+
+new Intl.NumberFormat('en-GB').format('-Infinity');
+>new Intl.NumberFormat('en-GB').format('-Infinity') : string
+>                                                   : ^^^^^^
+>new Intl.NumberFormat('en-GB').format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>                                      : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>                               : ^^^^^^^^^^^^^^^^^
+>Intl.NumberFormat : Intl.NumberFormatConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Intl : typeof Intl
+>     : ^^^^^^^^^^^
+>NumberFormat : Intl.NumberFormatConstructor
+>             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'en-GB' : "en-GB"
+>        : ^^^^^^^
+>format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>       : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'-Infinity' : "-Infinity"
+>            : ^^^^^^^^^^^
+
+new Intl.NumberFormat('en-GB').format('+Infinity');
+>new Intl.NumberFormat('en-GB').format('+Infinity') : string
+>                                                   : ^^^^^^
+>new Intl.NumberFormat('en-GB').format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>                                      : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>                               : ^^^^^^^^^^^^^^^^^
+>Intl.NumberFormat : Intl.NumberFormatConstructor
+>                  : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>Intl : typeof Intl
+>     : ^^^^^^^^^^^
+>NumberFormat : Intl.NumberFormatConstructor
+>             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'en-GB' : "en-GB"
+>        : ^^^^^^^
+>format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | Intl.StringNumericLiteral): string; }
+>       : ^^^     ^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>'+Infinity' : "+Infinity"
+>            : ^^^^^^^^^^^
 

--- a/tests/baselines/reference/intlNumberFormatES2023.types
+++ b/tests/baselines/reference/intlNumberFormatES2023.types
@@ -251,3 +251,39 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 >0 : 0
 >  : ^
 
+// Arbitrary-precision string arguments
+new Intl.NumberFormat('en-GB').format('-12.3E-4');
+>new Intl.NumberFormat('en-GB').format('-12.3E-4') : string
+>new Intl.NumberFormat('en-GB').format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | `${number}`): string; }
+>new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>Intl.NumberFormat : Intl.NumberFormatConstructor
+>Intl : typeof Intl
+>NumberFormat : Intl.NumberFormatConstructor
+>'en-GB' : "en-GB"
+>format : { (value: number): string; (value: number | bigint): string; (value: number | bigint | `${number}`): string; }
+>'-12.3E-4' : "-12.3E-4"
+
+new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
+>new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8') : string
+>new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>Intl.NumberFormat : Intl.NumberFormatConstructor
+>Intl : typeof Intl
+>NumberFormat : Intl.NumberFormatConstructor
+>'en-GB' : "en-GB"
+>formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>'123.4' : "123.4"
+>'567.8' : "567.8"
+
+new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
+>new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8') : Intl.NumberRangeFormatPart[]
+>new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>new Intl.NumberFormat('en-GB') : Intl.NumberFormat
+>Intl.NumberFormat : Intl.NumberFormatConstructor
+>Intl : typeof Intl
+>NumberFormat : Intl.NumberFormatConstructor
+>'en-GB' : "en-GB"
+>formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>'123E-4' : "123E-4"
+>'567E8' : "567E8"
+

--- a/tests/baselines/reference/intlNumberFormatES2023.types
+++ b/tests/baselines/reference/intlNumberFormatES2023.types
@@ -158,8 +158,8 @@ new Intl.NumberFormat('en-GB', { useGrouping: 'always' });
 new Intl.NumberFormat('en-GB').formatRange(10, 100);
 >new Intl.NumberFormat('en-GB').formatRange(10, 100) : string
 >                                                    : ^^^^^^
->new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint, end: number | bigint) => string
->                                           : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>                                           : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -170,8 +170,8 @@ new Intl.NumberFormat('en-GB').formatRange(10, 100);
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRange : (start: number | bigint, end: number | bigint) => string
->            : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>            : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10 : 10
 >   : ^^
 >100 : 100
@@ -180,8 +180,8 @@ new Intl.NumberFormat('en-GB').formatRange(10, 100);
 new Intl.NumberFormat('en-GB').formatRange(10n, 1000n);
 >new Intl.NumberFormat('en-GB').formatRange(10n, 1000n) : string
 >                                                       : ^^^^^^
->new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint, end: number | bigint) => string
->                                           : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>                                           : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -192,8 +192,8 @@ new Intl.NumberFormat('en-GB').formatRange(10n, 1000n);
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRange : (start: number | bigint, end: number | bigint) => string
->            : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRange : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => string
+>            : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10n : 10n
 >    : ^^^
 >1000n : 1000n
@@ -204,8 +204,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000)[0];
 >                                                               : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000) : Intl.NumberRangeFormatPart[]
 >                                                            : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint, end: number | bigint) => Intl.NumberRangeFormatPart[]
->                                                  : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>                                                  : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -216,8 +216,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000)[0];
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRangeToParts : (start: number | bigint, end: number | bigint) => Intl.NumberRangeFormatPart[]
->                   : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>                   : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10 : 10
 >   : ^^
 >1000 : 1000
@@ -230,8 +230,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 >                                                                 : ^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n) : Intl.NumberRangeFormatPart[]
 >                                                              : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
->new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint, end: number | bigint) => Intl.NumberRangeFormatPart[]
->                                                  : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>new Intl.NumberFormat('en-GB').formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>                                                  : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >new Intl.NumberFormat('en-GB') : Intl.NumberFormat
 >                               : ^^^^^^^^^^^^^^^^^
 >Intl.NumberFormat : Intl.NumberFormatConstructor
@@ -242,8 +242,8 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 >             : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >'en-GB' : "en-GB"
 >        : ^^^^^^^
->formatRangeToParts : (start: number | bigint, end: number | bigint) => Intl.NumberRangeFormatPart[]
->                   : ^     ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+>formatRangeToParts : (start: number | bigint | `${number}`, end: number | bigint | `${number}`) => Intl.NumberRangeFormatPart[]
+>                   : ^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 >10n : 10n
 >    : ^^^
 >1000n : 1000n

--- a/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
+++ b/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
@@ -29,3 +29,6 @@ new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
 new Intl.NumberFormat('en-GB').format('-12.3E-4');
 new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
 new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');
+new Intl.NumberFormat('en-GB').format('Infinity');
+new Intl.NumberFormat('en-GB').format('-Infinity');
+new Intl.NumberFormat('en-GB').format('+Infinity');

--- a/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
+++ b/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
@@ -24,3 +24,8 @@ new Intl.NumberFormat('en-GB').formatRange(10, 100);
 new Intl.NumberFormat('en-GB').formatRange(10n, 1000n);
 new Intl.NumberFormat('en-GB').formatRangeToParts(10, 1000)[0];
 new Intl.NumberFormat('en-GB').formatRangeToParts(10n, 1000n)[0];
+
+// Arbitrary-precision string arguments
+new Intl.NumberFormat('en-GB').format('-12.3E-4');
+new Intl.NumberFormat('en-GB').formatRange('123.4', '567.8');
+new Intl.NumberFormat('en-GB').formatRangeToParts('123E-4', '567E8');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #52124 

Note: This is **not** a coercion like in other JS APIs that also "accept" strings by coercing them, it is specifically designed to handle arbitrary-length decimals without precision loss. This was added as an explicit feature in Intl.NumberFormat v3 (which is why I added it to `es2023.intl`, which also houses `formatRange()`, which also got added in v3): https://github.com/tc39/proposal-intl-numberformat-v3#interpret-strings-as-decimals-ecma-402-334

The format matches what `${number}` accepts (plus `Infinity`):

> The general syntax for decimal strings, essentially #.#E#, is a widely understood format in computing. The specific version we use is the ECMA-262 StringNumericLiteral grammar, which also allows non-base-10 numbers like hexadecimal and binary.

Spec link: https://tc39.es/ecma402/#sec-runtime-semantics-stringintlmv

It is very common to represent monetary numbers as strings in JSON APIs to avoid any precision loss and those can currently not be passed to the `Intl.NumberFormat` API without casting `as any`. The resulting type errors currently misleads developers into using `parseFloat()` to make the type error go away, which causes precision loss.

It is supported by all browsers: https://caniuse.com/mdn-javascript_builtins_intl_numberformat_format_number_parameter-string_decimal