### PR TITLE
Properly set `hasAction` for erasing modifiers in class member completions

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -7019,6 +7019,10 @@
         "category": "Message",
         "code": 90060
     },
+    "Update modifiers of '{0}'": {
+        "category": "Message",
+        "code": 90061
+    },
 
     "Convert function to an ES2015 class": {
         "category": "Message",

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1246,6 +1246,7 @@ function completionInfoFromData(
     const {
         symbols,
         contextToken,
+        previousToken,
         completionKind,
         isInSnippetScope,
         isNewIdentifierLocation,
@@ -1305,6 +1306,7 @@ function completionInfoFromData(
         entries,
         /*replacementToken*/ undefined,
         contextToken,
+        previousToken,
         location,
         position,
         sourceFile,
@@ -1634,6 +1636,7 @@ function createCompletionEntry(
     sortText: SortText,
     replacementToken: Node | undefined,
     contextToken: Node | undefined,
+    previousToken: Node | undefined,
     location: Node,
     position: number,
     sourceFile: SourceFile,
@@ -1757,7 +1760,19 @@ function createCompletionEntry(
         isClassLikeMemberCompletion(symbol, location, sourceFile)
     ) {
         let importAdder;
-        const memberCompletionEntry = getEntryForMemberCompletion(host, program, options, preferences, name, symbol, location, position, contextToken, formatContext);
+        const memberCompletionEntry = getEntryForMemberCompletion(
+            host,
+            program,
+            options,
+            preferences,
+            name,
+            symbol,
+            location,
+            position,
+            contextToken,
+            previousToken,
+            formatContext,
+        );
         if (memberCompletionEntry) {
             ({ insertText, filterText, isSnippet, importAdder } = memberCompletionEntry);
             if (importAdder?.hasFixes() || memberCompletionEntry.eraseRange) {
@@ -1915,6 +1930,7 @@ function getEntryForMemberCompletion(
     location: Node,
     position: number,
     contextToken: Node | undefined,
+    previousToken: Node | undefined,
     formatContext: formatting.FormatContext | undefined,
 ): { insertText: string; filterText?: string; isSnippet?: true; importAdder?: codefix.ImportAdder; eraseRange?: TextRange; } | undefined {
     const classLikeDeclaration = findAncestor(location, isClassLike);
@@ -1953,7 +1969,7 @@ function getEntryForMemberCompletion(
     }
 
     let modifiers = ModifierFlags.None;
-    const { modifiers: presentModifiers, range: eraseRange, decorators: presentDecorators } = getPresentModifiers(contextToken, sourceFile, position);
+    const { modifiers: presentModifiers, range: eraseRange, decorators: presentDecorators } = getPresentModifiers(contextToken, previousToken, sourceFile, position);
     // Whether the suggested member should be abstract.
     // e.g. in `abstract class C { abstract | }`, we should offer abstract method signatures at position `|`.
     const isAbstract = presentModifiers & ModifierFlags.Abstract && classLikeDeclaration.modifierFlagsCache & ModifierFlags.Abstract;
@@ -2054,11 +2070,13 @@ function getEntryForMemberCompletion(
 
 function getPresentModifiers(
     contextToken: Node | undefined,
+    previousToken: Node | undefined,
     sourceFile: SourceFile,
     position: number,
 ): { modifiers: ModifierFlags; decorators?: Decorator[]; range?: TextRange; } {
     if (
         !contextToken ||
+        !previousToken ||
         getLineAndCharacterOfPosition(sourceFile, position).line
             > getLineAndCharacterOfPosition(sourceFile, contextToken.getEnd()).line
     ) {
@@ -2067,7 +2085,24 @@ function getPresentModifiers(
     let modifiers = ModifierFlags.None;
     let decorators: Decorator[] | undefined;
     let contextMod;
-    const range: TextRange = { pos: position, end: position };
+    /*
+    We have two cases:
+    1.
+    `class C {
+        someToken otherToken |
+    }`
+    `contextToken` is `otherToken`,
+    `previousToken` is `otherToken`
+    and
+    2.
+    `class C {
+        someToken otherToken|
+    }`
+    `contextToken` is `someToken`,
+    `previousToken` is `otherToken`
+    */
+    const startPos = contextToken === previousToken ? position : previousToken.getStart(sourceFile);
+    const range: TextRange = { pos: startPos, end: startPos };
     /*
     Cases supported:
     In
@@ -2083,23 +2118,21 @@ function getPresentModifiers(
     }`
         `contextToken` is ``override`` (as a keyword),
     `contextToken.parent` is property declaration,
-    `location` is identifier ``m``,
-    `location.parent` is property declaration ``protected override m``,
-    `location.parent.parent` is class declaration ``class C { ... }``.
+    `location` is identifier ``m``.
     */
-    if (isPropertyDeclaration(contextToken.parent) && contextToken.parent.modifiers) {
-        modifiers |= modifiersToFlags(contextToken.parent.modifiers) & ModifierFlags.Modifier;
-        decorators = contextToken.parent.modifiers.filter(isDecorator) || [];
-        range.pos = Math.min(range.pos, Math.min(...contextToken.parent.modifiers.map(n => n.getStart(sourceFile))));
-    }
     if (contextMod = isModifierLike(contextToken)) {
+        if (isPropertyDeclaration(contextToken.parent) && contextToken.parent.modifiers) {
+            modifiers |= modifiersToFlags(contextToken.parent.modifiers) & ModifierFlags.Modifier;
+            decorators = contextToken.parent.modifiers.filter(isDecorator) || [];
+            range.pos = Math.min(...contextToken.parent.modifiers.map(n => n.getStart(sourceFile)));
+        }
         const contextModifierFlag = modifierToFlag(contextMod);
         if (!(modifiers & contextModifierFlag)) {
             modifiers |= contextModifierFlag;
             range.pos = Math.min(range.pos, contextToken.getStart(sourceFile));
         }
     }
-    return { modifiers, decorators, range: range.pos !== position ? range : undefined };
+    return { modifiers, decorators, range: range.pos < range.end ? range : undefined };
 }
 
 function isModifierLike(node: Node): ModifierSyntaxKind | undefined {
@@ -2512,6 +2545,7 @@ export function getCompletionEntriesFromSymbols(
     entries: SortedArray<CompletionEntry>,
     replacementToken: Node | undefined,
     contextToken: Node | undefined,
+    previousToken: Node | undefined,
     location: Node,
     position: number,
     sourceFile: SourceFile,
@@ -2565,6 +2599,7 @@ export function getCompletionEntriesFromSymbols(
             sortText,
             replacementToken,
             contextToken,
+            previousToken,
             location,
             position,
             sourceFile,
@@ -2939,6 +2974,7 @@ function getCompletionEntryCodeActionsAndSourceDisplay(
             location,
             position,
             contextToken,
+            previousToken,
             formatContext,
         )!;
         if (importAdder?.hasFixes() || eraseRange) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1760,7 +1760,7 @@ function createCompletionEntry(
         const memberCompletionEntry = getEntryForMemberCompletion(host, program, options, preferences, name, symbol, location, position, contextToken, formatContext);
         if (memberCompletionEntry) {
             ({ insertText, filterText, isSnippet, importAdder } = memberCompletionEntry);
-            if (importAdder?.hasFixes() || memberCompletionEntry.eraseRange ) {
+            if (importAdder?.hasFixes() || memberCompletionEntry.eraseRange) {
                 hasAction = true;
                 source = CompletionSource.ClassMemberSnippet;
             }

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -236,7 +236,6 @@ function convertStringLiteralCompletions(
                 entries,
                 contextToken,
                 contextToken,
-                contextToken,
                 sourceFile,
                 position,
                 sourceFile,

--- a/src/services/stringCompletions.ts
+++ b/src/services/stringCompletions.ts
@@ -236,6 +236,7 @@ function convertStringLiteralCompletions(
                 entries,
                 contextToken,
                 contextToken,
+                contextToken,
                 sourceFile,
                 position,
                 sourceFile,

--- a/tests/cases/fourslash/completionsOverridingMethod0.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod0.ts
@@ -267,6 +267,8 @@ verify.completions({
             sortText: completion.SortText.LocationPriority,
             insertText: "static met(n: number): number {\n}",
             filterText: "met",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         }
     ],
 });

--- a/tests/cases/fourslash/completionsOverridingMethod12.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod12.ts
@@ -31,6 +31,8 @@ verify.completions({
             sortText: completion.SortText.LocationPriority,
             insertText: "abstract get P(): string;",
             filterText: "P",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         },
     ],
 });
@@ -49,6 +51,33 @@ verify.completions({
             sortText: completion.SortText.LocationPriority,
             insertText: "abstract override get P(): string;",
             filterText: "P",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         },
     ],
+});
+
+verify.applyCodeActionFromCompletion("b", {
+    preferences: {
+      includeCompletionsWithInsertText: true,
+      includeCompletionsWithSnippetText: false,
+      includeCompletionsWithClassMemberSnippets: true,
+    },
+    name: "P",
+    source: completion.CompletionSource.ClassMemberSnippet,
+    description: "Update modifiers of 'P'",
+    newFileContent:
+`abstract class A {
+    public get P(): string {
+        return "";
+    }
+}
+
+abstract class B extends A {
+    abstract 
+}
+
+abstract class B1 extends A {
+    
+}`
 });

--- a/tests/cases/fourslash/completionsOverridingMethod18.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod18.ts
@@ -1,0 +1,67 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+// @newline: LF
+
+//// declare function decorator(...args: any[]): any;
+
+//// class DecoratorBase {
+////     protected foo(a: string): string;
+////     protected foo(a: number): number;
+////     protected foo(a: any): any {
+////         return a;
+////     }
+//// }
+
+//// class DecoratorSub extends DecoratorBase {
+////     @decorator protected /**/
+//// }
+
+verify.completions({
+    marker: "",
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: false,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+    includes: [
+        {
+            name: "foo",
+            sortText: completion.SortText.LocationPriority,
+            insertText:
+`protected foo(a: string): string;
+protected foo(a: number): number;
+@decorator
+protected foo(a: any) {
+}`,
+            filterText: "foo",
+            replacementSpan: undefined,
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
+        },
+    ]
+});
+
+verify.applyCodeActionFromCompletion("", {
+    preferences: {
+      includeCompletionsWithInsertText: true,
+      includeCompletionsWithSnippetText: false,
+      includeCompletionsWithClassMemberSnippets: true,
+    },
+    name: "foo",
+    source: completion.CompletionSource.ClassMemberSnippet,
+    description: "Update modifiers of 'foo'",
+    newFileContent:
+`declare function decorator(...args: any[]): any;
+class DecoratorBase {
+    protected foo(a: string): string;
+    protected foo(a: number): number;
+    protected foo(a: any) {
+        return a;
+    }
+}
+class DecoratorSub extends DecoratorBase {
+    
+}`
+});

--- a/tests/cases/fourslash/completionsOverridingMethod19.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod19.ts
@@ -1,0 +1,60 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+// @newline: LF
+//// class Base {
+////     method() {}
+////     protected prop = 1;
+//// }
+//// class E extends Base {
+////     protected notamodifier override /**/
+//// }
+
+verify.completions({
+    marker: "",
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: false,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+    includes: [
+        {
+            name: "method",
+            sortText: completion.SortText.LocationPriority,
+            insertText: "override method(): void {\n}",
+            filterText: "method",
+            replacementSpan: undefined,
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
+        },
+        {
+            name: "prop",
+            sortText: completion.SortText.LocationPriority,
+            insertText: "protected override prop: number;",
+            filterText: "prop",
+            replacementSpan: undefined,
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
+        },
+    ]
+},);
+
+verify.applyCodeActionFromCompletion("", {
+    preferences: {
+      includeCompletionsWithInsertText: true,
+      includeCompletionsWithSnippetText: false,
+      includeCompletionsWithClassMemberSnippets: true,
+    },
+    name: "method",
+    source: completion.CompletionSource.ClassMemberSnippet,
+    description: "Update modifiers of 'method'",
+    newFileContent:
+`class Base {
+    method() {}
+    protected prop = 1;
+}
+class E extends Base {
+    protected notamodifier 
+}`
+});

--- a/tests/cases/fourslash/completionsOverridingMethod20.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod20.ts
@@ -2,19 +2,11 @@
 
 // @Filename: a.ts
 // @newline: LF
-
-//// declare function decorator(...args: any[]): any;
-
-//// class DecoratorBase {
-////     protected foo(a: string): string;
-////     protected foo(a: number): number;
-////     protected foo(a: any): any {
-////         return a;
-////     }
+//// abstract class AFoo {
+////     abstract bar(): Promise<void>;
 //// }
-
-//// class DecoratorSub extends DecoratorBase {
-////     @decorator protected /**/
+//// class Foo extends AFoo {
+////     async b/**/
 //// }
 
 verify.completions({
@@ -27,21 +19,16 @@ verify.completions({
     },
     includes: [
         {
-            name: "foo",
+            name: "bar",
             sortText: completion.SortText.LocationPriority,
-            insertText:
-`protected foo(a: string): string;
-protected foo(a: number): number;
-@decorator
-protected foo(a: any) {
-}`,
-            filterText: "foo",
+            insertText: "async bar(): void {\n}",
+            filterText: "bar",
             replacementSpan: undefined,
             hasAction: true,
             source: completion.CompletionSource.ClassMemberSnippet,
         },
     ]
-});
+},);
 
 verify.applyCodeActionFromCompletion("", {
     preferences: {
@@ -49,19 +36,14 @@ verify.applyCodeActionFromCompletion("", {
       includeCompletionsWithSnippetText: false,
       includeCompletionsWithClassMemberSnippets: true,
     },
-    name: "foo",
+    name: "bar",
     source: completion.CompletionSource.ClassMemberSnippet,
-    description: "Update modifiers of 'foo'",
+    description: "Update modifiers of 'bar'",
     newFileContent:
-`declare function decorator(...args: any[]): any;
-class DecoratorBase {
-    protected foo(a: string): string;
-    protected foo(a: number): number;
-    protected foo(a: any): any {
-        return a;
-    }
+`abstract class AFoo {
+    abstract bar(): Promise<void>;
 }
-class DecoratorSub extends DecoratorBase {
-    
+class Foo extends AFoo {
+    b
 }`
 });

--- a/tests/cases/fourslash/completionsOverridingMethod21.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod21.ts
@@ -5,12 +5,12 @@
 //// abstract class AFoo {
 ////     abstract bar(): Promise<void>;
 //// }
-//// class Foo extends AFoo {
-////     async b/*a*/
+//// class BFoo extends AFoo {
+////     async /*b*/
 //// }
 
 verify.completions({
-    marker: "a",
+    marker: "b",
     isNewIdentifierLocation: true,
     preferences: {
         includeCompletionsWithInsertText: true,
@@ -29,8 +29,7 @@ verify.completions({
         },
     ]
 });
-
-verify.applyCodeActionFromCompletion("a", {
+verify.applyCodeActionFromCompletion("b", {
     preferences: {
       includeCompletionsWithInsertText: true,
       includeCompletionsWithSnippetText: false,
@@ -43,7 +42,7 @@ verify.applyCodeActionFromCompletion("a", {
 `abstract class AFoo {
     abstract bar(): Promise<void>;
 }
-class Foo extends AFoo {
-    b
+class BFoo extends AFoo {
+    
 }`
 });

--- a/tests/cases/fourslash/completionsOverridingMethod22.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod22.ts
@@ -1,0 +1,53 @@
+/// <reference path="fourslash.ts" />
+
+// Bug #57333
+// @newline: LF
+// @Filename: b.ts
+//// export type C = { x: number }
+//// export interface ExtShape {
+////     $returnPromise(id: number): Promise<C>;
+////     $return(id: number): C;
+//// }
+
+// @Filename: test.ts
+//// import { ExtShape } from './b';
+//// abstract class ExtBase implements ExtShape {
+////     public $/**/
+//// }
+
+verify.completions({
+    marker: "",
+    isNewIdentifierLocation: true,
+    preferences: {
+        includeCompletionsWithInsertText: true,
+        includeCompletionsWithSnippetText: false,
+        includeCompletionsWithClassMemberSnippets: true,
+    },
+    includes: [
+        {
+            name: "$returnPromise",
+            sortText: completion.SortText.LocationPriority,
+            insertText: "public \\$returnPromise(id: number): Promise<C> {\n}",
+            filterText: "$returnPromise",
+            replacementSpan: undefined,
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
+        }
+    ]
+});
+
+verify.applyCodeActionFromCompletion("", {
+    preferences: {
+      includeCompletionsWithInsertText: true,
+      includeCompletionsWithSnippetText: false,
+      includeCompletionsWithClassMemberSnippets: true,
+    },
+    name: "$returnPromise",
+    source: completion.CompletionSource.ClassMemberSnippet,
+    description: "Includes imports of types referenced by '$returnPromise'",
+    newFileContent:
+`import { C, ExtShape } from './b';
+abstract class ExtBase implements ExtShape {
+    $
+}`
+});

--- a/tests/cases/fourslash/completionsOverridingMethod5.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod5.ts
@@ -54,13 +54,17 @@ verify.completions({
             name: "met",
             sortText: completion.SortText.LocationPriority,
             insertText: "abstract met(n: string): void;",
-            filterText: "met"
+            filterText: "met",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         },
         {
             name: "met2",
             sortText: completion.SortText.LocationPriority,
             insertText: "abstract met2(n: number): void;",
-            filterText: "met2"
+            filterText: "met2",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         }
     ],
 });
@@ -78,13 +82,17 @@ verify.completions({
             name: "met",
             sortText: completion.SortText.LocationPriority,
             insertText: "abstract met(n: string): void;",
-            filterText: "met"
+            filterText: "met",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         },
         {
             name: "met2",
             sortText: completion.SortText.LocationPriority,
             insertText: "abstract met2(n: number): void;",
-            filterText: "met2"
+            filterText: "met2",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         }
     ],
 });

--- a/tests/cases/fourslash/completionsOverridingMethod6.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod6.ts
@@ -24,10 +24,6 @@
 ////     override /*d*/
 //// }
 
-//// class E extends Base {
-////     protected notamodifier override /*e*/
-//// }
-
 //// class f extends Base {
 ////     protected /*f*/
 //// }
@@ -72,6 +68,8 @@ verify.completions(
                 insertText: "public abstract method(): void;",
                 filterText: "method",
                 replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
             {
                 name: "prop",
@@ -79,6 +77,8 @@ verify.completions(
                 insertText: "public abstract prop: number;",
                 filterText: "prop",
                 replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
         ],
     },
@@ -97,6 +97,8 @@ verify.completions(
                 insertText: "public override method(): void {\n}",
                 filterText: "method",
                 replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
             {
                 name: "prop",
@@ -104,6 +106,8 @@ verify.completions(
                 insertText: "public override prop: number;",
                 filterText: "prop",
                 replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
         ]
     },
@@ -122,6 +126,8 @@ verify.completions(
                 insertText: "override method(): void {\n}",
                 filterText: "method",
                 replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
             {
                 name: "prop",
@@ -129,31 +135,8 @@ verify.completions(
                 insertText: "protected override prop: number;",
                 filterText: "prop",
                 replacementSpan: undefined,
-            },
-        ]
-    },
-    {
-        marker: "e",
-        isNewIdentifierLocation: true,
-        preferences: {
-            includeCompletionsWithInsertText: true,
-            includeCompletionsWithSnippetText: false,
-            includeCompletionsWithClassMemberSnippets: true,
-        },
-        includes: [
-            {
-                name: "method",
-                sortText: completion.SortText.LocationPriority,
-                insertText: "override method(): void {\n}",
-                filterText: "method",
-                replacementSpan: undefined,
-            },
-            {
-                name: "prop",
-                sortText: completion.SortText.LocationPriority,
-                insertText: "protected override prop: number;",
-                filterText: "prop",
-                replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
         ]
     },
@@ -173,6 +156,8 @@ verify.completions(
                 insertText: "protected prop: number;",
                 filterText: "prop",
                 replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
         ]
     },
@@ -196,8 +181,9 @@ protected foo(a: any) {
 }`,
                 filterText: "foo",
                 replacementSpan: undefined,
+                hasAction: true,
+                source: completion.CompletionSource.ClassMemberSnippet,
             },
         ]
     },
 );
-

--- a/tests/cases/fourslash/completionsOverridingMethod6.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod6.ts
@@ -28,20 +28,6 @@
 ////     protected /*f*/
 //// }
 
-//// declare function decorator(...args: any[]): any;
-
-//// class DecoratorBase {
-////     protected foo(a: string): string;
-////     protected foo(a: number): number;
-////     protected foo(a: any): any {
-////         return a;
-////     }
-//// }
-
-//// class DecoratorSub extends DecoratorBase {
-////     @decorator protected /*g*/
-//// }
-
 verify.completions(
     {
         marker: "a",
@@ -155,31 +141,6 @@ verify.completions(
                 sortText: completion.SortText.LocationPriority,
                 insertText: "protected prop: number;",
                 filterText: "prop",
-                replacementSpan: undefined,
-                hasAction: true,
-                source: completion.CompletionSource.ClassMemberSnippet,
-            },
-        ]
-    },
-    {
-        marker: "g",
-        isNewIdentifierLocation: true,
-        preferences: {
-            includeCompletionsWithInsertText: true,
-            includeCompletionsWithSnippetText: false,
-            includeCompletionsWithClassMemberSnippets: true,
-        },
-        includes: [
-            {
-                name: "foo",
-                sortText: completion.SortText.LocationPriority,
-                insertText:
-`protected foo(a: string): string;
-protected foo(a: number): number;
-@decorator
-protected foo(a: any) {
-}`,
-                filterText: "foo",
                 replacementSpan: undefined,
                 hasAction: true,
                 source: completion.CompletionSource.ClassMemberSnippet,

--- a/tests/cases/fourslash/completionsOverridingMethod7.ts
+++ b/tests/cases/fourslash/completionsOverridingMethod7.ts
@@ -28,6 +28,28 @@ verify.completions({
 `abstract M<T>(t: T): void;
 abstract M<T>(t: T, x: number): void;`,
             filterText: "M",
+            hasAction: true,
+            source: completion.CompletionSource.ClassMemberSnippet,
         },
     ],
+});
+
+verify.applyCodeActionFromCompletion("a", {
+    preferences: {
+      includeCompletionsWithInsertText: true,
+      includeCompletionsWithSnippetText: false,
+      includeCompletionsWithClassMemberSnippets: true,
+    },
+    name: "M",
+    source: completion.CompletionSource.ClassMemberSnippet,
+    description: "Update modifiers of 'M'",
+    newFileContent:
+`abstract class Base {
+    abstract M<T>(t: T): void;
+    abstract M<T>(t: T, x: number): void;
+}
+
+abstract class Derived extends Base {
+    
+}`
 });


### PR DESCRIPTION
Fixes #57301.
Also fixes #57333.
@iisaduan pointed out that class member completions were always duplicating modifiers (any modifiers, not just `async`).

To update on my [last comment](https://github.com/microsoft/TypeScript/pull/52525#issuecomment-1441005953) on the original PR for dealing with modifiers in class member completions, the current behavior (with this fix) is:

- We only offer the completion if the already present modifiers match the modifiers the completion would insert
- The modifiers already present may be out of order, so we always add *all* the modifiers as part of the member completion entry, and send a code action to erase the present modifiers.

Example:

```ts
class Base {
    protected prop = 1;
}
class E extends Base {
    override protected |
}
```

becomes, after accepting completion for `prop`:

```ts
class Base {
    protected prop = 1;
}
class E extends Base {
    protected override prop: number;|
}
```
