### PR TITLE
fix(57590): [Formatting] Remove spaces between `...` and type name in tuple spread

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -398,6 +398,9 @@ export function getAllRules(): RuleSpec[] {
         // Remove extra space between for and await
         rule("SpaceBetweenForAndAwaitKeyword", SyntaxKind.ForKeyword, SyntaxKind.AwaitKeyword, [isNonJsxSameLineTokenContext], RuleAction.InsertSpace),
 
+        // Remove extra spaces between ... and type name in tuple spread
+        rule("SpaceBetweenDotDotDotAndTypeName", SyntaxKind.DotDotDotToken, typeNames, [isNonJsxSameLineTokenContext], RuleAction.DeleteSpace),
+
         // Add a space between statements. All keywords except (do,else,case) has open/close parens after them.
         // So, we have a rule to add a space for [),Any], [do,Any], [else,Any], and [case,Any]
         rule(

--- a/tests/cases/fourslash/formatRemoveSpaceBetweenDotDotDotAndTypeName.ts
+++ b/tests/cases/fourslash/formatRemoveSpaceBetweenDotDotDotAndTypeName.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts"/>
+
+//// let a: [... any[]];
+//// let b: [...   number[]];
+//// let c: [...     string[]];
+
+format.document();
+verify.currentFileContentIs(
+    `let a: [...any[]];
+let b: [...number[]];
+let c: [...string[]];`
+);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `main` branch
* [ ] You've successfully run `hereby runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/main/CONTRIBUTING.md

** Please don't send typo fixes! **
Please don't send a PR solely for the purpose of fixing a typo, unless that
typo truly hurts understanding of the text. Each PR represents work for the
maintainers, and that work should provide commensurate value.

If you're interested in sending a PR, the issue tracker has many issues marked `help wanted`.
-->

Fixes #57590
